### PR TITLE
Compile 'with'/'without' clauses as semi-joins

### DIFF
--- a/Cql/CoreTests/RelationshipClauseTests.cs
+++ b/Cql/CoreTests/RelationshipClauseTests.cs
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+#nullable enable
+
+using Hl7.Cql.CqlToElm;
+using Hl7.Cql.CqlToElm.Toolkit;
+using Hl7.Cql.CqlToElm.Toolkit.Extensions;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Invocation.Toolkit;
+using Hl7.Cql.Invocation.Toolkit.Extensions;
+using Hl7.Cql.Runtime;
+
+namespace CoreTests;
+
+/// <summary>
+/// Tests for the query 'with'/'without' relationship clauses (see issue #1366).
+/// A 'with' is a semi-join and a 'without' an anti-semi-join: each source element must be
+/// emitted at most once, no matter how many related elements satisfy the 'such that' condition,
+/// and duplicates in the source must be preserved.
+/// </summary>
+[TestClass]
+public class RelationshipClauseTests
+{
+    private static LibrarySetInvoker _invoker = null!;
+    private static CqlVersionedLibraryIdentifier _libraryIdentifier;
+
+    [ClassInitialize]
+    public static void Initialize(TestContext context)
+    {
+        var cqlLibrary = CqlLibraryString.Parse(
+            """
+            library RelationshipClauseTest version '1.0.0'
+
+            define "Sources": { 1, 2, 3 }
+            define "SourcesWithDuplicates": { 1, 1, 3 }
+            define "Related": { 10, 20, 30 }
+
+            // 1 matches 20 and 30, 2 matches 10, 3 matches nothing
+            define "With Clause":
+              "Sources" S
+                with "Related" R
+                  such that (S = 1 and R > 10) or (S = 2 and R = 10)
+
+            define "Without Clause":
+              "Sources" S
+                without "Related" R
+                  such that (S = 1 and R > 10) or (S = 2 and R = 10)
+
+            define "With Clause Preserves Duplicates":
+              "SourcesWithDuplicates" S
+                with "Related" R
+                  such that R = 10 * S
+
+            define "Without Clause Preserves Duplicates":
+              "SourcesWithDuplicates" S
+                without "Related" R
+                  such that R = 100 * S
+
+            define "Multiple With Clauses":
+              "Sources" S
+                with "Related" R1
+                  such that R1 = 10 * S
+                with "Related" R2
+                  such that R2 > 10 * S
+            """);
+        _libraryIdentifier = cqlLibrary.LibraryIdentifier;
+        _invoker = new CqlToolkit()
+                   .AddCqlLibraries(cqlLibrary)
+                   .CreateLibrarySetInvoker();
+    }
+
+    [ClassCleanup]
+    public static void Cleanup()
+    {
+        _invoker?.Dispose();
+    }
+
+    private static IEnumerable<int?> Invoke(string definition) =>
+        ((IEnumerable<int?>)_invoker.InvokeLibraryDefinition(FhirCqlContext.ForBundle(), _libraryIdentifier, definition)!);
+
+    [TestMethod]
+    public void With_EmitsEachSourceElementAtMostOnce()
+    {
+        // Element 1 has two matching related elements but must be emitted only once.
+        Invoke("With Clause").Should().Equal(1, 2);
+    }
+
+    [TestMethod]
+    public void Without_KeepsOnlySourceElementsWithNoMatch()
+    {
+        Invoke("Without Clause").Should().Equal(3);
+    }
+
+    [TestMethod]
+    public void With_PreservesDuplicateSourceElements()
+    {
+        // Both 1s match related element 10 and must both be kept.
+        Invoke("With Clause Preserves Duplicates").Should().Equal(1, 1, 3);
+    }
+
+    [TestMethod]
+    public void Without_PreservesDuplicateSourceElements()
+    {
+        // Nothing matches, so the whole source survives, including the duplicate.
+        Invoke("Without Clause Preserves Duplicates").Should().Equal(1, 1, 3);
+    }
+
+    [TestMethod]
+    public void MultipleWiths_ApplyEachExistenceFilterOnce()
+    {
+        // 1 matches R1 = 10 and R2 in { 20, 30 }; 2 matches R1 = 20 and R2 = 30; 3 matches R1 = 30 but no R2.
+        Invoke("Multiple With Clauses").Should().Equal(1, 2);
+    }
+}

--- a/Cql/Cql.Compiler/ExpressionBuilderContext.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilderContext.cs
@@ -1743,18 +1743,11 @@ internal partial class ExpressionBuilderContext
                 {
                     using (PushElement(relationship))
                     {
-                        var selectManyLambda = WithToSelectManyBody(scopeParameter, relationship);
-
-                        var selectManyCall = BindCqlOperator(nameof(ICqlOperators.SelectMany), @return, selectManyLambda);
-                        if (relationship is Without)
-                        {
-                            var callExcept = BindCqlOperator(nameof(ICqlOperators.Except), @return, selectManyCall);
-                            @return = callExcept;
-                        }
-                        else
-                        {
-                            @return = selectManyCall;
-                        }
+                        // A 'with' is a semi-join and a 'without' an anti-semi-join: each source
+                        // element is kept or dropped based on whether a matching related element
+                        // exists, and is emitted at most once no matter how many elements match.
+                        var existsLambda = WithToExistenceCheck(scopeParameter, relationship);
+                        @return = BindCqlOperator(nameof(ICqlOperators.Where), @return, existsLambda);
                     }
                 }
             }
@@ -2063,7 +2056,7 @@ internal partial class ExpressionBuilderContext
         return @return;
     }
 
-    protected LambdaExpression WithToSelectManyBody(
+    protected LambdaExpression WithToExistenceCheck(
         ParameterExpression rootScopeParameter,
         RelationshipClause with)
     {
@@ -2081,10 +2074,10 @@ internal partial class ExpressionBuilderContext
 
         //Func<Bundle, Context, IEnumerable<Encounter>> x = (bundle, ctx) =>
         //    bundle.Entry.ByResourceType<Encounter>()
-        //    .SelectMany(E =>
+        //    .Where(E =>
         //        bundle.Entry.ByResourceType<Condition>() // <--
         //            .Where(P => true) // such that goes here
-        //            .Select(P => E));
+        //            .Any());          // negated for a 'without'
         var source = TranslateArg(with.expression);
         if (!_typeResolver.IsListType(source.Type))
         {
@@ -2105,13 +2098,10 @@ internal partial class ExpressionBuilderContext
 
             var whereLambda = Expression.Lambda(suchThatBody, whereLambdaParameter);
             var callWhereOnSource = BindCqlOperator(nameof(ICqlOperators.Where), source, whereLambda);
-
-            var selectLambdaParameter = Expression.Parameter(sourceElementType, with.alias);
-            var selectBody = rootScopeParameter; // P => E
-            var selectLambda = Expression.Lambda(selectBody, selectLambdaParameter);
-            var callSelectOnWhere = BindCqlOperator(nameof(ICqlOperators.Select), callWhereOnSource, selectLambda);
-            var selectManyLambda = Expression.Lambda(callSelectOnWhere, rootScopeParameter);
-            return selectManyLambda;
+            var exists = BindCqlOperator(nameof(ICqlOperators.Exists), callWhereOnSource);
+            if (with is Without)
+                exists = BindCqlOperator(nameof(ICqlOperators.Not), exists);
+            return Expression.Lambda(exists, rootScopeParameter);
         }
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
@@ -228,38 +228,37 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
     {
         IEnumerable<Encounter> a_ = this.Outpatient_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet f_ = this.Heart_Failure(context);
             IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> i_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> j_ = context.Operators.Union<Condition>(g_ as IEnumerable<Condition>, i_ as IEnumerable<Condition>);
 
             bool? k_(Condition HeartFailure) {
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HeartFailure);
-                Period p_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                bool? r_ = context.Operators.Overlaps(o_, q_, "day");
-                bool? s_ = this.isVerified(context, HeartFailure);
-                bool? t_ = context.Operators.And(r_, s_);
-                return t_;
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HeartFailure);
+                Period o_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.Overlaps(n_, p_, "day");
+                bool? r_ = this.isVerified(context, HeartFailure);
+                bool? s_ = context.Operators.And(q_, r_);
+                return s_;
             }
 
             IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
-            Encounter m_(Condition HeartFailure) => QualifyingEncounter;
-            IEnumerable<Encounter> n_ = context.Operators.Select<Condition, Encounter>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Condition>(l_);
+            return m_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter QualifyingEncounter) {
-            CqlInterval<CqlDateTime> u_ = this.Measurement_Period(context);
-            Period v_ = QualifyingEncounter?.Period;
-            CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-            bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, "day");
-            bool? y_ = this.isEncounterFinished(context, QualifyingEncounter);
-            bool? z_ = context.Operators.And(x_, y_);
-            return z_;
+            CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
+            Period u_ = QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+            bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, "day");
+            bool? x_ = this.isEncounterFinished(context, QualifyingEncounter);
+            bool? y_ = context.Operators.And(w_, x_);
+            return y_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
@@ -342,29 +341,28 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
     {
         IEnumerable<Encounter> a_ = this.Heart_Failure_Outpatient_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter HFOutpatientEncounter) {
+        bool? b_(Encounter HFOutpatientEncounter) {
             IEnumerable<object> d_ = this.Moderate_or_Severe_LVSD_Findings(context);
 
             bool? e_(object LVSDFindings) {
-                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LVSDFindings as Condition);
-                object j_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
-                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
-                CqlDateTime m_ = context.Operators.Start(i_ ?? l_);
-                Period n_ = HFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                bool? q_ = context.Operators.Before(m_, p_, (string)default);
-                return q_;
+                CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LVSDFindings as Condition);
+                object i_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
+                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
+                CqlDateTime l_ = context.Operators.Start(h_ ?? k_);
+                Period m_ = HFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                bool? p_ = context.Operators.Before(l_, o_, (string)default);
+                return p_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object LVSDFindings) => HFOutpatientEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -383,34 +381,33 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
         IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
         IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
 
-        IEnumerable<Condition> f_(Condition HeartTransplantComplications) {
+        bool? f_(Condition HeartTransplantComplications) {
             IEnumerable<Encounter> k_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? l_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HeartTransplantComplications);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                FhirDateTime r_ = HeartTransplantComplications?.RecordedDateElement;
-                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(r_);
-                CqlDate t_ = context.Operators.DateFrom(q_ ?? s_);
-                Period u_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.End(v_);
-                CqlDate x_ = context.Operators.DateFrom(w_);
-                bool? y_ = context.Operators.SameOrBefore(t_, x_, (string)default);
-                return y_;
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HeartTransplantComplications);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                FhirDateTime q_ = HeartTransplantComplications?.RecordedDateElement;
+                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
+                CqlDate s_ = context.Operators.DateFrom(p_ ?? r_);
+                Period t_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime v_ = context.Operators.End(u_);
+                CqlDate w_ = context.Operators.DateFrom(v_);
+                bool? x_ = context.Operators.SameOrBefore(s_, w_, (string)default);
+                return x_;
             }
 
             IEnumerable<Encounter> m_ = context.Operators.Where<Encounter>(k_, l_);
-            Condition n_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => HeartTransplantComplications;
-            IEnumerable<Condition> o_ = context.Operators.Select<Encounter, Condition>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Encounter>(m_);
+            return n_;
         }
 
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 
         bool? h_(Condition HeartTransplantComplications) {
-            bool? z_ = this.isVerified(context, HeartTransplantComplications);
-            return z_;
+            bool? y_ = this.isVerified(context, HeartTransplantComplications);
+            return y_;
         }
 
         IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
@@ -431,67 +428,67 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
         CqlValueSet a_ = this.Left_Ventricular_Assist_Device_Placement(context);
         IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> c_(Procedure LVADPlacement) {
+        bool? c_(Procedure LVADPlacement) {
             IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
 
-                object m_() {
+                object l_() {
+
+                    bool s_() {
+                        DataType w_ = LVADPlacement?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
 
                     bool t_() {
-                        DataType x_ = LVADPlacement?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
+                        DataType z_ = LVADPlacement?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        DataType aa_ = LVADPlacement?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        DataType ac_ = LVADPlacement?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
                     }
 
 
                     bool v_() {
-                        DataType ad_ = LVADPlacement?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
+                        DataType af_ = LVADPlacement?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
                     }
 
-
-                    bool w_() {
-                        DataType ag_ = LVADPlacement?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
+                    if (s_())
                     {
-                        DataType aj_ = LVADPlacement?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
+                        DataType ai_ = LVADPlacement?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = LVADPlacement?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
-                        DataType al_ = LVADPlacement?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        DataType am_ = LVADPlacement?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
-                        DataType an_ = LVADPlacement?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = LVADPlacement?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ao_ = LVADPlacement?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -499,29 +496,28 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
                     };
                 }
 
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
-                CqlDateTime o_ = context.Operators.Start(n_);
-                Period p_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.End(q_);
-                bool? s_ = context.Operators.Before(o_, r_, "day");
-                return s_;
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
+                CqlDateTime n_ = context.Operators.Start(m_);
+                Period o_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                bool? r_ = context.Operators.Before(n_, q_, "day");
+                return r_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            Procedure k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => LVADPlacement;
-            IEnumerable<Procedure> l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 
         bool? e_(Procedure LVADPlacement) {
-            Code<EventStatus> ar_ = LVADPlacement?.StatusElement;
-            EventStatus? as_ = ar_?.Value;
-            string at_ = context.Operators.Convert<string>(as_);
-            bool? au_ = context.Operators.Equal(at_, "completed");
-            return au_;
+            Code<EventStatus> aq_ = LVADPlacement?.StatusElement;
+            EventStatus? ar_ = aq_?.Value;
+            string as_ = context.Operators.Convert<string>(ar_);
+            bool? at_ = context.Operators.Equal(as_, "completed");
+            return at_;
         }
 
         IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
@@ -544,34 +540,33 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
         IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
         IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
 
-        IEnumerable<Condition> f_(Condition LVADComplications) {
+        bool? f_(Condition LVADComplications) {
             IEnumerable<Encounter> k_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? l_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LVADComplications);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                FhirDateTime r_ = LVADComplications?.RecordedDateElement;
-                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(r_);
-                CqlDate t_ = context.Operators.DateFrom(q_ ?? s_);
-                Period u_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.End(v_);
-                CqlDate x_ = context.Operators.DateFrom(w_);
-                bool? y_ = context.Operators.SameOrBefore(t_, x_, (string)default);
-                return y_;
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LVADComplications);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                FhirDateTime q_ = LVADComplications?.RecordedDateElement;
+                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
+                CqlDate s_ = context.Operators.DateFrom(p_ ?? r_);
+                Period t_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime v_ = context.Operators.End(u_);
+                CqlDate w_ = context.Operators.DateFrom(v_);
+                bool? x_ = context.Operators.SameOrBefore(s_, w_, (string)default);
+                return x_;
             }
 
             IEnumerable<Encounter> m_ = context.Operators.Where<Encounter>(k_, l_);
-            Condition n_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => LVADComplications;
-            IEnumerable<Condition> o_ = context.Operators.Select<Encounter, Condition>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Encounter>(m_);
+            return n_;
         }
 
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 
         bool? h_(Condition LVADComplications) {
-            bool? z_ = this.isVerified(context, LVADComplications);
-            return z_;
+            bool? y_ = this.isVerified(context, LVADComplications);
+            return y_;
         }
 
         IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
@@ -634,67 +629,67 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
         CqlValueSet a_ = this.Heart_Transplant(context);
         IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> c_(Procedure HeartTransplant) {
+        bool? c_(Procedure HeartTransplant) {
             IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
 
-                object m_() {
+                object l_() {
+
+                    bool s_() {
+                        DataType w_ = HeartTransplant?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
 
                     bool t_() {
-                        DataType x_ = HeartTransplant?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
+                        DataType z_ = HeartTransplant?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        DataType aa_ = HeartTransplant?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        DataType ac_ = HeartTransplant?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
                     }
 
 
                     bool v_() {
-                        DataType ad_ = HeartTransplant?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
+                        DataType af_ = HeartTransplant?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
                     }
 
-
-                    bool w_() {
-                        DataType ag_ = HeartTransplant?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
+                    if (s_())
                     {
-                        DataType aj_ = HeartTransplant?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
+                        DataType ai_ = HeartTransplant?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = HeartTransplant?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
-                        DataType al_ = HeartTransplant?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        DataType am_ = HeartTransplant?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
-                        DataType an_ = HeartTransplant?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = HeartTransplant?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ao_ = HeartTransplant?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -702,29 +697,28 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
                     };
                 }
 
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
-                CqlDateTime o_ = context.Operators.Start(n_);
-                Period p_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.End(q_);
-                bool? s_ = context.Operators.Before(o_, r_, (string)default);
-                return s_;
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
+                CqlDateTime n_ = context.Operators.Start(m_);
+                Period o_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                bool? r_ = context.Operators.Before(n_, q_, (string)default);
+                return r_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            Procedure k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => HeartTransplant;
-            IEnumerable<Procedure> l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 
         bool? e_(Procedure HeartTransplant) {
-            Code<EventStatus> ar_ = HeartTransplant?.StatusElement;
-            EventStatus? as_ = ar_?.Value;
-            string at_ = context.Operators.Convert<string>(as_);
-            bool? au_ = context.Operators.Equal(at_, "completed");
-            return au_;
+            Code<EventStatus> aq_ = HeartTransplant?.StatusElement;
+            EventStatus? ar_ = aq_?.Value;
+            string as_ = context.Operators.Convert<string>(ar_);
+            bool? at_ = context.Operators.Equal(as_, "completed");
+            return at_;
         }
 
         IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
@@ -753,26 +747,25 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
         bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
         IEnumerable<Encounter> j_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period(context);
 
-        IEnumerable<Encounter> k_(Encounter Encounter1) {
+        bool? k_(Encounter Encounter1) {
             IEnumerable<Encounter> r_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period(context);
 
             bool? s_(Encounter Encounter2) {
-                Id w_ = Encounter2?.IdElement;
-                string x_ = w_?.Value;
-                Id y_ = Encounter1?.IdElement;
-                string z_ = y_?.Value;
-                bool? aa_ = context.Operators.Equivalent(x_, z_);
-                bool? ab_ = context.Operators.Not(aa_);
-                return ab_;
+                Id v_ = Encounter2?.IdElement;
+                string w_ = v_?.Value;
+                Id x_ = Encounter1?.IdElement;
+                string y_ = x_?.Value;
+                bool? z_ = context.Operators.Equivalent(w_, y_);
+                bool? aa_ = context.Operators.Not(z_);
+                return aa_;
             }
 
             IEnumerable<Encounter> t_ = context.Operators.Where<Encounter>(r_, s_);
-            Encounter u_(Encounter Encounter2) => Encounter1;
-            IEnumerable<Encounter> v_ = context.Operators.Select<Encounter, Encounter>(t_, u_);
-            return v_;
+            bool? u_ = context.Operators.Exists<Encounter>(t_);
+            return u_;
         }
 
-        IEnumerable<Encounter> l_ = context.Operators.SelectMany<Encounter, Encounter>(j_, k_);
+        IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
         bool? m_ = context.Operators.Exists<Encounter>(l_);
         bool? n_ = context.Operators.And(i_, m_);
         IEnumerable<Encounter> o_ = this.Heart_Failure_Outpatient_Encounter(context);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
@@ -254,50 +254,49 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> k_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? l_(Medication M) {
-                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
-                string s_ = context.Operators.Last<string>(r_);
-                bool? t_ = context.Operators.Equal(p_, s_);
-                CodeableConcept u_ = M?.Code;
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                CqlValueSet w_ = this.Dementia_Medications(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
+                string r_ = context.Operators.Last<string>(q_);
+                bool? s_ = context.Operators.Equal(o_, r_);
+                CodeableConcept t_ = M?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlValueSet v_ = this.Dementia_Medications(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Medication> m_ = context.Operators.Where<Medication>(k_, l_);
-            MedicationRequest n_(Medication M) => MR;
-            IEnumerable<MedicationRequest> o_ = context.Operators.Select<Medication, MedicationRequest>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Medication>(m_);
+            return n_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationActive(context, f_);
 
         bool? h_(MedicationRequest DementiaMedication) {
-            CqlInterval<CqlDate> z_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DementiaMedication);
-            CqlDate aa_ = z_?.low;
-            CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(aa_);
-            CqlDate ad_ = z_?.high;
-            CqlDateTime ae_ = context.Operators.ConvertDateToDateTime(ad_);
-            bool? ag_ = z_?.lowClosed;
-            bool? ai_ = z_?.highClosed;
-            CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ab_, ae_, ag_, ai_);
-            CqlInterval<CqlDateTime> ak_ = this.Measurement_Period(context);
-            CqlDateTime al_ = context.Operators.Start(ak_);
-            CqlQuantity am_ = context.Operators.Quantity(1m, "year");
-            CqlDateTime an_ = context.Operators.Subtract(al_, am_);
-            CqlDateTime ap_ = context.Operators.End(ak_);
-            CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(an_, ap_, true, true);
-            bool? ar_ = context.Operators.Overlaps(aj_, aq_, "day");
-            return ar_;
+            CqlInterval<CqlDate> y_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DementiaMedication);
+            CqlDate z_ = y_?.low;
+            CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+            CqlDate ac_ = y_?.high;
+            CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(ac_);
+            bool? af_ = y_?.lowClosed;
+            bool? ah_ = y_?.highClosed;
+            CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(aa_, ad_, af_, ah_);
+            CqlInterval<CqlDateTime> aj_ = this.Measurement_Period(context);
+            CqlDateTime ak_ = context.Operators.Start(aj_);
+            CqlQuantity al_ = context.Operators.Quantity(1m, "year");
+            CqlDateTime am_ = context.Operators.Subtract(ak_, al_);
+            CqlDateTime ao_ = context.Operators.End(aj_);
+            CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(am_, ao_, true, true);
+            bool? aq_ = context.Operators.Overlaps(ai_, ap_, "day");
+            return aq_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
@@ -53,33 +53,32 @@ public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_
     public IEnumerable<Encounter> Encounter_with_Comorbid_Condition_History(CqlContext context, IEnumerable<Encounter> episodes, IEnumerable<Condition> comorbidConditions)
     {
 
-        IEnumerable<Encounter> a_(Encounter episode) {
+        bool? a_(Encounter episode) {
 
             bool? f_(Condition comcondition) {
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, comcondition as Condition);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                CqlDate l_ = context.Operators.DateFrom(k_);
-                Period m_ = episode?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlDate p_ = context.Operators.DateFrom(o_);
-                CqlQuantity q_ = context.Operators.Quantity(1m, "year");
-                CqlDate r_ = context.Operators.Subtract(p_, q_);
-                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime u_ = context.Operators.Start(t_);
-                CqlDate v_ = context.Operators.DateFrom(u_);
-                CqlInterval<CqlDate> w_ = context.Operators.Interval(r_, v_, true, true);
-                bool? x_ = context.Operators.In<CqlDate>(l_, w_, (string)default);
-                return x_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, comcondition as Condition);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                CqlDate k_ = context.Operators.DateFrom(j_);
+                Period l_ = episode?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlDate o_ = context.Operators.DateFrom(n_);
+                CqlQuantity p_ = context.Operators.Quantity(1m, "year");
+                CqlDate q_ = context.Operators.Subtract(o_, p_);
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlDate u_ = context.Operators.DateFrom(t_);
+                CqlInterval<CqlDate> v_ = context.Operators.Interval(q_, u_, true, true);
+                bool? w_ = context.Operators.In<CqlDate>(k_, v_, (string)default);
+                return w_;
             }
 
             IEnumerable<Condition> g_ = context.Operators.Where<Condition>(comorbidConditions, f_);
-            Encounter h_(Condition comcondition) => episode;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Condition>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> b_ = context.Operators.SelectMany<Encounter, Encounter>(episodes, a_);
+        IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(episodes, a_);
         Encounter c_(Encounter episode) => episode;
         IEnumerable<Encounter> d_ = context.Operators.Select<Encounter, Encounter>(b_, c_);
         IEnumerable<Encounter> e_ = context.Operators.Distinct<Encounter>(d_);
@@ -91,34 +90,33 @@ public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_
     public IEnumerable<Encounter> Encounter_with_Competing_Diagnosis_History(CqlContext context, IEnumerable<Encounter> episodes, IEnumerable<Condition> competingConditions)
     {
 
-        IEnumerable<Encounter> a_(Encounter episode) {
+        bool? a_(Encounter episode) {
 
             bool? f_(Condition competcondition) {
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, competcondition as Condition);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                Period l_ = episode?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                CqlQuantity r_ = context.Operators.Quantity(3m, "days");
-                CqlDateTime s_ = context.Operators.Add(q_, r_);
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(n_, s_, true, true);
-                bool? u_ = context.Operators.In<CqlDateTime>(k_, t_, "day");
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                bool? y_ = context.Operators.Not((bool?)(x_ is null));
-                bool? z_ = context.Operators.And(u_, y_);
-                return z_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, competcondition as Condition);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                Period k_ = episode?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                CqlQuantity q_ = context.Operators.Quantity(3m, "days");
+                CqlDateTime r_ = context.Operators.Add(p_, q_);
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(m_, r_, true, true);
+                bool? t_ = context.Operators.In<CqlDateTime>(j_, s_, "day");
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                bool? x_ = context.Operators.Not((bool?)(w_ is null));
+                bool? y_ = context.Operators.And(t_, x_);
+                return y_;
             }
 
             IEnumerable<Condition> g_ = context.Operators.Where<Condition>(competingConditions, f_);
-            Encounter h_(Condition competcondition) => episode;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Condition>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> b_ = context.Operators.SelectMany<Encounter, Encounter>(episodes, a_);
+        IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(episodes, a_);
         Encounter c_(Encounter episode) => episode;
         IEnumerable<Encounter> d_ = context.Operators.Select<Encounter, Encounter>(b_, c_);
         IEnumerable<Encounter> e_ = context.Operators.Distinct<Encounter>(d_);
@@ -130,33 +128,32 @@ public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_
     public IEnumerable<Encounter> Encounter_with_Antibiotic_Medication_History(CqlContext context, IEnumerable<Encounter> episodes, IEnumerable<MedicationRequest> antibioticMedications)
     {
 
-        IEnumerable<Encounter> a_(Encounter episode) {
+        bool? a_(Encounter episode) {
 
             bool? c_(MedicationRequest ActiveMedication) {
-                CqlInterval<CqlDate> g_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveMedication);
-                Period h_ = episode?.Period;
-                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
-                CqlDateTime j_ = context.Operators.Start(i_);
-                CqlDate k_ = context.Operators.DateFrom(j_);
-                CqlQuantity l_ = context.Operators.Quantity(30m, "days");
-                CqlDate m_ = context.Operators.Subtract(k_, l_);
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
-                CqlDateTime p_ = context.Operators.Start(o_);
-                CqlDate q_ = context.Operators.DateFrom(p_);
-                CqlQuantity r_ = context.Operators.Quantity(1m, "day");
-                CqlDate s_ = context.Operators.Subtract(q_, r_);
-                CqlInterval<CqlDate> t_ = context.Operators.Interval(m_, s_, true, true);
-                bool? u_ = context.Operators.Overlaps(g_, t_, "day");
-                return u_;
+                CqlInterval<CqlDate> f_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveMedication);
+                Period g_ = episode?.Period;
+                CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, g_);
+                CqlDateTime i_ = context.Operators.Start(h_);
+                CqlDate j_ = context.Operators.DateFrom(i_);
+                CqlQuantity k_ = context.Operators.Quantity(30m, "days");
+                CqlDate l_ = context.Operators.Subtract(j_, k_);
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, g_);
+                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlDate p_ = context.Operators.DateFrom(o_);
+                CqlQuantity q_ = context.Operators.Quantity(1m, "day");
+                CqlDate r_ = context.Operators.Subtract(p_, q_);
+                CqlInterval<CqlDate> s_ = context.Operators.Interval(l_, r_, true, true);
+                bool? t_ = context.Operators.Overlaps(f_, s_, "day");
+                return t_;
             }
 
             IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(antibioticMedications, c_);
-            Encounter e_(MedicationRequest ActiveMedication) => episode;
-            IEnumerable<Encounter> f_ = context.Operators.Select<MedicationRequest, Encounter>(d_, e_);
-            return f_;
+            bool? e_ = context.Operators.Exists<MedicationRequest>(d_);
+            return e_;
         }
 
-        IEnumerable<Encounter> b_ = context.Operators.SelectMany<Encounter, Encounter>(episodes, a_);
+        IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(episodes, a_);
         return b_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
@@ -368,72 +368,72 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_Age_Range(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithAge) {
+        bool? b_(Encounter EncounterWithAge) {
             CqlValueSet d_ = this.Delivery_Procedures(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure DeliveryProcedure) {
-                Code<EventStatus> j_ = DeliveryProcedure?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
+                Code<EventStatus> i_ = DeliveryProcedure?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
 
-                object n_() {
+                object m_() {
+
+                    bool s_() {
+                        DataType w_ = DeliveryProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
 
                     bool t_() {
-                        DataType x_ = DeliveryProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
+                        DataType z_ = DeliveryProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        DataType aa_ = DeliveryProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        DataType ac_ = DeliveryProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
                     }
 
 
                     bool v_() {
-                        DataType ad_ = DeliveryProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
+                        DataType af_ = DeliveryProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
                     }
 
-
-                    bool w_() {
-                        DataType ag_ = DeliveryProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
+                    if (s_())
                     {
-                        DataType aj_ = DeliveryProcedure?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
+                        DataType ai_ = DeliveryProcedure?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = DeliveryProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
-                        DataType al_ = DeliveryProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        DataType am_ = DeliveryProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
-                        DataType an_ = DeliveryProcedure?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = DeliveryProcedure?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ao_ = DeliveryProcedure?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -441,21 +441,20 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                     };
                 }
 
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                CqlDateTime p_ = context.Operators.Start(o_);
-                CqlInterval<CqlDateTime> q_ = this.hospitalizationWithEDOBTriageObservation(context, EncounterWithAge);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
-                bool? s_ = context.Operators.And(m_, r_);
-                return s_;
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlInterval<CqlDateTime> p_ = this.hospitalizationWithEDOBTriageObservation(context, EncounterWithAge);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
+                bool? r_ = context.Operators.And(l_, q_);
+                return r_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure DeliveryProcedure) => EncounterWithAge;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
@@ -254,67 +254,67 @@ public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_
     {
         IEnumerable<Encounter> a_ = this.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             IEnumerable<object> d_ = this.Intervention_Comfort_Measures(context);
 
             bool? e_(object ComfortMeasure) {
 
-                object i_() {
+                object h_() {
+
+                    bool o_() {
+                        object s_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                        bool u_ = t_ is CqlDateTime;
+                        return u_;
+                    }
+
 
                     bool p_() {
-                        object t_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                        bool v_ = u_ is CqlDateTime;
-                        return v_;
+                        object v_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlInterval<CqlDateTime>;
+                        return x_;
                     }
 
 
                     bool q_() {
-                        object w_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                        bool y_ = x_ is CqlInterval<CqlDateTime>;
-                        return y_;
+                        object y_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlQuantity;
+                        return aa_;
                     }
 
 
                     bool r_() {
-                        object z_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlQuantity;
-                        return ab_;
+                        object ab_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlInterval<CqlQuantity>;
+                        return ad_;
                     }
 
-
-                    bool s_() {
-                        object ac_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlInterval<CqlQuantity>;
-                        return ae_;
-                    }
-
-                    if (p_())
+                    if (o_())
                     {
-                        object af_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        return (ag_ as CqlDateTime) as object;
+                        object ae_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        return (af_ as CqlDateTime) as object;
+                    }
+                    else if (p_())
+                    {
+                        object ag_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        return (ah_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (q_())
                     {
-                        object ah_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        return (ai_ as CqlInterval<CqlDateTime>) as object;
+                        object ai_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlQuantity) as object;
                     }
                     else if (r_())
                     {
-                        object aj_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlQuantity) as object;
-                    }
-                    else if (s_())
-                    {
-                        object al_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlQuantity>) as object;
+                        object ak_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -322,22 +322,21 @@ public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_
                     };
                 }
 
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
-                CqlDateTime k_ = context.Operators.Start(j_);
-                object l_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-                CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, (string)default);
-                return o_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_());
+                CqlDateTime j_ = context.Operators.Start(i_);
+                object k_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+                CqlDateTime l_ = context.Operators.LateBoundProperty<CqlDateTime>(k_, "value");
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                bool? n_ = context.Operators.In<CqlDateTime>(j_ ?? l_, m_, (string)default);
+                return n_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object ComfortMeasure) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
@@ -1920,69 +1920,69 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<Encounter> a_ = this.Singleton_Delivery_Encounters_At_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births(context);
 
-        IEnumerable<Encounter> b_(Encounter ThirtySevenWeeksPlusEncounter) {
+        bool? b_(Encounter ThirtySevenWeeksPlusEncounter) {
             CqlValueSet d_ = this.Cesarean_Birth(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure CSection) {
-                CqlInterval<CqlDateTime> j_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, ThirtySevenWeeksPlusEncounter);
+                CqlInterval<CqlDateTime> i_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, ThirtySevenWeeksPlusEncounter);
 
-                object k_() {
+                object j_() {
+
+                    bool r_() {
+                        DataType v_ = CSection?.Performed;
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlDateTime;
+                        return x_;
+                    }
+
 
                     bool s_() {
-                        DataType w_ = CSection?.Performed;
-                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                        bool y_ = x_ is CqlDateTime;
-                        return y_;
+                        DataType y_ = CSection?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlInterval<CqlDateTime>;
+                        return aa_;
                     }
 
 
                     bool t_() {
-                        DataType z_ = CSection?.Performed;
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
-                        return ab_;
+                        DataType ab_ = CSection?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlQuantity;
+                        return ad_;
                     }
 
 
                     bool u_() {
-                        DataType ac_ = CSection?.Performed;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlQuantity;
-                        return ae_;
+                        DataType ae_ = CSection?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
+                        return ag_;
                     }
 
-
-                    bool v_() {
-                        DataType af_ = CSection?.Performed;
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
-                        return ah_;
-                    }
-
-                    if (s_())
+                    if (r_())
                     {
-                        DataType ai_ = CSection?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlDateTime) as object;
+                        DataType ah_ = CSection?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlDateTime) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType aj_ = CSection?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (t_())
                     {
-                        DataType ak_ = CSection?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                        DataType al_ = CSection?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlQuantity) as object;
                     }
                     else if (u_())
                     {
-                        DataType am_ = CSection?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlQuantity) as object;
-                    }
-                    else if (v_())
-                    {
-                        DataType ao_ = CSection?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                        DataType an_ = CSection?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1990,23 +1990,22 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
                     };
                 }
 
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
-                Code<EventStatus> n_ = CSection?.StatusElement;
-                EventStatus? o_ = n_?.Value;
-                string p_ = context.Operators.Convert<string>(o_);
-                bool? q_ = context.Operators.Equal(p_, "completed");
-                bool? r_ = context.Operators.And(m_, q_);
-                return r_;
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, k_, (string)default);
+                Code<EventStatus> m_ = CSection?.StatusElement;
+                EventStatus? n_ = m_?.Value;
+                string o_ = context.Operators.Convert<string>(n_);
+                bool? p_ = context.Operators.Equal(o_, "completed");
+                bool? q_ = context.Operators.And(l_, p_);
+                return q_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure CSection) => ThirtySevenWeeksPlusEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
@@ -323,27 +323,26 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Inpatient_Falls(context);
             IEnumerable<AdverseEvent> e_ = context.Operators.Retrieve<AdverseEvent>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent"));
 
             bool? f_(AdverseEvent FallsDocumentation) {
-                FhirDateTime j_ = FallsDocumentation?.DateElement;
-                CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
-                FhirDateTime l_ = FallsDocumentation?.RecordedDateElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, (string)default);
-                return o_;
+                FhirDateTime i_ = FallsDocumentation?.DateElement;
+                CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+                FhirDateTime k_ = FallsDocumentation?.RecordedDateElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+                bool? n_ = context.Operators.In<CqlDateTime>(j_ ?? l_, m_, (string)default);
+                return n_;
             }
 
             IEnumerable<AdverseEvent> g_ = context.Operators.Where<AdverseEvent>(e_, f_);
-            Encounter h_(AdverseEvent FallsDocumentation) => InpatientEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<AdverseEvent, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<AdverseEvent>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -627,45 +626,44 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi"));
 
-        IEnumerable<Observation> b_(Observation BMI) {
+        bool? b_(Observation BMI) {
             IEnumerable<Encounter> g_ = this.Qualifying_Encounter(context);
 
             bool? h_(Encounter InpatientEncounter) {
-                DataType l_ = BMI?.Effective;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                DataType r_ = BMI?.Value;
-                CqlQuantity s_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, r_ as Quantity);
-                bool? t_ = context.Operators.Not((bool?)(s_ is null));
-                bool? u_ = context.Operators.And(q_, t_);
-                Code<ObservationStatus> v_ = BMI?.StatusElement;
-                ObservationStatus? w_ = v_?.Value;
-                string x_ = context.Operators.Convert<string>(w_);
-                string[] y_ = [
+                DataType k_ = BMI?.Effective;
+                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+                bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                DataType q_ = BMI?.Value;
+                CqlQuantity r_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, q_ as Quantity);
+                bool? s_ = context.Operators.Not((bool?)(r_ is null));
+                bool? t_ = context.Operators.And(p_, s_);
+                Code<ObservationStatus> u_ = BMI?.StatusElement;
+                ObservationStatus? v_ = u_?.Value;
+                string w_ = context.Operators.Convert<string>(v_);
+                string[] x_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
-                bool? aa_ = context.Operators.And(u_, z_);
-                return aa_;
+                bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
+                bool? z_ = context.Operators.And(t_, y_);
+                return z_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter InpatientEncounter) => BMI;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
         CqlQuantity d_(Observation BMI) {
-            DataType ab_ = BMI?.Value;
-            CqlQuantity ac_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ab_ as Quantity);
-            return ac_ as CqlQuantity;
+            DataType aa_ = BMI?.Value;
+            CqlQuantity ab_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aa_ as Quantity);
+            return ab_ as CqlQuantity;
         }
 
         IEnumerable<CqlQuantity> e_ = context.Operators.Select<Observation, CqlQuantity>(c_, d_);
@@ -890,70 +888,69 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Anticoagulants_for_All_Indications(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Anticoagulants_for_All_Indications(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Anticoagulants_for_All_Indications(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest Anticoagulants) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = Anticoagulants?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = Anticoagulants?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = Anticoagulants?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                bool? ak_ = context.Operators.Equal(aj_, "order");
-                MedicationRequest.MedicationRequestIntent? am_ = ah_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                bool? ao_ = context.Operators.Equal(an_, "plan");
-                ResourceReference ap_ = Anticoagulants?.Subject;
-                FhirString aq_ = ap_?.ReferenceElement;
-                string ar_ = aq_?.Value;
-                string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = Anticoagulants?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                bool? ai_ = context.Operators.Equal(ah_, "order");
+                MedicationRequest.MedicationRequestIntent? ak_ = af_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                bool? am_ = context.Operators.Equal(al_, "plan");
+                ResourceReference an_ = Anticoagulants?.Subject;
+                FhirString ao_ = an_?.ReferenceElement;
+                string ap_ = ao_?.Value;
+                string aq_ = QICoreCommon_4_0_000.Instance.getId(context, ap_);
 
-                Id at_() {
+                Id ar_() {
 
-                    bool bq_() {
-                        Patient br_ = this.Patient(context);
-                        bool bs_ = br_ is Resource;
-                        return bs_;
+                    bool bo_() {
+                        Patient bp_ = this.Patient(context);
+                        bool bq_ = bp_ is Resource;
+                        return bq_;
                     }
 
-                    if (bq_())
+                    if (bo_())
                     {
-                        Patient bt_ = this.Patient(context);
-                        return (bt_ as Resource).IdElement;
+                        Patient br_ = this.Patient(context);
+                        return (br_ as Resource).IdElement;
                     }
                     else
                     {
@@ -961,35 +958,34 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     };
                 }
 
-                string au_ = (at_())?.Value;
-                bool? av_ = context.Operators.Equal(as_, au_);
-                bool? aw_ = context.Operators.And(ao_, av_);
-                bool? ax_ = context.Operators.Or(ak_, aw_);
-                bool? ay_ = context.Operators.And(ag_, ax_);
-                bool? az_ = QICoreCommon_4_0_000.Instance.isCommunity(context, Anticoagulants as MedicationRequest);
-                bool? ba_ = context.Operators.And(ay_, az_);
-                CqlInterval<CqlDate> bb_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, Anticoagulants);
-                CqlDate bc_ = bb_?.low;
-                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
-                CqlDate bf_ = bb_?.high;
-                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                bool? bi_ = bb_?.lowClosed;
-                bool? bk_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(bd_, bg_, bi_, bk_);
-                Period bm_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
-                bool? bo_ = context.Operators.OverlapsBefore(bl_, bn_, "day");
-                bool? bp_ = context.Operators.And(ba_, bo_);
-                return bp_;
+                string as_ = (ar_())?.Value;
+                bool? at_ = context.Operators.Equal(aq_, as_);
+                bool? au_ = context.Operators.And(am_, at_);
+                bool? av_ = context.Operators.Or(ai_, au_);
+                bool? aw_ = context.Operators.And(ae_, av_);
+                bool? ax_ = QICoreCommon_4_0_000.Instance.isCommunity(context, Anticoagulants as MedicationRequest);
+                bool? ay_ = context.Operators.And(aw_, ax_);
+                CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, Anticoagulants);
+                CqlDate ba_ = az_?.low;
+                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
+                CqlDate bd_ = az_?.high;
+                CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+                bool? bg_ = az_?.lowClosed;
+                bool? bi_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bb_, be_, bg_, bi_);
+                Period bk_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                bool? bm_ = context.Operators.OverlapsBefore(bj_, bl_, "day");
+                bool? bn_ = context.Operators.And(ay_, bm_);
+                return bn_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest Anticoagulants) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1004,63 +1000,61 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Anticoagulants_for_All_Indications(context);
             IEnumerable<MedicationAdministration> e_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
             IEnumerable<MedicationAdministration> f_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-            IEnumerable<MedicationAdministration> g_(MedicationAdministration MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationAdministration MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Anticoagulants_for_All_Indications(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Anticoagulants_for_All_Indications(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationAdministration q_(Medication M) => MR;
-                IEnumerable<MedicationAdministration> r_ = context.Operators.Select<Medication, MedicationAdministration>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationAdministration> h_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(f_, g_);
+            IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
             IEnumerable<MedicationAdministration> i_ = context.Operators.Union<MedicationAdministration>(e_, h_);
 
             bool? j_(MedicationAdministration Anticoagulants) {
-                DataType ac_ = Anticoagulants?.Effective;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
-                CqlDateTime af_ = context.Operators.Start(ae_);
-                CqlInterval<CqlDateTime> ag_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                bool? ah_ = context.Operators.In<CqlDateTime>(af_, ag_, (string)default);
-                Code<MedicationAdministration.MedicationAdministrationStatusCodes> ai_ = Anticoagulants?.StatusElement;
-                MedicationAdministration.MedicationAdministrationStatusCodes? aj_ = ai_?.Value;
-                string ak_ = context.Operators.Convert<string>(aj_);
-                string[] al_ = [
+                DataType aa_ = Anticoagulants?.Effective;
+                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                CqlInterval<CqlDateTime> ae_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+                bool? af_ = context.Operators.In<CqlDateTime>(ad_, ae_, (string)default);
+                Code<MedicationAdministration.MedicationAdministrationStatusCodes> ag_ = Anticoagulants?.StatusElement;
+                MedicationAdministration.MedicationAdministrationStatusCodes? ah_ = ag_?.Value;
+                string ai_ = context.Operators.Convert<string>(ah_);
+                string[] aj_ = [
                     "in-progress",
                     "completed",
                 ];
-                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
-                bool? an_ = context.Operators.And(ah_, am_);
-                return an_;
+                bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
+                bool? al_ = context.Operators.And(af_, ak_);
+                return al_;
             }
 
             IEnumerable<MedicationAdministration> k_ = context.Operators.Where<MedicationAdministration>(i_, j_);
-            Encounter l_(MedicationAdministration Anticoagulants) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationAdministration, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationAdministration>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1075,70 +1069,69 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Antidepressants(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Antidepressants(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Antidepressants(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest AntidepressantMed) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = AntidepressantMed?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = AntidepressantMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = AntidepressantMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                bool? ak_ = context.Operators.Equal(aj_, "order");
-                MedicationRequest.MedicationRequestIntent? am_ = ah_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                bool? ao_ = context.Operators.Equal(an_, "plan");
-                ResourceReference ap_ = AntidepressantMed?.Subject;
-                FhirString aq_ = ap_?.ReferenceElement;
-                string ar_ = aq_?.Value;
-                string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = AntidepressantMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                bool? ai_ = context.Operators.Equal(ah_, "order");
+                MedicationRequest.MedicationRequestIntent? ak_ = af_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                bool? am_ = context.Operators.Equal(al_, "plan");
+                ResourceReference an_ = AntidepressantMed?.Subject;
+                FhirString ao_ = an_?.ReferenceElement;
+                string ap_ = ao_?.Value;
+                string aq_ = QICoreCommon_4_0_000.Instance.getId(context, ap_);
 
-                Id at_() {
+                Id ar_() {
 
-                    bool bq_() {
-                        Patient br_ = this.Patient(context);
-                        bool bs_ = br_ is Resource;
-                        return bs_;
+                    bool bo_() {
+                        Patient bp_ = this.Patient(context);
+                        bool bq_ = bp_ is Resource;
+                        return bq_;
                     }
 
-                    if (bq_())
+                    if (bo_())
                     {
-                        Patient bt_ = this.Patient(context);
-                        return (bt_ as Resource).IdElement;
+                        Patient br_ = this.Patient(context);
+                        return (br_ as Resource).IdElement;
                     }
                     else
                     {
@@ -1146,35 +1139,34 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     };
                 }
 
-                string au_ = (at_())?.Value;
-                bool? av_ = context.Operators.Equal(as_, au_);
-                bool? aw_ = context.Operators.And(ao_, av_);
-                bool? ax_ = context.Operators.Or(ak_, aw_);
-                bool? ay_ = context.Operators.And(ag_, ax_);
-                bool? az_ = QICoreCommon_4_0_000.Instance.isCommunity(context, AntidepressantMed as MedicationRequest);
-                bool? ba_ = context.Operators.And(ay_, az_);
-                CqlInterval<CqlDate> bb_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AntidepressantMed);
-                CqlDate bc_ = bb_?.low;
-                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
-                CqlDate bf_ = bb_?.high;
-                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                bool? bi_ = bb_?.lowClosed;
-                bool? bk_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(bd_, bg_, bi_, bk_);
-                Period bm_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
-                bool? bo_ = context.Operators.OverlapsBefore(bl_, bn_, "day");
-                bool? bp_ = context.Operators.And(ba_, bo_);
-                return bp_;
+                string as_ = (ar_())?.Value;
+                bool? at_ = context.Operators.Equal(aq_, as_);
+                bool? au_ = context.Operators.And(am_, at_);
+                bool? av_ = context.Operators.Or(ai_, au_);
+                bool? aw_ = context.Operators.And(ae_, av_);
+                bool? ax_ = QICoreCommon_4_0_000.Instance.isCommunity(context, AntidepressantMed as MedicationRequest);
+                bool? ay_ = context.Operators.And(aw_, ax_);
+                CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AntidepressantMed);
+                CqlDate ba_ = az_?.low;
+                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
+                CqlDate bd_ = az_?.high;
+                CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+                bool? bg_ = az_?.lowClosed;
+                bool? bi_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bb_, be_, bg_, bi_);
+                Period bk_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                bool? bm_ = context.Operators.OverlapsBefore(bj_, bl_, "day");
+                bool? bn_ = context.Operators.And(ay_, bm_);
+                return bn_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest AntidepressantMed) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1189,70 +1181,69 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Antihypertensives(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Antihypertensives(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Antihypertensives(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest BPMed) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = BPMed?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = BPMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = BPMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                bool? ak_ = context.Operators.Equal(aj_, "order");
-                MedicationRequest.MedicationRequestIntent? am_ = ah_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                bool? ao_ = context.Operators.Equal(an_, "plan");
-                ResourceReference ap_ = BPMed?.Subject;
-                FhirString aq_ = ap_?.ReferenceElement;
-                string ar_ = aq_?.Value;
-                string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = BPMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                bool? ai_ = context.Operators.Equal(ah_, "order");
+                MedicationRequest.MedicationRequestIntent? ak_ = af_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                bool? am_ = context.Operators.Equal(al_, "plan");
+                ResourceReference an_ = BPMed?.Subject;
+                FhirString ao_ = an_?.ReferenceElement;
+                string ap_ = ao_?.Value;
+                string aq_ = QICoreCommon_4_0_000.Instance.getId(context, ap_);
 
-                Id at_() {
+                Id ar_() {
 
-                    bool bq_() {
-                        Patient br_ = this.Patient(context);
-                        bool bs_ = br_ is Resource;
-                        return bs_;
+                    bool bo_() {
+                        Patient bp_ = this.Patient(context);
+                        bool bq_ = bp_ is Resource;
+                        return bq_;
                     }
 
-                    if (bq_())
+                    if (bo_())
                     {
-                        Patient bt_ = this.Patient(context);
-                        return (bt_ as Resource).IdElement;
+                        Patient br_ = this.Patient(context);
+                        return (br_ as Resource).IdElement;
                     }
                     else
                     {
@@ -1260,35 +1251,34 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     };
                 }
 
-                string au_ = (at_())?.Value;
-                bool? av_ = context.Operators.Equal(as_, au_);
-                bool? aw_ = context.Operators.And(ao_, av_);
-                bool? ax_ = context.Operators.Or(ak_, aw_);
-                bool? ay_ = context.Operators.And(ag_, ax_);
-                bool? az_ = QICoreCommon_4_0_000.Instance.isCommunity(context, BPMed as MedicationRequest);
-                bool? ba_ = context.Operators.And(ay_, az_);
-                CqlInterval<CqlDate> bb_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, BPMed);
-                CqlDate bc_ = bb_?.low;
-                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
-                CqlDate bf_ = bb_?.high;
-                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                bool? bi_ = bb_?.lowClosed;
-                bool? bk_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(bd_, bg_, bi_, bk_);
-                Period bm_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
-                bool? bo_ = context.Operators.OverlapsBefore(bl_, bn_, "day");
-                bool? bp_ = context.Operators.And(ba_, bo_);
-                return bp_;
+                string as_ = (ar_())?.Value;
+                bool? at_ = context.Operators.Equal(aq_, as_);
+                bool? au_ = context.Operators.And(am_, at_);
+                bool? av_ = context.Operators.Or(ai_, au_);
+                bool? aw_ = context.Operators.And(ae_, av_);
+                bool? ax_ = QICoreCommon_4_0_000.Instance.isCommunity(context, BPMed as MedicationRequest);
+                bool? ay_ = context.Operators.And(aw_, ax_);
+                CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, BPMed);
+                CqlDate ba_ = az_?.low;
+                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
+                CqlDate bd_ = az_?.high;
+                CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+                bool? bg_ = az_?.lowClosed;
+                bool? bi_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bb_, be_, bg_, bi_);
+                Period bk_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                bool? bm_ = context.Operators.OverlapsBefore(bj_, bl_, "day");
+                bool? bn_ = context.Operators.And(ay_, bm_);
+                return bn_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest BPMed) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1303,70 +1293,69 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Central_Nervous_System_Depressants(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Central_Nervous_System_Depressants(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Central_Nervous_System_Depressants(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest CNSMed) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = CNSMed?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = CNSMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = CNSMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                bool? ak_ = context.Operators.Equal(aj_, "order");
-                MedicationRequest.MedicationRequestIntent? am_ = ah_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                bool? ao_ = context.Operators.Equal(an_, "plan");
-                ResourceReference ap_ = CNSMed?.Subject;
-                FhirString aq_ = ap_?.ReferenceElement;
-                string ar_ = aq_?.Value;
-                string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = CNSMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                bool? ai_ = context.Operators.Equal(ah_, "order");
+                MedicationRequest.MedicationRequestIntent? ak_ = af_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                bool? am_ = context.Operators.Equal(al_, "plan");
+                ResourceReference an_ = CNSMed?.Subject;
+                FhirString ao_ = an_?.ReferenceElement;
+                string ap_ = ao_?.Value;
+                string aq_ = QICoreCommon_4_0_000.Instance.getId(context, ap_);
 
-                Id at_() {
+                Id ar_() {
 
-                    bool bq_() {
-                        Patient br_ = this.Patient(context);
-                        bool bs_ = br_ is Resource;
-                        return bs_;
+                    bool bo_() {
+                        Patient bp_ = this.Patient(context);
+                        bool bq_ = bp_ is Resource;
+                        return bq_;
                     }
 
-                    if (bq_())
+                    if (bo_())
                     {
-                        Patient bt_ = this.Patient(context);
-                        return (bt_ as Resource).IdElement;
+                        Patient br_ = this.Patient(context);
+                        return (br_ as Resource).IdElement;
                     }
                     else
                     {
@@ -1374,35 +1363,34 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     };
                 }
 
-                string au_ = (at_())?.Value;
-                bool? av_ = context.Operators.Equal(as_, au_);
-                bool? aw_ = context.Operators.And(ao_, av_);
-                bool? ax_ = context.Operators.Or(ak_, aw_);
-                bool? ay_ = context.Operators.And(ag_, ax_);
-                bool? az_ = QICoreCommon_4_0_000.Instance.isCommunity(context, CNSMed as MedicationRequest);
-                bool? ba_ = context.Operators.And(ay_, az_);
-                CqlInterval<CqlDate> bb_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, CNSMed);
-                CqlDate bc_ = bb_?.low;
-                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
-                CqlDate bf_ = bb_?.high;
-                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                bool? bi_ = bb_?.lowClosed;
-                bool? bk_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(bd_, bg_, bi_, bk_);
-                Period bm_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
-                bool? bo_ = context.Operators.OverlapsBefore(bl_, bn_, "day");
-                bool? bp_ = context.Operators.And(ba_, bo_);
-                return bp_;
+                string as_ = (ar_())?.Value;
+                bool? at_ = context.Operators.Equal(aq_, as_);
+                bool? au_ = context.Operators.And(am_, at_);
+                bool? av_ = context.Operators.Or(ai_, au_);
+                bool? aw_ = context.Operators.And(ae_, av_);
+                bool? ax_ = QICoreCommon_4_0_000.Instance.isCommunity(context, CNSMed as MedicationRequest);
+                bool? ay_ = context.Operators.And(aw_, ax_);
+                CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, CNSMed);
+                CqlDate ba_ = az_?.low;
+                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
+                CqlDate bd_ = az_?.high;
+                CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+                bool? bg_ = az_?.lowClosed;
+                bool? bi_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bb_, be_, bg_, bi_);
+                Period bk_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                bool? bm_ = context.Operators.OverlapsBefore(bj_, bl_, "day");
+                bool? bn_ = context.Operators.And(ay_, bm_);
+                return bn_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest CNSMed) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1417,70 +1405,69 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Diuretics(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Diuretics(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Diuretics(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest DiureticMed) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = DiureticMed?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = DiureticMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = DiureticMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                bool? ak_ = context.Operators.Equal(aj_, "order");
-                MedicationRequest.MedicationRequestIntent? am_ = ah_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                bool? ao_ = context.Operators.Equal(an_, "plan");
-                ResourceReference ap_ = DiureticMed?.Subject;
-                FhirString aq_ = ap_?.ReferenceElement;
-                string ar_ = aq_?.Value;
-                string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = DiureticMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                bool? ai_ = context.Operators.Equal(ah_, "order");
+                MedicationRequest.MedicationRequestIntent? ak_ = af_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                bool? am_ = context.Operators.Equal(al_, "plan");
+                ResourceReference an_ = DiureticMed?.Subject;
+                FhirString ao_ = an_?.ReferenceElement;
+                string ap_ = ao_?.Value;
+                string aq_ = QICoreCommon_4_0_000.Instance.getId(context, ap_);
 
-                Id at_() {
+                Id ar_() {
 
-                    bool bq_() {
-                        Patient br_ = this.Patient(context);
-                        bool bs_ = br_ is Resource;
-                        return bs_;
+                    bool bo_() {
+                        Patient bp_ = this.Patient(context);
+                        bool bq_ = bp_ is Resource;
+                        return bq_;
                     }
 
-                    if (bq_())
+                    if (bo_())
                     {
-                        Patient bt_ = this.Patient(context);
-                        return (bt_ as Resource).IdElement;
+                        Patient br_ = this.Patient(context);
+                        return (br_ as Resource).IdElement;
                     }
                     else
                     {
@@ -1488,35 +1475,34 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     };
                 }
 
-                string au_ = (at_())?.Value;
-                bool? av_ = context.Operators.Equal(as_, au_);
-                bool? aw_ = context.Operators.And(ao_, av_);
-                bool? ax_ = context.Operators.Or(ak_, aw_);
-                bool? ay_ = context.Operators.And(ag_, ax_);
-                bool? az_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DiureticMed as MedicationRequest);
-                bool? ba_ = context.Operators.And(ay_, az_);
-                CqlInterval<CqlDate> bb_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DiureticMed);
-                CqlDate bc_ = bb_?.low;
-                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
-                CqlDate bf_ = bb_?.high;
-                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                bool? bi_ = bb_?.lowClosed;
-                bool? bk_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(bd_, bg_, bi_, bk_);
-                Period bm_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
-                bool? bo_ = context.Operators.OverlapsBefore(bl_, bn_, "day");
-                bool? bp_ = context.Operators.And(ba_, bo_);
-                return bp_;
+                string as_ = (ar_())?.Value;
+                bool? at_ = context.Operators.Equal(aq_, as_);
+                bool? au_ = context.Operators.And(am_, at_);
+                bool? av_ = context.Operators.Or(ai_, au_);
+                bool? aw_ = context.Operators.And(ae_, av_);
+                bool? ax_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DiureticMed as MedicationRequest);
+                bool? ay_ = context.Operators.And(aw_, ax_);
+                CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DiureticMed);
+                CqlDate ba_ = az_?.low;
+                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
+                CqlDate bd_ = az_?.high;
+                CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+                bool? bg_ = az_?.lowClosed;
+                bool? bi_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bb_, be_, bg_, bi_);
+                Period bk_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                bool? bm_ = context.Operators.OverlapsBefore(bj_, bl_, "day");
+                bool? bn_ = context.Operators.And(ay_, bm_);
+                return bn_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest DiureticMed) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1531,70 +1517,69 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Opioids(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Opioids(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Opioids(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest OpioidMed) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = OpioidMed?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = OpioidMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = OpioidMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                bool? ak_ = context.Operators.Equal(aj_, "order");
-                MedicationRequest.MedicationRequestIntent? am_ = ah_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                bool? ao_ = context.Operators.Equal(an_, "plan");
-                ResourceReference ap_ = OpioidMed?.Subject;
-                FhirString aq_ = ap_?.ReferenceElement;
-                string ar_ = aq_?.Value;
-                string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = OpioidMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                bool? ai_ = context.Operators.Equal(ah_, "order");
+                MedicationRequest.MedicationRequestIntent? ak_ = af_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                bool? am_ = context.Operators.Equal(al_, "plan");
+                ResourceReference an_ = OpioidMed?.Subject;
+                FhirString ao_ = an_?.ReferenceElement;
+                string ap_ = ao_?.Value;
+                string aq_ = QICoreCommon_4_0_000.Instance.getId(context, ap_);
 
-                Id at_() {
+                Id ar_() {
 
-                    bool bq_() {
-                        Patient br_ = this.Patient(context);
-                        bool bs_ = br_ is Resource;
-                        return bs_;
+                    bool bo_() {
+                        Patient bp_ = this.Patient(context);
+                        bool bq_ = bp_ is Resource;
+                        return bq_;
                     }
 
-                    if (bq_())
+                    if (bo_())
                     {
-                        Patient bt_ = this.Patient(context);
-                        return (bt_ as Resource).IdElement;
+                        Patient br_ = this.Patient(context);
+                        return (br_ as Resource).IdElement;
                     }
                     else
                     {
@@ -1602,35 +1587,34 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     };
                 }
 
-                string au_ = (at_())?.Value;
-                bool? av_ = context.Operators.Equal(as_, au_);
-                bool? aw_ = context.Operators.And(ao_, av_);
-                bool? ax_ = context.Operators.Or(ak_, aw_);
-                bool? ay_ = context.Operators.And(ag_, ax_);
-                bool? az_ = QICoreCommon_4_0_000.Instance.isCommunity(context, OpioidMed as MedicationRequest);
-                bool? ba_ = context.Operators.And(ay_, az_);
-                CqlInterval<CqlDate> bb_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OpioidMed);
-                CqlDate bc_ = bb_?.low;
-                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
-                CqlDate bf_ = bb_?.high;
-                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                bool? bi_ = bb_?.lowClosed;
-                bool? bk_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(bd_, bg_, bi_, bk_);
-                Period bm_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
-                bool? bo_ = context.Operators.OverlapsBefore(bl_, bn_, "day");
-                bool? bp_ = context.Operators.And(ba_, bo_);
-                return bp_;
+                string as_ = (ar_())?.Value;
+                bool? at_ = context.Operators.Equal(aq_, as_);
+                bool? au_ = context.Operators.And(am_, at_);
+                bool? av_ = context.Operators.Or(ai_, au_);
+                bool? aw_ = context.Operators.And(ae_, av_);
+                bool? ax_ = QICoreCommon_4_0_000.Instance.isCommunity(context, OpioidMed as MedicationRequest);
+                bool? ay_ = context.Operators.And(aw_, ax_);
+                CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OpioidMed);
+                CqlDate ba_ = az_?.low;
+                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
+                CqlDate bd_ = az_?.high;
+                CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+                bool? bg_ = az_?.lowClosed;
+                bool? bi_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bb_, be_, bg_, bi_);
+                Period bk_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                bool? bm_ = context.Operators.OverlapsBefore(bj_, bl_, "day");
+                bool? bn_ = context.Operators.And(ay_, bm_);
+                return bn_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest OpioidMed) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
@@ -662,72 +662,72 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_Than_Or_Equal_To_20_Weeks_Gestation(context);
 
-        IEnumerable<Encounter> b_(Encounter TwentyWeeksPlusEncounter) {
+        bool? b_(Encounter TwentyWeeksPlusEncounter) {
             CqlValueSet d_ = this.Blood_Transfusion(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure BloodTransfusion) {
-                Code<EventStatus> j_ = BloodTransfusion?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
+                Code<EventStatus> i_ = BloodTransfusion?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
 
-                object n_() {
+                object m_() {
+
+                    bool s_() {
+                        DataType w_ = BloodTransfusion?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
 
                     bool t_() {
-                        DataType x_ = BloodTransfusion?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
+                        DataType z_ = BloodTransfusion?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        DataType aa_ = BloodTransfusion?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        DataType ac_ = BloodTransfusion?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
                     }
 
 
                     bool v_() {
-                        DataType ad_ = BloodTransfusion?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
+                        DataType af_ = BloodTransfusion?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
                     }
 
-
-                    bool w_() {
-                        DataType ag_ = BloodTransfusion?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
+                    if (s_())
                     {
-                        DataType aj_ = BloodTransfusion?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
+                        DataType ai_ = BloodTransfusion?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = BloodTransfusion?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
-                        DataType al_ = BloodTransfusion?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        DataType am_ = BloodTransfusion?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
-                        DataType an_ = BloodTransfusion?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = BloodTransfusion?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ao_ = BloodTransfusion?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -735,21 +735,20 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     };
                 }
 
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                CqlDateTime p_ = context.Operators.Start(o_);
-                CqlInterval<CqlDateTime> q_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
-                bool? s_ = context.Operators.And(m_, r_);
-                return s_;
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlInterval<CqlDateTime> p_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
+                bool? r_ = context.Operators.And(l_, q_);
+                return r_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure BloodTransfusion) => TwentyWeeksPlusEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -781,72 +780,72 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_Than_Or_Equal_To_20_Weeks_Gestation(context);
 
-        IEnumerable<Encounter> b_(Encounter TwentyWeeksPlusEncounter) {
+        bool? b_(Encounter TwentyWeeksPlusEncounter) {
             CqlValueSet d_ = this.Hysterectomy(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure Hysterectomy) {
-                Code<EventStatus> j_ = Hysterectomy?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
+                Code<EventStatus> i_ = Hysterectomy?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
 
-                object n_() {
+                object m_() {
+
+                    bool s_() {
+                        DataType w_ = Hysterectomy?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
 
                     bool t_() {
-                        DataType x_ = Hysterectomy?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
+                        DataType z_ = Hysterectomy?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        DataType aa_ = Hysterectomy?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        DataType ac_ = Hysterectomy?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
                     }
 
 
                     bool v_() {
-                        DataType ad_ = Hysterectomy?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
+                        DataType af_ = Hysterectomy?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
                     }
 
-
-                    bool w_() {
-                        DataType ag_ = Hysterectomy?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
+                    if (s_())
                     {
-                        DataType aj_ = Hysterectomy?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
+                        DataType ai_ = Hysterectomy?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = Hysterectomy?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
-                        DataType al_ = Hysterectomy?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        DataType am_ = Hysterectomy?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
-                        DataType an_ = Hysterectomy?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = Hysterectomy?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ao_ = Hysterectomy?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -854,21 +853,20 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     };
                 }
 
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                CqlDateTime p_ = context.Operators.Start(o_);
-                CqlInterval<CqlDateTime> q_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
-                bool? s_ = context.Operators.And(m_, r_);
-                return s_;
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlInterval<CqlDateTime> p_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
+                bool? r_ = context.Operators.And(l_, q_);
+                return r_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure Hysterectomy) => TwentyWeeksPlusEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -903,71 +901,71 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_Than_Or_Equal_To_20_Weeks_Gestation(context);
 
-        IEnumerable<Encounter> b_(Encounter TwentyWeeksPlusEncounter) {
+        bool? b_(Encounter TwentyWeeksPlusEncounter) {
             IEnumerable<Procedure> d_ = this.Cardiac_Conversion__Tracheostomy_Or_Ventilation_Procedures(context);
 
             bool? e_(Procedure ConvTrachVentProcedures) {
-                Code<EventStatus> i_ = ConvTrachVentProcedures?.StatusElement;
-                EventStatus? j_ = i_?.Value;
-                string k_ = context.Operators.Convert<string>(j_);
-                bool? l_ = context.Operators.Equal(k_, "completed");
+                Code<EventStatus> h_ = ConvTrachVentProcedures?.StatusElement;
+                EventStatus? i_ = h_?.Value;
+                string j_ = context.Operators.Convert<string>(i_);
+                bool? k_ = context.Operators.Equal(j_, "completed");
 
-                object m_() {
+                object l_() {
+
+                    bool r_() {
+                        DataType v_ = ConvTrachVentProcedures?.Performed;
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlDateTime;
+                        return x_;
+                    }
+
 
                     bool s_() {
-                        DataType w_ = ConvTrachVentProcedures?.Performed;
-                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                        bool y_ = x_ is CqlDateTime;
-                        return y_;
+                        DataType y_ = ConvTrachVentProcedures?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlInterval<CqlDateTime>;
+                        return aa_;
                     }
 
 
                     bool t_() {
-                        DataType z_ = ConvTrachVentProcedures?.Performed;
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
-                        return ab_;
+                        DataType ab_ = ConvTrachVentProcedures?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlQuantity;
+                        return ad_;
                     }
 
 
                     bool u_() {
-                        DataType ac_ = ConvTrachVentProcedures?.Performed;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlQuantity;
-                        return ae_;
+                        DataType ae_ = ConvTrachVentProcedures?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
+                        return ag_;
                     }
 
-
-                    bool v_() {
-                        DataType af_ = ConvTrachVentProcedures?.Performed;
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
-                        return ah_;
-                    }
-
-                    if (s_())
+                    if (r_())
                     {
-                        DataType ai_ = ConvTrachVentProcedures?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlDateTime) as object;
+                        DataType ah_ = ConvTrachVentProcedures?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlDateTime) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType aj_ = ConvTrachVentProcedures?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (t_())
                     {
-                        DataType ak_ = ConvTrachVentProcedures?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                        DataType al_ = ConvTrachVentProcedures?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlQuantity) as object;
                     }
                     else if (u_())
                     {
-                        DataType am_ = ConvTrachVentProcedures?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlQuantity) as object;
-                    }
-                    else if (v_())
-                    {
-                        DataType ao_ = ConvTrachVentProcedures?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                        DataType an_ = ConvTrachVentProcedures?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -975,21 +973,20 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     };
                 }
 
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlInterval<CqlDateTime> p_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                bool? r_ = context.Operators.And(l_, q_);
-                return r_;
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
+                bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                bool? q_ = context.Operators.And(k_, p_);
+                return q_;
             }
 
             IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
-            Encounter g_(Procedure ConvTrachVentProcedures) => TwentyWeeksPlusEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Procedure, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Procedure>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
@@ -123,96 +123,94 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             CqlValueSet d_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest DischargeAntithrombotic) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = DischargeAntithrombotic?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = DischargeAntithrombotic?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = DischargeAntithrombotic?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                string[] ak_ = [
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = DischargeAntithrombotic?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                string[] ai_ = [
                     "order",
                     "original-order",
                     "reflex-order",
                     "filler-order",
                     "instance-order",
                 ];
-                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                bool? am_ = context.Operators.And(ag_, al_);
-                bool? an_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAntithrombotic as MedicationRequest);
-                bool? ao_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAntithrombotic as MedicationRequest);
-                bool? ap_ = context.Operators.Or(an_, ao_);
-                bool? aq_ = context.Operators.And(am_, ap_);
-                FhirDateTime ar_ = DischargeAntithrombotic?.AuthoredOnElement;
-                CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
-                Period at_ = IschemicStrokeEncounter?.Period;
-                CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, at_);
-                bool? av_ = context.Operators.In<CqlDateTime>(as_, au_, (string)default);
-                bool? aw_ = context.Operators.And(aq_, av_);
-                IEnumerable<Task> ax_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+                bool? ak_ = context.Operators.And(ae_, aj_);
+                bool? al_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAntithrombotic as MedicationRequest);
+                bool? am_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAntithrombotic as MedicationRequest);
+                bool? an_ = context.Operators.Or(al_, am_);
+                bool? ao_ = context.Operators.And(ak_, an_);
+                FhirDateTime ap_ = DischargeAntithrombotic?.AuthoredOnElement;
+                CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(ap_);
+                Period ar_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                bool? at_ = context.Operators.In<CqlDateTime>(aq_, as_, (string)default);
+                bool? au_ = context.Operators.And(ao_, at_);
+                IEnumerable<Task> av_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-                bool? ay_(Task TaskReject) {
-                    ResourceReference bd_ = TaskReject?.Focus;
-                    bool? be_ = QICoreCommon_4_0_000.Instance.references(context, bd_, DischargeAntithrombotic);
-                    CodeableConcept bf_ = TaskReject?.Code;
-                    CqlConcept bg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bf_);
-                    CqlCode bh_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                    CqlConcept bi_ = context.Operators.ConvertCodeToConcept(bh_);
-                    bool? bj_ = context.Operators.Equivalent(bg_, bi_);
-                    bool? bk_ = context.Operators.And(be_, bj_);
-                    return bk_;
+                bool? aw_(Task TaskReject) {
+                    ResourceReference bb_ = TaskReject?.Focus;
+                    bool? bc_ = QICoreCommon_4_0_000.Instance.references(context, bb_, DischargeAntithrombotic);
+                    CodeableConcept bd_ = TaskReject?.Code;
+                    CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_);
+                    CqlCode bf_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                    CqlConcept bg_ = context.Operators.ConvertCodeToConcept(bf_);
+                    bool? bh_ = context.Operators.Equivalent(be_, bg_);
+                    bool? bi_ = context.Operators.And(bc_, bh_);
+                    return bi_;
                 }
 
-                IEnumerable<Task> az_ = context.Operators.Where<Task>(ax_, ay_);
-                bool? ba_ = context.Operators.Exists<Task>(az_);
-                bool? bb_ = context.Operators.Not(ba_);
-                bool? bc_ = context.Operators.And(aw_, bb_);
-                return bc_;
+                IEnumerable<Task> ax_ = context.Operators.Where<Task>(av_, aw_);
+                bool? ay_ = context.Operators.Exists<Task>(ax_);
+                bool? az_ = context.Operators.Not(ay_);
+                bool? ba_ = context.Operators.And(au_, az_);
+                return ba_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest DischargeAntithrombotic) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -283,72 +281,70 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> i_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> j_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> k_(MedicationRequest MR) {
+        bool? k_(MedicationRequest MR) {
             IEnumerable<Medication> at_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? au_(Medication M) {
-                object ay_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object az_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ba_ = context.Operators.Split((string)az_, "/");
-                string bb_ = context.Operators.Last<string>(ba_);
-                bool? bc_ = context.Operators.Equal(ay_, bb_);
-                CodeableConcept bd_ = M?.Code;
-                CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_);
-                CqlValueSet bf_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                bool? bg_ = context.Operators.ConceptInValueSet(be_, bf_);
-                bool? bh_ = context.Operators.And(bc_, bg_);
-                return bh_;
+                object ax_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ay_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> az_ = context.Operators.Split((string)ay_, "/");
+                string ba_ = context.Operators.Last<string>(az_);
+                bool? bb_ = context.Operators.Equal(ax_, ba_);
+                CodeableConcept bc_ = M?.Code;
+                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_);
+                CqlValueSet be_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                bool? bf_ = context.Operators.ConceptInValueSet(bd_, be_);
+                bool? bg_ = context.Operators.And(bb_, bf_);
+                return bg_;
             }
 
             IEnumerable<Medication> av_ = context.Operators.Where<Medication>(at_, au_);
-            MedicationRequest aw_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ax_ = context.Operators.Select<Medication, MedicationRequest>(av_, aw_);
-            return ax_;
+            bool? aw_ = context.Operators.Exists<Medication>(av_);
+            return aw_;
         }
 
-        IEnumerable<MedicationRequest> l_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(j_, k_);
+        IEnumerable<MedicationRequest> l_ = context.Operators.Where<MedicationRequest>(j_, k_);
         IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(i_, l_);
 
-        IEnumerable<MedicationRequest> n_(MedicationRequest MedReqAntithrombotic) {
-            IEnumerable<Task> bi_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+        bool? n_(MedicationRequest MedReqAntithrombotic) {
+            IEnumerable<Task> bh_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            bool? bj_(Task TaskReject) {
-                ResourceReference bn_ = TaskReject?.Focus;
-                bool? bo_ = QICoreCommon_4_0_000.Instance.references(context, bn_, MedReqAntithrombotic);
-                CodeableConcept bp_ = TaskReject?.StatusReason;
-                CqlConcept bq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bp_);
-                CqlValueSet br_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                bool? bs_ = context.Operators.ConceptInValueSet(bq_, br_);
-                CqlConcept bu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bp_);
-                CqlValueSet bv_ = this.Patient_Refusal(context);
-                bool? bw_ = context.Operators.ConceptInValueSet(bu_, bv_);
-                bool? bx_ = context.Operators.Or(bs_, bw_);
-                bool? by_ = context.Operators.And(bo_, bx_);
-                Code<MedicationRequest.MedicationrequestStatus> bz_ = MedReqAntithrombotic?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ca_ = bz_?.Value;
-                string cb_ = context.Operators.Convert<string>(ca_);
-                string[] cc_ = [
+            bool? bi_(Task TaskReject) {
+                ResourceReference bl_ = TaskReject?.Focus;
+                bool? bm_ = QICoreCommon_4_0_000.Instance.references(context, bl_, MedReqAntithrombotic);
+                CodeableConcept bn_ = TaskReject?.StatusReason;
+                CqlConcept bo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bn_);
+                CqlValueSet bp_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                bool? bq_ = context.Operators.ConceptInValueSet(bo_, bp_);
+                CqlConcept bs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bn_);
+                CqlValueSet bt_ = this.Patient_Refusal(context);
+                bool? bu_ = context.Operators.ConceptInValueSet(bs_, bt_);
+                bool? bv_ = context.Operators.Or(bq_, bu_);
+                bool? bw_ = context.Operators.And(bm_, bv_);
+                Code<MedicationRequest.MedicationrequestStatus> bx_ = MedReqAntithrombotic?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? by_ = bx_?.Value;
+                string bz_ = context.Operators.Convert<string>(by_);
+                string[] ca_ = [
                     "active",
                     "completed",
                 ];
-                bool? cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
-                bool? ce_ = context.Operators.And(by_, cd_);
-                CodeableConcept cf_ = TaskReject?.Code;
-                CqlConcept cg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cf_);
-                CqlCode ch_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                CqlConcept ci_ = context.Operators.ConvertCodeToConcept(ch_);
-                bool? cj_ = context.Operators.Equivalent(cg_, ci_);
-                bool? ck_ = context.Operators.And(ce_, cj_);
-                return ck_;
+                bool? cb_ = context.Operators.In<string>(bz_, (IEnumerable<string>)ca_);
+                bool? cc_ = context.Operators.And(bw_, cb_);
+                CodeableConcept cd_ = TaskReject?.Code;
+                CqlConcept ce_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cd_);
+                CqlCode cf_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept cg_ = context.Operators.ConvertCodeToConcept(cf_);
+                bool? ch_ = context.Operators.Equivalent(ce_, cg_);
+                bool? ci_ = context.Operators.And(cc_, ch_);
+                return ci_;
             }
 
-            IEnumerable<Task> bk_ = context.Operators.Where<Task>(bi_, bj_);
-            MedicationRequest bl_(Task TaskReject) => MedReqAntithrombotic;
-            IEnumerable<MedicationRequest> bm_ = context.Operators.Select<Task, MedicationRequest>(bk_, bl_);
-            return bm_;
+            IEnumerable<Task> bj_ = context.Operators.Where<Task>(bh_, bi_);
+            bool? bk_ = context.Operators.Exists<Task>(bj_);
+            return bk_;
         }
 
-        IEnumerable<MedicationRequest> o_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(m_, n_);
+        IEnumerable<MedicationRequest> o_ = context.Operators.Where<MedicationRequest>(m_, n_);
         IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(g_ as IEnumerable<MedicationRequest>, o_ as IEnumerable<MedicationRequest>);
         return p_;
     }
@@ -364,25 +360,24 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             IEnumerable<MedicationRequest> d_ = this.Reason_For_Not_Giving_Antithrombotic_At_Discharge(context);
 
             bool? e_(MedicationRequest NoDischargeAntithrombotic) {
-                FhirDateTime i_ = NoDischargeAntithrombotic?.AuthoredOnElement;
-                CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
-                Period k_ = IschemicStrokeEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
-                return m_;
+                FhirDateTime h_ = NoDischargeAntithrombotic?.AuthoredOnElement;
+                CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
+                Period j_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? l_ = context.Operators.In<CqlDateTime>(i_, k_, (string)default);
+                return l_;
             }
 
             IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
-            Encounter g_(MedicationRequest NoDischargeAntithrombotic) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -399,58 +394,57 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationRequest l_(Medication M) => MR;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest PharmacologicalContraindications) {
-            bool? x_ = QICoreCommon_4_0_000.Instance.isCommunity(context, PharmacologicalContraindications as MedicationRequest);
-            bool? y_ = QICoreCommon_4_0_000.Instance.isDischarge(context, PharmacologicalContraindications as MedicationRequest);
-            bool? z_ = context.Operators.Or(x_, y_);
-            Code<MedicationRequest.MedicationrequestStatus> aa_ = PharmacologicalContraindications?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
-            string ac_ = context.Operators.Convert<string>(ab_);
-            string[] ad_ = [
+            bool? w_ = QICoreCommon_4_0_000.Instance.isCommunity(context, PharmacologicalContraindications as MedicationRequest);
+            bool? x_ = QICoreCommon_4_0_000.Instance.isDischarge(context, PharmacologicalContraindications as MedicationRequest);
+            bool? y_ = context.Operators.Or(w_, x_);
+            Code<MedicationRequest.MedicationrequestStatus> z_ = PharmacologicalContraindications?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-            bool? af_ = context.Operators.And(z_, ae_);
-            Code<MedicationRequest.MedicationRequestIntent> ag_ = PharmacologicalContraindications?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
-            string ai_ = context.Operators.Convert<string>(ah_);
-            string[] aj_ = [
+            bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            bool? ae_ = context.Operators.And(y_, ad_);
+            Code<MedicationRequest.MedicationRequestIntent> af_ = PharmacologicalContraindications?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+            string ah_ = context.Operators.Convert<string>(ag_);
+            string[] ai_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-            bool? al_ = context.Operators.And(af_, ak_);
-            return al_;
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+            bool? ak_ = context.Operators.And(ae_, aj_);
+            return ak_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -468,25 +462,24 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             IEnumerable<MedicationRequest> d_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy_At_Discharge(context);
 
             bool? e_(MedicationRequest DischargePharmacological) {
-                FhirDateTime i_ = DischargePharmacological?.AuthoredOnElement;
-                CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
-                Period k_ = IschemicStrokeEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
-                return m_;
+                FhirDateTime h_ = DischargePharmacological?.AuthoredOnElement;
+                CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
+                Period j_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? l_ = context.Operators.In<CqlDateTime>(i_, k_, (string)default);
+                return l_;
             }
 
             IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
-            Encounter g_(MedicationRequest DischargePharmacological) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
@@ -186,43 +186,42 @@ public partial class CMS1074FHIRCTIQR_1_0_000 : ILibrary, ISingleton<CMS1074FHIR
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
-        IEnumerable<Observation> d_(Observation CTScan) {
+        bool? d_(Observation CTScan) {
             IEnumerable<Encounter> f_ = this.Qualifying_Inpatient_Encounters(context);
 
             bool? g_(Encounter InpatientEncounters) {
-                Code<ObservationStatus> k_ = CTScan?.StatusElement;
-                ObservationStatus? l_ = k_?.Value;
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
+                Code<ObservationStatus> j_ = CTScan?.StatusElement;
+                ObservationStatus? k_ = j_?.Value;
+                string l_ = context.Operators.Convert<string>(k_);
+                string[] m_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                DataType p_ = CTScan?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                Period t_ = InpatientEncounters?.Period;
-                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, (string)default);
-                bool? w_ = context.Operators.And(o_, v_);
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.End(z_);
-                CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
-                bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, "day");
-                bool? ad_ = context.Operators.And(w_, ac_);
-                return ad_;
+                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+                DataType o_ = CTScan?.Effective;
+                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                Period s_ = InpatientEncounters?.Period;
+                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
+                bool? u_ = context.Operators.In<CqlDateTime>(r_, t_, (string)default);
+                bool? v_ = context.Operators.And(n_, u_);
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+                CqlDateTime z_ = context.Operators.End(y_);
+                CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
+                bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
+                bool? ac_ = context.Operators.And(v_, ab_);
+                return ac_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
-            Observation i_(Encounter InpatientEncounters) => CTScan;
-            IEnumerable<Observation> j_ = context.Operators.Select<Encounter, Observation>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Encounter>(h_);
+            return i_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
         return e_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS108FHIRVTEProphylaxis-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS108FHIRVTEProphylaxis-1.0.000.g.cs
@@ -529,67 +529,67 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
     {
         IEnumerable<Encounter> a_ = VTE_8_18_000.Instance.Encounter_With_Age_Range_And_Without_VTE_Diagnosis_Or_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             IEnumerable<object> d_ = this.Intervention_Comfort_Measures(context);
 
             bool? e_(object ComfortMeasure) {
 
-                object i_() {
+                object h_() {
+
+                    bool y_() {
+                        object ac_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlDateTime;
+                        return ae_;
+                    }
+
 
                     bool z_() {
-                        object ad_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlDateTime;
-                        return af_;
+                        object af_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlDateTime>;
+                        return ah_;
                     }
 
 
                     bool aa_() {
-                        object ag_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlDateTime>;
-                        return ai_;
+                        object ai_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        bool ak_ = aj_ is CqlQuantity;
+                        return ak_;
                     }
 
 
                     bool ab_() {
-                        object aj_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        bool al_ = ak_ is CqlQuantity;
-                        return al_;
+                        object al_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        bool an_ = am_ is CqlInterval<CqlQuantity>;
+                        return an_;
                     }
 
-
-                    bool ac_() {
-                        object am_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        bool ao_ = an_ is CqlInterval<CqlQuantity>;
-                        return ao_;
-                    }
-
-                    if (z_())
+                    if (y_())
                     {
-                        object ap_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlDateTime) as object;
+                        object ao_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlDateTime) as object;
+                    }
+                    else if (z_())
+                    {
+                        object aq_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (aa_())
                     {
-                        object ar_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlInterval<CqlDateTime>) as object;
+                        object as_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        return (at_ as CqlQuantity) as object;
                     }
                     else if (ab_())
                     {
-                        object at_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        return (au_ as CqlQuantity) as object;
-                    }
-                    else if (ac_())
-                    {
-                        object av_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        return (aw_ as CqlInterval<CqlQuantity>) as object;
+                        object au_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        return (av_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -597,29 +597,28 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                     };
                 }
 
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
-                CqlDateTime k_ = context.Operators.Start(j_);
-                object l_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-                CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
-                CqlInterval<CqlDate> n_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
-                CqlDate o_ = n_?.low;
-                CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
-                CqlDate r_ = n_?.high;
-                CqlDateTime s_ = context.Operators.ConvertDateToDateTime(r_);
-                bool? u_ = n_?.lowClosed;
-                bool? w_ = n_?.highClosed;
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(p_, s_, u_, w_);
-                bool? y_ = context.Operators.In<CqlDateTime>(k_ ?? m_, x_, "day");
-                return y_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_());
+                CqlDateTime j_ = context.Operators.Start(i_);
+                object k_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+                CqlDateTime l_ = context.Operators.LateBoundProperty<CqlDateTime>(k_, "value");
+                CqlInterval<CqlDate> m_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
+                CqlDate n_ = m_?.low;
+                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
+                CqlDate q_ = m_?.high;
+                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
+                bool? t_ = m_?.lowClosed;
+                bool? v_ = m_?.highClosed;
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(o_, r_, t_, v_);
+                bool? x_ = context.Operators.In<CqlDateTime>(j_ ?? l_, w_, "day");
+                return x_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object ComfortMeasure) => QualifyingEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1114,82 +1113,80 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         IEnumerable<MedicationAdministration> b_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> d_(MedicationAdministration MR) {
+        bool? d_(MedicationAdministration MR) {
             IEnumerable<Medication> bd_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? be_(Medication M) {
-                object bi_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object bj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> bk_ = context.Operators.Split((string)bj_, "/");
-                string bl_ = context.Operators.Last<string>(bk_);
-                bool? bm_ = context.Operators.Equal(bi_, bl_);
-                CodeableConcept bn_ = M?.Code;
-                CqlConcept bo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bn_);
-                CqlValueSet bp_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                bool? bq_ = context.Operators.ConceptInValueSet(bo_, bp_);
-                bool? br_ = context.Operators.And(bm_, bq_);
-                return br_;
+                object bh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object bi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> bj_ = context.Operators.Split((string)bi_, "/");
+                string bk_ = context.Operators.Last<string>(bj_);
+                bool? bl_ = context.Operators.Equal(bh_, bk_);
+                CodeableConcept bm_ = M?.Code;
+                CqlConcept bn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bm_);
+                CqlValueSet bo_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                bool? bp_ = context.Operators.ConceptInValueSet(bn_, bo_);
+                bool? bq_ = context.Operators.And(bl_, bp_);
+                return bq_;
             }
 
             IEnumerable<Medication> bf_ = context.Operators.Where<Medication>(bd_, be_);
-            MedicationAdministration bg_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> bh_ = context.Operators.Select<Medication, MedicationAdministration>(bf_, bg_);
-            return bh_;
+            bool? bg_ = context.Operators.Exists<Medication>(bf_);
+            return bg_;
         }
 
-        IEnumerable<MedicationAdministration> e_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, d_);
+        IEnumerable<MedicationAdministration> e_ = context.Operators.Where<MedicationAdministration>(c_, d_);
         IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(b_, e_);
 
         bool? g_(MedicationAdministration VTEMedication) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> bs_ = VTEMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? bt_ = bs_?.Value;
-            string bu_ = context.Operators.Convert<string>(bt_);
-            bool? bv_ = context.Operators.Equal(bu_, "completed");
-            MedicationAdministration.DosageComponent bw_ = VTEMedication?.Dosage;
-            CodeableConcept bx_ = bw_?.Route;
-            CqlConcept by_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bx_);
-            CqlValueSet bz_ = this.Subcutaneous_route(context);
-            bool? ca_ = context.Operators.ConceptInValueSet(by_, bz_);
-            bool? cb_ = context.Operators.And(bv_, ca_);
-            return cb_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> br_ = VTEMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? bs_ = br_?.Value;
+            string bt_ = context.Operators.Convert<string>(bs_);
+            bool? bu_ = context.Operators.Equal(bt_, "completed");
+            MedicationAdministration.DosageComponent bv_ = VTEMedication?.Dosage;
+            CodeableConcept bw_ = bv_?.Route;
+            CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
+            CqlValueSet by_ = this.Subcutaneous_route(context);
+            bool? bz_ = context.Operators.ConceptInValueSet(bx_, by_);
+            bool? ca_ = context.Operators.And(bu_, bz_);
+            return ca_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
         CqlValueSet i_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
         IEnumerable<MedicationAdministration> j_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> l_(MedicationAdministration MR) {
-            IEnumerable<Medication> cc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? l_(MedicationAdministration MR) {
+            IEnumerable<Medication> cb_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? cd_(Medication M) {
-                object ch_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ci_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> cj_ = context.Operators.Split((string)ci_, "/");
-                string ck_ = context.Operators.Last<string>(cj_);
-                bool? cl_ = context.Operators.Equal(ch_, ck_);
-                CodeableConcept cm_ = M?.Code;
-                CqlConcept cn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cm_);
-                CqlValueSet co_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                bool? cp_ = context.Operators.ConceptInValueSet(cn_, co_);
-                bool? cq_ = context.Operators.And(cl_, cp_);
-                return cq_;
+            bool? cc_(Medication M) {
+                object cf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ch_ = context.Operators.Split((string)cg_, "/");
+                string ci_ = context.Operators.Last<string>(ch_);
+                bool? cj_ = context.Operators.Equal(cf_, ci_);
+                CodeableConcept ck_ = M?.Code;
+                CqlConcept cl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ck_);
+                CqlValueSet cm_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                bool? cn_ = context.Operators.ConceptInValueSet(cl_, cm_);
+                bool? co_ = context.Operators.And(cj_, cn_);
+                return co_;
             }
 
-            IEnumerable<Medication> ce_ = context.Operators.Where<Medication>(cc_, cd_);
-            MedicationAdministration cf_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> cg_ = context.Operators.Select<Medication, MedicationAdministration>(ce_, cf_);
-            return cg_;
+            IEnumerable<Medication> cd_ = context.Operators.Where<Medication>(cb_, cc_);
+            bool? ce_ = context.Operators.Exists<Medication>(cd_);
+            return ce_;
         }
 
-        IEnumerable<MedicationAdministration> m_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, l_);
+        IEnumerable<MedicationAdministration> m_ = context.Operators.Where<MedicationAdministration>(c_, l_);
         IEnumerable<MedicationAdministration> n_ = context.Operators.Union<MedicationAdministration>(j_, m_);
 
         bool? o_(MedicationAdministration LMWH) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cr_ = LMWH?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? cs_ = cr_?.Value;
-            string ct_ = context.Operators.Convert<string>(cs_);
-            bool? cu_ = context.Operators.Equal(ct_, "completed");
-            return cu_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cp_ = LMWH?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? cq_ = cp_?.Value;
+            string cr_ = context.Operators.Convert<string>(cq_);
+            bool? cs_ = context.Operators.Equal(cr_, "completed");
+            return cs_;
         }
 
         IEnumerable<MedicationAdministration> p_ = context.Operators.Where<MedicationAdministration>(n_, o_);
@@ -1197,76 +1194,74 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         CqlValueSet r_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
         IEnumerable<MedicationAdministration> s_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, r_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> u_(MedicationAdministration MR) {
-            IEnumerable<Medication> cv_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? u_(MedicationAdministration MR) {
+            IEnumerable<Medication> ct_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? cw_(Medication M) {
-                object da_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object db_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> dc_ = context.Operators.Split((string)db_, "/");
-                string dd_ = context.Operators.Last<string>(dc_);
-                bool? de_ = context.Operators.Equal(da_, dd_);
-                CodeableConcept df_ = M?.Code;
-                CqlConcept dg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, df_);
-                CqlValueSet dh_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                bool? di_ = context.Operators.ConceptInValueSet(dg_, dh_);
-                bool? dj_ = context.Operators.And(de_, di_);
-                return dj_;
+            bool? cu_(Medication M) {
+                object cx_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cy_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> cz_ = context.Operators.Split((string)cy_, "/");
+                string da_ = context.Operators.Last<string>(cz_);
+                bool? db_ = context.Operators.Equal(cx_, da_);
+                CodeableConcept dc_ = M?.Code;
+                CqlConcept dd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dc_);
+                CqlValueSet de_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                bool? df_ = context.Operators.ConceptInValueSet(dd_, de_);
+                bool? dg_ = context.Operators.And(db_, df_);
+                return dg_;
             }
 
-            IEnumerable<Medication> cx_ = context.Operators.Where<Medication>(cv_, cw_);
-            MedicationAdministration cy_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> cz_ = context.Operators.Select<Medication, MedicationAdministration>(cx_, cy_);
-            return cz_;
+            IEnumerable<Medication> cv_ = context.Operators.Where<Medication>(ct_, cu_);
+            bool? cw_ = context.Operators.Exists<Medication>(cv_);
+            return cw_;
         }
 
-        IEnumerable<MedicationAdministration> v_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, u_);
+        IEnumerable<MedicationAdministration> v_ = context.Operators.Where<MedicationAdministration>(c_, u_);
         IEnumerable<MedicationAdministration> w_ = context.Operators.Union<MedicationAdministration>(s_, v_);
 
         bool? x_(MedicationAdministration FactorXa) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> dk_ = FactorXa?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? dl_ = dk_?.Value;
-            string dm_ = context.Operators.Convert<string>(dl_);
-            bool? dn_ = context.Operators.Equal(dm_, "completed");
-            return dn_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> dh_ = FactorXa?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? di_ = dh_?.Value;
+            string dj_ = context.Operators.Convert<string>(di_);
+            bool? dk_ = context.Operators.Equal(dj_, "completed");
+            return dk_;
         }
 
         IEnumerable<MedicationAdministration> y_ = context.Operators.Where<MedicationAdministration>(w_, x_);
         CqlValueSet z_ = this.Warfarin(context);
         IEnumerable<MedicationAdministration> aa_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, z_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> ac_(MedicationAdministration MR) {
-            IEnumerable<Medication> do_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ac_(MedicationAdministration MR) {
+            IEnumerable<Medication> dl_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? dp_(Medication M) {
-                object dt_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object du_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> dv_ = context.Operators.Split((string)du_, "/");
-                string dw_ = context.Operators.Last<string>(dv_);
-                bool? dx_ = context.Operators.Equal(dt_, dw_);
-                CodeableConcept dy_ = M?.Code;
-                CqlConcept dz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dy_);
-                CqlValueSet ea_ = this.Warfarin(context);
-                bool? eb_ = context.Operators.ConceptInValueSet(dz_, ea_);
-                bool? ec_ = context.Operators.And(dx_, eb_);
-                return ec_;
+            bool? dm_(Medication M) {
+                object dp_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object dq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> dr_ = context.Operators.Split((string)dq_, "/");
+                string ds_ = context.Operators.Last<string>(dr_);
+                bool? dt_ = context.Operators.Equal(dp_, ds_);
+                CodeableConcept du_ = M?.Code;
+                CqlConcept dv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, du_);
+                CqlValueSet dw_ = this.Warfarin(context);
+                bool? dx_ = context.Operators.ConceptInValueSet(dv_, dw_);
+                bool? dy_ = context.Operators.And(dt_, dx_);
+                return dy_;
             }
 
-            IEnumerable<Medication> dq_ = context.Operators.Where<Medication>(do_, dp_);
-            MedicationAdministration dr_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> ds_ = context.Operators.Select<Medication, MedicationAdministration>(dq_, dr_);
-            return ds_;
+            IEnumerable<Medication> dn_ = context.Operators.Where<Medication>(dl_, dm_);
+            bool? do_ = context.Operators.Exists<Medication>(dn_);
+            return do_;
         }
 
-        IEnumerable<MedicationAdministration> ad_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, ac_);
+        IEnumerable<MedicationAdministration> ad_ = context.Operators.Where<MedicationAdministration>(c_, ac_);
         IEnumerable<MedicationAdministration> ae_ = context.Operators.Union<MedicationAdministration>(aa_, ad_);
 
         bool? af_(MedicationAdministration WarfarinAdm) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ed_ = WarfarinAdm?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ee_ = ed_?.Value;
-            string ef_ = context.Operators.Convert<string>(ee_);
-            bool? eg_ = context.Operators.Equal(ef_, "completed");
-            return eg_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> dz_ = WarfarinAdm?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? ea_ = dz_?.Value;
+            string eb_ = context.Operators.Convert<string>(ea_);
+            bool? ec_ = context.Operators.Equal(eb_, "completed");
+            return ec_;
         }
 
         IEnumerable<MedicationAdministration> ag_ = context.Operators.Where<MedicationAdministration>(ae_, af_);
@@ -1275,38 +1270,37 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         CqlValueSet aj_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
         IEnumerable<MedicationAdministration> ak_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> am_(MedicationAdministration MR) {
-            IEnumerable<Medication> eh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? am_(MedicationAdministration MR) {
+            IEnumerable<Medication> ed_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ei_(Medication M) {
-                object em_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object en_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> eo_ = context.Operators.Split((string)en_, "/");
-                string ep_ = context.Operators.Last<string>(eo_);
-                bool? eq_ = context.Operators.Equal(em_, ep_);
-                CodeableConcept er_ = M?.Code;
-                CqlConcept es_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, er_);
-                CqlValueSet et_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                bool? eu_ = context.Operators.ConceptInValueSet(es_, et_);
-                bool? ev_ = context.Operators.And(eq_, eu_);
-                return ev_;
+            bool? ee_(Medication M) {
+                object eh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ei_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ej_ = context.Operators.Split((string)ei_, "/");
+                string ek_ = context.Operators.Last<string>(ej_);
+                bool? el_ = context.Operators.Equal(eh_, ek_);
+                CodeableConcept em_ = M?.Code;
+                CqlConcept en_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, em_);
+                CqlValueSet eo_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                bool? ep_ = context.Operators.ConceptInValueSet(en_, eo_);
+                bool? eq_ = context.Operators.And(el_, ep_);
+                return eq_;
             }
 
-            IEnumerable<Medication> ej_ = context.Operators.Where<Medication>(eh_, ei_);
-            MedicationAdministration ek_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> el_ = context.Operators.Select<Medication, MedicationAdministration>(ej_, ek_);
-            return el_;
+            IEnumerable<Medication> ef_ = context.Operators.Where<Medication>(ed_, ee_);
+            bool? eg_ = context.Operators.Exists<Medication>(ef_);
+            return eg_;
         }
 
-        IEnumerable<MedicationAdministration> an_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, am_);
+        IEnumerable<MedicationAdministration> an_ = context.Operators.Where<MedicationAdministration>(c_, am_);
         IEnumerable<MedicationAdministration> ao_ = context.Operators.Union<MedicationAdministration>(ak_, an_);
 
         bool? ap_(MedicationAdministration Rivaroxaban) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ew_ = Rivaroxaban?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ex_ = ew_?.Value;
-            string ey_ = context.Operators.Convert<string>(ex_);
-            bool? ez_ = context.Operators.Equal(ey_, "completed");
-            return ez_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> er_ = Rivaroxaban?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? es_ = er_?.Value;
+            string et_ = context.Operators.Convert<string>(es_);
+            bool? eu_ = context.Operators.Equal(et_, "completed");
+            return eu_;
         }
 
         IEnumerable<MedicationAdministration> aq_ = context.Operators.Where<MedicationAdministration>(ao_, ap_);
@@ -1320,11 +1314,11 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         IEnumerable<Procedure> ay_ = context.Operators.Union<Procedure>(av_, ax_);
 
         bool? az_(Procedure DeviceApplied) {
-            Code<EventStatus> fa_ = DeviceApplied?.StatusElement;
-            EventStatus? fb_ = fa_?.Value;
-            string fc_ = context.Operators.Convert<string>(fb_);
-            bool? fd_ = context.Operators.Equal(fc_, "completed");
-            return fd_;
+            Code<EventStatus> ev_ = DeviceApplied?.StatusElement;
+            EventStatus? ew_ = ev_?.Value;
+            string ex_ = context.Operators.Convert<string>(ew_);
+            bool? ey_ = context.Operators.Equal(ex_, "completed");
+            return ey_;
         }
 
         IEnumerable<Procedure> ba_ = context.Operators.Where<Procedure>(ay_, az_);
@@ -1899,72 +1893,71 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> d_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> e_(MedicationAdministration MR) {
+        bool? e_(MedicationAdministration MR) {
             IEnumerable<Medication> ah_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? ai_(Medication M) {
-                object am_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object an_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ao_ = context.Operators.Split((string)an_, "/");
-                string ap_ = context.Operators.Last<string>(ao_);
-                bool? aq_ = context.Operators.Equal(am_, ap_);
-                CodeableConcept ar_ = M?.Code;
-                CqlConcept as_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ar_);
-                CqlValueSet at_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                bool? au_ = context.Operators.ConceptInValueSet(as_, at_);
-                bool? av_ = context.Operators.And(aq_, au_);
-                return av_;
+                object al_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object am_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> an_ = context.Operators.Split((string)am_, "/");
+                string ao_ = context.Operators.Last<string>(an_);
+                bool? ap_ = context.Operators.Equal(al_, ao_);
+                CodeableConcept aq_ = M?.Code;
+                CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
+                CqlValueSet as_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                bool? at_ = context.Operators.ConceptInValueSet(ar_, as_);
+                bool? au_ = context.Operators.And(ap_, at_);
+                return au_;
             }
 
             IEnumerable<Medication> aj_ = context.Operators.Where<Medication>(ah_, ai_);
-            MedicationAdministration ak_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> al_ = context.Operators.Select<Medication, MedicationAdministration>(aj_, ak_);
-            return al_;
+            bool? ak_ = context.Operators.Exists<Medication>(aj_);
+            return ak_;
         }
 
-        IEnumerable<MedicationAdministration> f_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(d_, e_);
+        IEnumerable<MedicationAdministration> f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
         IEnumerable<MedicationAdministration> g_ = context.Operators.Union<MedicationAdministration>(c_, f_);
         IEnumerable<ValueTuple<Encounter, MedicationAdministration>> h_ = context.Operators.CrossJoin<Encounter, MedicationAdministration>(a_, g_);
 
         (CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)? i_(ValueTuple<Encounter, MedicationAdministration> _valueTuple) {
-            (CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)? aw_ = (CqlTupleMetadata_EBRQeiSMaTgecHVEbVOIMZEcb, _valueTuple.Item1, _valueTuple.Item2);
-            return aw_;
+            (CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)? av_ = (CqlTupleMetadata_EBRQeiSMaTgecHVEbVOIMZEcb, _valueTuple.Item1, _valueTuple.Item2);
+            return av_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)?> j_ = context.Operators.Select<ValueTuple<Encounter, MedicationAdministration>, (CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)?>(h_, i_);
 
         bool? k_((CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)? tuple_cdbvhiekdcojzrccbhjghhgeo) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ax_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.FactorXaMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ay_ = ax_?.Value;
-            string az_ = context.Operators.Convert<string>(ay_);
-            bool? ba_ = context.Operators.Equal(az_, "completed");
-            DataType bb_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.FactorXaMedication?.Effective;
-            object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-            CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-            CqlDateTime be_ = context.Operators.Start(bd_);
-            Period bf_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.QualifyingEncounter?.Period;
-            CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-            CqlDateTime bh_ = context.Operators.Start(bg_);
-            CqlInterval<CqlDate> bi_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bh_);
-            CqlDate bj_ = bi_?.low;
-            CqlDateTime bk_ = context.Operators.ConvertDateToDateTime(bj_);
-            CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-            CqlDateTime bn_ = context.Operators.Start(bm_);
-            CqlInterval<CqlDate> bo_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bn_);
-            CqlDate bp_ = bo_?.high;
-            CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(bp_);
-            CqlInterval<CqlDateTime> bs_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-            CqlDateTime bt_ = context.Operators.Start(bs_);
-            CqlInterval<CqlDate> bu_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bt_);
-            bool? bv_ = bu_?.lowClosed;
-            CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-            CqlDateTime by_ = context.Operators.Start(bx_);
-            CqlInterval<CqlDate> bz_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, by_);
-            bool? ca_ = bz_?.highClosed;
-            CqlInterval<CqlDateTime> cb_ = context.Operators.Interval(bk_, bq_, bv_, ca_);
-            bool? cc_ = context.Operators.In<CqlDateTime>(be_, cb_, "day");
-            bool? cd_ = context.Operators.And(ba_, cc_);
-            return cd_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> aw_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.FactorXaMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? ax_ = aw_?.Value;
+            string ay_ = context.Operators.Convert<string>(ax_);
+            bool? az_ = context.Operators.Equal(ay_, "completed");
+            DataType ba_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.FactorXaMedication?.Effective;
+            object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+            CqlInterval<CqlDateTime> bc_ = QICoreCommon_4_0_000.Instance.toInterval(context, bb_);
+            CqlDateTime bd_ = context.Operators.Start(bc_);
+            Period be_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, be_);
+            CqlDateTime bg_ = context.Operators.Start(bf_);
+            CqlInterval<CqlDate> bh_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bg_);
+            CqlDate bi_ = bh_?.low;
+            CqlDateTime bj_ = context.Operators.ConvertDateToDateTime(bi_);
+            CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, be_);
+            CqlDateTime bm_ = context.Operators.Start(bl_);
+            CqlInterval<CqlDate> bn_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bm_);
+            CqlDate bo_ = bn_?.high;
+            CqlDateTime bp_ = context.Operators.ConvertDateToDateTime(bo_);
+            CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, be_);
+            CqlDateTime bs_ = context.Operators.Start(br_);
+            CqlInterval<CqlDate> bt_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bs_);
+            bool? bu_ = bt_?.lowClosed;
+            CqlInterval<CqlDateTime> bw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, be_);
+            CqlDateTime bx_ = context.Operators.Start(bw_);
+            CqlInterval<CqlDate> by_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bx_);
+            bool? bz_ = by_?.highClosed;
+            CqlInterval<CqlDateTime> ca_ = context.Operators.Interval(bj_, bp_, bu_, bz_);
+            bool? cb_ = context.Operators.In<CqlDateTime>(bd_, ca_, "day");
+            bool? cc_ = context.Operators.And(az_, cb_);
+            return cc_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)?> l_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)?>(j_, k_);
@@ -1975,107 +1968,106 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         IEnumerable<Procedure> r_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, q_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
         IEnumerable<MedicationAdministration> t_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> v_(MedicationAdministration MR) {
-            IEnumerable<Medication> ce_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? v_(MedicationAdministration MR) {
+            IEnumerable<Medication> cd_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? cf_(Medication M) {
-                object cj_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ck_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> cl_ = context.Operators.Split((string)ck_, "/");
-                string cm_ = context.Operators.Last<string>(cl_);
-                bool? cn_ = context.Operators.Equal(cj_, cm_);
-                CodeableConcept co_ = M?.Code;
-                CqlConcept cp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, co_);
-                CqlValueSet cq_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                bool? cr_ = context.Operators.ConceptInValueSet(cp_, cq_);
-                bool? cs_ = context.Operators.And(cn_, cr_);
-                return cs_;
+            bool? ce_(Medication M) {
+                object ch_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ci_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> cj_ = context.Operators.Split((string)ci_, "/");
+                string ck_ = context.Operators.Last<string>(cj_);
+                bool? cl_ = context.Operators.Equal(ch_, ck_);
+                CodeableConcept cm_ = M?.Code;
+                CqlConcept cn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cm_);
+                CqlValueSet co_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                bool? cp_ = context.Operators.ConceptInValueSet(cn_, co_);
+                bool? cq_ = context.Operators.And(cl_, cp_);
+                return cq_;
             }
 
-            IEnumerable<Medication> cg_ = context.Operators.Where<Medication>(ce_, cf_);
-            MedicationAdministration ch_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> ci_ = context.Operators.Select<Medication, MedicationAdministration>(cg_, ch_);
-            return ci_;
+            IEnumerable<Medication> cf_ = context.Operators.Where<Medication>(cd_, ce_);
+            bool? cg_ = context.Operators.Exists<Medication>(cf_);
+            return cg_;
         }
 
-        IEnumerable<MedicationAdministration> w_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(d_, v_);
+        IEnumerable<MedicationAdministration> w_ = context.Operators.Where<MedicationAdministration>(d_, v_);
         IEnumerable<MedicationAdministration> x_ = context.Operators.Union<MedicationAdministration>(t_, w_);
         IEnumerable<ValueTuple<Encounter, Procedure, MedicationAdministration>> y_ = context.Operators.CrossJoin<Encounter, Procedure, MedicationAdministration>(a_, r_, x_);
 
         (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? z_(ValueTuple<Encounter, Procedure, MedicationAdministration> _valueTuple) {
-            (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? ct_ = (CqlTupleMetadata_CdgLdDFHNTDXFGGVTOMXhQZR, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
-            return ct_;
+            (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? cr_ = (CqlTupleMetadata_CdgLdDFHNTDXFGGVTOMXhQZR, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+            return cr_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?> aa_ = context.Operators.Select<ValueTuple<Encounter, Procedure, MedicationAdministration>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?>(y_, z_);
 
         bool? ab_((CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? tuple_dejnabiogwrwyxienqokgepgj) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cu_ = tuple_dejnabiogwrwyxienqokgepgj?.FactorXaMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? cv_ = cu_?.Value;
-            string cw_ = context.Operators.Convert<string>(cv_);
-            bool? cx_ = context.Operators.Equal(cw_, "completed");
-            Code<EventStatus> cy_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.StatusElement;
-            EventStatus? cz_ = cy_?.Value;
-            string da_ = context.Operators.Convert<string>(cz_);
-            bool? db_ = context.Operators.Equal(da_, "completed");
-            bool? dc_ = context.Operators.And(cx_, db_);
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cs_ = tuple_dejnabiogwrwyxienqokgepgj?.FactorXaMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? ct_ = cs_?.Value;
+            string cu_ = context.Operators.Convert<string>(ct_);
+            bool? cv_ = context.Operators.Equal(cu_, "completed");
+            Code<EventStatus> cw_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? cx_ = cw_?.Value;
+            string cy_ = context.Operators.Convert<string>(cx_);
+            bool? cz_ = context.Operators.Equal(cy_, "completed");
+            bool? da_ = context.Operators.And(cv_, cz_);
 
-            object dd_() {
+            object db_() {
+
+                bool eo_() {
+                    DataType es_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
+                    bool eu_ = et_ is CqlDateTime;
+                    return eu_;
+                }
+
+
+                bool ep_() {
+                    DataType ev_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
+                    bool ex_ = ew_ is CqlInterval<CqlDateTime>;
+                    return ex_;
+                }
+
 
                 bool eq_() {
-                    DataType eu_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
-                    bool ew_ = ev_ is CqlDateTime;
-                    return ew_;
+                    DataType ey_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object ez_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ey_);
+                    bool fa_ = ez_ is CqlQuantity;
+                    return fa_;
                 }
 
 
                 bool er_() {
-                    DataType ex_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object ey_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ex_);
-                    bool ez_ = ey_ is CqlInterval<CqlDateTime>;
-                    return ez_;
+                    DataType fb_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object fc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fb_);
+                    bool fd_ = fc_ is CqlInterval<CqlQuantity>;
+                    return fd_;
                 }
 
-
-                bool es_() {
-                    DataType fa_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object fb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fa_);
-                    bool fc_ = fb_ is CqlQuantity;
-                    return fc_;
+                if (eo_())
+                {
+                    DataType fe_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object ff_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fe_);
+                    return (ff_ as CqlDateTime) as object;
                 }
-
-
-                bool et_() {
-                    DataType fd_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object fe_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fd_);
-                    bool ff_ = fe_ is CqlInterval<CqlQuantity>;
-                    return ff_;
-                }
-
-                if (eq_())
+                else if (ep_())
                 {
                     DataType fg_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object fh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fg_);
-                    return (fh_ as CqlDateTime) as object;
+                    return (fh_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (er_())
+                else if (eq_())
                 {
                     DataType fi_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object fj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fi_);
-                    return (fj_ as CqlInterval<CqlDateTime>) as object;
+                    return (fj_ as CqlQuantity) as object;
                 }
-                else if (es_())
+                else if (er_())
                 {
                     DataType fk_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object fl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fk_);
-                    return (fl_ as CqlQuantity) as object;
-                }
-                else if (et_())
-                {
-                    DataType fm_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object fn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fm_);
-                    return (fn_ as CqlInterval<CqlQuantity>) as object;
+                    return (fl_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2083,76 +2075,76 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 };
             }
 
-            CqlInterval<CqlDateTime> de_ = QICoreCommon_4_0_000.Instance.toInterval(context, dd_());
-            CqlDateTime df_ = context.Operators.End(de_);
-            Period dg_ = tuple_dejnabiogwrwyxienqokgepgj?.QualifyingEncounter?.Period;
-            CqlInterval<CqlDateTime> dh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dg_);
-            CqlDateTime di_ = context.Operators.Start(dh_);
-            CqlQuantity dj_ = context.Operators.Quantity(1m, "day");
-            CqlDateTime dk_ = context.Operators.Add(di_, dj_);
-            bool? dl_ = context.Operators.SameAs(df_, dk_, "day");
-            bool? dm_ = context.Operators.And(dc_, dl_);
-            DataType dn_ = tuple_dejnabiogwrwyxienqokgepgj?.FactorXaMedication?.Effective;
-            object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
-            CqlInterval<CqlDateTime> dp_ = QICoreCommon_4_0_000.Instance.toInterval(context, do_);
-            CqlDateTime dq_ = context.Operators.Start(dp_);
+            CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_());
+            CqlDateTime dd_ = context.Operators.End(dc_);
+            Period de_ = tuple_dejnabiogwrwyxienqokgepgj?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, de_);
+            CqlDateTime dg_ = context.Operators.Start(df_);
+            CqlQuantity dh_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime di_ = context.Operators.Add(dg_, dh_);
+            bool? dj_ = context.Operators.SameAs(dd_, di_, "day");
+            bool? dk_ = context.Operators.And(da_, dj_);
+            DataType dl_ = tuple_dejnabiogwrwyxienqokgepgj?.FactorXaMedication?.Effective;
+            object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+            CqlInterval<CqlDateTime> dn_ = QICoreCommon_4_0_000.Instance.toInterval(context, dm_);
+            CqlDateTime do_ = context.Operators.Start(dn_);
 
-            object dr_() {
+            object dp_() {
+
+                bool fm_() {
+                    DataType fq_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object fr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fq_);
+                    bool fs_ = fr_ is CqlDateTime;
+                    return fs_;
+                }
+
+
+                bool fn_() {
+                    DataType ft_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object fu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ft_);
+                    bool fv_ = fu_ is CqlInterval<CqlDateTime>;
+                    return fv_;
+                }
+
 
                 bool fo_() {
-                    DataType fs_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object ft_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fs_);
-                    bool fu_ = ft_ is CqlDateTime;
-                    return fu_;
+                    DataType fw_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object fx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fw_);
+                    bool fy_ = fx_ is CqlQuantity;
+                    return fy_;
                 }
 
 
                 bool fp_() {
-                    DataType fv_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object fw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fv_);
-                    bool fx_ = fw_ is CqlInterval<CqlDateTime>;
-                    return fx_;
+                    DataType fz_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object ga_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fz_);
+                    bool gb_ = ga_ is CqlInterval<CqlQuantity>;
+                    return gb_;
                 }
 
-
-                bool fq_() {
-                    DataType fy_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object fz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fy_);
-                    bool ga_ = fz_ is CqlQuantity;
-                    return ga_;
+                if (fm_())
+                {
+                    DataType gc_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object gd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gc_);
+                    return (gd_ as CqlDateTime) as object;
                 }
-
-
-                bool fr_() {
-                    DataType gb_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object gc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gb_);
-                    bool gd_ = gc_ is CqlInterval<CqlQuantity>;
-                    return gd_;
-                }
-
-                if (fo_())
+                else if (fn_())
                 {
                     DataType ge_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object gf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ge_);
-                    return (gf_ as CqlDateTime) as object;
+                    return (gf_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (fp_())
+                else if (fo_())
                 {
                     DataType gg_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object gh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gg_);
-                    return (gh_ as CqlInterval<CqlDateTime>) as object;
+                    return (gh_ as CqlQuantity) as object;
                 }
-                else if (fq_())
+                else if (fp_())
                 {
                     DataType gi_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object gj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gi_);
-                    return (gj_ as CqlQuantity) as object;
-                }
-                else if (fr_())
-                {
-                    DataType gk_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object gl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gk_);
-                    return (gl_ as CqlInterval<CqlQuantity>) as object;
+                    return (gj_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2160,68 +2152,68 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 };
             }
 
-            CqlInterval<CqlDateTime> ds_ = QICoreCommon_4_0_000.Instance.toInterval(context, dr_());
-            CqlDateTime dt_ = context.Operators.End(ds_);
-            CqlInterval<CqlDate> du_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dt_);
-            CqlDate dv_ = du_?.low;
-            CqlDateTime dw_ = context.Operators.ConvertDateToDateTime(dv_);
+            CqlInterval<CqlDateTime> dq_ = QICoreCommon_4_0_000.Instance.toInterval(context, dp_());
+            CqlDateTime dr_ = context.Operators.End(dq_);
+            CqlInterval<CqlDate> ds_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dr_);
+            CqlDate dt_ = ds_?.low;
+            CqlDateTime du_ = context.Operators.ConvertDateToDateTime(dt_);
 
-            object dx_() {
+            object dv_() {
+
+                bool gk_() {
+                    DataType go_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object gp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, go_);
+                    bool gq_ = gp_ is CqlDateTime;
+                    return gq_;
+                }
+
+
+                bool gl_() {
+                    DataType gr_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object gs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gr_);
+                    bool gt_ = gs_ is CqlInterval<CqlDateTime>;
+                    return gt_;
+                }
+
 
                 bool gm_() {
-                    DataType gq_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object gr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gq_);
-                    bool gs_ = gr_ is CqlDateTime;
-                    return gs_;
+                    DataType gu_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object gv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gu_);
+                    bool gw_ = gv_ is CqlQuantity;
+                    return gw_;
                 }
 
 
                 bool gn_() {
-                    DataType gt_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object gu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gt_);
-                    bool gv_ = gu_ is CqlInterval<CqlDateTime>;
-                    return gv_;
+                    DataType gx_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object gy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gx_);
+                    bool gz_ = gy_ is CqlInterval<CqlQuantity>;
+                    return gz_;
                 }
 
-
-                bool go_() {
-                    DataType gw_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object gx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gw_);
-                    bool gy_ = gx_ is CqlQuantity;
-                    return gy_;
+                if (gk_())
+                {
+                    DataType ha_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object hb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ha_);
+                    return (hb_ as CqlDateTime) as object;
                 }
-
-
-                bool gp_() {
-                    DataType gz_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object ha_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gz_);
-                    bool hb_ = ha_ is CqlInterval<CqlQuantity>;
-                    return hb_;
-                }
-
-                if (gm_())
+                else if (gl_())
                 {
                     DataType hc_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object hd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hc_);
-                    return (hd_ as CqlDateTime) as object;
+                    return (hd_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (gn_())
+                else if (gm_())
                 {
                     DataType he_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object hf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, he_);
-                    return (hf_ as CqlInterval<CqlDateTime>) as object;
+                    return (hf_ as CqlQuantity) as object;
                 }
-                else if (go_())
+                else if (gn_())
                 {
                     DataType hg_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object hh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hg_);
-                    return (hh_ as CqlQuantity) as object;
-                }
-                else if (gp_())
-                {
-                    DataType hi_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object hj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hi_);
-                    return (hj_ as CqlInterval<CqlQuantity>) as object;
+                    return (hh_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2229,68 +2221,68 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 };
             }
 
-            CqlInterval<CqlDateTime> dy_ = QICoreCommon_4_0_000.Instance.toInterval(context, dx_());
-            CqlDateTime dz_ = context.Operators.End(dy_);
-            CqlInterval<CqlDate> ea_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dz_);
-            CqlDate eb_ = ea_?.high;
-            CqlDateTime ec_ = context.Operators.ConvertDateToDateTime(eb_);
+            CqlInterval<CqlDateTime> dw_ = QICoreCommon_4_0_000.Instance.toInterval(context, dv_());
+            CqlDateTime dx_ = context.Operators.End(dw_);
+            CqlInterval<CqlDate> dy_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dx_);
+            CqlDate dz_ = dy_?.high;
+            CqlDateTime ea_ = context.Operators.ConvertDateToDateTime(dz_);
 
-            object ed_() {
+            object eb_() {
+
+                bool hi_() {
+                    DataType hm_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object hn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hm_);
+                    bool ho_ = hn_ is CqlDateTime;
+                    return ho_;
+                }
+
+
+                bool hj_() {
+                    DataType hp_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object hq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hp_);
+                    bool hr_ = hq_ is CqlInterval<CqlDateTime>;
+                    return hr_;
+                }
+
 
                 bool hk_() {
-                    DataType ho_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object hp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ho_);
-                    bool hq_ = hp_ is CqlDateTime;
-                    return hq_;
+                    DataType hs_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object ht_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hs_);
+                    bool hu_ = ht_ is CqlQuantity;
+                    return hu_;
                 }
 
 
                 bool hl_() {
-                    DataType hr_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object hs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hr_);
-                    bool ht_ = hs_ is CqlInterval<CqlDateTime>;
-                    return ht_;
+                    DataType hv_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object hw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hv_);
+                    bool hx_ = hw_ is CqlInterval<CqlQuantity>;
+                    return hx_;
                 }
 
-
-                bool hm_() {
-                    DataType hu_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object hv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hu_);
-                    bool hw_ = hv_ is CqlQuantity;
-                    return hw_;
+                if (hi_())
+                {
+                    DataType hy_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object hz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hy_);
+                    return (hz_ as CqlDateTime) as object;
                 }
-
-
-                bool hn_() {
-                    DataType hx_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object hy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hx_);
-                    bool hz_ = hy_ is CqlInterval<CqlQuantity>;
-                    return hz_;
-                }
-
-                if (hk_())
+                else if (hj_())
                 {
                     DataType ia_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object ib_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ia_);
-                    return (ib_ as CqlDateTime) as object;
+                    return (ib_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (hl_())
+                else if (hk_())
                 {
                     DataType ic_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object id_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ic_);
-                    return (id_ as CqlInterval<CqlDateTime>) as object;
+                    return (id_ as CqlQuantity) as object;
                 }
-                else if (hm_())
+                else if (hl_())
                 {
                     DataType ie_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object if_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ie_);
-                    return (if_ as CqlQuantity) as object;
-                }
-                else if (hn_())
-                {
-                    DataType ig_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object ih_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ig_);
-                    return (ih_ as CqlInterval<CqlQuantity>) as object;
+                    return (if_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2298,67 +2290,67 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 };
             }
 
-            CqlInterval<CqlDateTime> ee_ = QICoreCommon_4_0_000.Instance.toInterval(context, ed_());
-            CqlDateTime ef_ = context.Operators.End(ee_);
-            CqlInterval<CqlDate> eg_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ef_);
-            bool? eh_ = eg_?.lowClosed;
+            CqlInterval<CqlDateTime> ec_ = QICoreCommon_4_0_000.Instance.toInterval(context, eb_());
+            CqlDateTime ed_ = context.Operators.End(ec_);
+            CqlInterval<CqlDate> ee_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ed_);
+            bool? ef_ = ee_?.lowClosed;
 
-            object ei_() {
+            object eg_() {
+
+                bool ig_() {
+                    DataType ik_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object il_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ik_);
+                    bool im_ = il_ is CqlDateTime;
+                    return im_;
+                }
+
+
+                bool ih_() {
+                    DataType in_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object io_ = FHIRHelpers_4_4_000.Instance.ToValue(context, in_);
+                    bool ip_ = io_ is CqlInterval<CqlDateTime>;
+                    return ip_;
+                }
+
 
                 bool ii_() {
-                    DataType im_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object in_ = FHIRHelpers_4_4_000.Instance.ToValue(context, im_);
-                    bool io_ = in_ is CqlDateTime;
-                    return io_;
+                    DataType iq_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object ir_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iq_);
+                    bool is_ = ir_ is CqlQuantity;
+                    return is_;
                 }
 
 
                 bool ij_() {
-                    DataType ip_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object iq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ip_);
-                    bool ir_ = iq_ is CqlInterval<CqlDateTime>;
-                    return ir_;
+                    DataType it_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object iu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, it_);
+                    bool iv_ = iu_ is CqlInterval<CqlQuantity>;
+                    return iv_;
                 }
 
-
-                bool ik_() {
-                    DataType is_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object it_ = FHIRHelpers_4_4_000.Instance.ToValue(context, is_);
-                    bool iu_ = it_ is CqlQuantity;
-                    return iu_;
+                if (ig_())
+                {
+                    DataType iw_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+                    object ix_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iw_);
+                    return (ix_ as CqlDateTime) as object;
                 }
-
-
-                bool il_() {
-                    DataType iv_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object iw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iv_);
-                    bool ix_ = iw_ is CqlInterval<CqlQuantity>;
-                    return ix_;
-                }
-
-                if (ii_())
+                else if (ih_())
                 {
                     DataType iy_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object iz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iy_);
-                    return (iz_ as CqlDateTime) as object;
+                    return (iz_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (ij_())
+                else if (ii_())
                 {
                     DataType ja_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object jb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ja_);
-                    return (jb_ as CqlInterval<CqlDateTime>) as object;
+                    return (jb_ as CqlQuantity) as object;
                 }
-                else if (ik_())
+                else if (ij_())
                 {
                     DataType jc_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
                     object jd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jc_);
-                    return (jd_ as CqlQuantity) as object;
-                }
-                else if (il_())
-                {
-                    DataType je_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                    object jf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, je_);
-                    return (jf_ as CqlInterval<CqlQuantity>) as object;
+                    return (jd_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2366,14 +2358,14 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 };
             }
 
-            CqlInterval<CqlDateTime> ej_ = QICoreCommon_4_0_000.Instance.toInterval(context, ei_());
-            CqlDateTime ek_ = context.Operators.End(ej_);
-            CqlInterval<CqlDate> el_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ek_);
-            bool? em_ = el_?.highClosed;
-            CqlInterval<CqlDateTime> en_ = context.Operators.Interval(dw_, ec_, eh_, em_);
-            bool? eo_ = context.Operators.In<CqlDateTime>(dq_, en_, "day");
-            bool? ep_ = context.Operators.And(dm_, eo_);
-            return ep_;
+            CqlInterval<CqlDateTime> eh_ = QICoreCommon_4_0_000.Instance.toInterval(context, eg_());
+            CqlDateTime ei_ = context.Operators.End(eh_);
+            CqlInterval<CqlDate> ej_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ei_);
+            bool? ek_ = ej_?.highClosed;
+            CqlInterval<CqlDateTime> el_ = context.Operators.Interval(du_, ea_, ef_, ek_);
+            bool? em_ = context.Operators.In<CqlDateTime>(do_, el_, "day");
+            bool? en_ = context.Operators.And(dk_, em_);
+            return en_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?> ac_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?>(aa_, ab_);
@@ -2395,132 +2387,130 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
     {
         IEnumerable<Encounter> a_ = VTE_8_18_000.Instance.Encounter_With_Age_Range_And_Without_VTE_Diagnosis_Or_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet l_ = this.Atrial_Fibrillation_or_Flutter(context);
             IEnumerable<Condition> m_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? n_(Condition AtrialFibrillation) {
-                CodeableConcept r_ = AtrialFibrillation?.VerificationStatus;
-                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                bool? t_ = context.Operators.Not((bool?)(s_ is null));
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                CqlCode w_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
-                bool? y_ = context.Operators.Equivalent(v_, x_);
-                bool? z_ = context.Operators.Not(y_);
-                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                CqlCode ac_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
-                bool? ae_ = context.Operators.Equivalent(ab_, ad_);
-                bool? af_ = context.Operators.Not(ae_);
-                bool? ag_ = context.Operators.And(z_, af_);
-                DataType ah_ = AtrialFibrillation?.Onset;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                CqlDateTime ak_ = context.Operators.Start(aj_);
-                Period al_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                CqlDateTime an_ = context.Operators.End(am_);
-                bool? ao_ = context.Operators.SameOrBefore(ak_, an_, (string)default);
-                bool? ap_ = context.Operators.And(ag_, ao_);
-                bool? aq_ = context.Operators.Implies(t_, ap_);
-                return aq_;
+                CodeableConcept q_ = AtrialFibrillation?.VerificationStatus;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                bool? s_ = context.Operators.Not((bool?)(r_ is null));
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlCode v_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
+                bool? x_ = context.Operators.Equivalent(u_, w_);
+                bool? y_ = context.Operators.Not(x_);
+                CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlCode ab_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
+                bool? ad_ = context.Operators.Equivalent(aa_, ac_);
+                bool? ae_ = context.Operators.Not(ad_);
+                bool? af_ = context.Operators.And(y_, ae_);
+                DataType ag_ = AtrialFibrillation?.Onset;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
+                CqlDateTime aj_ = context.Operators.Start(ai_);
+                Period ak_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
+                CqlDateTime am_ = context.Operators.End(al_);
+                bool? an_ = context.Operators.SameOrBefore(aj_, am_, (string)default);
+                bool? ao_ = context.Operators.And(af_, an_);
+                bool? ap_ = context.Operators.Implies(s_, ao_);
+                return ap_;
             }
 
             IEnumerable<Condition> o_ = context.Operators.Where<Condition>(m_, n_);
-            Encounter p_(Condition AtrialFibrillation) => QualifyingEncounter;
-            IEnumerable<Encounter> q_ = context.Operators.Select<Condition, Encounter>(o_, p_);
-            return q_;
+            bool? p_ = context.Operators.Exists<Condition>(o_);
+            return p_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? e_(Encounter QualifyingEncounter) {
-            CqlValueSet ar_ = this.Atrial_Fibrillation_or_Flutter(context);
-            bool? as_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounter, ar_);
-            return as_;
+            CqlValueSet aq_ = this.Atrial_Fibrillation_or_Flutter(context);
+            bool? ar_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounter, aq_);
+            return ar_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
         IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 
-        IEnumerable<Encounter> i_(Encounter QualifyingEncounter) {
-            CqlValueSet at_ = this.Venous_Thromboembolism(context);
-            IEnumerable<Condition> au_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, at_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? i_(Encounter QualifyingEncounter) {
+            CqlValueSet as_ = this.Venous_Thromboembolism(context);
+            IEnumerable<Condition> at_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, as_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            bool? av_(Condition VTEDiagnosis) {
-                CodeableConcept az_ = VTEDiagnosis?.ClinicalStatus;
-                CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                CqlCode bb_ = QICoreCommon_4_0_000.Instance.inactive(context);
-                CqlConcept bc_ = context.Operators.ConvertCodeToConcept(bb_);
-                bool? bd_ = context.Operators.Equivalent(ba_, bc_);
-                CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                CqlCode bg_ = QICoreCommon_4_0_000.Instance.remission(context);
-                CqlConcept bh_ = context.Operators.ConvertCodeToConcept(bg_);
-                bool? bi_ = context.Operators.Equivalent(bf_, bh_);
-                bool? bj_ = context.Operators.Or(bd_, bi_);
-                CqlConcept bl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                CqlCode bm_ = QICoreCommon_4_0_000.Instance.resolved(context);
-                CqlConcept bn_ = context.Operators.ConvertCodeToConcept(bm_);
-                bool? bo_ = context.Operators.Equivalent(bl_, bn_);
-                bool? bp_ = context.Operators.Or(bj_, bo_);
-                CodeableConcept bq_ = VTEDiagnosis?.VerificationStatus;
-                CqlConcept br_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
-                bool? bs_ = context.Operators.Not((bool?)(br_ is null));
-                bool? bt_ = context.Operators.And(bp_, bs_);
-                CqlConcept bv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
-                CqlCode bw_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept bx_ = context.Operators.ConvertCodeToConcept(bw_);
-                bool? by_ = context.Operators.Equivalent(bv_, bx_);
-                bool? bz_ = context.Operators.Not(by_);
-                CqlConcept cb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
-                CqlCode cc_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept cd_ = context.Operators.ConvertCodeToConcept(cc_);
-                bool? ce_ = context.Operators.Equivalent(cb_, cd_);
-                bool? cf_ = context.Operators.Not(ce_);
-                bool? cg_ = context.Operators.And(bz_, cf_);
-                DataType ch_ = VTEDiagnosis?.Onset;
-                object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                CqlInterval<CqlDateTime> cj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ci_);
+            bool? au_(Condition VTEDiagnosis) {
+                CodeableConcept ax_ = VTEDiagnosis?.ClinicalStatus;
+                CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                CqlCode az_ = QICoreCommon_4_0_000.Instance.inactive(context);
+                CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
+                bool? bb_ = context.Operators.Equivalent(ay_, ba_);
+                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                CqlCode be_ = QICoreCommon_4_0_000.Instance.remission(context);
+                CqlConcept bf_ = context.Operators.ConvertCodeToConcept(be_);
+                bool? bg_ = context.Operators.Equivalent(bd_, bf_);
+                bool? bh_ = context.Operators.Or(bb_, bg_);
+                CqlConcept bj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                CqlCode bk_ = QICoreCommon_4_0_000.Instance.resolved(context);
+                CqlConcept bl_ = context.Operators.ConvertCodeToConcept(bk_);
+                bool? bm_ = context.Operators.Equivalent(bj_, bl_);
+                bool? bn_ = context.Operators.Or(bh_, bm_);
+                CodeableConcept bo_ = VTEDiagnosis?.VerificationStatus;
+                CqlConcept bp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
+                bool? bq_ = context.Operators.Not((bool?)(bp_ is null));
+                bool? br_ = context.Operators.And(bn_, bq_);
+                CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
+                CqlCode bu_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept bv_ = context.Operators.ConvertCodeToConcept(bu_);
+                bool? bw_ = context.Operators.Equivalent(bt_, bv_);
+                bool? bx_ = context.Operators.Not(bw_);
+                CqlConcept bz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
+                CqlCode ca_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept cb_ = context.Operators.ConvertCodeToConcept(ca_);
+                bool? cc_ = context.Operators.Equivalent(bz_, cb_);
+                bool? cd_ = context.Operators.Not(cc_);
+                bool? ce_ = context.Operators.And(bx_, cd_);
+                DataType cf_ = VTEDiagnosis?.Onset;
+                object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                CqlInterval<CqlDateTime> ch_ = QICoreCommon_4_0_000.Instance.toInterval(context, cg_);
 
-                CqlInterval<CqlDateTime> ck_() {
+                CqlInterval<CqlDateTime> ci_() {
 
-                    bool co_() {
-                        Period cp_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
-                        CqlDateTime cr_ = context.Operators.Start(cq_);
-                        return cr_ is null;
+                    bool cm_() {
+                        Period cn_ = QualifyingEncounter?.Period;
+                        CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cn_);
+                        CqlDateTime cp_ = context.Operators.Start(co_);
+                        return cp_ is null;
                     }
 
-                    if (co_())
+                    if (cm_())
                     {
                         return default;
                     }
                     else
                     {
-                        Period cs_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cs_);
-                        CqlDateTime cu_ = context.Operators.Start(ct_);
-                        CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cs_);
-                        CqlDateTime cx_ = context.Operators.Start(cw_);
-                        CqlInterval<CqlDateTime> cy_ = context.Operators.Interval(cu_, cx_, true, true);
-                        return cy_;
+                        Period cq_ = QualifyingEncounter?.Period;
+                        CqlInterval<CqlDateTime> cr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
+                        CqlDateTime cs_ = context.Operators.Start(cr_);
+                        CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
+                        CqlDateTime cv_ = context.Operators.Start(cu_);
+                        CqlInterval<CqlDateTime> cw_ = context.Operators.Interval(cs_, cv_, true, true);
+                        return cw_;
                     };
                 }
 
-                bool? cl_ = context.Operators.Before(cj_, ck_(), (string)default);
-                bool? cm_ = context.Operators.And(cg_, cl_);
-                bool? cn_ = context.Operators.Implies(bt_, cm_);
-                return cn_;
+                bool? cj_ = context.Operators.Before(ch_, ci_(), (string)default);
+                bool? ck_ = context.Operators.And(ce_, cj_);
+                bool? cl_ = context.Operators.Implies(br_, ck_);
+                return cl_;
             }
 
-            IEnumerable<Condition> aw_ = context.Operators.Where<Condition>(au_, av_);
-            Encounter ax_(Condition VTEDiagnosis) => QualifyingEncounter;
-            IEnumerable<Encounter> ay_ = context.Operators.Select<Condition, Encounter>(aw_, ax_);
-            return ay_;
+            IEnumerable<Condition> av_ = context.Operators.Where<Condition>(at_, au_);
+            bool? aw_ = context.Operators.Exists<Condition>(av_);
+            return aw_;
         }
 
-        IEnumerable<Encounter> j_ = context.Operators.SelectMany<Encounter, Encounter>(a_, i_);
+        IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(a_, i_);
         IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
         return k_;
     }
@@ -2536,7 +2526,7 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
     {
         IEnumerable<Encounter> a_ = VTE_8_18_000.Instance.Encounter_With_Age_Range_And_Without_VTE_Diagnosis_Or_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Hip_Replacement_Surgery(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
             CqlValueSet f_ = this.Knee_Replacement_Surgery(context);
@@ -2544,67 +2534,67 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 
             bool? i_(Procedure HipKneeProcedure) {
-                Code<EventStatus> m_ = HipKneeProcedure?.StatusElement;
-                EventStatus? n_ = m_?.Value;
-                string o_ = context.Operators.Convert<string>(n_);
-                bool? p_ = context.Operators.Equal(o_, "completed");
+                Code<EventStatus> l_ = HipKneeProcedure?.StatusElement;
+                EventStatus? m_ = l_?.Value;
+                string n_ = context.Operators.Convert<string>(m_);
+                bool? o_ = context.Operators.Equal(n_, "completed");
 
-                object q_() {
+                object p_() {
+
+                    bool x_() {
+                        DataType ab_ = HipKneeProcedure?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlDateTime;
+                        return ad_;
+                    }
+
 
                     bool y_() {
-                        DataType ac_ = HipKneeProcedure?.Performed;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlDateTime;
-                        return ae_;
+                        DataType ae_ = HipKneeProcedure?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlDateTime>;
+                        return ag_;
                     }
 
 
                     bool z_() {
-                        DataType af_ = HipKneeProcedure?.Performed;
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlInterval<CqlDateTime>;
-                        return ah_;
+                        DataType ah_ = HipKneeProcedure?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        bool aj_ = ai_ is CqlQuantity;
+                        return aj_;
                     }
 
 
                     bool aa_() {
-                        DataType ai_ = HipKneeProcedure?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        bool ak_ = aj_ is CqlQuantity;
-                        return ak_;
+                        DataType ak_ = HipKneeProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        bool am_ = al_ is CqlInterval<CqlQuantity>;
+                        return am_;
                     }
 
-
-                    bool ab_() {
-                        DataType al_ = HipKneeProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        bool an_ = am_ is CqlInterval<CqlQuantity>;
-                        return an_;
-                    }
-
-                    if (y_())
+                    if (x_())
                     {
-                        DataType ao_ = HipKneeProcedure?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlDateTime) as object;
+                        DataType an_ = HipKneeProcedure?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlDateTime) as object;
+                    }
+                    else if (y_())
+                    {
+                        DataType ap_ = HipKneeProcedure?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        return (aq_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (z_())
                     {
-                        DataType aq_ = HipKneeProcedure?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        return (ar_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ar_ = HipKneeProcedure?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        return (as_ as CqlQuantity) as object;
                     }
                     else if (aa_())
                     {
-                        DataType as_ = HipKneeProcedure?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        return (at_ as CqlQuantity) as object;
-                    }
-                    else if (ab_())
-                    {
-                        DataType au_ = HipKneeProcedure?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        return (av_ as CqlInterval<CqlQuantity>) as object;
+                        DataType at_ = HipKneeProcedure?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        return (au_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2612,23 +2602,22 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                CqlDateTime s_ = context.Operators.Start(r_);
-                Period t_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                CqlDateTime v_ = context.Operators.End(u_);
-                bool? w_ = context.Operators.SameOrBefore(s_, v_, (string)default);
-                bool? x_ = context.Operators.And(p_, w_);
-                return x_;
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                CqlDateTime r_ = context.Operators.Start(q_);
+                Period s_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
+                CqlDateTime u_ = context.Operators.End(t_);
+                bool? v_ = context.Operators.SameOrBefore(r_, u_, (string)default);
+                bool? w_ = context.Operators.And(o_, v_);
+                return w_;
             }
 
             IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
-            Encounter k_(Procedure HipKneeProcedure) => QualifyingEncounter;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Procedure, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Procedure>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -2765,120 +2754,117 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         IEnumerable<MedicationAdministration> r_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, q_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> s_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> t_(MedicationAdministration MR) {
+        bool? t_(MedicationAdministration MR) {
             IEnumerable<Medication> cp_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? cq_(Medication M) {
-                object cu_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object cv_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> cw_ = context.Operators.Split((string)cv_, "/");
-                string cx_ = context.Operators.Last<string>(cw_);
-                bool? cy_ = context.Operators.Equal(cu_, cx_);
-                CodeableConcept cz_ = M?.Code;
-                CqlConcept da_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cz_);
-                CqlValueSet db_ = this.Unfractionated_Heparin(context);
-                bool? dc_ = context.Operators.ConceptInValueSet(da_, db_);
-                bool? dd_ = context.Operators.And(cy_, dc_);
-                return dd_;
+                object ct_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cu_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> cv_ = context.Operators.Split((string)cu_, "/");
+                string cw_ = context.Operators.Last<string>(cv_);
+                bool? cx_ = context.Operators.Equal(ct_, cw_);
+                CodeableConcept cy_ = M?.Code;
+                CqlConcept cz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cy_);
+                CqlValueSet da_ = this.Unfractionated_Heparin(context);
+                bool? db_ = context.Operators.ConceptInValueSet(cz_, da_);
+                bool? dc_ = context.Operators.And(cx_, db_);
+                return dc_;
             }
 
             IEnumerable<Medication> cr_ = context.Operators.Where<Medication>(cp_, cq_);
-            MedicationAdministration cs_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> ct_ = context.Operators.Select<Medication, MedicationAdministration>(cr_, cs_);
-            return ct_;
+            bool? cs_ = context.Operators.Exists<Medication>(cr_);
+            return cs_;
         }
 
-        IEnumerable<MedicationAdministration> u_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(s_, t_);
+        IEnumerable<MedicationAdministration> u_ = context.Operators.Where<MedicationAdministration>(s_, t_);
         IEnumerable<MedicationAdministration> v_ = context.Operators.Union<MedicationAdministration>(r_, u_);
 
         bool? w_(MedicationAdministration UnfractionatedHeparin) {
-            MedicationAdministration.DosageComponent de_ = UnfractionatedHeparin?.Dosage;
-            CodeableConcept df_ = de_?.Route;
-            CqlConcept dg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, df_);
-            CqlValueSet dh_ = this.Intravenous_route(context);
-            bool? di_ = context.Operators.ConceptInValueSet(dg_, dh_);
-            return di_;
+            MedicationAdministration.DosageComponent dd_ = UnfractionatedHeparin?.Dosage;
+            CodeableConcept de_ = dd_?.Route;
+            CqlConcept df_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, de_);
+            CqlValueSet dg_ = this.Intravenous_route(context);
+            bool? dh_ = context.Operators.ConceptInValueSet(df_, dg_);
+            return dh_;
         }
 
         IEnumerable<MedicationAdministration> x_ = context.Operators.Where<MedicationAdministration>(v_, w_);
         CqlValueSet y_ = this.Direct_Thrombin_Inhibitor(context);
         IEnumerable<MedicationAdministration> z_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> ab_(MedicationAdministration MR) {
-            IEnumerable<Medication> dj_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ab_(MedicationAdministration MR) {
+            IEnumerable<Medication> di_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? dk_(Medication M) {
-                object do_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object dp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> dq_ = context.Operators.Split((string)dp_, "/");
-                string dr_ = context.Operators.Last<string>(dq_);
-                bool? ds_ = context.Operators.Equal(do_, dr_);
-                CodeableConcept dt_ = M?.Code;
-                CqlConcept du_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dt_);
-                CqlValueSet dv_ = this.Direct_Thrombin_Inhibitor(context);
-                bool? dw_ = context.Operators.ConceptInValueSet(du_, dv_);
-                bool? dx_ = context.Operators.And(ds_, dw_);
-                return dx_;
+            bool? dj_(Medication M) {
+                object dm_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object dn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> do_ = context.Operators.Split((string)dn_, "/");
+                string dp_ = context.Operators.Last<string>(do_);
+                bool? dq_ = context.Operators.Equal(dm_, dp_);
+                CodeableConcept dr_ = M?.Code;
+                CqlConcept ds_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dr_);
+                CqlValueSet dt_ = this.Direct_Thrombin_Inhibitor(context);
+                bool? du_ = context.Operators.ConceptInValueSet(ds_, dt_);
+                bool? dv_ = context.Operators.And(dq_, du_);
+                return dv_;
             }
 
-            IEnumerable<Medication> dl_ = context.Operators.Where<Medication>(dj_, dk_);
-            MedicationAdministration dm_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> dn_ = context.Operators.Select<Medication, MedicationAdministration>(dl_, dm_);
-            return dn_;
+            IEnumerable<Medication> dk_ = context.Operators.Where<Medication>(di_, dj_);
+            bool? dl_ = context.Operators.Exists<Medication>(dk_);
+            return dl_;
         }
 
-        IEnumerable<MedicationAdministration> ac_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(s_, ab_);
+        IEnumerable<MedicationAdministration> ac_ = context.Operators.Where<MedicationAdministration>(s_, ab_);
         IEnumerable<MedicationAdministration> ad_ = context.Operators.Union<MedicationAdministration>(z_, ac_);
         IEnumerable<MedicationAdministration> ae_ = context.Operators.Union<MedicationAdministration>(x_, ad_);
         CqlValueSet af_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
         IEnumerable<MedicationAdministration> ag_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, af_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> ai_(MedicationAdministration MR) {
-            IEnumerable<Medication> dy_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ai_(MedicationAdministration MR) {
+            IEnumerable<Medication> dw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? dz_(Medication M) {
-                object ed_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ee_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ef_ = context.Operators.Split((string)ee_, "/");
-                string eg_ = context.Operators.Last<string>(ef_);
-                bool? eh_ = context.Operators.Equal(ed_, eg_);
-                CodeableConcept ei_ = M?.Code;
-                CqlConcept ej_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ei_);
-                CqlValueSet ek_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
-                bool? el_ = context.Operators.ConceptInValueSet(ej_, ek_);
-                bool? em_ = context.Operators.And(eh_, el_);
-                return em_;
+            bool? dx_(Medication M) {
+                object ea_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object eb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ec_ = context.Operators.Split((string)eb_, "/");
+                string ed_ = context.Operators.Last<string>(ec_);
+                bool? ee_ = context.Operators.Equal(ea_, ed_);
+                CodeableConcept ef_ = M?.Code;
+                CqlConcept eg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ef_);
+                CqlValueSet eh_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
+                bool? ei_ = context.Operators.ConceptInValueSet(eg_, eh_);
+                bool? ej_ = context.Operators.And(ee_, ei_);
+                return ej_;
             }
 
-            IEnumerable<Medication> ea_ = context.Operators.Where<Medication>(dy_, dz_);
-            MedicationAdministration eb_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> ec_ = context.Operators.Select<Medication, MedicationAdministration>(ea_, eb_);
-            return ec_;
+            IEnumerable<Medication> dy_ = context.Operators.Where<Medication>(dw_, dx_);
+            bool? dz_ = context.Operators.Exists<Medication>(dy_);
+            return dz_;
         }
 
-        IEnumerable<MedicationAdministration> aj_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(s_, ai_);
+        IEnumerable<MedicationAdministration> aj_ = context.Operators.Where<MedicationAdministration>(s_, ai_);
         IEnumerable<MedicationAdministration> ak_ = context.Operators.Union<MedicationAdministration>(ag_, aj_);
         IEnumerable<MedicationAdministration> al_ = context.Operators.Union<MedicationAdministration>(ae_, ak_);
 
         bool? am_(MedicationAdministration AnticoagulantMedication) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> en_ = AnticoagulantMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? eo_ = en_?.Value;
-            string ep_ = context.Operators.Convert<string>(eo_);
-            bool? eq_ = context.Operators.Equal(ep_, "completed");
-            return eq_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ek_ = AnticoagulantMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? el_ = ek_?.Value;
+            string em_ = context.Operators.Convert<string>(el_);
+            bool? en_ = context.Operators.Equal(em_, "completed");
+            return en_;
         }
 
         IEnumerable<MedicationAdministration> an_ = context.Operators.Where<MedicationAdministration>(al_, am_);
 
         (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? ao_(MedicationAdministration AnticoagulantMedication) {
-            Id er_ = AnticoagulantMedication?.IdElement;
-            string es_ = er_?.Value;
-            DataType et_ = AnticoagulantMedication?.Effective;
-            object eu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, et_);
-            CqlInterval<CqlDateTime> ev_ = QICoreCommon_4_0_000.Instance.toInterval(context, eu_);
-            CqlDateTime ew_ = context.Operators.Start(ev_);
-            (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? ex_ = (CqlTupleMetadata_DMAfXNhTfZDWOGdfEceXbfaSJ, es_, ew_);
-            return ex_;
+            Id eo_ = AnticoagulantMedication?.IdElement;
+            string ep_ = eo_?.Value;
+            DataType eq_ = AnticoagulantMedication?.Effective;
+            object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+            CqlInterval<CqlDateTime> es_ = QICoreCommon_4_0_000.Instance.toInterval(context, er_);
+            CqlDateTime et_ = context.Operators.Start(es_);
+            (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? eu_ = (CqlTupleMetadata_DMAfXNhTfZDWOGdfEceXbfaSJ, ep_, et_);
+            return eu_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?> ap_ = context.Operators.Select<MedicationAdministration, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>(an_, ao_);
@@ -2898,30 +2884,29 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
     {
         IEnumerable<Encounter> a_ = VTE_8_18_000.Instance.Encounter_With_Age_Range_And_Without_VTE_Diagnosis_Or_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             IEnumerable<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?> d_ = this.Low_Risk_Indicator_For_VTE(context);
 
             bool? e_((CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE) {
-                CqlDateTime i_ = LowRiskForVTE?.LowRiskDatetime;
-                CqlInterval<CqlDate> j_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
-                CqlDate k_ = j_?.low;
-                CqlDateTime l_ = context.Operators.ConvertDateToDateTime(k_);
-                CqlDate n_ = j_?.high;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                bool? q_ = j_?.lowClosed;
-                bool? s_ = j_?.highClosed;
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(l_, o_, q_, s_);
-                bool? u_ = context.Operators.In<CqlDateTime>(i_, t_, "day");
-                return u_;
+                CqlDateTime h_ = LowRiskForVTE?.LowRiskDatetime;
+                CqlInterval<CqlDate> i_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
+                CqlDate j_ = i_?.low;
+                CqlDateTime k_ = context.Operators.ConvertDateToDateTime(j_);
+                CqlDate m_ = i_?.high;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                bool? p_ = i_?.lowClosed;
+                bool? r_ = i_?.highClosed;
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(k_, n_, p_, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(h_, s_, "day");
+                return t_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE) => QualifyingEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -3470,184 +3455,179 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         IEnumerable<MedicationRequest> bs_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> bt_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> bu_(MedicationRequest MR) {
+        bool? bu_(MedicationRequest MR) {
             IEnumerable<Medication> eu_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? ev_(Medication M) {
-                object ez_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object fa_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fb_ = context.Operators.Split((string)fa_, "/");
-                string fc_ = context.Operators.Last<string>(fb_);
-                bool? fd_ = context.Operators.Equal(ez_, fc_);
-                CodeableConcept fe_ = M?.Code;
-                CqlConcept ff_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fe_);
-                CqlValueSet fg_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                bool? fh_ = context.Operators.ConceptInValueSet(ff_, fg_);
-                bool? fi_ = context.Operators.And(fd_, fh_);
-                return fi_;
+                object ey_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ez_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fa_ = context.Operators.Split((string)ez_, "/");
+                string fb_ = context.Operators.Last<string>(fa_);
+                bool? fc_ = context.Operators.Equal(ey_, fb_);
+                CodeableConcept fd_ = M?.Code;
+                CqlConcept fe_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fd_);
+                CqlValueSet ff_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                bool? fg_ = context.Operators.ConceptInValueSet(fe_, ff_);
+                bool? fh_ = context.Operators.And(fc_, fg_);
+                return fh_;
             }
 
             IEnumerable<Medication> ew_ = context.Operators.Where<Medication>(eu_, ev_);
-            MedicationRequest ex_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ey_ = context.Operators.Select<Medication, MedicationRequest>(ew_, ex_);
-            return ey_;
+            bool? ex_ = context.Operators.Exists<Medication>(ew_);
+            return ex_;
         }
 
-        IEnumerable<MedicationRequest> bv_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, bu_);
+        IEnumerable<MedicationRequest> bv_ = context.Operators.Where<MedicationRequest>(bt_, bu_);
         IEnumerable<MedicationRequest> bw_ = context.Operators.Union<MedicationRequest>(bs_, bv_);
         IEnumerable<MedicationRequest> by_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ca_(MedicationRequest MR) {
-            IEnumerable<Medication> fj_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ca_(MedicationRequest MR) {
+            IEnumerable<Medication> fi_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? fk_(Medication M) {
-                object fo_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object fp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fq_ = context.Operators.Split((string)fp_, "/");
-                string fr_ = context.Operators.Last<string>(fq_);
-                bool? fs_ = context.Operators.Equal(fo_, fr_);
-                CodeableConcept ft_ = M?.Code;
-                CqlConcept fu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ft_);
-                CqlValueSet fv_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                bool? fw_ = context.Operators.ConceptInValueSet(fu_, fv_);
-                bool? fx_ = context.Operators.And(fs_, fw_);
-                return fx_;
+            bool? fj_(Medication M) {
+                object fm_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object fn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fo_ = context.Operators.Split((string)fn_, "/");
+                string fp_ = context.Operators.Last<string>(fo_);
+                bool? fq_ = context.Operators.Equal(fm_, fp_);
+                CodeableConcept fr_ = M?.Code;
+                CqlConcept fs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fr_);
+                CqlValueSet ft_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                bool? fu_ = context.Operators.ConceptInValueSet(fs_, ft_);
+                bool? fv_ = context.Operators.And(fq_, fu_);
+                return fv_;
             }
 
-            IEnumerable<Medication> fl_ = context.Operators.Where<Medication>(fj_, fk_);
-            MedicationRequest fm_(Medication M) => MR;
-            IEnumerable<MedicationRequest> fn_ = context.Operators.Select<Medication, MedicationRequest>(fl_, fm_);
-            return fn_;
+            IEnumerable<Medication> fk_ = context.Operators.Where<Medication>(fi_, fj_);
+            bool? fl_ = context.Operators.Exists<Medication>(fk_);
+            return fl_;
         }
 
-        IEnumerable<MedicationRequest> cb_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, ca_);
+        IEnumerable<MedicationRequest> cb_ = context.Operators.Where<MedicationRequest>(bt_, ca_);
         IEnumerable<MedicationRequest> cc_ = context.Operators.Union<MedicationRequest>(by_, cb_);
         IEnumerable<MedicationRequest> cd_ = context.Operators.Union<MedicationRequest>(bw_, cc_);
         IEnumerable<MedicationRequest> cf_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ch_(MedicationRequest MR) {
-            IEnumerable<Medication> fy_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ch_(MedicationRequest MR) {
+            IEnumerable<Medication> fw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? fz_(Medication M) {
-                object gd_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ge_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> gf_ = context.Operators.Split((string)ge_, "/");
-                string gg_ = context.Operators.Last<string>(gf_);
-                bool? gh_ = context.Operators.Equal(gd_, gg_);
-                CodeableConcept gi_ = M?.Code;
-                CqlConcept gj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gi_);
-                CqlValueSet gk_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                bool? gl_ = context.Operators.ConceptInValueSet(gj_, gk_);
-                bool? gm_ = context.Operators.And(gh_, gl_);
-                return gm_;
+            bool? fx_(Medication M) {
+                object ga_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object gb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gc_ = context.Operators.Split((string)gb_, "/");
+                string gd_ = context.Operators.Last<string>(gc_);
+                bool? ge_ = context.Operators.Equal(ga_, gd_);
+                CodeableConcept gf_ = M?.Code;
+                CqlConcept gg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gf_);
+                CqlValueSet gh_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                bool? gi_ = context.Operators.ConceptInValueSet(gg_, gh_);
+                bool? gj_ = context.Operators.And(ge_, gi_);
+                return gj_;
             }
 
-            IEnumerable<Medication> ga_ = context.Operators.Where<Medication>(fy_, fz_);
-            MedicationRequest gb_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gc_ = context.Operators.Select<Medication, MedicationRequest>(ga_, gb_);
-            return gc_;
+            IEnumerable<Medication> fy_ = context.Operators.Where<Medication>(fw_, fx_);
+            bool? fz_ = context.Operators.Exists<Medication>(fy_);
+            return fz_;
         }
 
-        IEnumerable<MedicationRequest> ci_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, ch_);
+        IEnumerable<MedicationRequest> ci_ = context.Operators.Where<MedicationRequest>(bt_, ch_);
         IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cf_, ci_);
         IEnumerable<MedicationRequest> ck_ = context.Operators.Union<MedicationRequest>(cd_, cj_);
         IEnumerable<MedicationRequest> cm_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, r_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> co_(MedicationRequest MR) {
-            IEnumerable<Medication> gn_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? co_(MedicationRequest MR) {
+            IEnumerable<Medication> gk_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? go_(Medication M) {
-                object gs_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object gt_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> gu_ = context.Operators.Split((string)gt_, "/");
-                string gv_ = context.Operators.Last<string>(gu_);
-                bool? gw_ = context.Operators.Equal(gs_, gv_);
-                CodeableConcept gx_ = M?.Code;
-                CqlConcept gy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gx_);
-                CqlValueSet gz_ = this.Warfarin(context);
-                bool? ha_ = context.Operators.ConceptInValueSet(gy_, gz_);
-                bool? hb_ = context.Operators.And(gw_, ha_);
-                return hb_;
+            bool? gl_(Medication M) {
+                object go_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object gp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gq_ = context.Operators.Split((string)gp_, "/");
+                string gr_ = context.Operators.Last<string>(gq_);
+                bool? gs_ = context.Operators.Equal(go_, gr_);
+                CodeableConcept gt_ = M?.Code;
+                CqlConcept gu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gt_);
+                CqlValueSet gv_ = this.Warfarin(context);
+                bool? gw_ = context.Operators.ConceptInValueSet(gu_, gv_);
+                bool? gx_ = context.Operators.And(gs_, gw_);
+                return gx_;
             }
 
-            IEnumerable<Medication> gp_ = context.Operators.Where<Medication>(gn_, go_);
-            MedicationRequest gq_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gr_ = context.Operators.Select<Medication, MedicationRequest>(gp_, gq_);
-            return gr_;
+            IEnumerable<Medication> gm_ = context.Operators.Where<Medication>(gk_, gl_);
+            bool? gn_ = context.Operators.Exists<Medication>(gm_);
+            return gn_;
         }
 
-        IEnumerable<MedicationRequest> cp_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, co_);
+        IEnumerable<MedicationRequest> cp_ = context.Operators.Where<MedicationRequest>(bt_, co_);
         IEnumerable<MedicationRequest> cq_ = context.Operators.Union<MedicationRequest>(cm_, cp_);
         IEnumerable<MedicationRequest> cr_ = context.Operators.Union<MedicationRequest>(ck_, cq_);
         IEnumerable<MedicationRequest> ct_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, x_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> cv_(MedicationRequest MR) {
-            IEnumerable<Medication> hc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? cv_(MedicationRequest MR) {
+            IEnumerable<Medication> gy_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? hd_(Medication M) {
-                object hh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hj_ = context.Operators.Split((string)hi_, "/");
-                string hk_ = context.Operators.Last<string>(hj_);
-                bool? hl_ = context.Operators.Equal(hh_, hk_);
-                CodeableConcept hm_ = M?.Code;
-                CqlConcept hn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hm_);
-                CqlValueSet ho_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                bool? hp_ = context.Operators.ConceptInValueSet(hn_, ho_);
-                bool? hq_ = context.Operators.And(hl_, hp_);
-                return hq_;
+            bool? gz_(Medication M) {
+                object hc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object hd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> he_ = context.Operators.Split((string)hd_, "/");
+                string hf_ = context.Operators.Last<string>(he_);
+                bool? hg_ = context.Operators.Equal(hc_, hf_);
+                CodeableConcept hh_ = M?.Code;
+                CqlConcept hi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hh_);
+                CqlValueSet hj_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                bool? hk_ = context.Operators.ConceptInValueSet(hi_, hj_);
+                bool? hl_ = context.Operators.And(hg_, hk_);
+                return hl_;
             }
 
-            IEnumerable<Medication> he_ = context.Operators.Where<Medication>(hc_, hd_);
-            MedicationRequest hf_(Medication M) => MR;
-            IEnumerable<MedicationRequest> hg_ = context.Operators.Select<Medication, MedicationRequest>(he_, hf_);
-            return hg_;
+            IEnumerable<Medication> ha_ = context.Operators.Where<Medication>(gy_, gz_);
+            bool? hb_ = context.Operators.Exists<Medication>(ha_);
+            return hb_;
         }
 
-        IEnumerable<MedicationRequest> cw_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, cv_);
+        IEnumerable<MedicationRequest> cw_ = context.Operators.Where<MedicationRequest>(bt_, cv_);
         IEnumerable<MedicationRequest> cx_ = context.Operators.Union<MedicationRequest>(ct_, cw_);
         IEnumerable<MedicationRequest> cy_ = context.Operators.Union<MedicationRequest>(cr_, cx_);
         IEnumerable<Task> cz_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
         IEnumerable<ValueTuple<MedicationRequest, Task>> da_ = context.Operators.CrossJoin<MedicationRequest, Task>(cy_, cz_);
 
         (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? db_(ValueTuple<MedicationRequest, Task> _valueTuple) {
-            (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? hr_ = (CqlTupleMetadata_IIUQMBcJhJBPgdDOLHaTTRUE, _valueTuple.Item1, _valueTuple.Item2);
-            return hr_;
+            (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? hm_ = (CqlTupleMetadata_IIUQMBcJhJBPgdDOLHaTTRUE, _valueTuple.Item1, _valueTuple.Item2);
+            return hm_;
         }
 
         IEnumerable<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?> dc_ = context.Operators.Select<ValueTuple<MedicationRequest, Task>, (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?>(da_, db_);
 
         bool? dd_((CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? tuple_iiuqmbcjhjbpgddolhattrue) {
-            ResourceReference hs_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Focus;
-            bool? ht_ = QICoreCommon_4_0_000.Instance.references(context, hs_, tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject);
-            CodeableConcept hu_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
-            CqlConcept hv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hu_);
-            CqlCode hw_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-            CqlConcept hx_ = context.Operators.ConvertCodeToConcept(hw_);
-            bool? hy_ = context.Operators.Equivalent(hv_, hx_);
-            bool? hz_ = context.Operators.And(ht_, hy_);
-            Code<MedicationRequest.MedicationrequestStatus> ia_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ib_ = ia_?.Value;
-            string ic_ = context.Operators.Convert<string>(ib_);
-            bool? id_ = context.Operators.Equal(ic_, "active");
-            bool? ie_ = context.Operators.And(hz_, id_);
-            return ie_;
+            ResourceReference hn_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Focus;
+            bool? ho_ = QICoreCommon_4_0_000.Instance.references(context, hn_, tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject);
+            CodeableConcept hp_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
+            CqlConcept hq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hp_);
+            CqlCode hr_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+            CqlConcept hs_ = context.Operators.ConvertCodeToConcept(hr_);
+            bool? ht_ = context.Operators.Equivalent(hq_, hs_);
+            bool? hu_ = context.Operators.And(ho_, ht_);
+            Code<MedicationRequest.MedicationrequestStatus> hv_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? hw_ = hv_?.Value;
+            string hx_ = context.Operators.Convert<string>(hw_);
+            bool? hy_ = context.Operators.Equal(hx_, "active");
+            bool? hz_ = context.Operators.And(hu_, hy_);
+            return hz_;
         }
 
         IEnumerable<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?> de_ = context.Operators.Where<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?>(dc_, dd_);
 
         (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? df_((CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? tuple_iiuqmbcjhjbpgddolhattrue) {
-            Id if_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.IdElement;
-            string ig_ = if_?.Value;
-            CodeableConcept ih_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.StatusReason;
-            CqlConcept ii_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ih_);
-            CqlConcept[] ij_ = [
-                ii_,
+            Id ia_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.IdElement;
+            string ib_ = ia_?.Value;
+            CodeableConcept ic_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.StatusReason;
+            CqlConcept id_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ic_);
+            CqlConcept[] ie_ = [
+                id_,
             ];
-            FhirDateTime ik_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.AuthoredOnElement;
-            CqlDateTime il_ = context.Operators.Convert<CqlDateTime>(ik_);
-            (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? im_ = (CqlTupleMetadata_CNeQfiIHcQEUBjZNVZiOLfdeP, ig_, (IEnumerable<CqlConcept>)ij_, il_);
-            return im_;
+            FhirDateTime if_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.AuthoredOnElement;
+            CqlDateTime ig_ = context.Operators.Convert<CqlDateTime>(if_);
+            (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? ih_ = (CqlTupleMetadata_CNeQfiIHcQEUBjZNVZiOLfdeP, ib_, (IEnumerable<CqlConcept>)ie_, ig_);
+            return ih_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?> dg_ = context.Operators.Select<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(de_, df_);
@@ -3667,34 +3647,33 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
     {
         IEnumerable<Encounter> a_ = VTE_8_18_000.Instance.Encounter_With_Age_Range_And_Without_VTE_Diagnosis_Or_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             IEnumerable<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?> d_ = this.No_VTE_Prophylaxis_Medication_Administered_Or_Ordered(context);
 
             bool? e_((CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication) {
-                IEnumerable<CqlConcept> i_ = NoVTEMedication?.medicationStatusReason;
-                CqlValueSet j_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                bool? k_ = context.Operators.ConceptsInValueSet(i_, j_);
-                CqlDateTime l_ = NoVTEMedication?.authoredOn;
-                CqlInterval<CqlDate> m_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
-                CqlDate n_ = m_?.low;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                CqlDate q_ = m_?.high;
-                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
-                bool? t_ = m_?.lowClosed;
-                bool? v_ = m_?.highClosed;
-                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(o_, r_, t_, v_);
-                bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, "day");
-                bool? y_ = context.Operators.And(k_, x_);
-                return y_;
+                IEnumerable<CqlConcept> h_ = NoVTEMedication?.medicationStatusReason;
+                CqlValueSet i_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                bool? j_ = context.Operators.ConceptsInValueSet(h_, i_);
+                CqlDateTime k_ = NoVTEMedication?.authoredOn;
+                CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
+                CqlDate m_ = l_?.low;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                CqlDate p_ = l_?.high;
+                CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+                bool? s_ = l_?.lowClosed;
+                bool? u_ = l_?.highClosed;
+                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(n_, q_, s_, u_);
+                bool? w_ = context.Operators.In<CqlDateTime>(k_, v_, "day");
+                bool? x_ = context.Operators.And(j_, w_);
+                return x_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication) => QualifyingEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -3897,34 +3876,33 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
     {
         IEnumerable<Encounter> a_ = VTE_8_18_000.Instance.Encounter_With_Age_Range_And_Without_VTE_Diagnosis_Or_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             IEnumerable<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?> d_ = this.No_Mechanical_VTE_Prophylaxis_Performed_Or_Ordered(context);
 
             bool? e_((CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice) {
-                CqlConcept i_ = NoVTEDevice?.requestStatusReason;
-                CqlValueSet j_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                bool? k_ = context.Operators.ConceptInValueSet(i_, j_);
-                CqlDateTime l_ = NoVTEDevice?.authoredOn;
-                CqlInterval<CqlDate> m_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
-                CqlDate n_ = m_?.low;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                CqlDate q_ = m_?.high;
-                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
-                bool? t_ = m_?.lowClosed;
-                bool? v_ = m_?.highClosed;
-                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(o_, r_, t_, v_);
-                bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, "day");
-                bool? y_ = context.Operators.And(k_, x_);
-                return y_;
+                CqlConcept h_ = NoVTEDevice?.requestStatusReason;
+                CqlValueSet i_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                bool? j_ = context.Operators.ConceptInValueSet(h_, i_);
+                CqlDateTime k_ = NoVTEDevice?.authoredOn;
+                CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
+                CqlDate m_ = l_?.low;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                CqlDate p_ = l_?.high;
+                CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+                bool? s_ = l_?.lowClosed;
+                bool? u_ = l_?.highClosed;
+                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(n_, q_, s_, u_);
+                bool? w_ = context.Operators.In<CqlDateTime>(k_, v_, "day");
+                bool? x_ = context.Operators.And(j_, w_);
+                return x_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice) => QualifyingEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -4782,30 +4760,29 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
     {
         IEnumerable<Encounter> a_ = VTE_8_18_000.Instance.Encounter_With_Age_Range_And_Without_VTE_Diagnosis_Or_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             IEnumerable<object> d_ = this.No_Mechanical_Or_Pharmacological_VTE_Prophylaxis_Due_To_Patient_Refusal(context);
 
             bool? e_(object PatientRefusal) {
-                CqlDateTime i_ = context.Operators.LateBoundProperty<CqlDateTime>(PatientRefusal, "authoredOn");
-                CqlInterval<CqlDate> j_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
-                CqlDate k_ = j_?.low;
-                CqlDateTime l_ = context.Operators.ConvertDateToDateTime(k_);
-                CqlDate n_ = j_?.high;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                bool? q_ = j_?.lowClosed;
-                bool? s_ = j_?.highClosed;
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(l_, o_, q_, s_);
-                bool? u_ = context.Operators.In<CqlDateTime>(i_, t_, "day");
-                return u_;
+                CqlDateTime h_ = context.Operators.LateBoundProperty<CqlDateTime>(PatientRefusal, "authoredOn");
+                CqlInterval<CqlDate> i_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
+                CqlDate j_ = i_?.low;
+                CqlDateTime k_ = context.Operators.ConvertDateToDateTime(j_);
+                CqlDate m_ = i_?.high;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                bool? p_ = i_?.lowClosed;
+                bool? r_ = i_?.highClosed;
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(k_, n_, p_, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(h_, s_, "day");
+                return t_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object PatientRefusal) => QualifyingEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1157FHIRHIVRetention-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1157FHIRHIVRetention-1.0.000.g.cs
@@ -299,40 +299,39 @@ public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1
         IEnumerable<Encounter> ae_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ad_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
         IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 
-        IEnumerable<Encounter> ag_(Encounter ValidEncounter) {
+        bool? ag_(Encounter ValidEncounter) {
             CqlValueSet ai_ = this.HIV(context);
             IEnumerable<Condition> aj_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> al_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> am_ = context.Operators.Union<Condition>(aj_ as IEnumerable<Condition>, al_ as IEnumerable<Condition>);
 
             bool? an_(Condition HIVDiagnosis) {
-                CqlInterval<CqlDateTime> ar_ = this.Measurement_Period(context);
-                Period as_ = ValidEncounter?.Period;
-                CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
-                bool? au_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ar_, at_, "day");
-                Code<Encounter.EncounterStatus> av_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? aw_ = av_?.Value;
-                Code<Encounter.EncounterStatus> ax_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aw_);
-                bool? ay_ = context.Operators.Equal(ax_, "finished");
-                bool? az_ = context.Operators.And(au_, ay_);
-                CqlInterval<CqlDateTime> ba_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HIVDiagnosis);
-                CqlDateTime bb_ = context.Operators.Start(ba_);
-                CqlInterval<CqlDateTime> bd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
-                CqlDateTime be_ = context.Operators.Start(bd_);
-                bool? bf_ = context.Operators.SameOrBefore(bb_, be_, "day");
-                bool? bg_ = context.Operators.And(az_, bf_);
-                bool? bh_ = this.isVerified(context, HIVDiagnosis);
-                bool? bi_ = context.Operators.And(bg_, bh_);
-                return bi_;
+                CqlInterval<CqlDateTime> aq_ = this.Measurement_Period(context);
+                Period ar_ = ValidEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aq_, as_, "day");
+                Code<Encounter.EncounterStatus> au_ = ValidEncounter?.StatusElement;
+                Encounter.EncounterStatus? av_ = au_?.Value;
+                Code<Encounter.EncounterStatus> aw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(av_);
+                bool? ax_ = context.Operators.Equal(aw_, "finished");
+                bool? ay_ = context.Operators.And(at_, ax_);
+                CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HIVDiagnosis);
+                CqlDateTime ba_ = context.Operators.Start(az_);
+                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                bool? be_ = context.Operators.SameOrBefore(ba_, bd_, "day");
+                bool? bf_ = context.Operators.And(ay_, be_);
+                bool? bg_ = this.isVerified(context, HIVDiagnosis);
+                bool? bh_ = context.Operators.And(bf_, bg_);
+                return bh_;
             }
 
             IEnumerable<Condition> ao_ = context.Operators.Where<Condition>(am_, an_);
-            Encounter ap_(Condition HIVDiagnosis) => ValidEncounter;
-            IEnumerable<Encounter> aq_ = context.Operators.Select<Condition, Encounter>(ao_, ap_);
-            return aq_;
+            bool? ap_ = context.Operators.Exists<Condition>(ao_);
+            return ap_;
         }
 
-        IEnumerable<Encounter> ah_ = context.Operators.SelectMany<Encounter, Encounter>(af_, ag_);
+        IEnumerable<Encounter> ah_ = context.Operators.Where<Encounter>(af_, ag_);
         return ah_;
     }
 
@@ -347,54 +346,53 @@ public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1
     {
         IEnumerable<Encounter> a_ = this.Encounter_During_Measurement_Period_With_HIV(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithHIV) {
+        bool? b_(Encounter EncounterWithHIV) {
             CqlValueSet e_ = this.HIV_Viral_Load_Tests(context);
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
 
             bool? g_(Observation ViralLoadTest) {
-                Code<ObservationStatus> k_ = ViralLoadTest?.StatusElement;
-                ObservationStatus? l_ = k_?.Value;
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
+                Code<ObservationStatus> j_ = ViralLoadTest?.StatusElement;
+                ObservationStatus? k_ = j_?.Value;
+                string l_ = context.Operators.Convert<string>(k_);
+                string[] m_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                DataType q_ = ViralLoadTest?.Effective;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, "day");
-                bool? u_ = context.Operators.And(o_, t_);
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                Period z_ = EncounterWithHIV?.Period;
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlDateTime ab_ = context.Operators.End(aa_);
-                CqlQuantity ac_ = context.Operators.Quantity(90m, "days");
-                CqlDateTime ad_ = context.Operators.Add(ab_, ac_);
-                bool? ae_ = context.Operators.SameOrAfter(y_, ad_, "day");
-                CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlDateTime ah_ = context.Operators.Start(ag_);
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.End(ak_);
-                CqlDateTime an_ = context.Operators.Add(al_, ac_);
-                bool? ao_ = context.Operators.SameOrAfter(ah_, an_, "day");
-                bool? ap_ = context.Operators.Or(ae_, ao_);
-                bool? aq_ = context.Operators.And(u_, ap_);
-                return aq_;
+                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+                CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+                DataType p_ = ViralLoadTest?.Effective;
+                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, "day");
+                bool? t_ = context.Operators.And(n_, s_);
+                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                Period y_ = EncounterWithHIV?.Period;
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlDateTime aa_ = context.Operators.End(z_);
+                CqlQuantity ab_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
+                bool? ad_ = context.Operators.SameOrAfter(x_, ac_, "day");
+                CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlDateTime ag_ = context.Operators.Start(af_);
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+                CqlDateTime ak_ = context.Operators.End(aj_);
+                CqlDateTime am_ = context.Operators.Add(ak_, ab_);
+                bool? an_ = context.Operators.SameOrAfter(ag_, am_, "day");
+                bool? ao_ = context.Operators.Or(ad_, an_);
+                bool? ap_ = context.Operators.And(t_, ao_);
+                return ap_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
-            Encounter i_(Observation ViralLoadTest) => EncounterWithHIV;
-            IEnumerable<Encounter> j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Observation>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         bool? d_ = context.Operators.Exists<Encounter>(c_);
         return d_;
     }
@@ -410,32 +408,31 @@ public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1
     {
         IEnumerable<Encounter> a_ = this.Encounter_During_Measurement_Period_With_HIV(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithHIV) {
+        bool? b_(Encounter EncounterWithHIV) {
             IEnumerable<Encounter> e_ = this.Encounter_During_Measurement_Period_With_HIV(context);
 
             bool? f_(Encounter AnotherEncounterWithHIV) {
-                bool? j_ = context.Operators.Equivalent(EncounterWithHIV, AnotherEncounterWithHIV);
-                bool? k_ = context.Operators.Not(j_);
-                Period l_ = AnotherEncounterWithHIV?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                Period o_ = EncounterWithHIV?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                CqlDateTime q_ = context.Operators.End(p_);
-                CqlQuantity r_ = context.Operators.Quantity(90m, "days");
-                CqlDateTime s_ = context.Operators.Add(q_, r_);
-                bool? t_ = context.Operators.SameOrAfter(n_, s_, "day");
-                bool? u_ = context.Operators.And(k_, t_);
-                return u_;
+                bool? i_ = context.Operators.Equivalent(EncounterWithHIV, AnotherEncounterWithHIV);
+                bool? j_ = context.Operators.Not(i_);
+                Period k_ = AnotherEncounterWithHIV?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                Period n_ = EncounterWithHIV?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                CqlQuantity q_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime r_ = context.Operators.Add(p_, q_);
+                bool? s_ = context.Operators.SameOrAfter(m_, r_, "day");
+                bool? t_ = context.Operators.And(j_, s_);
+                return t_;
             }
 
             IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
-            Encounter h_(Encounter AnotherEncounterWithHIV) => EncounterWithHIV;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Encounter, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Encounter>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         bool? d_ = context.Operators.Exists<Encounter>(c_);
         return d_;
     }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
@@ -403,47 +403,46 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Anticoagulant_Medications(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Anticoagulant_Medications(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationRequest l_(Medication M) => MR;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest AntiCoagulant) {
-            Code<MedicationRequest.MedicationrequestStatus> x_ = AntiCoagulant?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? y_ = x_?.Value;
-            string z_ = context.Operators.Convert<string>(y_);
-            string[] aa_ = [
+            Code<MedicationRequest.MedicationrequestStatus> w_ = AntiCoagulant?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
                 "active",
                 "completed",
             ];
-            bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-            Code<MedicationRequest.MedicationRequestIntent> ac_ = AntiCoagulant?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
-            string ae_ = context.Operators.Convert<string>(ad_);
-            bool? af_ = context.Operators.Equal(ae_, "order");
-            bool? ag_ = context.Operators.And(ab_, af_);
-            return ag_;
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            Code<MedicationRequest.MedicationRequestIntent> ab_ = AntiCoagulant?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ac_ = ab_?.Value;
+            string ad_ = context.Operators.Convert<string>(ac_);
+            bool? ae_ = context.Operators.Equal(ad_, "order");
+            bool? af_ = context.Operators.And(aa_, ae_);
+            return af_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -1087,36 +1086,35 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters(context);
 
-        IEnumerable<Encounter> b_(Encounter CurrentQualifiedVTE) {
+        bool? b_(Encounter CurrentQualifiedVTE) {
             IEnumerable<Encounter> d_ = this.Qualified_VTE_Encounters(context);
 
             bool? e_(Encounter PreviousQualifiedVTE) {
-                Period i_ = PreviousQualifiedVTE?.Period;
-                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                Period l_ = CurrentQualifiedVTE?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(6m, "months");
-                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, false);
-                bool? u_ = context.Operators.In<CqlDateTime>(k_, t_, (string)default);
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                bool? y_ = context.Operators.Not((bool?)(x_ is null));
-                bool? z_ = context.Operators.And(u_, y_);
-                return z_;
+                Period h_ = PreviousQualifiedVTE?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                Period k_ = CurrentQualifiedVTE?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlQuantity n_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(o_, r_, true, false);
+                bool? t_ = context.Operators.In<CqlDateTime>(j_, s_, (string)default);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                bool? x_ = context.Operators.Not((bool?)(w_ is null));
+                bool? y_ = context.Operators.And(t_, x_);
+                return y_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter PreviousQualifiedVTE) => CurrentQualifiedVTE;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1148,34 +1146,33 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters_During_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter DelayedVTEEncounter) {
+        bool? b_(Encounter DelayedVTEEncounter) {
             IEnumerable<Encounter> d_ = this.Qualifying_Performed_PCP_Visits_With_VTE_Symptom(context);
 
             bool? e_(Encounter IndexPCPVisit) {
-                Period i_ = DelayedVTEEncounter?.Period;
-                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                Period l_ = IndexPCPVisit?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.End(m_);
-                CqlQuantity o_ = context.Operators.Quantity(2m, "day");
-                CqlDateTime p_ = context.Operators.Add(n_, o_);
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlQuantity t_ = context.Operators.Quantity(30m, "days");
-                CqlDateTime u_ = context.Operators.Add(s_, t_);
-                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(p_, u_, true, true);
-                bool? w_ = context.Operators.In<CqlDateTime>(k_, v_, "day");
-                return w_;
+                Period h_ = DelayedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                Period k_ = IndexPCPVisit?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.End(l_);
+                CqlQuantity n_ = context.Operators.Quantity(2m, "day");
+                CqlDateTime o_ = context.Operators.Add(m_, n_);
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime r_ = context.Operators.End(q_);
+                CqlQuantity s_ = context.Operators.Quantity(30m, "days");
+                CqlDateTime t_ = context.Operators.Add(r_, s_);
+                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(o_, t_, true, true);
+                bool? v_ = context.Operators.In<CqlDateTime>(j_, u_, "day");
+                return v_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter IndexPCPVisit) => DelayedVTEEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
@@ -139,40 +139,39 @@ public partial class CMS1206FHIRCTOQR_1_0_000 : ILibrary, ISingleton<CMS1206FHIR
     {
         IEnumerable<Observation> a_ = this.Qualified_Scan(context);
 
-        IEnumerable<Observation> c_(Observation QualifiedCTScan) {
-            CqlValueSet f_ = this.Encounter_Inpatient(context);
-            IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        bool? b_(Observation QualifiedCTScan) {
+            CqlValueSet d_ = this.Encounter_Inpatient(context);
+            IEnumerable<Encounter> e_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-            bool? h_(Encounter InpatientEncounter) {
-                Code<Encounter.EncounterStatus> l_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? m_ = l_?.Value;
-                Code<Encounter.EncounterStatus> n_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(m_);
-                bool? o_ = context.Operators.Equivalent(n_, "finished");
-                Period p_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.End(q_);
-                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
-                bool? u_ = context.Operators.And(o_, t_);
-                DataType v_ = QualifiedCTScan?.Effective;
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                bool? ab_ = context.Operators.In<CqlDateTime>(y_, aa_, (string)default);
-                bool? ac_ = context.Operators.And(u_, ab_);
-                return ac_;
+            bool? f_(Encounter InpatientEncounter) {
+                Code<Encounter.EncounterStatus> j_ = InpatientEncounter?.StatusElement;
+                Encounter.EncounterStatus? k_ = j_?.Value;
+                Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
+                bool? m_ = context.Operators.Equivalent(l_, "finished");
+                Period n_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
+                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
+                bool? s_ = context.Operators.And(m_, r_);
+                DataType t_ = QualifiedCTScan?.Effective;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                bool? z_ = context.Operators.In<CqlDateTime>(w_, y_, (string)default);
+                bool? aa_ = context.Operators.And(s_, z_);
+                return aa_;
             }
 
-            IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter InpatientEncounter) => QualifiedCTScan;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
+            bool? h_ = context.Operators.Exists<Encounter>(g_);
+            bool? i_ = context.Operators.Not(h_);
+            return i_;
         }
 
-        IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(a_, c_);
-        IEnumerable<Observation> e_ = context.Operators.Except<Observation>(a_, d_);
-        return e_;
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
+        return c_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
@@ -424,43 +424,42 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_Age_And_Without_Obstetrical_Condition(context);
 
-        IEnumerable<Encounter> b_(Encounter ElectiveEncounter) {
+        bool? b_(Encounter ElectiveEncounter) {
             CqlValueSet d_ = this.General_And_Neuraxial_Anesthesia(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure SurgeryWithAnesthesia) {
-                Code<EventStatus> j_ = SurgeryWithAnesthesia?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
-                DataType n_ = SurgeryWithAnesthesia?.Performed;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_ as object);
-                CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, ElectiveEncounter);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
-                bool? s_ = context.Operators.And(m_, r_);
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_ as object);
-                CqlDateTime x_ = context.Operators.Start(q_);
-                CqlDateTime z_ = context.Operators.Start(q_);
-                CqlQuantity aa_ = context.Operators.Quantity(3m, "days");
-                CqlDateTime ab_ = context.Operators.Add(z_, aa_);
-                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(x_, ab_, false, true);
-                bool? ad_ = context.Operators.In<CqlDateTime>(v_, ac_, (string)default);
-                CqlDateTime af_ = context.Operators.Start(q_);
-                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
-                bool? ah_ = context.Operators.And(ad_, ag_);
-                bool? ai_ = context.Operators.And(s_, ah_);
-                return ai_;
+                Code<EventStatus> i_ = SurgeryWithAnesthesia?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
+                DataType m_ = SurgeryWithAnesthesia?.Performed;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_ as object);
+                CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, ElectiveEncounter);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
+                bool? r_ = context.Operators.And(l_, q_);
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_ as object);
+                CqlDateTime w_ = context.Operators.Start(p_);
+                CqlDateTime y_ = context.Operators.Start(p_);
+                CqlQuantity z_ = context.Operators.Quantity(3m, "days");
+                CqlDateTime aa_ = context.Operators.Add(y_, z_);
+                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(w_, aa_, false, true);
+                bool? ac_ = context.Operators.In<CqlDateTime>(u_, ab_, (string)default);
+                CqlDateTime ae_ = context.Operators.Start(p_);
+                bool? af_ = context.Operators.Not((bool?)(ae_ is null));
+                bool? ag_ = context.Operators.And(ac_, af_);
+                bool? ah_ = context.Operators.And(r_, ag_);
+                return ah_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure SurgeryWithAnesthesia) => ElectiveEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -657,27 +656,26 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet d_ = this.Head__Neck__And_Thoracic_Surgeries_With_High_Risk_Airway_Compromise(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure HeadNeckProcedures) {
-                Code<EventStatus> j_ = HeadNeckProcedures?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
-                bool? n_ = this.startsDuringHospitalization(context, HeadNeckProcedures as object, EncounterWithSurgery);
-                bool? o_ = context.Operators.And(m_, n_);
-                return o_;
+                Code<EventStatus> i_ = HeadNeckProcedures?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
+                bool? m_ = this.startsDuringHospitalization(context, HeadNeckProcedures as object, EncounterWithSurgery);
+                bool? n_ = context.Operators.And(l_, m_);
+                return n_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure HeadNeckProcedures) => EncounterWithSurgery;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -810,72 +808,72 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet d_ = this.Mechanical_Ventilation(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure Ventilation) {
-                Code<EventStatus> j_ = Ventilation?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
+                Code<EventStatus> i_ = Ventilation?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
 
-                object n_() {
+                object m_() {
+
+                    bool y_() {
+                        DataType ac_ = Ventilation?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlDateTime;
+                        return ae_;
+                    }
+
 
                     bool z_() {
-                        DataType ad_ = Ventilation?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlDateTime;
-                        return af_;
+                        DataType af_ = Ventilation?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlDateTime>;
+                        return ah_;
                     }
 
 
                     bool aa_() {
-                        DataType ag_ = Ventilation?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlDateTime>;
-                        return ai_;
+                        DataType ai_ = Ventilation?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        bool ak_ = aj_ is CqlQuantity;
+                        return ak_;
                     }
 
 
                     bool ab_() {
-                        DataType aj_ = Ventilation?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        bool al_ = ak_ is CqlQuantity;
-                        return al_;
+                        DataType al_ = Ventilation?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        bool an_ = am_ is CqlInterval<CqlQuantity>;
+                        return an_;
                     }
 
-
-                    bool ac_() {
-                        DataType am_ = Ventilation?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        bool ao_ = an_ is CqlInterval<CqlQuantity>;
-                        return ao_;
-                    }
-
-                    if (z_())
+                    if (y_())
                     {
-                        DataType ap_ = Ventilation?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlDateTime) as object;
+                        DataType ao_ = Ventilation?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlDateTime) as object;
+                    }
+                    else if (z_())
+                    {
+                        DataType aq_ = Ventilation?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (aa_())
                     {
-                        DataType ar_ = Ventilation?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlInterval<CqlDateTime>) as object;
+                        DataType as_ = Ventilation?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        return (at_ as CqlQuantity) as object;
                     }
                     else if (ab_())
                     {
-                        DataType at_ = Ventilation?.Performed;
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        return (au_ as CqlQuantity) as object;
-                    }
-                    else if (ac_())
-                    {
-                        DataType av_ = Ventilation?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        return (aw_ as CqlInterval<CqlQuantity>) as object;
+                        DataType au_ = Ventilation?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        return (av_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -883,73 +881,73 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                CqlDateTime p_ = context.Operators.Start(o_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                CqlDateTime o_ = context.Operators.Start(n_);
 
-                object q_() {
+                object p_() {
+
+                    bool aw_() {
+                        Procedure ba_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bb_ = ba_?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        bool bd_ = bc_ is CqlDateTime;
+                        return bd_;
+                    }
+
 
                     bool ax_() {
-                        Procedure bb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bc_ = bb_?.Performed;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        bool be_ = bd_ is CqlDateTime;
-                        return be_;
+                        Procedure be_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bf_ = be_?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        bool bh_ = bg_ is CqlInterval<CqlDateTime>;
+                        return bh_;
                     }
 
 
                     bool ay_() {
-                        Procedure bf_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bg_ = bf_?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        bool bi_ = bh_ is CqlInterval<CqlDateTime>;
-                        return bi_;
+                        Procedure bi_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bj_ = bi_?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        bool bl_ = bk_ is CqlQuantity;
+                        return bl_;
                     }
 
 
                     bool az_() {
-                        Procedure bj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bk_ = bj_?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        bool bm_ = bl_ is CqlQuantity;
-                        return bm_;
+                        Procedure bm_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bn_ = bm_?.Performed;
+                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                        bool bp_ = bo_ is CqlInterval<CqlQuantity>;
+                        return bp_;
                     }
 
-
-                    bool ba_() {
-                        Procedure bn_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bo_ = bn_?.Performed;
-                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
-                        bool bq_ = bp_ is CqlInterval<CqlQuantity>;
-                        return bq_;
-                    }
-
-                    if (ax_())
+                    if (aw_())
                     {
-                        Procedure br_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bs_ = br_?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        return (bt_ as CqlDateTime) as object;
+                        Procedure bq_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType br_ = bq_?.Performed;
+                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                        return (bs_ as CqlDateTime) as object;
+                    }
+                    else if (ax_())
+                    {
+                        Procedure bt_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bu_ = bt_?.Performed;
+                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                        return (bv_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ay_())
                     {
-                        Procedure bu_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bv_ = bu_?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        return (bw_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure bw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bx_ = bw_?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        return (by_ as CqlQuantity) as object;
                     }
                     else if (az_())
                     {
-                        Procedure bx_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType by_ = bx_?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        return (bz_ as CqlQuantity) as object;
-                    }
-                    else if (ba_())
-                    {
-                        Procedure ca_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cb_ = ca_?.Performed;
-                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                        return (cc_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure bz_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ca_ = bz_?.Performed;
+                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                        return (cb_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -957,24 +955,23 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlQuantity t_ = context.Operators.Quantity(1m, "hour");
-                CqlDateTime u_ = context.Operators.Subtract(s_, t_);
-                bool? v_ = context.Operators.Before(p_, u_, (string)default);
-                bool? w_ = context.Operators.And(m_, v_);
-                bool? x_ = this.startsDuringHospitalization(context, Ventilation as object, EncounterWithSurgery);
-                bool? y_ = context.Operators.And(w_, x_);
-                return y_;
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                bool? u_ = context.Operators.Before(o_, t_, (string)default);
+                bool? v_ = context.Operators.And(l_, u_);
+                bool? w_ = this.startsDuringHospitalization(context, Ventilation as object, EncounterWithSurgery);
+                bool? x_ = context.Operators.And(v_, w_);
+                return x_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure Ventilation) => EncounterWithSurgery;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1038,89 +1035,89 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet f_ = this.Carbon_Dioxide_Partial_Pressure_In_Arterial_Blood(context);
             IEnumerable<Observation> g_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
 
             bool? h_(Observation CarbonDioxide) {
-                Code<ObservationStatus> l_ = CarbonDioxide?.StatusElement;
-                ObservationStatus? m_ = l_?.Value;
-                string n_ = context.Operators.Convert<string>(m_);
-                string[] o_ = [
+                Code<ObservationStatus> k_ = CarbonDioxide?.StatusElement;
+                ObservationStatus? l_ = k_?.Value;
+                string m_ = context.Operators.Convert<string>(l_);
+                string[] n_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
-                DataType q_ = CarbonDioxide?.Effective;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.Start(s_);
+                bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
+                DataType p_ = CarbonDioxide?.Effective;
+                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
 
-                object u_() {
+                object t_() {
+
+                    bool ao_() {
+                        Procedure as_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType at_ = as_?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        bool av_ = au_ is CqlDateTime;
+                        return av_;
+                    }
+
 
                     bool ap_() {
-                        Procedure at_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType au_ = at_?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlDateTime;
-                        return aw_;
+                        Procedure aw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ax_ = aw_?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlInterval<CqlDateTime>;
+                        return az_;
                     }
 
 
                     bool aq_() {
-                        Procedure ax_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ay_ = ax_?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlInterval<CqlDateTime>;
-                        return ba_;
+                        Procedure ba_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bb_ = ba_?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        bool bd_ = bc_ is CqlQuantity;
+                        return bd_;
                     }
 
 
                     bool ar_() {
-                        Procedure bb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bc_ = bb_?.Performed;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        bool be_ = bd_ is CqlQuantity;
-                        return be_;
+                        Procedure be_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bf_ = be_?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        bool bh_ = bg_ is CqlInterval<CqlQuantity>;
+                        return bh_;
                     }
 
-
-                    bool as_() {
-                        Procedure bf_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bg_ = bf_?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        bool bi_ = bh_ is CqlInterval<CqlQuantity>;
-                        return bi_;
-                    }
-
-                    if (ap_())
+                    if (ao_())
                     {
-                        Procedure bj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bk_ = bj_?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        return (bl_ as CqlDateTime) as object;
+                        Procedure bi_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bj_ = bi_?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        return (bk_ as CqlDateTime) as object;
+                    }
+                    else if (ap_())
+                    {
+                        Procedure bl_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bm_ = bl_?.Performed;
+                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                        return (bn_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (aq_())
                     {
-                        Procedure bm_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bn_ = bm_?.Performed;
-                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                        return (bo_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure bo_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bp_ = bo_?.Performed;
+                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+                        return (bq_ as CqlQuantity) as object;
                     }
                     else if (ar_())
                     {
-                        Procedure bp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bq_ = bp_?.Performed;
-                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                        return (br_ as CqlQuantity) as object;
-                    }
-                    else if (as_())
-                    {
-                        Procedure bs_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bt_ = bs_?.Performed;
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        return (bu_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure br_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bs_ = br_?.Performed;
+                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                        return (bt_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1128,75 +1125,75 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime y_ = context.Operators.Subtract(w_, x_);
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlQuantity w_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime x_ = context.Operators.Subtract(v_, w_);
 
-                object z_() {
+                object y_() {
+
+                    bool bu_() {
+                        Procedure by_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bz_ = by_?.Performed;
+                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                        bool cb_ = ca_ is CqlDateTime;
+                        return cb_;
+                    }
+
 
                     bool bv_() {
-                        Procedure bz_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ca_ = bz_?.Performed;
-                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                        bool cc_ = cb_ is CqlDateTime;
-                        return cc_;
+                        Procedure cc_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cd_ = cc_?.Performed;
+                        object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                        bool cf_ = ce_ is CqlInterval<CqlDateTime>;
+                        return cf_;
                     }
 
 
                     bool bw_() {
-                        Procedure cd_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ce_ = cd_?.Performed;
-                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
-                        bool cg_ = cf_ is CqlInterval<CqlDateTime>;
-                        return cg_;
+                        Procedure cg_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ch_ = cg_?.Performed;
+                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                        bool cj_ = ci_ is CqlQuantity;
+                        return cj_;
                     }
 
 
                     bool bx_() {
-                        Procedure ch_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ci_ = ch_?.Performed;
-                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                        bool ck_ = cj_ is CqlQuantity;
-                        return ck_;
+                        Procedure ck_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cl_ = ck_?.Performed;
+                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                        bool cn_ = cm_ is CqlInterval<CqlQuantity>;
+                        return cn_;
                     }
 
-
-                    bool by_() {
-                        Procedure cl_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cm_ = cl_?.Performed;
-                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                        bool co_ = cn_ is CqlInterval<CqlQuantity>;
-                        return co_;
-                    }
-
-                    if (bv_())
+                    if (bu_())
                     {
-                        Procedure cp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cq_ = cp_?.Performed;
-                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                        return (cr_ as CqlDateTime) as object;
+                        Procedure co_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cp_ = co_?.Performed;
+                        object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+                        return (cq_ as CqlDateTime) as object;
+                    }
+                    else if (bv_())
+                    {
+                        Procedure cr_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cs_ = cr_?.Performed;
+                        object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
+                        return (ct_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bw_())
                     {
-                        Procedure cs_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ct_ = cs_?.Performed;
-                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                        return (cu_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure cu_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cv_ = cu_?.Performed;
+                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                        return (cw_ as CqlQuantity) as object;
                     }
                     else if (bx_())
                     {
-                        Procedure cv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cw_ = cv_?.Performed;
-                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                        return (cx_ as CqlQuantity) as object;
-                    }
-                    else if (by_())
-                    {
-                        Procedure cy_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cz_ = cy_?.Performed;
-                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
-                        return (da_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure cx_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cy_ = cx_?.Performed;
+                        object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+                        return (cz_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1204,75 +1201,75 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, false);
-                bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(x_, aa_, true, false);
+                bool? ac_ = context.Operators.In<CqlDateTime>(s_, ab_, (string)default);
 
-                object ae_() {
+                object ad_() {
+
+                    bool da_() {
+                        Procedure de_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType df_ = de_?.Performed;
+                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                        bool dh_ = dg_ is CqlDateTime;
+                        return dh_;
+                    }
+
 
                     bool db_() {
-                        Procedure df_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dg_ = df_?.Performed;
-                        object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
-                        bool di_ = dh_ is CqlDateTime;
-                        return di_;
+                        Procedure di_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dj_ = di_?.Performed;
+                        object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+                        bool dl_ = dk_ is CqlInterval<CqlDateTime>;
+                        return dl_;
                     }
 
 
                     bool dc_() {
-                        Procedure dj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dk_ = dj_?.Performed;
-                        object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
-                        bool dm_ = dl_ is CqlInterval<CqlDateTime>;
-                        return dm_;
+                        Procedure dm_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dn_ = dm_?.Performed;
+                        object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+                        bool dp_ = do_ is CqlQuantity;
+                        return dp_;
                     }
 
 
                     bool dd_() {
-                        Procedure dn_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType do_ = dn_?.Performed;
-                        object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
-                        bool dq_ = dp_ is CqlQuantity;
-                        return dq_;
+                        Procedure dq_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dr_ = dq_?.Performed;
+                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                        bool dt_ = ds_ is CqlInterval<CqlQuantity>;
+                        return dt_;
                     }
 
-
-                    bool de_() {
-                        Procedure dr_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ds_ = dr_?.Performed;
-                        object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
-                        bool du_ = dt_ is CqlInterval<CqlQuantity>;
-                        return du_;
-                    }
-
-                    if (db_())
+                    if (da_())
                     {
-                        Procedure dv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dw_ = dv_?.Performed;
-                        object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                        return (dx_ as CqlDateTime) as object;
+                        Procedure du_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dv_ = du_?.Performed;
+                        object dw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dv_);
+                        return (dw_ as CqlDateTime) as object;
+                    }
+                    else if (db_())
+                    {
+                        Procedure dx_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dy_ = dx_?.Performed;
+                        object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
+                        return (dz_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (dc_())
                     {
-                        Procedure dy_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dz_ = dy_?.Performed;
-                        object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
-                        return (ea_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure ea_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType eb_ = ea_?.Performed;
+                        object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
+                        return (ec_ as CqlQuantity) as object;
                     }
                     else if (dd_())
                     {
-                        Procedure eb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ec_ = eb_?.Performed;
-                        object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
-                        return (ed_ as CqlQuantity) as object;
-                    }
-                    else if (de_())
-                    {
-                        Procedure ee_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ef_ = ee_?.Performed;
-                        object eg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ef_);
-                        return (eg_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure ed_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ee_ = ed_?.Performed;
+                        object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
+                        return (ef_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1280,110 +1277,109 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_());
-                CqlDateTime ag_ = context.Operators.Start(af_);
-                bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
-                bool? ai_ = context.Operators.And(ad_, ah_);
-                bool? aj_ = context.Operators.And(p_, ai_);
-                DataType ak_ = CarbonDioxide?.Value;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(50m, "mm[Hg]");
-                bool? an_ = context.Operators.Greater(al_ as CqlQuantity, am_);
-                bool? ao_ = context.Operators.And(aj_, an_);
-                return ao_;
+                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_());
+                CqlDateTime af_ = context.Operators.Start(ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ac_, ag_);
+                bool? ai_ = context.Operators.And(o_, ah_);
+                DataType aj_ = CarbonDioxide?.Value;
+                object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                CqlQuantity al_ = context.Operators.Quantity(50m, "mm[Hg]");
+                bool? am_ = context.Operators.Greater(ak_ as CqlQuantity, al_);
+                bool? an_ = context.Operators.And(ai_, am_);
+                return an_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
-            Encounter j_(Observation CarbonDioxide) => EncounterWithSurgery;
-            IEnumerable<Encounter> k_ = context.Operators.Select<Observation, Encounter>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Observation>(i_);
+            return j_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
-        IEnumerable<Encounter> d_(Encounter EncounterWithSurgery) {
-            CqlValueSet eh_ = this.Arterial_Blood_pH(context);
-            IEnumerable<Observation> ei_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, eh_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        bool? d_(Encounter EncounterWithSurgery) {
+            CqlValueSet eg_ = this.Arterial_Blood_pH(context);
+            IEnumerable<Observation> eh_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, eg_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
 
-            bool? ej_(Observation BloodpH) {
-                Code<ObservationStatus> en_ = BloodpH?.StatusElement;
-                ObservationStatus? eo_ = en_?.Value;
-                string ep_ = context.Operators.Convert<string>(eo_);
-                string[] eq_ = [
+            bool? ei_(Observation BloodpH) {
+                Code<ObservationStatus> el_ = BloodpH?.StatusElement;
+                ObservationStatus? em_ = el_?.Value;
+                string en_ = context.Operators.Convert<string>(em_);
+                string[] eo_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? er_ = context.Operators.In<string>(ep_, (IEnumerable<string>)eq_);
-                DataType es_ = BloodpH?.Effective;
-                object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
-                CqlInterval<CqlDateTime> eu_ = QICoreCommon_4_0_000.Instance.toInterval(context, et_);
-                CqlDateTime ev_ = context.Operators.Start(eu_);
+                bool? ep_ = context.Operators.In<string>(en_, (IEnumerable<string>)eo_);
+                DataType eq_ = BloodpH?.Effective;
+                object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+                CqlInterval<CqlDateTime> es_ = QICoreCommon_4_0_000.Instance.toInterval(context, er_);
+                CqlDateTime et_ = context.Operators.Start(es_);
 
-                object ew_() {
+                object eu_() {
+
+                    bool fp_() {
+                        Procedure ft_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType fu_ = ft_?.Performed;
+                        object fv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fu_);
+                        bool fw_ = fv_ is CqlDateTime;
+                        return fw_;
+                    }
+
+
+                    bool fq_() {
+                        Procedure fx_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType fy_ = fx_?.Performed;
+                        object fz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fy_);
+                        bool ga_ = fz_ is CqlInterval<CqlDateTime>;
+                        return ga_;
+                    }
+
 
                     bool fr_() {
-                        Procedure fv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType fw_ = fv_?.Performed;
-                        object fx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fw_);
-                        bool fy_ = fx_ is CqlDateTime;
-                        return fy_;
+                        Procedure gb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType gc_ = gb_?.Performed;
+                        object gd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gc_);
+                        bool ge_ = gd_ is CqlQuantity;
+                        return ge_;
                     }
 
 
                     bool fs_() {
-                        Procedure fz_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ga_ = fz_?.Performed;
-                        object gb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ga_);
-                        bool gc_ = gb_ is CqlInterval<CqlDateTime>;
-                        return gc_;
+                        Procedure gf_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType gg_ = gf_?.Performed;
+                        object gh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gg_);
+                        bool gi_ = gh_ is CqlInterval<CqlQuantity>;
+                        return gi_;
                     }
 
-
-                    bool ft_() {
-                        Procedure gd_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ge_ = gd_?.Performed;
-                        object gf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ge_);
-                        bool gg_ = gf_ is CqlQuantity;
-                        return gg_;
-                    }
-
-
-                    bool fu_() {
-                        Procedure gh_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType gi_ = gh_?.Performed;
-                        object gj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gi_);
-                        bool gk_ = gj_ is CqlInterval<CqlQuantity>;
-                        return gk_;
-                    }
-
-                    if (fr_())
+                    if (fp_())
                     {
-                        Procedure gl_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType gm_ = gl_?.Performed;
-                        object gn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gm_);
-                        return (gn_ as CqlDateTime) as object;
+                        Procedure gj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType gk_ = gj_?.Performed;
+                        object gl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gk_);
+                        return (gl_ as CqlDateTime) as object;
+                    }
+                    else if (fq_())
+                    {
+                        Procedure gm_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType gn_ = gm_?.Performed;
+                        object go_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gn_);
+                        return (go_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (fr_())
+                    {
+                        Procedure gp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType gq_ = gp_?.Performed;
+                        object gr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gq_);
+                        return (gr_ as CqlQuantity) as object;
                     }
                     else if (fs_())
                     {
-                        Procedure go_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType gp_ = go_?.Performed;
-                        object gq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gp_);
-                        return (gq_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (ft_())
-                    {
-                        Procedure gr_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType gs_ = gr_?.Performed;
-                        object gt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gs_);
-                        return (gt_ as CqlQuantity) as object;
-                    }
-                    else if (fu_())
-                    {
-                        Procedure gu_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType gv_ = gu_?.Performed;
-                        object gw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gv_);
-                        return (gw_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure gs_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType gt_ = gs_?.Performed;
+                        object gu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gt_);
+                        return (gu_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1391,75 +1387,75 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> ex_ = QICoreCommon_4_0_000.Instance.toInterval(context, ew_());
-                CqlDateTime ey_ = context.Operators.Start(ex_);
-                CqlQuantity ez_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime fa_ = context.Operators.Subtract(ey_, ez_);
+                CqlInterval<CqlDateTime> ev_ = QICoreCommon_4_0_000.Instance.toInterval(context, eu_());
+                CqlDateTime ew_ = context.Operators.Start(ev_);
+                CqlQuantity ex_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime ey_ = context.Operators.Subtract(ew_, ex_);
 
-                object fb_() {
+                object ez_() {
+
+                    bool gv_() {
+                        Procedure gz_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ha_ = gz_?.Performed;
+                        object hb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ha_);
+                        bool hc_ = hb_ is CqlDateTime;
+                        return hc_;
+                    }
+
+
+                    bool gw_() {
+                        Procedure hd_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType he_ = hd_?.Performed;
+                        object hf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, he_);
+                        bool hg_ = hf_ is CqlInterval<CqlDateTime>;
+                        return hg_;
+                    }
+
 
                     bool gx_() {
-                        Procedure hb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType hc_ = hb_?.Performed;
-                        object hd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hc_);
-                        bool he_ = hd_ is CqlDateTime;
-                        return he_;
+                        Procedure hh_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType hi_ = hh_?.Performed;
+                        object hj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hi_);
+                        bool hk_ = hj_ is CqlQuantity;
+                        return hk_;
                     }
 
 
                     bool gy_() {
-                        Procedure hf_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType hg_ = hf_?.Performed;
-                        object hh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hg_);
-                        bool hi_ = hh_ is CqlInterval<CqlDateTime>;
-                        return hi_;
+                        Procedure hl_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType hm_ = hl_?.Performed;
+                        object hn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hm_);
+                        bool ho_ = hn_ is CqlInterval<CqlQuantity>;
+                        return ho_;
                     }
 
-
-                    bool gz_() {
-                        Procedure hj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType hk_ = hj_?.Performed;
-                        object hl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hk_);
-                        bool hm_ = hl_ is CqlQuantity;
-                        return hm_;
-                    }
-
-
-                    bool ha_() {
-                        Procedure hn_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ho_ = hn_?.Performed;
-                        object hp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ho_);
-                        bool hq_ = hp_ is CqlInterval<CqlQuantity>;
-                        return hq_;
-                    }
-
-                    if (gx_())
+                    if (gv_())
                     {
-                        Procedure hr_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType hs_ = hr_?.Performed;
-                        object ht_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hs_);
-                        return (ht_ as CqlDateTime) as object;
+                        Procedure hp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType hq_ = hp_?.Performed;
+                        object hr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hq_);
+                        return (hr_ as CqlDateTime) as object;
+                    }
+                    else if (gw_())
+                    {
+                        Procedure hs_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ht_ = hs_?.Performed;
+                        object hu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ht_);
+                        return (hu_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (gx_())
+                    {
+                        Procedure hv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType hw_ = hv_?.Performed;
+                        object hx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hw_);
+                        return (hx_ as CqlQuantity) as object;
                     }
                     else if (gy_())
                     {
-                        Procedure hu_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType hv_ = hu_?.Performed;
-                        object hw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hv_);
-                        return (hw_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (gz_())
-                    {
-                        Procedure hx_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType hy_ = hx_?.Performed;
-                        object hz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hy_);
-                        return (hz_ as CqlQuantity) as object;
-                    }
-                    else if (ha_())
-                    {
-                        Procedure ia_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ib_ = ia_?.Performed;
-                        object ic_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ib_);
-                        return (ic_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure hy_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType hz_ = hy_?.Performed;
+                        object ia_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hz_);
+                        return (ia_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1467,75 +1463,75 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> fc_ = QICoreCommon_4_0_000.Instance.toInterval(context, fb_());
-                CqlDateTime fd_ = context.Operators.Start(fc_);
-                CqlInterval<CqlDateTime> fe_ = context.Operators.Interval(fa_, fd_, true, false);
-                bool? ff_ = context.Operators.In<CqlDateTime>(ev_, fe_, (string)default);
+                CqlInterval<CqlDateTime> fa_ = QICoreCommon_4_0_000.Instance.toInterval(context, ez_());
+                CqlDateTime fb_ = context.Operators.Start(fa_);
+                CqlInterval<CqlDateTime> fc_ = context.Operators.Interval(ey_, fb_, true, false);
+                bool? fd_ = context.Operators.In<CqlDateTime>(et_, fc_, (string)default);
 
-                object fg_() {
+                object fe_() {
+
+                    bool ib_() {
+                        Procedure if_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ig_ = if_?.Performed;
+                        object ih_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ig_);
+                        bool ii_ = ih_ is CqlDateTime;
+                        return ii_;
+                    }
+
+
+                    bool ic_() {
+                        Procedure ij_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ik_ = ij_?.Performed;
+                        object il_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ik_);
+                        bool im_ = il_ is CqlInterval<CqlDateTime>;
+                        return im_;
+                    }
+
 
                     bool id_() {
-                        Procedure ih_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ii_ = ih_?.Performed;
-                        object ij_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ii_);
-                        bool ik_ = ij_ is CqlDateTime;
-                        return ik_;
+                        Procedure in_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType io_ = in_?.Performed;
+                        object ip_ = FHIRHelpers_4_4_000.Instance.ToValue(context, io_);
+                        bool iq_ = ip_ is CqlQuantity;
+                        return iq_;
                     }
 
 
                     bool ie_() {
-                        Procedure il_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType im_ = il_?.Performed;
-                        object in_ = FHIRHelpers_4_4_000.Instance.ToValue(context, im_);
-                        bool io_ = in_ is CqlInterval<CqlDateTime>;
-                        return io_;
+                        Procedure ir_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType is_ = ir_?.Performed;
+                        object it_ = FHIRHelpers_4_4_000.Instance.ToValue(context, is_);
+                        bool iu_ = it_ is CqlInterval<CqlQuantity>;
+                        return iu_;
                     }
 
-
-                    bool if_() {
-                        Procedure ip_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType iq_ = ip_?.Performed;
-                        object ir_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iq_);
-                        bool is_ = ir_ is CqlQuantity;
-                        return is_;
-                    }
-
-
-                    bool ig_() {
-                        Procedure it_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType iu_ = it_?.Performed;
-                        object iv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iu_);
-                        bool iw_ = iv_ is CqlInterval<CqlQuantity>;
-                        return iw_;
-                    }
-
-                    if (id_())
+                    if (ib_())
                     {
-                        Procedure ix_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType iy_ = ix_?.Performed;
-                        object iz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iy_);
-                        return (iz_ as CqlDateTime) as object;
+                        Procedure iv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType iw_ = iv_?.Performed;
+                        object ix_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iw_);
+                        return (ix_ as CqlDateTime) as object;
+                    }
+                    else if (ic_())
+                    {
+                        Procedure iy_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType iz_ = iy_?.Performed;
+                        object ja_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iz_);
+                        return (ja_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (id_())
+                    {
+                        Procedure jb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType jc_ = jb_?.Performed;
+                        object jd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jc_);
+                        return (jd_ as CqlQuantity) as object;
                     }
                     else if (ie_())
                     {
-                        Procedure ja_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType jb_ = ja_?.Performed;
-                        object jc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jb_);
-                        return (jc_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (if_())
-                    {
-                        Procedure jd_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType je_ = jd_?.Performed;
-                        object jf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, je_);
-                        return (jf_ as CqlQuantity) as object;
-                    }
-                    else if (ig_())
-                    {
-                        Procedure jg_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType jh_ = jg_?.Performed;
-                        object ji_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jh_);
-                        return (ji_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure je_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType jf_ = je_?.Performed;
+                        object jg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jf_);
+                        return (jg_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1543,26 +1539,25 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> fh_ = QICoreCommon_4_0_000.Instance.toInterval(context, fg_());
-                CqlDateTime fi_ = context.Operators.Start(fh_);
-                bool? fj_ = context.Operators.Not((bool?)(fi_ is null));
-                bool? fk_ = context.Operators.And(ff_, fj_);
-                bool? fl_ = context.Operators.And(er_, fk_);
-                DataType fm_ = BloodpH?.Value;
-                object fn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fm_);
-                CqlQuantity fo_ = context.Operators.Quantity(7.30m, "[pH]");
-                bool? fp_ = context.Operators.Less(fn_ as CqlQuantity, fo_);
-                bool? fq_ = context.Operators.And(fl_, fp_);
-                return fq_;
+                CqlInterval<CqlDateTime> ff_ = QICoreCommon_4_0_000.Instance.toInterval(context, fe_());
+                CqlDateTime fg_ = context.Operators.Start(ff_);
+                bool? fh_ = context.Operators.Not((bool?)(fg_ is null));
+                bool? fi_ = context.Operators.And(fd_, fh_);
+                bool? fj_ = context.Operators.And(ep_, fi_);
+                DataType fk_ = BloodpH?.Value;
+                object fl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fk_);
+                CqlQuantity fm_ = context.Operators.Quantity(7.30m, "[pH]");
+                bool? fn_ = context.Operators.Less(fl_ as CqlQuantity, fm_);
+                bool? fo_ = context.Operators.And(fj_, fn_);
+                return fo_;
             }
 
-            IEnumerable<Observation> ek_ = context.Operators.Where<Observation>(ei_, ej_);
-            Encounter el_(Observation BloodpH) => EncounterWithSurgery;
-            IEnumerable<Encounter> em_ = context.Operators.Select<Observation, Encounter>(ek_, el_);
-            return em_;
+            IEnumerable<Observation> ej_ = context.Operators.Where<Observation>(eh_, ei_);
+            bool? ek_ = context.Operators.Exists<Observation>(ej_);
+            return ek_;
         }
 
-        IEnumerable<Encounter> e_ = context.Operators.SelectMany<Encounter, Encounter>(c_, d_);
+        IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
         return e_;
     }
 
@@ -1577,89 +1572,89 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet d_ = this.Oxygen_Partial_Pressure_In_Arterial_Blood(context);
             IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
 
             bool? f_(Observation Oxygen) {
-                Code<ObservationStatus> j_ = Oxygen?.StatusElement;
-                ObservationStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                string[] m_ = [
+                Code<ObservationStatus> i_ = Oxygen?.StatusElement;
+                ObservationStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-                DataType o_ = Oxygen?.Effective;
-                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
+                bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                DataType n_ = Oxygen?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
 
-                object s_() {
+                object r_() {
+
+                    bool am_() {
+                        Procedure aq_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ar_ = aq_?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        bool at_ = as_ is CqlDateTime;
+                        return at_;
+                    }
+
 
                     bool an_() {
-                        Procedure ar_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType as_ = ar_?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        bool au_ = at_ is CqlDateTime;
-                        return au_;
+                        Procedure au_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType av_ = au_?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        bool ax_ = aw_ is CqlInterval<CqlDateTime>;
+                        return ax_;
                     }
 
 
                     bool ao_() {
-                        Procedure av_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType aw_ = av_?.Performed;
-                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                        bool ay_ = ax_ is CqlInterval<CqlDateTime>;
-                        return ay_;
+                        Procedure ay_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType az_ = ay_?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        bool bb_ = ba_ is CqlQuantity;
+                        return bb_;
                     }
 
 
                     bool ap_() {
-                        Procedure az_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ba_ = az_?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        bool bc_ = bb_ is CqlQuantity;
-                        return bc_;
+                        Procedure bc_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bd_ = bc_?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        bool bf_ = be_ is CqlInterval<CqlQuantity>;
+                        return bf_;
                     }
 
-
-                    bool aq_() {
-                        Procedure bd_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType be_ = bd_?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        bool bg_ = bf_ is CqlInterval<CqlQuantity>;
-                        return bg_;
-                    }
-
-                    if (an_())
+                    if (am_())
                     {
-                        Procedure bh_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bi_ = bh_?.Performed;
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        return (bj_ as CqlDateTime) as object;
+                        Procedure bg_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bh_ = bg_?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        return (bi_ as CqlDateTime) as object;
+                    }
+                    else if (an_())
+                    {
+                        Procedure bj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bk_ = bj_?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        return (bl_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ao_())
                     {
-                        Procedure bk_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bl_ = bk_?.Performed;
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        return (bm_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure bm_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bn_ = bm_?.Performed;
+                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                        return (bo_ as CqlQuantity) as object;
                     }
                     else if (ap_())
                     {
-                        Procedure bn_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bo_ = bn_?.Performed;
-                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
-                        return (bp_ as CqlQuantity) as object;
-                    }
-                    else if (aq_())
-                    {
-                        Procedure bq_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType br_ = bq_?.Performed;
-                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
-                        return (bs_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure bp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bq_ = bp_?.Performed;
+                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                        return (br_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1667,75 +1662,75 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_());
-                CqlDateTime u_ = context.Operators.Start(t_);
-                CqlQuantity v_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime w_ = context.Operators.Subtract(u_, v_);
+                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlQuantity u_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
 
-                object x_() {
+                object w_() {
+
+                    bool bs_() {
+                        Procedure bw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bx_ = bw_?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        bool bz_ = by_ is CqlDateTime;
+                        return bz_;
+                    }
+
 
                     bool bt_() {
-                        Procedure bx_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType by_ = bx_?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        bool ca_ = bz_ is CqlDateTime;
-                        return ca_;
+                        Procedure ca_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cb_ = ca_?.Performed;
+                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+                        bool cd_ = cc_ is CqlInterval<CqlDateTime>;
+                        return cd_;
                     }
 
 
                     bool bu_() {
-                        Procedure cb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cc_ = cb_?.Performed;
-                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        bool ce_ = cd_ is CqlInterval<CqlDateTime>;
-                        return ce_;
+                        Procedure ce_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cf_ = ce_?.Performed;
+                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                        bool ch_ = cg_ is CqlQuantity;
+                        return ch_;
                     }
 
 
                     bool bv_() {
-                        Procedure cf_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cg_ = cf_?.Performed;
-                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
-                        bool ci_ = ch_ is CqlQuantity;
-                        return ci_;
+                        Procedure ci_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cj_ = ci_?.Performed;
+                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                        bool cl_ = ck_ is CqlInterval<CqlQuantity>;
+                        return cl_;
                     }
 
-
-                    bool bw_() {
-                        Procedure cj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ck_ = cj_?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        bool cm_ = cl_ is CqlInterval<CqlQuantity>;
-                        return cm_;
-                    }
-
-                    if (bt_())
+                    if (bs_())
                     {
-                        Procedure cn_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType co_ = cn_?.Performed;
-                        object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
-                        return (cp_ as CqlDateTime) as object;
+                        Procedure cm_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cn_ = cm_?.Performed;
+                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+                        return (co_ as CqlDateTime) as object;
+                    }
+                    else if (bt_())
+                    {
+                        Procedure cp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cq_ = cp_?.Performed;
+                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                        return (cr_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bu_())
                     {
-                        Procedure cq_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cr_ = cq_?.Performed;
-                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
-                        return (cs_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure cs_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ct_ = cs_?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        return (cu_ as CqlQuantity) as object;
                     }
                     else if (bv_())
                     {
-                        Procedure ct_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cu_ = ct_?.Performed;
-                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
-                        return (cv_ as CqlQuantity) as object;
-                    }
-                    else if (bw_())
-                    {
-                        Procedure cw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cx_ = cw_?.Performed;
-                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
-                        return (cy_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure cv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType cw_ = cv_?.Performed;
+                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                        return (cx_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1743,75 +1738,75 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
-                CqlDateTime z_ = context.Operators.Start(y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, false);
-                bool? ab_ = context.Operators.In<CqlDateTime>(r_, aa_, (string)default);
+                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_());
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, false);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, (string)default);
 
-                object ac_() {
+                object ab_() {
+
+                    bool cy_() {
+                        Procedure dc_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dd_ = dc_?.Performed;
+                        object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
+                        bool df_ = de_ is CqlDateTime;
+                        return df_;
+                    }
+
 
                     bool cz_() {
-                        Procedure dd_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType de_ = dd_?.Performed;
-                        object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
-                        bool dg_ = df_ is CqlDateTime;
-                        return dg_;
+                        Procedure dg_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dh_ = dg_?.Performed;
+                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+                        bool dj_ = di_ is CqlInterval<CqlDateTime>;
+                        return dj_;
                     }
 
 
                     bool da_() {
-                        Procedure dh_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType di_ = dh_?.Performed;
-                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                        bool dk_ = dj_ is CqlInterval<CqlDateTime>;
-                        return dk_;
+                        Procedure dk_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dl_ = dk_?.Performed;
+                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+                        bool dn_ = dm_ is CqlQuantity;
+                        return dn_;
                     }
 
 
                     bool db_() {
-                        Procedure dl_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dm_ = dl_?.Performed;
-                        object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
-                        bool do_ = dn_ is CqlQuantity;
-                        return do_;
+                        Procedure do_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dp_ = do_?.Performed;
+                        object dq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dp_);
+                        bool dr_ = dq_ is CqlInterval<CqlQuantity>;
+                        return dr_;
                     }
 
-
-                    bool dc_() {
-                        Procedure dp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dq_ = dp_?.Performed;
-                        object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
-                        bool ds_ = dr_ is CqlInterval<CqlQuantity>;
-                        return ds_;
-                    }
-
-                    if (cz_())
+                    if (cy_())
                     {
-                        Procedure dt_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType du_ = dt_?.Performed;
-                        object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                        return (dv_ as CqlDateTime) as object;
+                        Procedure ds_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dt_ = ds_?.Performed;
+                        object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                        return (du_ as CqlDateTime) as object;
+                    }
+                    else if (cz_())
+                    {
+                        Procedure dv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dw_ = dv_?.Performed;
+                        object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                        return (dx_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (da_())
                     {
-                        Procedure dw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dx_ = dw_?.Performed;
-                        object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
-                        return (dy_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure dy_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dz_ = dy_?.Performed;
+                        object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
+                        return (ea_ as CqlQuantity) as object;
                     }
                     else if (db_())
                     {
-                        Procedure dz_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ea_ = dz_?.Performed;
-                        object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                        return (eb_ as CqlQuantity) as object;
-                    }
-                    else if (dc_())
-                    {
-                        Procedure ec_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ed_ = ec_?.Performed;
-                        object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
-                        return (ee_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure eb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ec_ = eb_?.Performed;
+                        object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
+                        return (ed_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1819,26 +1814,25 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_());
-                CqlDateTime ae_ = context.Operators.Start(ad_);
-                bool? af_ = context.Operators.Not((bool?)(ae_ is null));
-                bool? ag_ = context.Operators.And(ab_, af_);
-                bool? ah_ = context.Operators.And(n_, ag_);
-                DataType ai_ = Oxygen?.Value;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(50m, "mm[Hg]");
-                bool? al_ = context.Operators.Less(aj_ as CqlQuantity, ak_);
-                bool? am_ = context.Operators.And(ah_, al_);
-                return am_;
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_());
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                bool? ag_ = context.Operators.And(m_, af_);
+                DataType ah_ = Oxygen?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlQuantity aj_ = context.Operators.Quantity(50m, "mm[Hg]");
+                bool? ak_ = context.Operators.Less(ai_ as CqlQuantity, aj_);
+                bool? al_ = context.Operators.And(ag_, ak_);
+                return al_;
             }
 
             IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
-            Encounter h_(Observation Oxygen) => EncounterWithSurgery;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Observation>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1918,78 +1912,78 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet d_ = this.Tracheostomy_Procedures(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure TracheostomySurgery) {
-                Code<EventStatus> j_ = TracheostomySurgery?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
-                bool? n_ = this.startsDuringHospitalization(context, TracheostomySurgery as object, EncounterWithSurgery);
-                bool? o_ = context.Operators.And(m_, n_);
+                Code<EventStatus> i_ = TracheostomySurgery?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
+                bool? m_ = this.startsDuringHospitalization(context, TracheostomySurgery as object, EncounterWithSurgery);
+                bool? n_ = context.Operators.And(l_, m_);
 
-                CqlInterval<CqlDateTime> p_() {
+                CqlInterval<CqlDateTime> o_() {
 
-                    bool u_() {
+                    bool t_() {
 
-                        object v_() {
+                        object u_() {
+
+                            bool x_() {
+                                DataType ab_ = TracheostomySurgery?.Performed;
+                                object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                                bool ad_ = ac_ is CqlDateTime;
+                                return ad_;
+                            }
+
 
                             bool y_() {
-                                DataType ac_ = TracheostomySurgery?.Performed;
-                                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                                bool ae_ = ad_ is CqlDateTime;
-                                return ae_;
+                                DataType ae_ = TracheostomySurgery?.Performed;
+                                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                                bool ag_ = af_ is CqlInterval<CqlDateTime>;
+                                return ag_;
                             }
 
 
                             bool z_() {
-                                DataType af_ = TracheostomySurgery?.Performed;
-                                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                                bool ah_ = ag_ is CqlInterval<CqlDateTime>;
-                                return ah_;
+                                DataType ah_ = TracheostomySurgery?.Performed;
+                                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                                bool aj_ = ai_ is CqlQuantity;
+                                return aj_;
                             }
 
 
                             bool aa_() {
-                                DataType ai_ = TracheostomySurgery?.Performed;
-                                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                                bool ak_ = aj_ is CqlQuantity;
-                                return ak_;
+                                DataType ak_ = TracheostomySurgery?.Performed;
+                                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                                bool am_ = al_ is CqlInterval<CqlQuantity>;
+                                return am_;
                             }
 
-
-                            bool ab_() {
-                                DataType al_ = TracheostomySurgery?.Performed;
-                                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                                bool an_ = am_ is CqlInterval<CqlQuantity>;
-                                return an_;
-                            }
-
-                            if (y_())
+                            if (x_())
                             {
-                                DataType ao_ = TracheostomySurgery?.Performed;
-                                object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                                return (ap_ as CqlDateTime) as object;
+                                DataType an_ = TracheostomySurgery?.Performed;
+                                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                                return (ao_ as CqlDateTime) as object;
+                            }
+                            else if (y_())
+                            {
+                                DataType ap_ = TracheostomySurgery?.Performed;
+                                object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                                return (aq_ as CqlInterval<CqlDateTime>) as object;
                             }
                             else if (z_())
                             {
-                                DataType aq_ = TracheostomySurgery?.Performed;
-                                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                                return (ar_ as CqlInterval<CqlDateTime>) as object;
+                                DataType ar_ = TracheostomySurgery?.Performed;
+                                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                                return (as_ as CqlQuantity) as object;
                             }
                             else if (aa_())
                             {
-                                DataType as_ = TracheostomySurgery?.Performed;
-                                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                                return (at_ as CqlQuantity) as object;
-                            }
-                            else if (ab_())
-                            {
-                                DataType au_ = TracheostomySurgery?.Performed;
-                                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                                return (av_ as CqlInterval<CqlQuantity>) as object;
+                                DataType at_ = TracheostomySurgery?.Performed;
+                                object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                                return (au_ as CqlInterval<CqlQuantity>) as object;
                             }
                             else
                             {
@@ -1997,74 +1991,74 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                             };
                         }
 
-                        CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_());
-                        CqlDateTime x_ = context.Operators.Start(w_);
-                        return x_ is null;
+                        CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
+                        CqlDateTime w_ = context.Operators.Start(v_);
+                        return w_ is null;
                     }
 
-                    if (u_())
+                    if (t_())
                     {
                         return default;
                     }
                     else
                     {
 
-                        object aw_() {
+                        object av_() {
+
+                            bool bc_() {
+                                DataType bg_ = TracheostomySurgery?.Performed;
+                                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                                bool bi_ = bh_ is CqlDateTime;
+                                return bi_;
+                            }
+
 
                             bool bd_() {
-                                DataType bh_ = TracheostomySurgery?.Performed;
-                                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                                bool bj_ = bi_ is CqlDateTime;
-                                return bj_;
+                                DataType bj_ = TracheostomySurgery?.Performed;
+                                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                                bool bl_ = bk_ is CqlInterval<CqlDateTime>;
+                                return bl_;
                             }
 
 
                             bool be_() {
-                                DataType bk_ = TracheostomySurgery?.Performed;
-                                object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                                bool bm_ = bl_ is CqlInterval<CqlDateTime>;
-                                return bm_;
+                                DataType bm_ = TracheostomySurgery?.Performed;
+                                object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                                bool bo_ = bn_ is CqlQuantity;
+                                return bo_;
                             }
 
 
                             bool bf_() {
-                                DataType bn_ = TracheostomySurgery?.Performed;
-                                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                                bool bp_ = bo_ is CqlQuantity;
-                                return bp_;
+                                DataType bp_ = TracheostomySurgery?.Performed;
+                                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+                                bool br_ = bq_ is CqlInterval<CqlQuantity>;
+                                return br_;
                             }
 
-
-                            bool bg_() {
-                                DataType bq_ = TracheostomySurgery?.Performed;
-                                object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                                bool bs_ = br_ is CqlInterval<CqlQuantity>;
-                                return bs_;
-                            }
-
-                            if (bd_())
+                            if (bc_())
                             {
-                                DataType bt_ = TracheostomySurgery?.Performed;
-                                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                                return (bu_ as CqlDateTime) as object;
+                                DataType bs_ = TracheostomySurgery?.Performed;
+                                object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                                return (bt_ as CqlDateTime) as object;
+                            }
+                            else if (bd_())
+                            {
+                                DataType bu_ = TracheostomySurgery?.Performed;
+                                object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                                return (bv_ as CqlInterval<CqlDateTime>) as object;
                             }
                             else if (be_())
                             {
-                                DataType bv_ = TracheostomySurgery?.Performed;
-                                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                                return (bw_ as CqlInterval<CqlDateTime>) as object;
+                                DataType bw_ = TracheostomySurgery?.Performed;
+                                object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+                                return (bx_ as CqlQuantity) as object;
                             }
                             else if (bf_())
                             {
-                                DataType bx_ = TracheostomySurgery?.Performed;
-                                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                                return (by_ as CqlQuantity) as object;
-                            }
-                            else if (bg_())
-                            {
-                                DataType bz_ = TracheostomySurgery?.Performed;
-                                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                                return (ca_ as CqlInterval<CqlQuantity>) as object;
+                                DataType by_ = TracheostomySurgery?.Performed;
+                                object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
+                                return (bz_ as CqlInterval<CqlQuantity>) as object;
                             }
                             else
                             {
@@ -2072,65 +2066,65 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                             };
                         }
 
-                        CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_());
-                        CqlDateTime ay_ = context.Operators.Start(ax_);
+                        CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_());
+                        CqlDateTime ax_ = context.Operators.Start(aw_);
 
-                        object az_() {
+                        object ay_() {
+
+                            bool ca_() {
+                                DataType ce_ = TracheostomySurgery?.Performed;
+                                object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                                bool cg_ = cf_ is CqlDateTime;
+                                return cg_;
+                            }
+
 
                             bool cb_() {
-                                DataType cf_ = TracheostomySurgery?.Performed;
-                                object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                                bool ch_ = cg_ is CqlDateTime;
-                                return ch_;
+                                DataType ch_ = TracheostomySurgery?.Performed;
+                                object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                                bool cj_ = ci_ is CqlInterval<CqlDateTime>;
+                                return cj_;
                             }
 
 
                             bool cc_() {
-                                DataType ci_ = TracheostomySurgery?.Performed;
-                                object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                                bool ck_ = cj_ is CqlInterval<CqlDateTime>;
-                                return ck_;
+                                DataType ck_ = TracheostomySurgery?.Performed;
+                                object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+                                bool cm_ = cl_ is CqlQuantity;
+                                return cm_;
                             }
 
 
                             bool cd_() {
-                                DataType cl_ = TracheostomySurgery?.Performed;
-                                object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                                bool cn_ = cm_ is CqlQuantity;
-                                return cn_;
+                                DataType cn_ = TracheostomySurgery?.Performed;
+                                object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+                                bool cp_ = co_ is CqlInterval<CqlQuantity>;
+                                return cp_;
                             }
 
-
-                            bool ce_() {
-                                DataType co_ = TracheostomySurgery?.Performed;
-                                object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
-                                bool cq_ = cp_ is CqlInterval<CqlQuantity>;
-                                return cq_;
-                            }
-
-                            if (cb_())
+                            if (ca_())
                             {
-                                DataType cr_ = TracheostomySurgery?.Performed;
-                                object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
-                                return (cs_ as CqlDateTime) as object;
+                                DataType cq_ = TracheostomySurgery?.Performed;
+                                object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                                return (cr_ as CqlDateTime) as object;
+                            }
+                            else if (cb_())
+                            {
+                                DataType cs_ = TracheostomySurgery?.Performed;
+                                object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
+                                return (ct_ as CqlInterval<CqlDateTime>) as object;
                             }
                             else if (cc_())
                             {
-                                DataType ct_ = TracheostomySurgery?.Performed;
-                                object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                                return (cu_ as CqlInterval<CqlDateTime>) as object;
+                                DataType cu_ = TracheostomySurgery?.Performed;
+                                object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+                                return (cv_ as CqlQuantity) as object;
                             }
                             else if (cd_())
                             {
-                                DataType cv_ = TracheostomySurgery?.Performed;
-                                object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                                return (cw_ as CqlQuantity) as object;
-                            }
-                            else if (ce_())
-                            {
-                                DataType cx_ = TracheostomySurgery?.Performed;
-                                object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
-                                return (cy_ as CqlInterval<CqlQuantity>) as object;
+                                DataType cw_ = TracheostomySurgery?.Performed;
+                                object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                                return (cx_ as CqlInterval<CqlQuantity>) as object;
                             }
                             else
                             {
@@ -2138,78 +2132,78 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                             };
                         }
 
-                        CqlInterval<CqlDateTime> ba_ = QICoreCommon_4_0_000.Instance.toInterval(context, az_());
-                        CqlDateTime bb_ = context.Operators.Start(ba_);
-                        CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(ay_, bb_, true, true);
-                        return bc_;
+                        CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_());
+                        CqlDateTime ba_ = context.Operators.Start(az_);
+                        CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ax_, ba_, true, true);
+                        return bb_;
                     };
                 }
 
 
-                object q_() {
+                object p_() {
+
+                    bool cy_() {
+                        Procedure dc_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dd_ = dc_?.Performed;
+                        object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
+                        bool df_ = de_ is CqlDateTime;
+                        return df_;
+                    }
+
 
                     bool cz_() {
-                        Procedure dd_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType de_ = dd_?.Performed;
-                        object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
-                        bool dg_ = df_ is CqlDateTime;
-                        return dg_;
+                        Procedure dg_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dh_ = dg_?.Performed;
+                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+                        bool dj_ = di_ is CqlInterval<CqlDateTime>;
+                        return dj_;
                     }
 
 
                     bool da_() {
-                        Procedure dh_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType di_ = dh_?.Performed;
-                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                        bool dk_ = dj_ is CqlInterval<CqlDateTime>;
-                        return dk_;
+                        Procedure dk_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dl_ = dk_?.Performed;
+                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+                        bool dn_ = dm_ is CqlQuantity;
+                        return dn_;
                     }
 
 
                     bool db_() {
-                        Procedure dl_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dm_ = dl_?.Performed;
-                        object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
-                        bool do_ = dn_ is CqlQuantity;
-                        return do_;
+                        Procedure do_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dp_ = do_?.Performed;
+                        object dq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dp_);
+                        bool dr_ = dq_ is CqlInterval<CqlQuantity>;
+                        return dr_;
                     }
 
-
-                    bool dc_() {
-                        Procedure dp_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dq_ = dp_?.Performed;
-                        object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
-                        bool ds_ = dr_ is CqlInterval<CqlQuantity>;
-                        return ds_;
-                    }
-
-                    if (cz_())
+                    if (cy_())
                     {
-                        Procedure dt_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType du_ = dt_?.Performed;
-                        object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                        return (dv_ as CqlDateTime) as object;
+                        Procedure ds_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dt_ = ds_?.Performed;
+                        object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                        return (du_ as CqlDateTime) as object;
+                    }
+                    else if (cz_())
+                    {
+                        Procedure dv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dw_ = dv_?.Performed;
+                        object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                        return (dx_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (da_())
                     {
-                        Procedure dw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType dx_ = dw_?.Performed;
-                        object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
-                        return (dy_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure dy_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType dz_ = dy_?.Performed;
+                        object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
+                        return (ea_ as CqlQuantity) as object;
                     }
                     else if (db_())
                     {
-                        Procedure dz_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ea_ = dz_?.Performed;
-                        object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                        return (eb_ as CqlQuantity) as object;
-                    }
-                    else if (dc_())
-                    {
-                        Procedure ec_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ed_ = ec_?.Performed;
-                        object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
-                        return (ee_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure eb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ec_ = eb_?.Performed;
+                        object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
+                        return (ed_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2217,19 +2211,18 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                bool? s_ = context.Operators.Before(p_(), r_, "day");
-                bool? t_ = context.Operators.And(o_, s_);
-                return t_;
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                bool? r_ = context.Operators.Before(o_(), q_, "day");
+                bool? s_ = context.Operators.And(n_, r_);
+                return s_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure TracheostomySurgery) => EncounterWithSurgery;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -2244,74 +2237,74 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet d_ = this.Tracheostomy_Procedures(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure TracheostomySurgery) {
-                Code<EventStatus> j_ = TracheostomySurgery?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
-                bool? n_ = this.startsDuringHospitalization(context, TracheostomySurgery as object, EncounterWithSurgery);
-                bool? o_ = context.Operators.And(m_, n_);
+                Code<EventStatus> i_ = TracheostomySurgery?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
+                bool? m_ = this.startsDuringHospitalization(context, TracheostomySurgery as object, EncounterWithSurgery);
+                bool? n_ = context.Operators.And(l_, m_);
 
-                object p_() {
+                object o_() {
+
+                    bool v_() {
+                        DataType z_ = TracheostomySurgery?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlDateTime;
+                        return ab_;
+                    }
+
 
                     bool w_() {
-                        DataType aa_ = TracheostomySurgery?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlDateTime;
-                        return ac_;
+                        DataType ac_ = TracheostomySurgery?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlDateTime>;
+                        return ae_;
                     }
 
 
                     bool x_() {
-                        DataType ad_ = TracheostomySurgery?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlInterval<CqlDateTime>;
-                        return af_;
+                        DataType af_ = TracheostomySurgery?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlQuantity;
+                        return ah_;
                     }
 
 
                     bool y_() {
-                        DataType ag_ = TracheostomySurgery?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlQuantity;
-                        return ai_;
+                        DataType ai_ = TracheostomySurgery?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        bool ak_ = aj_ is CqlInterval<CqlQuantity>;
+                        return ak_;
                     }
 
-
-                    bool z_() {
-                        DataType aj_ = TracheostomySurgery?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        bool al_ = ak_ is CqlInterval<CqlQuantity>;
-                        return al_;
-                    }
-
-                    if (w_())
+                    if (v_())
                     {
-                        DataType am_ = TracheostomySurgery?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlDateTime) as object;
+                        DataType al_ = TracheostomySurgery?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlDateTime) as object;
+                    }
+                    else if (w_())
+                    {
+                        DataType an_ = TracheostomySurgery?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (x_())
                     {
-                        DataType ao_ = TracheostomySurgery?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ap_ = TracheostomySurgery?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        return (aq_ as CqlQuantity) as object;
                     }
                     else if (y_())
                     {
-                        DataType aq_ = TracheostomySurgery?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        return (ar_ as CqlQuantity) as object;
-                    }
-                    else if (z_())
-                    {
-                        DataType as_ = TracheostomySurgery?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        return (at_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ar_ = TracheostomySurgery?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        return (as_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2319,73 +2312,73 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
-                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
+                CqlDateTime q_ = context.Operators.Start(p_);
 
-                object s_() {
+                object r_() {
+
+                    bool at_() {
+                        Procedure ax_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType ay_ = ax_?.Performed;
+                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+                        bool ba_ = az_ is CqlDateTime;
+                        return ba_;
+                    }
+
 
                     bool au_() {
-                        Procedure ay_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType az_ = ay_?.Performed;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        bool bb_ = ba_ is CqlDateTime;
-                        return bb_;
+                        Procedure bb_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bc_ = bb_?.Performed;
+                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                        bool be_ = bd_ is CqlInterval<CqlDateTime>;
+                        return be_;
                     }
 
 
                     bool av_() {
-                        Procedure bc_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bd_ = bc_?.Performed;
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        bool bf_ = be_ is CqlInterval<CqlDateTime>;
-                        return bf_;
+                        Procedure bf_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bg_ = bf_?.Performed;
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        bool bi_ = bh_ is CqlQuantity;
+                        return bi_;
                     }
 
 
                     bool aw_() {
-                        Procedure bg_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bh_ = bg_?.Performed;
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        bool bj_ = bi_ is CqlQuantity;
-                        return bj_;
+                        Procedure bj_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bk_ = bj_?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        bool bm_ = bl_ is CqlInterval<CqlQuantity>;
+                        return bm_;
                     }
 
-
-                    bool ax_() {
-                        Procedure bk_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bl_ = bk_?.Performed;
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        bool bn_ = bm_ is CqlInterval<CqlQuantity>;
-                        return bn_;
-                    }
-
-                    if (au_())
+                    if (at_())
                     {
-                        Procedure bo_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bp_ = bo_?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        return (bq_ as CqlDateTime) as object;
+                        Procedure bn_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bo_ = bn_?.Performed;
+                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                        return (bp_ as CqlDateTime) as object;
+                    }
+                    else if (au_())
+                    {
+                        Procedure bq_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType br_ = bq_?.Performed;
+                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                        return (bs_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (av_())
                     {
-                        Procedure br_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bs_ = br_?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        return (bt_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure bt_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bu_ = bt_?.Performed;
+                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                        return (bv_ as CqlQuantity) as object;
                     }
                     else if (aw_())
                     {
-                        Procedure bu_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType bv_ = bu_?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        return (bw_ as CqlQuantity) as object;
-                    }
-                    else if (ax_())
-                    {
-                        Procedure bx_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType by_ = bx_?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        return (bz_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure bw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                        DataType bx_ = bw_?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        return (by_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2393,19 +2386,18 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_());
-                bool? u_ = context.Operators.In<CqlDateTime>(r_, t_, "day");
-                bool? v_ = context.Operators.And(o_, u_);
-                return v_;
+                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
+                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
+                bool? u_ = context.Operators.And(n_, t_);
+                return u_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure TracheostomySurgery) => EncounterWithSurgery;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -3004,38 +2996,37 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         List<Encounter.LocationComponent> a_ = encounter?.Location;
 
-        IEnumerable<Encounter.LocationComponent> b_(Encounter.LocationComponent EncounterLocation) {
+        bool? b_(Encounter.LocationComponent EncounterLocation) {
             IEnumerable<Location> f_ = context.Operators.Retrieve<Location>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location"));
 
             bool? g_(Location Location) {
-                ResourceReference k_ = EncounterLocation?.Location;
-                bool? l_ = QICoreCommon_4_0_000.Instance.references(context, k_, Location);
-                List<CodeableConcept> m_ = Location?.Type;
+                ResourceReference j_ = EncounterLocation?.Location;
+                bool? k_ = QICoreCommon_4_0_000.Instance.references(context, j_, Location);
+                List<CodeableConcept> l_ = Location?.Type;
 
-                CqlConcept n_(CodeableConcept @this) {
-                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return x_;
+                CqlConcept m_(CodeableConcept @this) {
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return w_;
                 }
 
-                IEnumerable<CqlConcept> o_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)m_, n_);
-                CqlCode p_ = this.ER(context);
-                bool? q_ = QICoreCommon_4_0_000.Instance.includesCode(context, o_, p_);
-                bool? r_ = context.Operators.And(l_, q_);
-                Period s_ = EncounterLocation?.Period;
-                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                CqlDateTime u_ = context.Operators.Start(t_);
-                bool? v_ = context.Operators.In<CqlDateTime>(u_, intrvl, (string)default);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                IEnumerable<CqlConcept> n_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)l_, m_);
+                CqlCode o_ = this.ER(context);
+                bool? p_ = QICoreCommon_4_0_000.Instance.includesCode(context, n_, o_);
+                bool? q_ = context.Operators.And(k_, p_);
+                Period r_ = EncounterLocation?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                bool? u_ = context.Operators.In<CqlDateTime>(t_, intrvl, (string)default);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Location> h_ = context.Operators.Where<Location>(f_, g_);
-            Encounter.LocationComponent i_(Location Location) => EncounterLocation;
-            IEnumerable<Encounter.LocationComponent> j_ = context.Operators.Select<Location, Encounter.LocationComponent>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Location>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SelectMany<Encounter.LocationComponent, Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
+        IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
         bool? d_ = context.Operators.Exists<Encounter.LocationComponent>(c_);
         bool? e_ = context.Operators.Not(d_);
         return e_;
@@ -3224,76 +3215,76 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet d_ = this.Intubation(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure EndotrachealTubeIn) {
-                Code<EventStatus> j_ = EndotrachealTubeIn?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
-                bool? n_ = this.starts30DaysOrLessAfterFirstAnesthesia(context, EndotrachealTubeIn, EncounterWithSurgery);
-                bool? o_ = context.Operators.And(m_, n_);
-                bool? p_ = this.startsDuringHospitalization(context, EndotrachealTubeIn as object, EncounterWithSurgery);
-                bool? q_ = context.Operators.And(o_, p_);
+                Code<EventStatus> i_ = EndotrachealTubeIn?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
+                bool? m_ = this.starts30DaysOrLessAfterFirstAnesthesia(context, EndotrachealTubeIn, EncounterWithSurgery);
+                bool? n_ = context.Operators.And(l_, m_);
+                bool? o_ = this.startsDuringHospitalization(context, EndotrachealTubeIn as object, EncounterWithSurgery);
+                bool? p_ = context.Operators.And(n_, o_);
 
-                object r_() {
+                object q_() {
+
+                    bool am_() {
+                        DataType aq_ = EndotrachealTubeIn?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        bool as_ = ar_ is CqlDateTime;
+                        return as_;
+                    }
+
 
                     bool an_() {
-                        DataType ar_ = EndotrachealTubeIn?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlDateTime;
-                        return at_;
+                        DataType at_ = EndotrachealTubeIn?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        bool av_ = au_ is CqlInterval<CqlDateTime>;
+                        return av_;
                     }
 
 
                     bool ao_() {
-                        DataType au_ = EndotrachealTubeIn?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
-                        return aw_;
+                        DataType aw_ = EndotrachealTubeIn?.Performed;
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        bool ay_ = ax_ is CqlQuantity;
+                        return ay_;
                     }
 
 
                     bool ap_() {
-                        DataType ax_ = EndotrachealTubeIn?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        bool az_ = ay_ is CqlQuantity;
-                        return az_;
+                        DataType az_ = EndotrachealTubeIn?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        bool bb_ = ba_ is CqlInterval<CqlQuantity>;
+                        return bb_;
                     }
 
-
-                    bool aq_() {
-                        DataType ba_ = EndotrachealTubeIn?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        bool bc_ = bb_ is CqlInterval<CqlQuantity>;
-                        return bc_;
-                    }
-
-                    if (an_())
+                    if (am_())
                     {
-                        DataType bd_ = EndotrachealTubeIn?.Performed;
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        return (be_ as CqlDateTime) as object;
+                        DataType bc_ = EndotrachealTubeIn?.Performed;
+                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                        return (bd_ as CqlDateTime) as object;
+                    }
+                    else if (an_())
+                    {
+                        DataType be_ = EndotrachealTubeIn?.Performed;
+                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+                        return (bf_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ao_())
                     {
-                        DataType bf_ = EndotrachealTubeIn?.Performed;
-                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                        return (bg_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bg_ = EndotrachealTubeIn?.Performed;
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        return (bh_ as CqlQuantity) as object;
                     }
                     else if (ap_())
                     {
-                        DataType bh_ = EndotrachealTubeIn?.Performed;
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        return (bi_ as CqlQuantity) as object;
-                    }
-                    else if (aq_())
-                    {
-                        DataType bj_ = EndotrachealTubeIn?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        return (bk_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bi_ = EndotrachealTubeIn?.Performed;
+                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                        return (bj_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -3301,73 +3292,73 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
-                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
+                CqlDateTime s_ = context.Operators.Start(r_);
 
-                object u_() {
+                object t_() {
+
+                    bool bk_() {
+                        Procedure bo_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType bp_ = bo_?.Performed;
+                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+                        bool br_ = bq_ is CqlDateTime;
+                        return br_;
+                    }
+
 
                     bool bl_() {
-                        Procedure bp_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType bq_ = bp_?.Performed;
-                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                        bool bs_ = br_ is CqlDateTime;
-                        return bs_;
+                        Procedure bs_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType bt_ = bs_?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        bool bv_ = bu_ is CqlInterval<CqlDateTime>;
+                        return bv_;
                     }
 
 
                     bool bm_() {
-                        Procedure bt_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType bu_ = bt_?.Performed;
-                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                        bool bw_ = bv_ is CqlInterval<CqlDateTime>;
-                        return bw_;
+                        Procedure bw_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType bx_ = bw_?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        bool bz_ = by_ is CqlQuantity;
+                        return bz_;
                     }
 
 
                     bool bn_() {
-                        Procedure bx_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType by_ = bx_?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        bool ca_ = bz_ is CqlQuantity;
-                        return ca_;
+                        Procedure ca_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType cb_ = ca_?.Performed;
+                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+                        bool cd_ = cc_ is CqlInterval<CqlQuantity>;
+                        return cd_;
                     }
 
-
-                    bool bo_() {
-                        Procedure cb_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType cc_ = cb_?.Performed;
-                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        bool ce_ = cd_ is CqlInterval<CqlQuantity>;
-                        return ce_;
-                    }
-
-                    if (bl_())
+                    if (bk_())
                     {
-                        Procedure cf_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType cg_ = cf_?.Performed;
-                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
-                        return (ch_ as CqlDateTime) as object;
+                        Procedure ce_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType cf_ = ce_?.Performed;
+                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                        return (cg_ as CqlDateTime) as object;
+                    }
+                    else if (bl_())
+                    {
+                        Procedure ch_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType ci_ = ch_?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        return (cj_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bm_())
                     {
-                        Procedure ci_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType cj_ = ci_?.Performed;
-                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                        return (ck_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure ck_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType cl_ = ck_?.Performed;
+                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                        return (cm_ as CqlQuantity) as object;
                     }
                     else if (bn_())
                     {
-                        Procedure cl_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType cm_ = cl_?.Performed;
-                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                        return (cn_ as CqlQuantity) as object;
-                    }
-                    else if (bo_())
-                    {
-                        Procedure co_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                        DataType cp_ = co_?.Performed;
-                        object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
-                        return (cq_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure cn_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                        DataType co_ = cn_?.Performed;
+                        object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+                        return (cp_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -3375,67 +3366,67 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.End(v_);
-                bool? x_ = context.Operators.After(t_, w_, (string)default);
-                bool? y_ = context.Operators.And(q_, x_);
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.End(u_);
+                bool? w_ = context.Operators.After(s_, v_, (string)default);
+                bool? x_ = context.Operators.And(p_, w_);
 
-                object z_() {
+                object y_() {
+
+                    bool cq_() {
+                        DataType cu_ = EndotrachealTubeIn?.Performed;
+                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+                        bool cw_ = cv_ is CqlDateTime;
+                        return cw_;
+                    }
+
 
                     bool cr_() {
-                        DataType cv_ = EndotrachealTubeIn?.Performed;
-                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                        bool cx_ = cw_ is CqlDateTime;
-                        return cx_;
+                        DataType cx_ = EndotrachealTubeIn?.Performed;
+                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
+                        bool cz_ = cy_ is CqlInterval<CqlDateTime>;
+                        return cz_;
                     }
 
 
                     bool cs_() {
-                        DataType cy_ = EndotrachealTubeIn?.Performed;
-                        object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
-                        bool da_ = cz_ is CqlInterval<CqlDateTime>;
-                        return da_;
+                        DataType da_ = EndotrachealTubeIn?.Performed;
+                        object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
+                        bool dc_ = db_ is CqlQuantity;
+                        return dc_;
                     }
 
 
                     bool ct_() {
-                        DataType db_ = EndotrachealTubeIn?.Performed;
-                        object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
-                        bool dd_ = dc_ is CqlQuantity;
-                        return dd_;
+                        DataType dd_ = EndotrachealTubeIn?.Performed;
+                        object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
+                        bool df_ = de_ is CqlInterval<CqlQuantity>;
+                        return df_;
                     }
 
-
-                    bool cu_() {
-                        DataType de_ = EndotrachealTubeIn?.Performed;
-                        object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
-                        bool dg_ = df_ is CqlInterval<CqlQuantity>;
-                        return dg_;
-                    }
-
-                    if (cr_())
+                    if (cq_())
                     {
-                        DataType dh_ = EndotrachealTubeIn?.Performed;
-                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
-                        return (di_ as CqlDateTime) as object;
+                        DataType dg_ = EndotrachealTubeIn?.Performed;
+                        object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
+                        return (dh_ as CqlDateTime) as object;
+                    }
+                    else if (cr_())
+                    {
+                        DataType di_ = EndotrachealTubeIn?.Performed;
+                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+                        return (dj_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (cs_())
                     {
-                        DataType dj_ = EndotrachealTubeIn?.Performed;
-                        object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
-                        return (dk_ as CqlInterval<CqlDateTime>) as object;
+                        DataType dk_ = EndotrachealTubeIn?.Performed;
+                        object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
+                        return (dl_ as CqlQuantity) as object;
                     }
                     else if (ct_())
                     {
-                        DataType dl_ = EndotrachealTubeIn?.Performed;
-                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                        return (dm_ as CqlQuantity) as object;
-                    }
-                    else if (cu_())
-                    {
-                        DataType dn_ = EndotrachealTubeIn?.Performed;
-                        object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
-                        return (do_ as CqlInterval<CqlQuantity>) as object;
+                        DataType dm_ = EndotrachealTubeIn?.Performed;
+                        object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
+                        return (dn_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -3443,44 +3434,43 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                bool? ab_ = this.isNotAtProceduralHospitalLocationDuring(context, EncounterWithSurgery, aa_);
-                bool? ac_ = context.Operators.And(y_, ab_);
-                IEnumerable<Procedure> ad_ = this.Intubation_During_General_Anesthesia_And_MAC(context);
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                bool? aa_ = this.isNotAtProceduralHospitalLocationDuring(context, EncounterWithSurgery, z_);
+                bool? ab_ = context.Operators.And(x_, aa_);
+                IEnumerable<Procedure> ac_ = this.Intubation_During_General_Anesthesia_And_MAC(context);
 
-                bool? ae_(Procedure @this) {
-                    string dp_ = (@this is Resource
+                bool? ad_(Procedure @this) {
+                    string do_ = (@this is Resource
                         ? (@this as Resource).IdElement
                         : default)?.Value;
-                    bool? dq_ = context.Operators.Not((bool?)(dp_ is null));
+                    bool? dp_ = context.Operators.Not((bool?)(do_ is null));
+                    return dp_;
+                }
+
+                IEnumerable<Procedure> ae_ = context.Operators.Where<Procedure>(ac_, ad_);
+
+                string af_(Procedure @this) {
+                    string dq_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
                     return dq_;
                 }
 
-                IEnumerable<Procedure> af_ = context.Operators.Where<Procedure>(ad_, ae_);
-
-                string ag_(Procedure @this) {
-                    string dr_ = (@this is Resource
-                        ? (@this as Resource).IdElement
-                        : default)?.Value;
-                    return dr_;
-                }
-
-                IEnumerable<string> ah_ = context.Operators.Select<Procedure, string>(af_, ag_);
-                Id ai_ = EndotrachealTubeIn?.IdElement;
-                string aj_ = ai_?.Value;
-                bool? ak_ = context.Operators.Contains<string>(ah_, aj_);
-                bool? al_ = context.Operators.Not(ak_);
-                bool? am_ = context.Operators.And(ac_, al_);
-                return am_;
+                IEnumerable<string> ag_ = context.Operators.Select<Procedure, string>(ae_, af_);
+                Id ah_ = EndotrachealTubeIn?.IdElement;
+                string ai_ = ah_?.Value;
+                bool? aj_ = context.Operators.Contains<string>(ag_, ai_);
+                bool? ak_ = context.Operators.Not(aj_);
+                bool? al_ = context.Operators.And(ab_, ak_);
+                return al_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure EndotrachealTubeIn) => EncounterWithSurgery;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -4769,33 +4759,32 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         List<Encounter.LocationComponent> a_ = encounter?.Location;
 
-        IEnumerable<Encounter.LocationComponent> b_(Encounter.LocationComponent EncounterLocation) {
+        bool? b_(Encounter.LocationComponent EncounterLocation) {
             IEnumerable<Location> f_ = context.Operators.Retrieve<Location>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location"));
 
             bool? g_(Location Location) {
-                ResourceReference k_ = EncounterLocation?.Location;
-                bool? l_ = QICoreCommon_4_0_000.Instance.references(context, k_, Location);
-                List<CodeableConcept> m_ = Location?.Type;
+                ResourceReference j_ = EncounterLocation?.Location;
+                bool? k_ = QICoreCommon_4_0_000.Instance.references(context, j_, Location);
+                List<CodeableConcept> l_ = Location?.Type;
 
-                CqlConcept n_(CodeableConcept @this) {
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return s_;
+                CqlConcept m_(CodeableConcept @this) {
+                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return r_;
                 }
 
-                IEnumerable<CqlConcept> o_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)m_, n_);
-                CqlCode p_ = this.ER(context);
-                bool? q_ = QICoreCommon_4_0_000.Instance.includesCode(context, o_, p_);
-                bool? r_ = context.Operators.And(l_, q_);
-                return r_;
+                IEnumerable<CqlConcept> n_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)l_, m_);
+                CqlCode o_ = this.ER(context);
+                bool? p_ = QICoreCommon_4_0_000.Instance.includesCode(context, n_, o_);
+                bool? q_ = context.Operators.And(k_, p_);
+                return q_;
             }
 
             IEnumerable<Location> h_ = context.Operators.Where<Location>(f_, g_);
-            Encounter.LocationComponent i_(Location Location) => EncounterLocation;
-            IEnumerable<Encounter.LocationComponent> j_ = context.Operators.Select<Location, Encounter.LocationComponent>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Location>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SelectMany<Encounter.LocationComponent, Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
+        IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
         bool? d_ = context.Operators.Exists<Encounter.LocationComponent>(c_);
         bool? e_ = context.Operators.Not(d_);
         return e_;
@@ -4812,77 +4801,77 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlCode d_ = this.Removal_of_endotracheal_tube__procedure_(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? g_(Procedure Extubation) {
-                Code<EventStatus> k_ = Extubation?.StatusElement;
-                EventStatus? l_ = k_?.Value;
-                string m_ = context.Operators.Convert<string>(l_);
-                bool? n_ = context.Operators.Equal(m_, "completed");
-                bool? o_ = this.isDuringHospitalization(context, Extubation as object, EncounterWithSurgery);
-                bool? p_ = context.Operators.And(n_, o_);
-                bool? q_ = this.starts30DaysOrLessAfterFirstAnesthesia(context, Extubation, EncounterWithSurgery);
-                bool? r_ = context.Operators.And(p_, q_);
+                Code<EventStatus> j_ = Extubation?.StatusElement;
+                EventStatus? k_ = j_?.Value;
+                string l_ = context.Operators.Convert<string>(k_);
+                bool? m_ = context.Operators.Equal(l_, "completed");
+                bool? n_ = this.isDuringHospitalization(context, Extubation as object, EncounterWithSurgery);
+                bool? o_ = context.Operators.And(m_, n_);
+                bool? p_ = this.starts30DaysOrLessAfterFirstAnesthesia(context, Extubation, EncounterWithSurgery);
+                bool? q_ = context.Operators.And(o_, p_);
 
-                object s_() {
+                object r_() {
+
+                    bool ax_() {
+                        DataType bb_ = Extubation?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        bool bd_ = bc_ is CqlDateTime;
+                        return bd_;
+                    }
+
 
                     bool ay_() {
-                        DataType bc_ = Extubation?.Performed;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        bool be_ = bd_ is CqlDateTime;
-                        return be_;
+                        DataType be_ = Extubation?.Performed;
+                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+                        bool bg_ = bf_ is CqlInterval<CqlDateTime>;
+                        return bg_;
                     }
 
 
                     bool az_() {
-                        DataType bf_ = Extubation?.Performed;
-                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                        bool bh_ = bg_ is CqlInterval<CqlDateTime>;
-                        return bh_;
+                        DataType bh_ = Extubation?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        bool bj_ = bi_ is CqlQuantity;
+                        return bj_;
                     }
 
 
                     bool ba_() {
-                        DataType bi_ = Extubation?.Performed;
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        bool bk_ = bj_ is CqlQuantity;
-                        return bk_;
+                        DataType bk_ = Extubation?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        bool bm_ = bl_ is CqlInterval<CqlQuantity>;
+                        return bm_;
                     }
 
-
-                    bool bb_() {
-                        DataType bl_ = Extubation?.Performed;
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        bool bn_ = bm_ is CqlInterval<CqlQuantity>;
-                        return bn_;
-                    }
-
-                    if (ay_())
+                    if (ax_())
                     {
-                        DataType bo_ = Extubation?.Performed;
-                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
-                        return (bp_ as CqlDateTime) as object;
+                        DataType bn_ = Extubation?.Performed;
+                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                        return (bo_ as CqlDateTime) as object;
+                    }
+                    else if (ay_())
+                    {
+                        DataType bp_ = Extubation?.Performed;
+                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+                        return (bq_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (az_())
                     {
-                        DataType bq_ = Extubation?.Performed;
-                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                        return (br_ as CqlInterval<CqlDateTime>) as object;
+                        DataType br_ = Extubation?.Performed;
+                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                        return (bs_ as CqlQuantity) as object;
                     }
                     else if (ba_())
                     {
-                        DataType bs_ = Extubation?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        return (bt_ as CqlQuantity) as object;
-                    }
-                    else if (bb_())
-                    {
-                        DataType bu_ = Extubation?.Performed;
-                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                        return (bv_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bt_ = Extubation?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        return (bu_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -4890,73 +4879,73 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_());
-                CqlDateTime u_ = context.Operators.Start(t_);
+                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
+                CqlDateTime t_ = context.Operators.Start(s_);
 
-                object v_() {
+                object u_() {
+
+                    bool bv_() {
+                        Procedure bz_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType ca_ = bz_?.Performed;
+                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                        bool cc_ = cb_ is CqlDateTime;
+                        return cc_;
+                    }
+
 
                     bool bw_() {
-                        Procedure ca_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType cb_ = ca_?.Performed;
-                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                        bool cd_ = cc_ is CqlDateTime;
-                        return cd_;
+                        Procedure cd_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType ce_ = cd_?.Performed;
+                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                        bool cg_ = cf_ is CqlInterval<CqlDateTime>;
+                        return cg_;
                     }
 
 
                     bool bx_() {
-                        Procedure ce_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType cf_ = ce_?.Performed;
-                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                        bool ch_ = cg_ is CqlInterval<CqlDateTime>;
-                        return ch_;
+                        Procedure ch_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType ci_ = ch_?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        bool ck_ = cj_ is CqlQuantity;
+                        return ck_;
                     }
 
 
                     bool by_() {
-                        Procedure ci_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType cj_ = ci_?.Performed;
-                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                        bool cl_ = ck_ is CqlQuantity;
-                        return cl_;
+                        Procedure cl_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType cm_ = cl_?.Performed;
+                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
+                        bool co_ = cn_ is CqlInterval<CqlQuantity>;
+                        return co_;
                     }
 
-
-                    bool bz_() {
-                        Procedure cm_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType cn_ = cm_?.Performed;
-                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                        bool cp_ = co_ is CqlInterval<CqlQuantity>;
-                        return cp_;
-                    }
-
-                    if (bw_())
+                    if (bv_())
                     {
-                        Procedure cq_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType cr_ = cq_?.Performed;
-                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
-                        return (cs_ as CqlDateTime) as object;
+                        Procedure cp_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType cq_ = cp_?.Performed;
+                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                        return (cr_ as CqlDateTime) as object;
+                    }
+                    else if (bw_())
+                    {
+                        Procedure cs_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType ct_ = cs_?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        return (cu_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bx_())
                     {
-                        Procedure ct_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType cu_ = ct_?.Performed;
-                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
-                        return (cv_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure cv_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType cw_ = cv_?.Performed;
+                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                        return (cx_ as CqlQuantity) as object;
                     }
                     else if (by_())
                     {
-                        Procedure cw_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType cx_ = cw_?.Performed;
-                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
-                        return (cy_ as CqlQuantity) as object;
-                    }
-                    else if (bz_())
-                    {
-                        Procedure cz_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                        DataType da_ = cz_?.Performed;
-                        object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-                        return (db_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure cy_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                        DataType cz_ = cy_?.Performed;
+                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
+                        return (da_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -4964,73 +4953,72 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_());
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime z_ = context.Operators.Add(x_, y_);
-                bool? aa_ = context.Operators.After(u_, z_, (string)default);
-                bool? ab_ = context.Operators.And(r_, aa_);
-                IEnumerable<Procedure> ac_ = this.Extubation_With_Preceding_Noninvasive_Oxygen(context);
+                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
+                CqlDateTime w_ = context.Operators.End(v_);
+                CqlQuantity x_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime y_ = context.Operators.Add(w_, x_);
+                bool? z_ = context.Operators.After(t_, y_, (string)default);
+                bool? aa_ = context.Operators.And(q_, z_);
+                IEnumerable<Procedure> ab_ = this.Extubation_With_Preceding_Noninvasive_Oxygen(context);
 
-                bool? ad_(Procedure @this) {
-                    string dc_ = (@this is Resource
+                bool? ac_(Procedure @this) {
+                    string db_ = (@this is Resource
                         ? (@this as Resource).IdElement
                         : default)?.Value;
-                    bool? dd_ = context.Operators.Not((bool?)(dc_ is null));
+                    bool? dc_ = context.Operators.Not((bool?)(db_ is null));
+                    return dc_;
+                }
+
+                IEnumerable<Procedure> ad_ = context.Operators.Where<Procedure>(ab_, ac_);
+
+                string ae_(Procedure @this) {
+                    string dd_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
                     return dd_;
                 }
 
-                IEnumerable<Procedure> ae_ = context.Operators.Where<Procedure>(ac_, ad_);
+                IEnumerable<string> af_ = context.Operators.Select<Procedure, string>(ad_, ae_);
+                Id ag_ = Extubation?.IdElement;
+                string ah_ = ag_?.Value;
+                bool? ai_ = context.Operators.Contains<string>(af_, ah_);
+                IEnumerable<Procedure> aj_ = this.Extubation_During_General_Anesthesia(context);
 
-                string af_(Procedure @this) {
+                bool? ak_(Procedure @this) {
                     string de_ = (@this is Resource
                         ? (@this as Resource).IdElement
                         : default)?.Value;
-                    return de_;
+                    bool? df_ = context.Operators.Not((bool?)(de_ is null));
+                    return df_;
                 }
 
-                IEnumerable<string> ag_ = context.Operators.Select<Procedure, string>(ae_, af_);
-                Id ah_ = Extubation?.IdElement;
-                string ai_ = ah_?.Value;
-                bool? aj_ = context.Operators.Contains<string>(ag_, ai_);
-                IEnumerable<Procedure> ak_ = this.Extubation_During_General_Anesthesia(context);
+                IEnumerable<Procedure> al_ = context.Operators.Where<Procedure>(aj_, ak_);
 
-                bool? al_(Procedure @this) {
-                    string df_ = (@this is Resource
+                string am_(Procedure @this) {
+                    string dg_ = (@this is Resource
                         ? (@this as Resource).IdElement
                         : default)?.Value;
-                    bool? dg_ = context.Operators.Not((bool?)(df_ is null));
                     return dg_;
                 }
 
-                IEnumerable<Procedure> am_ = context.Operators.Where<Procedure>(ak_, al_);
-
-                string an_(Procedure @this) {
-                    string dh_ = (@this is Resource
-                        ? (@this as Resource).IdElement
-                        : default)?.Value;
-                    return dh_;
-                }
-
-                IEnumerable<string> ao_ = context.Operators.Select<Procedure, string>(am_, an_);
-                string aq_ = ah_?.Value;
-                bool? ar_ = context.Operators.Contains<string>(ao_, aq_);
-                bool? as_ = context.Operators.Not(ar_);
-                bool? at_ = context.Operators.And(aj_, as_);
-                bool? au_ = context.Operators.Not(at_);
-                bool? av_ = context.Operators.And(ab_, au_);
-                bool? aw_ = this.isNotAtProceduralHospitalLocation(context, EncounterWithSurgery);
-                bool? ax_ = context.Operators.And(av_, aw_);
-                return ax_;
+                IEnumerable<string> an_ = context.Operators.Select<Procedure, string>(al_, am_);
+                string ap_ = ag_?.Value;
+                bool? aq_ = context.Operators.Contains<string>(an_, ap_);
+                bool? ar_ = context.Operators.Not(aq_);
+                bool? as_ = context.Operators.And(ai_, ar_);
+                bool? at_ = context.Operators.Not(as_);
+                bool? au_ = context.Operators.And(aa_, at_);
+                bool? av_ = this.isNotAtProceduralHospitalLocation(context, EncounterWithSurgery);
+                bool? aw_ = context.Operators.And(au_, av_);
+                return aw_;
             }
 
             IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
-            Encounter i_(Procedure Extubation) => EncounterWithSurgery;
-            IEnumerable<Encounter> j_ = context.Operators.Select<Procedure, Encounter>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Procedure>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -5045,72 +5033,72 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Encounter> a_ = this.Elective_Inpatient_Encounter_With_OR_Procedure_Within_3_Days(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithSurgery) {
+        bool? b_(Encounter EncounterWithSurgery) {
             CqlValueSet d_ = this.Mechanical_Ventilation(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure Ventilation) {
-                Code<EventStatus> j_ = Ventilation?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
+                Code<EventStatus> i_ = Ventilation?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
 
-                object n_() {
+                object m_() {
+
+                    bool bf_() {
+                        DataType bj_ = Ventilation?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        bool bl_ = bk_ is CqlDateTime;
+                        return bl_;
+                    }
+
 
                     bool bg_() {
-                        DataType bk_ = Ventilation?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        bool bm_ = bl_ is CqlDateTime;
-                        return bm_;
+                        DataType bm_ = Ventilation?.Performed;
+                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                        bool bo_ = bn_ is CqlInterval<CqlDateTime>;
+                        return bo_;
                     }
 
 
                     bool bh_() {
-                        DataType bn_ = Ventilation?.Performed;
-                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                        bool bp_ = bo_ is CqlInterval<CqlDateTime>;
-                        return bp_;
+                        DataType bp_ = Ventilation?.Performed;
+                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+                        bool br_ = bq_ is CqlQuantity;
+                        return br_;
                     }
 
 
                     bool bi_() {
-                        DataType bq_ = Ventilation?.Performed;
-                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                        bool bs_ = br_ is CqlQuantity;
-                        return bs_;
+                        DataType bs_ = Ventilation?.Performed;
+                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                        bool bu_ = bt_ is CqlInterval<CqlQuantity>;
+                        return bu_;
                     }
 
-
-                    bool bj_() {
-                        DataType bt_ = Ventilation?.Performed;
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        bool bv_ = bu_ is CqlInterval<CqlQuantity>;
-                        return bv_;
-                    }
-
-                    if (bg_())
+                    if (bf_())
                     {
-                        DataType bw_ = Ventilation?.Performed;
-                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                        return (bx_ as CqlDateTime) as object;
+                        DataType bv_ = Ventilation?.Performed;
+                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                        return (bw_ as CqlDateTime) as object;
+                    }
+                    else if (bg_())
+                    {
+                        DataType bx_ = Ventilation?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        return (by_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bh_())
                     {
-                        DataType by_ = Ventilation?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        return (bz_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bz_ = Ventilation?.Performed;
+                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                        return (ca_ as CqlQuantity) as object;
                     }
                     else if (bi_())
                     {
-                        DataType ca_ = Ventilation?.Performed;
-                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                        return (cb_ as CqlQuantity) as object;
-                    }
-                    else if (bj_())
-                    {
-                        DataType cc_ = Ventilation?.Performed;
-                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        return (cd_ as CqlInterval<CqlQuantity>) as object;
+                        DataType cb_ = Ventilation?.Performed;
+                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+                        return (cc_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -5118,73 +5106,73 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                CqlDateTime p_ = context.Operators.Start(o_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                CqlDateTime o_ = context.Operators.Start(n_);
 
-                object q_() {
+                object p_() {
+
+                    bool cd_() {
+                        Procedure ch_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType ci_ = ch_?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        bool ck_ = cj_ is CqlDateTime;
+                        return ck_;
+                    }
+
 
                     bool ce_() {
-                        Procedure ci_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType cj_ = ci_?.Performed;
-                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                        bool cl_ = ck_ is CqlDateTime;
-                        return cl_;
+                        Procedure cl_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType cm_ = cl_?.Performed;
+                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
+                        bool co_ = cn_ is CqlInterval<CqlDateTime>;
+                        return co_;
                     }
 
 
                     bool cf_() {
-                        Procedure cm_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType cn_ = cm_?.Performed;
-                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                        bool cp_ = co_ is CqlInterval<CqlDateTime>;
-                        return cp_;
+                        Procedure cp_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType cq_ = cp_?.Performed;
+                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                        bool cs_ = cr_ is CqlQuantity;
+                        return cs_;
                     }
 
 
                     bool cg_() {
-                        Procedure cq_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType cr_ = cq_?.Performed;
-                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
-                        bool ct_ = cs_ is CqlQuantity;
-                        return ct_;
+                        Procedure ct_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType cu_ = ct_?.Performed;
+                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+                        bool cw_ = cv_ is CqlInterval<CqlQuantity>;
+                        return cw_;
                     }
 
-
-                    bool ch_() {
-                        Procedure cu_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType cv_ = cu_?.Performed;
-                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                        bool cx_ = cw_ is CqlInterval<CqlQuantity>;
-                        return cx_;
-                    }
-
-                    if (ce_())
+                    if (cd_())
                     {
-                        Procedure cy_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType cz_ = cy_?.Performed;
-                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
-                        return (da_ as CqlDateTime) as object;
+                        Procedure cx_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType cy_ = cx_?.Performed;
+                        object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+                        return (cz_ as CqlDateTime) as object;
+                    }
+                    else if (ce_())
+                    {
+                        Procedure da_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType db_ = da_?.Performed;
+                        object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                        return (dc_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (cf_())
                     {
-                        Procedure db_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType dc_ = db_?.Performed;
-                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
-                        return (dd_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure dd_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType de_ = dd_?.Performed;
+                        object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                        return (df_ as CqlQuantity) as object;
                     }
                     else if (cg_())
                     {
-                        Procedure de_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType df_ = de_?.Performed;
-                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                        return (dg_ as CqlQuantity) as object;
-                    }
-                    else if (ch_())
-                    {
-                        Procedure dh_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType di_ = dh_?.Performed;
-                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                        return (dj_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure dg_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType dh_ = dg_?.Performed;
+                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+                        return (di_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -5192,69 +5180,69 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlQuantity t_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime u_ = context.Operators.Add(s_, t_);
-                bool? v_ = context.Operators.SameOrAfter(p_, u_, (string)default);
-                bool? w_ = context.Operators.And(m_, v_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                CqlDateTime r_ = context.Operators.End(q_);
+                CqlQuantity s_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime t_ = context.Operators.Add(r_, s_);
+                bool? u_ = context.Operators.SameOrAfter(o_, t_, (string)default);
+                bool? v_ = context.Operators.And(l_, u_);
 
-                object x_() {
+                object w_() {
+
+                    bool dj_() {
+                        DataType dn_ = Ventilation?.Performed;
+                        object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+                        bool dp_ = do_ is CqlDateTime;
+                        return dp_;
+                    }
+
 
                     bool dk_() {
-                        DataType do_ = Ventilation?.Performed;
-                        object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
-                        bool dq_ = dp_ is CqlDateTime;
-                        return dq_;
+                        DataType dq_ = Ventilation?.Performed;
+                        object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
+                        bool ds_ = dr_ is CqlInterval<CqlDateTime>;
+                        return ds_;
                     }
 
 
                     bool dl_() {
-                        DataType dr_ = Ventilation?.Performed;
-                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
-                        bool dt_ = ds_ is CqlInterval<CqlDateTime>;
-                        return dt_;
+                        DataType dt_ = Ventilation?.Performed;
+                        object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                        bool dv_ = du_ is CqlQuantity;
+                        return dv_;
                     }
 
 
                     bool dm_() {
-                        DataType du_ = Ventilation?.Performed;
-                        object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                        bool dw_ = dv_ is CqlQuantity;
-                        return dw_;
+                        DataType dw_ = Ventilation?.Performed;
+                        object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                        bool dy_ = dx_ is CqlInterval<CqlQuantity>;
+                        return dy_;
                     }
 
-
-                    bool dn_() {
-                        DataType dx_ = Ventilation?.Performed;
-                        object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
-                        bool dz_ = dy_ is CqlInterval<CqlQuantity>;
-                        return dz_;
-                    }
-
-                    if (dk_())
+                    if (dj_())
                     {
-                        DataType ea_ = Ventilation?.Performed;
-                        object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                        return (eb_ as CqlDateTime) as object;
+                        DataType dz_ = Ventilation?.Performed;
+                        object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
+                        return (ea_ as CqlDateTime) as object;
+                    }
+                    else if (dk_())
+                    {
+                        DataType eb_ = Ventilation?.Performed;
+                        object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
+                        return (ec_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (dl_())
                     {
-                        DataType ec_ = Ventilation?.Performed;
-                        object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
-                        return (ed_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ed_ = Ventilation?.Performed;
+                        object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
+                        return (ee_ as CqlQuantity) as object;
                     }
                     else if (dm_())
                     {
-                        DataType ee_ = Ventilation?.Performed;
-                        object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
-                        return (ef_ as CqlQuantity) as object;
-                    }
-                    else if (dn_())
-                    {
-                        DataType eg_ = Ventilation?.Performed;
-                        object eh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eg_);
-                        return (eh_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ef_ = Ventilation?.Performed;
+                        object eg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ef_);
+                        return (eg_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -5262,73 +5250,73 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
-                CqlDateTime z_ = context.Operators.Start(y_);
+                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_());
+                CqlDateTime y_ = context.Operators.Start(x_);
 
-                object aa_() {
+                object z_() {
+
+                    bool eh_() {
+                        Procedure el_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType em_ = el_?.Performed;
+                        object en_ = FHIRHelpers_4_4_000.Instance.ToValue(context, em_);
+                        bool eo_ = en_ is CqlDateTime;
+                        return eo_;
+                    }
+
 
                     bool ei_() {
-                        Procedure em_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType en_ = em_?.Performed;
-                        object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
-                        bool ep_ = eo_ is CqlDateTime;
-                        return ep_;
+                        Procedure ep_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType eq_ = ep_?.Performed;
+                        object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+                        bool es_ = er_ is CqlInterval<CqlDateTime>;
+                        return es_;
                     }
 
 
                     bool ej_() {
-                        Procedure eq_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType er_ = eq_?.Performed;
-                        object es_ = FHIRHelpers_4_4_000.Instance.ToValue(context, er_);
-                        bool et_ = es_ is CqlInterval<CqlDateTime>;
-                        return et_;
+                        Procedure et_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType eu_ = et_?.Performed;
+                        object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
+                        bool ew_ = ev_ is CqlQuantity;
+                        return ew_;
                     }
 
 
                     bool ek_() {
-                        Procedure eu_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType ev_ = eu_?.Performed;
-                        object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
-                        bool ex_ = ew_ is CqlQuantity;
-                        return ex_;
+                        Procedure ex_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType ey_ = ex_?.Performed;
+                        object ez_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ey_);
+                        bool fa_ = ez_ is CqlInterval<CqlQuantity>;
+                        return fa_;
                     }
 
-
-                    bool el_() {
-                        Procedure ey_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType ez_ = ey_?.Performed;
-                        object fa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ez_);
-                        bool fb_ = fa_ is CqlInterval<CqlQuantity>;
-                        return fb_;
-                    }
-
-                    if (ei_())
+                    if (eh_())
                     {
-                        Procedure fc_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType fd_ = fc_?.Performed;
-                        object fe_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fd_);
-                        return (fe_ as CqlDateTime) as object;
+                        Procedure fb_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType fc_ = fb_?.Performed;
+                        object fd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fc_);
+                        return (fd_ as CqlDateTime) as object;
+                    }
+                    else if (ei_())
+                    {
+                        Procedure fe_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType ff_ = fe_?.Performed;
+                        object fg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ff_);
+                        return (fg_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ej_())
                     {
-                        Procedure ff_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType fg_ = ff_?.Performed;
-                        object fh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fg_);
-                        return (fh_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure fh_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType fi_ = fh_?.Performed;
+                        object fj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fi_);
+                        return (fj_ as CqlQuantity) as object;
                     }
                     else if (ek_())
                     {
-                        Procedure fi_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType fj_ = fi_?.Performed;
-                        object fk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fj_);
-                        return (fk_ as CqlQuantity) as object;
-                    }
-                    else if (el_())
-                    {
-                        Procedure fl_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType fm_ = fl_?.Performed;
-                        object fn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fm_);
-                        return (fn_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure fk_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType fl_ = fk_?.Performed;
+                        object fm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fl_);
+                        return (fm_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -5336,73 +5324,73 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_());
-                CqlDateTime ac_ = context.Operators.End(ab_);
+                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
+                CqlDateTime ab_ = context.Operators.End(aa_);
 
-                object ad_() {
+                object ac_() {
+
+                    bool fn_() {
+                        Procedure fr_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType fs_ = fr_?.Performed;
+                        object ft_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fs_);
+                        bool fu_ = ft_ is CqlDateTime;
+                        return fu_;
+                    }
+
 
                     bool fo_() {
-                        Procedure fs_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType ft_ = fs_?.Performed;
-                        object fu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ft_);
-                        bool fv_ = fu_ is CqlDateTime;
-                        return fv_;
+                        Procedure fv_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType fw_ = fv_?.Performed;
+                        object fx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fw_);
+                        bool fy_ = fx_ is CqlInterval<CqlDateTime>;
+                        return fy_;
                     }
 
 
                     bool fp_() {
-                        Procedure fw_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType fx_ = fw_?.Performed;
-                        object fy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fx_);
-                        bool fz_ = fy_ is CqlInterval<CqlDateTime>;
-                        return fz_;
+                        Procedure fz_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType ga_ = fz_?.Performed;
+                        object gb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ga_);
+                        bool gc_ = gb_ is CqlQuantity;
+                        return gc_;
                     }
 
 
                     bool fq_() {
-                        Procedure ga_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType gb_ = ga_?.Performed;
-                        object gc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gb_);
-                        bool gd_ = gc_ is CqlQuantity;
-                        return gd_;
+                        Procedure gd_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType ge_ = gd_?.Performed;
+                        object gf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ge_);
+                        bool gg_ = gf_ is CqlInterval<CqlQuantity>;
+                        return gg_;
                     }
 
-
-                    bool fr_() {
-                        Procedure ge_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType gf_ = ge_?.Performed;
-                        object gg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gf_);
-                        bool gh_ = gg_ is CqlInterval<CqlQuantity>;
-                        return gh_;
-                    }
-
-                    if (fo_())
+                    if (fn_())
                     {
-                        Procedure gi_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType gj_ = gi_?.Performed;
-                        object gk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gj_);
-                        return (gk_ as CqlDateTime) as object;
+                        Procedure gh_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType gi_ = gh_?.Performed;
+                        object gj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gi_);
+                        return (gj_ as CqlDateTime) as object;
+                    }
+                    else if (fo_())
+                    {
+                        Procedure gk_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType gl_ = gk_?.Performed;
+                        object gm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gl_);
+                        return (gm_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (fp_())
                     {
-                        Procedure gl_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType gm_ = gl_?.Performed;
-                        object gn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gm_);
-                        return (gn_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure gn_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType go_ = gn_?.Performed;
+                        object gp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, go_);
+                        return (gp_ as CqlQuantity) as object;
                     }
                     else if (fq_())
                     {
-                        Procedure go_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType gp_ = go_?.Performed;
-                        object gq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gp_);
-                        return (gq_ as CqlQuantity) as object;
-                    }
-                    else if (fr_())
-                    {
-                        Procedure gr_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType gs_ = gr_?.Performed;
-                        object gt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gs_);
-                        return (gt_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure gq_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType gr_ = gq_?.Performed;
+                        object gs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gr_);
+                        return (gs_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -5410,77 +5398,77 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_());
-                CqlDateTime af_ = context.Operators.End(ae_);
-                CqlQuantity ag_ = context.Operators.Quantity(72m, "hours");
-                CqlDateTime ah_ = context.Operators.Add(af_, ag_);
-                CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ac_, ah_, false, true);
-                bool? aj_ = context.Operators.In<CqlDateTime>(z_, ai_, (string)default);
+                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_());
+                CqlDateTime ae_ = context.Operators.End(ad_);
+                CqlQuantity af_ = context.Operators.Quantity(72m, "hours");
+                CqlDateTime ag_ = context.Operators.Add(ae_, af_);
+                CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ab_, ag_, false, true);
+                bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, (string)default);
 
-                object ak_() {
+                object aj_() {
+
+                    bool gt_() {
+                        Procedure gx_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType gy_ = gx_?.Performed;
+                        object gz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gy_);
+                        bool ha_ = gz_ is CqlDateTime;
+                        return ha_;
+                    }
+
 
                     bool gu_() {
-                        Procedure gy_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType gz_ = gy_?.Performed;
-                        object ha_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gz_);
-                        bool hb_ = ha_ is CqlDateTime;
-                        return hb_;
+                        Procedure hb_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType hc_ = hb_?.Performed;
+                        object hd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hc_);
+                        bool he_ = hd_ is CqlInterval<CqlDateTime>;
+                        return he_;
                     }
 
 
                     bool gv_() {
-                        Procedure hc_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType hd_ = hc_?.Performed;
-                        object he_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hd_);
-                        bool hf_ = he_ is CqlInterval<CqlDateTime>;
-                        return hf_;
+                        Procedure hf_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType hg_ = hf_?.Performed;
+                        object hh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hg_);
+                        bool hi_ = hh_ is CqlQuantity;
+                        return hi_;
                     }
 
 
                     bool gw_() {
-                        Procedure hg_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType hh_ = hg_?.Performed;
-                        object hi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hh_);
-                        bool hj_ = hi_ is CqlQuantity;
-                        return hj_;
+                        Procedure hj_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType hk_ = hj_?.Performed;
+                        object hl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hk_);
+                        bool hm_ = hl_ is CqlInterval<CqlQuantity>;
+                        return hm_;
                     }
 
-
-                    bool gx_() {
-                        Procedure hk_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType hl_ = hk_?.Performed;
-                        object hm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hl_);
-                        bool hn_ = hm_ is CqlInterval<CqlQuantity>;
-                        return hn_;
-                    }
-
-                    if (gu_())
+                    if (gt_())
                     {
-                        Procedure ho_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType hp_ = ho_?.Performed;
-                        object hq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hp_);
-                        return (hq_ as CqlDateTime) as object;
+                        Procedure hn_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType ho_ = hn_?.Performed;
+                        object hp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ho_);
+                        return (hp_ as CqlDateTime) as object;
+                    }
+                    else if (gu_())
+                    {
+                        Procedure hq_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType hr_ = hq_?.Performed;
+                        object hs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hr_);
+                        return (hs_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (gv_())
                     {
-                        Procedure hr_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType hs_ = hr_?.Performed;
-                        object ht_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hs_);
-                        return (ht_ as CqlInterval<CqlDateTime>) as object;
+                        Procedure ht_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType hu_ = ht_?.Performed;
+                        object hv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hu_);
+                        return (hv_ as CqlQuantity) as object;
                     }
                     else if (gw_())
                     {
-                        Procedure hu_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType hv_ = hu_?.Performed;
-                        object hw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hv_);
-                        return (hw_ as CqlQuantity) as object;
-                    }
-                    else if (gx_())
-                    {
-                        Procedure hx_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType hy_ = hx_?.Performed;
-                        object hz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hy_);
-                        return (hz_ as CqlInterval<CqlQuantity>) as object;
+                        Procedure hw_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                        DataType hx_ = hw_?.Performed;
+                        object hy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hx_);
+                        return (hy_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -5488,52 +5476,51 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     };
                 }
 
-                CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_());
-                CqlDateTime am_ = context.Operators.End(al_);
-                bool? an_ = context.Operators.Not((bool?)(am_ is null));
-                bool? ao_ = context.Operators.And(aj_, an_);
-                bool? ap_ = context.Operators.And(w_, ao_);
-                bool? aq_ = this.starts30DaysOrLessAfterFirstAnesthesia(context, Ventilation, EncounterWithSurgery);
-                bool? ar_ = context.Operators.And(ap_, aq_);
-                bool? as_ = this.startsDuringHospitalization(context, Ventilation as object, EncounterWithSurgery);
-                bool? at_ = context.Operators.And(ar_, as_);
-                IEnumerable<Encounter> au_ = this.Encounter_With_Mechanical_Ventilation_Outside_Of_Procedural_Area_Within_30_Days_Of_End_Of_First_OR_Procedure_And_Preceded_By_Non_Invasive_Oxygen_Therapy(context);
+                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_());
+                CqlDateTime al_ = context.Operators.End(ak_);
+                bool? am_ = context.Operators.Not((bool?)(al_ is null));
+                bool? an_ = context.Operators.And(ai_, am_);
+                bool? ao_ = context.Operators.And(v_, an_);
+                bool? ap_ = this.starts30DaysOrLessAfterFirstAnesthesia(context, Ventilation, EncounterWithSurgery);
+                bool? aq_ = context.Operators.And(ao_, ap_);
+                bool? ar_ = this.startsDuringHospitalization(context, Ventilation as object, EncounterWithSurgery);
+                bool? as_ = context.Operators.And(aq_, ar_);
+                IEnumerable<Encounter> at_ = this.Encounter_With_Mechanical_Ventilation_Outside_Of_Procedural_Area_Within_30_Days_Of_End_Of_First_OR_Procedure_And_Preceded_By_Non_Invasive_Oxygen_Therapy(context);
 
-                bool? av_(Encounter @this) {
-                    string ia_ = (@this is Resource
+                bool? au_(Encounter @this) {
+                    string hz_ = (@this is Resource
                         ? (@this as Resource).IdElement
                         : default)?.Value;
-                    bool? ib_ = context.Operators.Not((bool?)(ia_ is null));
+                    bool? ia_ = context.Operators.Not((bool?)(hz_ is null));
+                    return ia_;
+                }
+
+                IEnumerable<Encounter> av_ = context.Operators.Where<Encounter>(at_, au_);
+
+                string aw_(Encounter @this) {
+                    string ib_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
                     return ib_;
                 }
 
-                IEnumerable<Encounter> aw_ = context.Operators.Where<Encounter>(au_, av_);
-
-                string ax_(Encounter @this) {
-                    string ic_ = (@this is Resource
-                        ? (@this as Resource).IdElement
-                        : default)?.Value;
-                    return ic_;
-                }
-
-                IEnumerable<string> ay_ = context.Operators.Select<Encounter, string>(aw_, ax_);
-                Id az_ = EncounterWithSurgery?.IdElement;
-                string ba_ = az_?.Value;
-                bool? bb_ = context.Operators.Contains<string>(ay_, ba_);
-                bool? bc_ = context.Operators.Not(bb_);
-                bool? bd_ = context.Operators.And(at_, bc_);
-                bool? be_ = this.isNotAtProceduralHospitalLocation(context, EncounterWithSurgery);
-                bool? bf_ = context.Operators.And(bd_, be_);
-                return bf_;
+                IEnumerable<string> ax_ = context.Operators.Select<Encounter, string>(av_, aw_);
+                Id ay_ = EncounterWithSurgery?.IdElement;
+                string az_ = ay_?.Value;
+                bool? ba_ = context.Operators.Contains<string>(ax_, az_);
+                bool? bb_ = context.Operators.Not(ba_);
+                bool? bc_ = context.Operators.And(as_, bb_);
+                bool? bd_ = this.isNotAtProceduralHospitalLocation(context, EncounterWithSurgery);
+                bool? be_ = context.Operators.And(bc_, bd_);
+                return be_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure Ventilation) => EncounterWithSurgery;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -5748,41 +5735,40 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
-        IEnumerable<Observation> d_(Observation ASAclass) {
+        bool? d_(Observation ASAclass) {
             IEnumerable<Encounter> i_ = this.Initial_Population(context);
 
             bool? j_(Encounter QualifyingEncounter) {
-                Code<ObservationStatus> n_ = ASAclass?.StatusElement;
-                ObservationStatus? o_ = n_?.Value;
-                string p_ = context.Operators.Convert<string>(o_);
-                string[] q_ = [
+                Code<ObservationStatus> m_ = ASAclass?.StatusElement;
+                ObservationStatus? n_ = m_?.Value;
+                string o_ = context.Operators.Convert<string>(n_);
+                string[] p_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-                bool? s_ = this.startsDuringHospitalization(context, ASAclass as object, QualifyingEncounter);
-                bool? t_ = context.Operators.And(r_, s_);
-                DataType u_ = ASAclass?.Value;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet w_ = this.ASA_Physical_Status_Class(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                bool? q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+                bool? r_ = this.startsDuringHospitalization(context, ASAclass as object, QualifyingEncounter);
+                bool? s_ = context.Operators.And(q_, r_);
+                DataType t_ = ASAclass?.Value;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet v_ = this.ASA_Physical_Status_Class(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
-            Observation l_(Encounter QualifyingEncounter) => ASAclass;
-            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Encounter>(k_);
+            return l_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         CqlConcept f_(Observation ASAclass) {
-            DataType z_ = ASAclass?.Value;
-            object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-            return aa_ as CqlConcept;
+            DataType y_ = ASAclass?.Value;
+            object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+            return z_ as CqlConcept;
         }
 
         IEnumerable<CqlConcept> g_ = context.Operators.Select<Observation, CqlConcept>(e_, f_);
@@ -5801,45 +5787,44 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     {
         IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi"));
 
-        IEnumerable<Observation> b_(Observation BMI) {
+        bool? b_(Observation BMI) {
             IEnumerable<Encounter> g_ = this.Initial_Population(context);
 
             bool? h_(Encounter InpatientEncounter) {
-                DataType l_ = BMI?.Effective;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                DataType r_ = BMI?.Value;
-                CqlQuantity s_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, r_ as Quantity);
-                bool? t_ = context.Operators.Not((bool?)(s_ is null));
-                bool? u_ = context.Operators.And(q_, t_);
-                Code<ObservationStatus> v_ = BMI?.StatusElement;
-                ObservationStatus? w_ = v_?.Value;
-                string x_ = context.Operators.Convert<string>(w_);
-                string[] y_ = [
+                DataType k_ = BMI?.Effective;
+                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+                bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                DataType q_ = BMI?.Value;
+                CqlQuantity r_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, q_ as Quantity);
+                bool? s_ = context.Operators.Not((bool?)(r_ is null));
+                bool? t_ = context.Operators.And(p_, s_);
+                Code<ObservationStatus> u_ = BMI?.StatusElement;
+                ObservationStatus? v_ = u_?.Value;
+                string w_ = context.Operators.Convert<string>(v_);
+                string[] x_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
-                bool? aa_ = context.Operators.And(u_, z_);
-                return aa_;
+                bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
+                bool? z_ = context.Operators.And(t_, y_);
+                return z_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter InpatientEncounter) => BMI;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
         CqlQuantity d_(Observation BMI) {
-            DataType ab_ = BMI?.Value;
-            CqlQuantity ac_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ab_ as Quantity);
-            return ac_ as CqlQuantity;
+            DataType aa_ = BMI?.Value;
+            CqlQuantity ab_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aa_ as Quantity);
+            return ab_ as CqlQuantity;
         }
 
         IEnumerable<CqlQuantity> e_ = context.Operators.Select<Observation, CqlQuantity>(c_, d_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
@@ -397,48 +397,47 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
     {
         IEnumerable<Encounter> a_ = this.ED_Triage(context);
 
-        IEnumerable<Encounter> b_(Encounter EDTriageinMP) {
+        bool? b_(Encounter EDTriageinMP) {
             IEnumerable<Encounter> d_ = this.Denominator(context);
 
             bool? e_(Encounter EDEncounter) {
-                Period i_ = EDTriageinMP?.Period;
-                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                Period k_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? m_ = context.Operators.OverlapsBefore(j_, l_, (string)default);
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
-                bool? s_ = context.Operators.Or(m_, r_);
-                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
-                bool? y_ = context.Operators.Or(s_, x_);
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                CqlDateTime ab_ = context.Operators.End(aa_);
-                CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlDateTime ae_ = context.Operators.Start(ad_);
-                CqlQuantity af_ = context.Operators.Quantity(120m, "minutes");
-                CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlDateTime aj_ = context.Operators.Start(ai_);
-                CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ag_, aj_, true, false);
-                bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, (string)default);
-                CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlDateTime ao_ = context.Operators.Start(an_);
-                bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
-                bool? aq_ = context.Operators.And(al_, ap_);
-                bool? ar_ = context.Operators.Or(y_, aq_);
-                return ar_;
+                Period h_ = EDTriageinMP?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                Period j_ = EDEncounter?.Period;
+                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? l_ = context.Operators.OverlapsBefore(i_, k_, (string)default);
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, (string)default);
+                bool? r_ = context.Operators.Or(l_, q_);
+                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, (string)default);
+                bool? x_ = context.Operators.Or(r_, w_);
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlDateTime aa_ = context.Operators.End(z_);
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                CqlQuantity ae_ = context.Operators.Quantity(120m, "minutes");
+                CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlDateTime ai_ = context.Operators.Start(ah_);
+                CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(af_, ai_, true, false);
+                bool? ak_ = context.Operators.In<CqlDateTime>(aa_, aj_, (string)default);
+                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlDateTime an_ = context.Operators.Start(am_);
+                bool? ao_ = context.Operators.Not((bool?)(an_ is null));
+                bool? ap_ = context.Operators.And(ak_, ao_);
+                bool? aq_ = context.Operators.Or(x_, ap_);
+                return aq_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter EDEncounter) => EDTriageinMP;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -784,25 +783,24 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
     {
         IEnumerable<Encounter> a_ = this.Denominator(context);
 
-        IEnumerable<Encounter> b_(Encounter EDEncounter) {
+        bool? b_(Encounter EDEncounter) {
             IEnumerable<Encounter> d_ = CQMCommon_4_1_000.Instance.Inpatient_Encounter(context);
 
             bool? e_(Encounter EncounterInpatient) {
-                CqlDateTime i_ = this.admitDecisionUsingEncounterOrder(context, EncounterInpatient);
-                CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
-                CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
-                CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
-                return m_;
+                CqlDateTime h_ = this.admitDecisionUsingEncounterOrder(context, EncounterInpatient);
+                CqlDateTime i_ = this.edDepartureTime(context, EDEncounter);
+                CqlQuantity j_ = context.Operators.Quantity(241m, "minutes");
+                CqlDateTime k_ = context.Operators.Subtract(i_, j_);
+                bool? l_ = context.Operators.SameOrBefore(h_, k_, (string)default);
+                return l_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter EncounterInpatient) => EDEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -888,25 +886,24 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
     {
         IEnumerable<Encounter> a_ = this.Denominator(context);
 
-        IEnumerable<Encounter> b_(Encounter EDEncounter) {
+        bool? b_(Encounter EDEncounter) {
             IEnumerable<Encounter> d_ = CQMCommon_4_1_000.Instance.Inpatient_Encounter(context);
 
             bool? e_(Encounter EncounterInpatient) {
-                CqlDateTime i_ = this.admitDecisionUsingAssessment(context, EncounterInpatient);
-                CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
-                CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
-                CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
-                return m_;
+                CqlDateTime h_ = this.admitDecisionUsingAssessment(context, EncounterInpatient);
+                CqlDateTime i_ = this.edDepartureTime(context, EDEncounter);
+                CqlQuantity j_ = context.Operators.Quantity(241m, "minutes");
+                CqlDateTime k_ = context.Operators.Subtract(i_, j_);
+                bool? l_ = context.Operators.SameOrBefore(h_, k_, (string)default);
+                return l_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter EncounterInpatient) => EDEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -985,25 +982,24 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
     {
         IEnumerable<Encounter> a_ = this.Denominator(context);
 
-        IEnumerable<Encounter> b_(Encounter EDEncounter) {
+        bool? b_(Encounter EDEncounter) {
             IEnumerable<Encounter> d_ = CQMCommon_4_1_000.Instance.Inpatient_Encounter(context);
 
             bool? e_(Encounter InpatientEncounter) {
-                CqlDateTime i_ = this.admitInpatientOrBedAssignmentEncounterOrder(context, InpatientEncounter);
-                CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
-                CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
-                CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
-                return m_;
+                CqlDateTime h_ = this.admitInpatientOrBedAssignmentEncounterOrder(context, InpatientEncounter);
+                CqlDateTime i_ = this.edDepartureTime(context, EDEncounter);
+                CqlQuantity j_ = context.Operators.Quantity(241m, "minutes");
+                CqlDateTime k_ = context.Operators.Subtract(i_, j_);
+                bool? l_ = context.Operators.SameOrBefore(h_, k_, (string)default);
+                return l_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter InpatientEncounter) => EDEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1051,25 +1047,24 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
     {
         IEnumerable<Encounter> a_ = this.Denominator(context);
 
-        IEnumerable<Encounter> b_(Encounter EDEncounter) {
+        bool? b_(Encounter EDEncounter) {
             IEnumerable<Encounter> d_ = CQMCommon_4_1_000.Instance.Inpatient_Encounter(context);
 
             bool? e_(Encounter Inpatient) {
-                CqlDateTime i_ = this.holdingInEDAfterAdmission(context, Inpatient);
-                CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
-                CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
-                CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
-                return m_;
+                CqlDateTime h_ = this.holdingInEDAfterAdmission(context, Inpatient);
+                CqlDateTime i_ = this.edDepartureTime(context, EDEncounter);
+                CqlQuantity j_ = context.Operators.Quantity(241m, "minutes");
+                CqlDateTime k_ = context.Operators.Subtract(i_, j_);
+                bool? l_ = context.Operators.SameOrBefore(h_, k_, (string)default);
+                return l_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter Inpatient) => EDEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1104,30 +1099,29 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
         CqlValueSet a_ = this.Observation_Services(context);
         IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        IEnumerable<Encounter> c_(Encounter EDObsEncounter) {
+        bool? c_(Encounter EDObsEncounter) {
             IEnumerable<Encounter> e_ = this.Denominator(context);
 
             bool? f_(Encounter EDEncounter) {
-                Period j_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
-                Period l_ = EDObsEncounter?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
-                Code<Encounter.EncounterStatus> o_ = EDObsEncounter?.StatusElement;
-                Encounter.EncounterStatus? p_ = o_?.Value;
-                Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
-                bool? r_ = context.Operators.Equal(q_, "finished");
-                bool? s_ = context.Operators.And(n_, r_);
-                return s_;
+                Period i_ = EDEncounter?.Period;
+                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                Period k_ = EDObsEncounter?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
+                Code<Encounter.EncounterStatus> n_ = EDObsEncounter?.StatusElement;
+                Encounter.EncounterStatus? o_ = n_?.Value;
+                Code<Encounter.EncounterStatus> p_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(o_);
+                bool? q_ = context.Operators.Equal(p_, "finished");
+                bool? r_ = context.Operators.And(m_, q_);
+                return r_;
             }
 
             IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
-            Encounter h_(Encounter EDEncounter) => EDObsEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Encounter, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Encounter>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+        IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
         return d_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
@@ -380,48 +380,47 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
     {
         IEnumerable<Encounter> a_ = this.ED_Triage(context);
 
-        IEnumerable<Encounter> b_(Encounter EDTriageinMP) {
+        bool? b_(Encounter EDTriageinMP) {
             IEnumerable<Encounter> d_ = this.Denominator(context);
 
             bool? e_(Encounter EDEncounter) {
-                Period i_ = EDTriageinMP?.Period;
-                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                Period k_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? m_ = context.Operators.OverlapsBefore(j_, l_, (string)default);
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
-                bool? s_ = context.Operators.Or(m_, r_);
-                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
-                bool? y_ = context.Operators.Or(s_, x_);
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                CqlDateTime ab_ = context.Operators.End(aa_);
-                CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlDateTime ae_ = context.Operators.Start(ad_);
-                CqlQuantity af_ = context.Operators.Quantity(120m, "minutes");
-                CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlDateTime aj_ = context.Operators.Start(ai_);
-                CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ag_, aj_, true, false);
-                bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, (string)default);
-                CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlDateTime ao_ = context.Operators.Start(an_);
-                bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
-                bool? aq_ = context.Operators.And(al_, ap_);
-                bool? ar_ = context.Operators.Or(y_, aq_);
-                return ar_;
+                Period h_ = EDTriageinMP?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                Period j_ = EDEncounter?.Period;
+                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? l_ = context.Operators.OverlapsBefore(i_, k_, (string)default);
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, (string)default);
+                bool? r_ = context.Operators.Or(l_, q_);
+                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, (string)default);
+                bool? x_ = context.Operators.Or(r_, w_);
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlDateTime aa_ = context.Operators.End(z_);
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                CqlQuantity ae_ = context.Operators.Quantity(120m, "minutes");
+                CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlDateTime ai_ = context.Operators.Start(ah_);
+                CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(af_, ai_, true, false);
+                bool? ak_ = context.Operators.In<CqlDateTime>(aa_, aj_, (string)default);
+                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                CqlDateTime an_ = context.Operators.Start(am_);
+                bool? ao_ = context.Operators.Not((bool?)(an_ is null));
+                bool? ap_ = context.Operators.And(ak_, ao_);
+                bool? aq_ = context.Operators.Or(x_, ap_);
+                return aq_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter EDEncounter) => EDTriageinMP;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -718,30 +717,29 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
         CqlValueSet a_ = this.Observation_Services(context);
         IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        IEnumerable<Encounter> c_(Encounter EDObsEncounter) {
+        bool? c_(Encounter EDObsEncounter) {
             IEnumerable<Encounter> e_ = this.Denominator(context);
 
             bool? f_(Encounter EDStay) {
-                Period j_ = EDStay?.Period;
-                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
-                Period l_ = EDObsEncounter?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
-                Code<Encounter.EncounterStatus> o_ = EDObsEncounter?.StatusElement;
-                Encounter.EncounterStatus? p_ = o_?.Value;
-                Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
-                bool? r_ = context.Operators.Equal(q_, "finished");
-                bool? s_ = context.Operators.And(n_, r_);
-                return s_;
+                Period i_ = EDStay?.Period;
+                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                Period k_ = EDObsEncounter?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
+                Code<Encounter.EncounterStatus> n_ = EDObsEncounter?.StatusElement;
+                Encounter.EncounterStatus? o_ = n_?.Value;
+                Code<Encounter.EncounterStatus> p_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(o_);
+                bool? q_ = context.Operators.Equal(p_, "finished");
+                bool? r_ = context.Operators.And(m_, q_);
+                return r_;
             }
 
             IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
-            Encounter h_(Encounter EDStay) => EDObsEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Encounter, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Encounter>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+        IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
         return d_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
@@ -166,59 +166,58 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
         IEnumerable<MedicationDispense> b_ = context.Operators.Retrieve<MedicationDispense>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense"));
         IEnumerable<MedicationDispense> c_ = context.Operators.Retrieve<MedicationDispense>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense"));
 
-        IEnumerable<MedicationDispense> d_(MedicationDispense MR) {
+        bool? d_(MedicationDispense MR) {
             IEnumerable<Medication> q_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? r_(Medication M) {
-                object v_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object w_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> x_ = context.Operators.Split((string)w_, "/");
-                string y_ = context.Operators.Last<string>(x_);
-                bool? z_ = context.Operators.Equal(v_, y_);
-                CodeableConcept aa_ = M?.Code;
-                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
-                CqlValueSet ac_ = this.Antidepressant_Medication(context);
-                bool? ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
-                bool? ae_ = context.Operators.And(z_, ad_);
-                return ae_;
+                object u_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object v_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> w_ = context.Operators.Split((string)v_, "/");
+                string x_ = context.Operators.Last<string>(w_);
+                bool? y_ = context.Operators.Equal(u_, x_);
+                CodeableConcept z_ = M?.Code;
+                CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
+                CqlValueSet ab_ = this.Antidepressant_Medication(context);
+                bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+                bool? ad_ = context.Operators.And(y_, ac_);
+                return ad_;
             }
 
             IEnumerable<Medication> s_ = context.Operators.Where<Medication>(q_, r_);
-            MedicationDispense t_(Medication M) => MR;
-            IEnumerable<MedicationDispense> u_ = context.Operators.Select<Medication, MedicationDispense>(s_, t_);
-            return u_;
+            bool? t_ = context.Operators.Exists<Medication>(s_);
+            return t_;
         }
 
-        IEnumerable<MedicationDispense> e_ = context.Operators.SelectMany<MedicationDispense, MedicationDispense>(c_, d_);
+        IEnumerable<MedicationDispense> e_ = context.Operators.Where<MedicationDispense>(c_, d_);
         IEnumerable<MedicationDispense> f_ = context.Operators.Union<MedicationDispense>(b_, e_);
         IEnumerable<MedicationDispense> g_ = Status_1_15_000.Instance.isMedicationDispensed(context, f_);
 
         bool? h_(MedicationDispense Antidepressant) {
-            CqlInterval<CqlDate> af_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
-            CqlDate ag_ = context.Operators.Start(af_);
-            CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
-            CqlInterval<CqlDateTime> ai_ = this.Intake_Period(context);
-            bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, "day");
-            return aj_;
+            CqlInterval<CqlDate> ae_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
+            CqlDate af_ = context.Operators.Start(ae_);
+            CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(af_);
+            CqlInterval<CqlDateTime> ah_ = this.Intake_Period(context);
+            bool? ai_ = context.Operators.In<CqlDateTime>(ag_, ah_, "day");
+            return ai_;
         }
 
         IEnumerable<MedicationDispense> i_ = context.Operators.Where<MedicationDispense>(g_, h_);
 
         (CqlTupleMetadata, CqlDate AntidepressantDate)? j_(MedicationDispense Antidepressant) {
-            CqlInterval<CqlDate> ak_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
-            CqlDate al_ = context.Operators.Start(ak_);
-            CqlDateTime am_ = context.Operators.ConvertDateToDateTime(al_);
-            CqlDate an_ = context.Operators.DateFrom(am_);
-            (CqlTupleMetadata, CqlDate AntidepressantDate)? ao_ = (CqlTupleMetadata_BZDEAYEYEiNadHNdHhSIPXaDL, an_);
-            return ao_;
+            CqlInterval<CqlDate> aj_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
+            CqlDate ak_ = context.Operators.Start(aj_);
+            CqlDateTime al_ = context.Operators.ConvertDateToDateTime(ak_);
+            CqlDate am_ = context.Operators.DateFrom(al_);
+            (CqlTupleMetadata, CqlDate AntidepressantDate)? an_ = (CqlTupleMetadata_BZDEAYEYEiNadHNdHhSIPXaDL, am_);
+            return an_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate AntidepressantDate)?> k_ = context.Operators.Select<MedicationDispense, (CqlTupleMetadata, CqlDate AntidepressantDate)?>(i_, j_);
         IEnumerable<(CqlTupleMetadata, CqlDate AntidepressantDate)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, CqlDate AntidepressantDate)?>(k_);
 
         object m_((CqlTupleMetadata, CqlDate AntidepressantDate)? @this) {
-            CqlDate ap_ = @this?.AntidepressantDate;
-            return ap_;
+            CqlDate ao_ = @this?.AntidepressantDate;
+            return ao_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate AntidepressantDate)?> n_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDate AntidepressantDate)?>(l_, m_, System.ComponentModel.ListSortDirection.Ascending);
@@ -377,51 +376,50 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> d_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> e_(MedicationRequest MR) {
+        bool? e_(MedicationRequest MR) {
             IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? n_(Medication M) {
-                object r_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object s_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> t_ = context.Operators.Split((string)s_, "/");
-                string u_ = context.Operators.Last<string>(t_);
-                bool? v_ = context.Operators.Equal(r_, u_);
-                CodeableConcept w_ = M?.Code;
-                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                CqlValueSet y_ = this.Antidepressant_Medication(context);
-                bool? z_ = context.Operators.ConceptInValueSet(x_, y_);
-                bool? aa_ = context.Operators.And(v_, z_);
-                return aa_;
+                object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                string t_ = context.Operators.Last<string>(s_);
+                bool? u_ = context.Operators.Equal(q_, t_);
+                CodeableConcept v_ = M?.Code;
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                CqlValueSet x_ = this.Antidepressant_Medication(context);
+                bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                bool? z_ = context.Operators.And(u_, y_);
+                return z_;
             }
 
             IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
-            MedicationRequest p_(Medication M) => MR;
-            IEnumerable<MedicationRequest> q_ = context.Operators.Select<Medication, MedicationRequest>(o_, p_);
-            return q_;
+            bool? p_ = context.Operators.Exists<Medication>(o_);
+            return p_;
         }
 
-        IEnumerable<MedicationRequest> f_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(d_, e_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
         IEnumerable<MedicationRequest> g_ = context.Operators.Union<MedicationRequest>(c_, f_);
         IEnumerable<MedicationRequest> h_ = Status_1_15_000.Instance.isMedicationActive(context, g_);
 
         bool? i_(MedicationRequest ActiveAntidepressant) {
-            CqlDate ab_ = this.IPSD(context);
-            bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
-            CqlInterval<CqlDate> ad_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveAntidepressant);
-            CqlDate ae_ = ad_?.low;
-            CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
-            CqlDate ah_ = ad_?.high;
-            CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(ah_);
-            bool? ak_ = ad_?.lowClosed;
-            bool? am_ = ad_?.highClosed;
-            CqlInterval<CqlDateTime> an_ = context.Operators.Interval(af_, ai_, ak_, am_);
-            CqlInterval<CqlDate> ao_ = CQMCommon_4_1_000.Instance.ToDateInterval(context, an_);
-            CqlQuantity aq_ = context.Operators.Quantity(105m, "days");
-            CqlDate ar_ = context.Operators.Subtract(ab_, aq_);
-            CqlInterval<CqlDate> at_ = context.Operators.Interval(ar_, ab_, true, false);
-            bool? au_ = context.Operators.Overlaps(ao_, at_, (string)default);
-            bool? av_ = context.Operators.And(ac_, au_);
-            return av_;
+            CqlDate aa_ = this.IPSD(context);
+            bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+            CqlInterval<CqlDate> ac_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveAntidepressant);
+            CqlDate ad_ = ac_?.low;
+            CqlDateTime ae_ = context.Operators.ConvertDateToDateTime(ad_);
+            CqlDate ag_ = ac_?.high;
+            CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
+            bool? aj_ = ac_?.lowClosed;
+            bool? al_ = ac_?.highClosed;
+            CqlInterval<CqlDateTime> am_ = context.Operators.Interval(ae_, ah_, aj_, al_);
+            CqlInterval<CqlDate> an_ = CQMCommon_4_1_000.Instance.ToDateInterval(context, am_);
+            CqlQuantity ap_ = context.Operators.Quantity(105m, "days");
+            CqlDate aq_ = context.Operators.Subtract(aa_, ap_);
+            CqlInterval<CqlDate> as_ = context.Operators.Interval(aq_, aa_, true, false);
+            bool? at_ = context.Operators.Overlaps(an_, as_, (string)default);
+            bool? au_ = context.Operators.And(ab_, at_);
+            return au_;
         }
 
         IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
@@ -443,41 +441,40 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
         IEnumerable<MedicationDispense> b_ = context.Operators.Retrieve<MedicationDispense>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense"));
         IEnumerable<MedicationDispense> c_ = context.Operators.Retrieve<MedicationDispense>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense"));
 
-        IEnumerable<MedicationDispense> d_(MedicationDispense MR) {
+        bool? d_(MedicationDispense MR) {
             IEnumerable<Medication> k_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? l_(Medication M) {
-                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
-                string s_ = context.Operators.Last<string>(r_);
-                bool? t_ = context.Operators.Equal(p_, s_);
-                CodeableConcept u_ = M?.Code;
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                CqlValueSet w_ = this.Antidepressant_Medication(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
+                string r_ = context.Operators.Last<string>(q_);
+                bool? s_ = context.Operators.Equal(o_, r_);
+                CodeableConcept t_ = M?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlValueSet v_ = this.Antidepressant_Medication(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Medication> m_ = context.Operators.Where<Medication>(k_, l_);
-            MedicationDispense n_(Medication M) => MR;
-            IEnumerable<MedicationDispense> o_ = context.Operators.Select<Medication, MedicationDispense>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Medication>(m_);
+            return n_;
         }
 
-        IEnumerable<MedicationDispense> e_ = context.Operators.SelectMany<MedicationDispense, MedicationDispense>(c_, d_);
+        IEnumerable<MedicationDispense> e_ = context.Operators.Where<MedicationDispense>(c_, d_);
         IEnumerable<MedicationDispense> f_ = context.Operators.Union<MedicationDispense>(b_, e_);
         IEnumerable<MedicationDispense> g_ = Status_1_15_000.Instance.isMedicationDispensed(context, f_);
 
         CqlInterval<CqlDate> h_(MedicationDispense Antidepressant) {
-            CqlInterval<CqlDate> z_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
-            CqlDate aa_ = this.IPSD(context);
-            CqlQuantity ac_ = context.Operators.Quantity(114m, "days");
-            CqlDate ad_ = context.Operators.Add(aa_, ac_);
-            CqlInterval<CqlDate> ae_ = context.Operators.Interval(aa_, ad_, true, true);
-            CqlInterval<CqlDate> af_ = context.Operators.Intersect<CqlDate>(z_, ae_);
-            return af_;
+            CqlInterval<CqlDate> y_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
+            CqlDate z_ = this.IPSD(context);
+            CqlQuantity ab_ = context.Operators.Quantity(114m, "days");
+            CqlDate ac_ = context.Operators.Add(z_, ab_);
+            CqlInterval<CqlDate> ad_ = context.Operators.Interval(z_, ac_, true, true);
+            CqlInterval<CqlDate> ae_ = context.Operators.Intersect<CqlDate>(y_, ad_);
+            return ae_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>(g_, h_);
@@ -526,41 +523,40 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
         IEnumerable<MedicationDispense> b_ = context.Operators.Retrieve<MedicationDispense>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense"));
         IEnumerable<MedicationDispense> c_ = context.Operators.Retrieve<MedicationDispense>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense"));
 
-        IEnumerable<MedicationDispense> d_(MedicationDispense MR) {
+        bool? d_(MedicationDispense MR) {
             IEnumerable<Medication> k_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? l_(Medication M) {
-                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
-                string s_ = context.Operators.Last<string>(r_);
-                bool? t_ = context.Operators.Equal(p_, s_);
-                CodeableConcept u_ = M?.Code;
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                CqlValueSet w_ = this.Antidepressant_Medication(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
+                string r_ = context.Operators.Last<string>(q_);
+                bool? s_ = context.Operators.Equal(o_, r_);
+                CodeableConcept t_ = M?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlValueSet v_ = this.Antidepressant_Medication(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Medication> m_ = context.Operators.Where<Medication>(k_, l_);
-            MedicationDispense n_(Medication M) => MR;
-            IEnumerable<MedicationDispense> o_ = context.Operators.Select<Medication, MedicationDispense>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Medication>(m_);
+            return n_;
         }
 
-        IEnumerable<MedicationDispense> e_ = context.Operators.SelectMany<MedicationDispense, MedicationDispense>(c_, d_);
+        IEnumerable<MedicationDispense> e_ = context.Operators.Where<MedicationDispense>(c_, d_);
         IEnumerable<MedicationDispense> f_ = context.Operators.Union<MedicationDispense>(b_, e_);
         IEnumerable<MedicationDispense> g_ = Status_1_15_000.Instance.isMedicationDispensed(context, f_);
 
         CqlInterval<CqlDate> h_(MedicationDispense Antidepressant) {
-            CqlInterval<CqlDate> z_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
-            CqlDate aa_ = this.IPSD(context);
-            CqlQuantity ac_ = context.Operators.Quantity(231m, "days");
-            CqlDate ad_ = context.Operators.Add(aa_, ac_);
-            CqlInterval<CqlDate> ae_ = context.Operators.Interval(aa_, ad_, true, true);
-            CqlInterval<CqlDate> af_ = context.Operators.Intersect<CqlDate>(z_, ae_);
-            return af_;
+            CqlInterval<CqlDate> y_ = CumulativeMedicationDuration_6_0_000.Instance.medicationDispensePeriod(context, Antidepressant);
+            CqlDate z_ = this.IPSD(context);
+            CqlQuantity ab_ = context.Operators.Quantity(231m, "days");
+            CqlDate ac_ = context.Operators.Add(z_, ab_);
+            CqlInterval<CqlDate> ad_ = context.Operators.Interval(z_, ac_, true, true);
+            CqlInterval<CqlDate> ae_ = context.Operators.Intersect<CqlDate>(y_, ad_);
+            return ae_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>(g_, h_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
@@ -439,14 +439,268 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
-        IEnumerable<Observation> d_(Observation ProstateCancerStaging) {
+        bool? d_(Observation ProstateCancerStaging) {
             Procedure m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period(context);
             Procedure[] n_ = [
                 m_,
             ];
 
             bool? o_(Procedure FirstProstateCancerTreatment) {
-                DataType s_ = ProstateCancerStaging?.Effective;
+                DataType r_ = ProstateCancerStaging?.Effective;
+                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
+                CqlDateTime u_ = context.Operators.Start(t_);
+
+                object v_() {
+
+                    bool af_() {
+                        DataType aj_ = FirstProstateCancerTreatment?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlDateTime;
+                        return al_;
+                    }
+
+
+                    bool ag_() {
+                        DataType am_ = FirstProstateCancerTreatment?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        bool ao_ = an_ is CqlInterval<CqlDateTime>;
+                        return ao_;
+                    }
+
+
+                    bool ah_() {
+                        DataType ap_ = FirstProstateCancerTreatment?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        bool ar_ = aq_ is CqlQuantity;
+                        return ar_;
+                    }
+
+
+                    bool ai_() {
+                        DataType as_ = FirstProstateCancerTreatment?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        bool au_ = at_ is CqlInterval<CqlQuantity>;
+                        return au_;
+                    }
+
+                    if (af_())
+                    {
+                        DataType av_ = FirstProstateCancerTreatment?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        return (aw_ as CqlDateTime) as object;
+                    }
+                    else if (ag_())
+                    {
+                        DataType ax_ = FirstProstateCancerTreatment?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        return (ay_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (ah_())
+                    {
+                        DataType az_ = FirstProstateCancerTreatment?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        return (ba_ as CqlQuantity) as object;
+                    }
+                    else if (ai_())
+                    {
+                        DataType bb_ = FirstProstateCancerTreatment?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        return (bc_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_());
+                CqlDateTime x_ = context.Operators.Start(w_);
+                bool? y_ = context.Operators.Before(u_, x_, (string)default);
+                Code<ObservationStatus> z_ = ProstateCancerStaging?.StatusElement;
+                ObservationStatus? aa_ = z_?.Value;
+                string ab_ = context.Operators.Convert<string>(aa_);
+                string[] ac_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+                bool? ae_ = context.Operators.And(y_, ad_);
+                return ae_;
+            }
+
+            IEnumerable<Procedure> p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
+            bool? q_ = context.Operators.Exists<Procedure>(p_);
+            return q_;
+        }
+
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
+
+        object f_(Observation @this) {
+            DataType bd_ = @this?.Effective;
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            CqlInterval<CqlDateTime> bf_ = QICoreCommon_4_0_000.Instance.toInterval(context, be_);
+            CqlDateTime bg_ = context.Operators.Start(bf_);
+            return bg_;
+        }
+
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.Last<Observation>(g_);
+        Observation[] i_ = [
+            h_,
+        ];
+
+        bool? j_(Observation LastProstateCancerStaging) {
+            DataType bh_ = LastProstateCancerStaging?.Value;
+            object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            CqlCode bj_ = this.American_Joint_Committee_on_Cancer_cT1a__qualifier_value_(context);
+            CqlConcept bk_ = context.Operators.ConvertCodeToConcept(bj_);
+            bool? bl_ = context.Operators.Equivalent(bi_ as CqlConcept, bk_);
+            object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            CqlCode bo_ = this.American_Joint_Committee_on_Cancer_cT1b__qualifier_value_(context);
+            CqlConcept bp_ = context.Operators.ConvertCodeToConcept(bo_);
+            bool? bq_ = context.Operators.Equivalent(bn_ as CqlConcept, bp_);
+            bool? br_ = context.Operators.Or(bl_, bq_);
+            object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            CqlCode bu_ = this.American_Joint_Committee_on_Cancer_cT1c__qualifier_value_(context);
+            CqlConcept bv_ = context.Operators.ConvertCodeToConcept(bu_);
+            bool? bw_ = context.Operators.Equivalent(bt_ as CqlConcept, bv_);
+            bool? bx_ = context.Operators.Or(br_, bw_);
+            object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            CqlCode ca_ = this.American_Joint_Committee_on_Cancer_cT2a__qualifier_value_(context);
+            CqlConcept cb_ = context.Operators.ConvertCodeToConcept(ca_);
+            bool? cc_ = context.Operators.Equivalent(bz_ as CqlConcept, cb_);
+            bool? cd_ = context.Operators.Or(bx_, cc_);
+            return cd_;
+        }
+
+        IEnumerable<Observation> k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
+        Observation l_ = context.Operators.SingletonFrom<Observation>(k_);
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent PSA Test Result is Low")]
+    public bool? Most_Recent_PSA_Test_Result_is_Low(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Most_Recent_PSA_Test_Result_is_Low, Most_Recent_PSA_Test_Result_is_Low_Compute);
+
+    private const long _cacheIndex_Most_Recent_PSA_Test_Result_is_Low = 7161242736514616586L;
+
+    private bool? Most_Recent_PSA_Test_Result_is_Low_Compute(CqlContext context)
+    {
+        CqlValueSet a_ = this.Prostate_Specific_Antigen_Test(context);
+        IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+
+        bool? c_(Observation PSATest) {
+            Observation m_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a(context);
+            Observation[] n_ = [
+                m_,
+            ];
+
+            bool? o_(Observation MostRecentProstateCancerStaging) {
+
+                CqlInterval<CqlDateTime> r_() {
+
+                    bool ac_() {
+                        DataType ad_ = PSATest?.Effective;
+                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                        CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+                        CqlDateTime ag_ = context.Operators.Start(af_);
+                        return ag_ is null;
+                    }
+
+                    if (ac_())
+                    {
+                        return default;
+                    }
+                    else
+                    {
+                        DataType ah_ = PSATest?.Effective;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+                        CqlDateTime ak_ = context.Operators.Start(aj_);
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
+                        CqlDateTime ao_ = context.Operators.Start(an_);
+                        CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ak_, ao_, true, true);
+                        return ap_;
+                    };
+                }
+
+                DataType s_ = MostRecentProstateCancerStaging?.Effective;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+                bool? v_ = context.Operators.Before(r_(), u_, (string)default);
+                Code<ObservationStatus> w_ = PSATest?.StatusElement;
+                ObservationStatus? x_ = w_?.Value;
+                string y_ = context.Operators.Convert<string>(x_);
+                string[] z_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+                bool? ab_ = context.Operators.And(v_, aa_);
+                return ab_;
+            }
+
+            IEnumerable<Observation> p_ = context.Operators.Where<Observation>((IEnumerable<Observation>)n_, o_);
+            bool? q_ = context.Operators.Exists<Observation>(p_);
+            return q_;
+        }
+
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
+
+        object e_(Observation @this) {
+            DataType aq_ = @this?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.Start(as_);
+            return at_;
+        }
+
+        IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation g_ = context.Operators.Last<Observation>(f_);
+        Observation[] h_ = [
+            g_,
+        ];
+
+        bool? i_(Observation LastPSATest) {
+            DataType au_ = LastPSATest?.Value;
+            object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+            CqlQuantity aw_ = context.Operators.Quantity(10m, "ng/mL");
+            bool? ax_ = context.Operators.Less(av_ as CqlQuantity, aw_);
+            return ax_;
+        }
+
+        IEnumerable<bool?> j_ = context.Operators.Select<Observation, bool?>((IEnumerable<Observation>)h_, i_);
+        IEnumerable<bool?> k_ = context.Operators.Distinct<bool?>(j_);
+        bool? l_ = context.Operators.SingletonFrom<bool?>(k_);
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Gleason Score is Low")]
+    public bool? Most_Recent_Gleason_Score_is_Low(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Most_Recent_Gleason_Score_is_Low, Most_Recent_Gleason_Score_is_Low_Compute);
+
+    private const long _cacheIndex_Most_Recent_Gleason_Score_is_Low = 7358005442362079522L;
+
+    private bool? Most_Recent_Gleason_Score_is_Low_Compute(CqlContext context)
+    {
+        CqlCode a_ = this.Gleason_score_in_Specimen_Qualitative(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
+
+        bool? d_(Observation GleasonScore) {
+            Procedure n_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period(context);
+            Procedure[] o_ = [
+                n_,
+            ];
+
+            bool? p_(Procedure FirstProstateCancerTreatment) {
+                DataType s_ = GleasonScore?.Effective;
                 object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
                 CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
                 CqlDateTime v_ = context.Operators.Start(u_);
@@ -517,7 +771,7 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                 CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_());
                 CqlDateTime y_ = context.Operators.Start(x_);
                 bool? z_ = context.Operators.Before(v_, y_, (string)default);
-                Code<ObservationStatus> aa_ = ProstateCancerStaging?.StatusElement;
+                Code<ObservationStatus> aa_ = GleasonScore?.StatusElement;
                 ObservationStatus? ab_ = aa_?.Value;
                 string ac_ = context.Operators.Convert<string>(ab_);
                 string[] ad_ = [
@@ -530,13 +784,12 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                 return af_;
             }
 
-            IEnumerable<Procedure> p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
-            Observation q_(Procedure FirstProstateCancerTreatment) => ProstateCancerStaging;
-            IEnumerable<Observation> r_ = context.Operators.Select<Procedure, Observation>(p_, q_);
+            IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)o_, p_);
+            bool? r_ = context.Operators.Exists<Procedure>(q_);
             return r_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         object f_(Observation @this) {
             DataType be_ = @this?.Effective;
@@ -552,267 +805,11 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
             h_,
         ];
 
-        bool? j_(Observation LastProstateCancerStaging) {
-            DataType bi_ = LastProstateCancerStaging?.Value;
-            object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-            CqlCode bk_ = this.American_Joint_Committee_on_Cancer_cT1a__qualifier_value_(context);
-            CqlConcept bl_ = context.Operators.ConvertCodeToConcept(bk_);
-            bool? bm_ = context.Operators.Equivalent(bj_ as CqlConcept, bl_);
-            object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-            CqlCode bp_ = this.American_Joint_Committee_on_Cancer_cT1b__qualifier_value_(context);
-            CqlConcept bq_ = context.Operators.ConvertCodeToConcept(bp_);
-            bool? br_ = context.Operators.Equivalent(bo_ as CqlConcept, bq_);
-            bool? bs_ = context.Operators.Or(bm_, br_);
-            object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-            CqlCode bv_ = this.American_Joint_Committee_on_Cancer_cT1c__qualifier_value_(context);
-            CqlConcept bw_ = context.Operators.ConvertCodeToConcept(bv_);
-            bool? bx_ = context.Operators.Equivalent(bu_ as CqlConcept, bw_);
-            bool? by_ = context.Operators.Or(bs_, bx_);
-            object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-            CqlCode cb_ = this.American_Joint_Committee_on_Cancer_cT2a__qualifier_value_(context);
-            CqlConcept cc_ = context.Operators.ConvertCodeToConcept(cb_);
-            bool? cd_ = context.Operators.Equivalent(ca_ as CqlConcept, cc_);
-            bool? ce_ = context.Operators.Or(by_, cd_);
-            return ce_;
-        }
-
-        IEnumerable<Observation> k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
-        Observation l_ = context.Operators.SingletonFrom<Observation>(k_);
-        return l_;
-    }
-
-
-    [CqlExpressionDefinition("Most Recent PSA Test Result is Low")]
-    public bool? Most_Recent_PSA_Test_Result_is_Low(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Most_Recent_PSA_Test_Result_is_Low, Most_Recent_PSA_Test_Result_is_Low_Compute);
-
-    private const long _cacheIndex_Most_Recent_PSA_Test_Result_is_Low = 7161242736514616586L;
-
-    private bool? Most_Recent_PSA_Test_Result_is_Low_Compute(CqlContext context)
-    {
-        CqlValueSet a_ = this.Prostate_Specific_Antigen_Test(context);
-        IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
-
-        IEnumerable<Observation> c_(Observation PSATest) {
-            Observation m_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a(context);
-            Observation[] n_ = [
-                m_,
-            ];
-
-            bool? o_(Observation MostRecentProstateCancerStaging) {
-
-                CqlInterval<CqlDateTime> s_() {
-
-                    bool ad_() {
-                        DataType ae_ = PSATest?.Effective;
-                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                        CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                        CqlDateTime ah_ = context.Operators.Start(ag_);
-                        return ah_ is null;
-                    }
-
-                    if (ad_())
-                    {
-                        return default;
-                    }
-                    else
-                    {
-                        DataType ai_ = PSATest?.Effective;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                        CqlDateTime al_ = context.Operators.Start(ak_);
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_);
-                        CqlDateTime ap_ = context.Operators.Start(ao_);
-                        CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(al_, ap_, true, true);
-                        return aq_;
-                    };
-                }
-
-                DataType t_ = MostRecentProstateCancerStaging?.Effective;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                bool? w_ = context.Operators.Before(s_(), v_, (string)default);
-                Code<ObservationStatus> x_ = PSATest?.StatusElement;
-                ObservationStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                bool? ac_ = context.Operators.And(w_, ab_);
-                return ac_;
-            }
-
-            IEnumerable<Observation> p_ = context.Operators.Where<Observation>((IEnumerable<Observation>)n_, o_);
-            Observation q_(Observation MostRecentProstateCancerStaging) => PSATest;
-            IEnumerable<Observation> r_ = context.Operators.Select<Observation, Observation>(p_, q_);
-            return r_;
-        }
-
-        IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
-
-        object e_(Observation @this) {
-            DataType ar_ = @this?.Effective;
-            object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-            CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
-            CqlDateTime au_ = context.Operators.Start(at_);
-            return au_;
-        }
-
-        IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-        Observation g_ = context.Operators.Last<Observation>(f_);
-        Observation[] h_ = [
-            g_,
-        ];
-
-        bool? i_(Observation LastPSATest) {
-            DataType av_ = LastPSATest?.Value;
-            object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-            CqlQuantity ax_ = context.Operators.Quantity(10m, "ng/mL");
-            bool? ay_ = context.Operators.Less(aw_ as CqlQuantity, ax_);
-            return ay_;
-        }
-
-        IEnumerable<bool?> j_ = context.Operators.Select<Observation, bool?>((IEnumerable<Observation>)h_, i_);
-        IEnumerable<bool?> k_ = context.Operators.Distinct<bool?>(j_);
-        bool? l_ = context.Operators.SingletonFrom<bool?>(k_);
-        return l_;
-    }
-
-
-    [CqlExpressionDefinition("Most Recent Gleason Score is Low")]
-    public bool? Most_Recent_Gleason_Score_is_Low(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Most_Recent_Gleason_Score_is_Low, Most_Recent_Gleason_Score_is_Low_Compute);
-
-    private const long _cacheIndex_Most_Recent_Gleason_Score_is_Low = 7358005442362079522L;
-
-    private bool? Most_Recent_Gleason_Score_is_Low_Compute(CqlContext context)
-    {
-        CqlCode a_ = this.Gleason_score_in_Specimen_Qualitative(context);
-        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
-
-        IEnumerable<Observation> d_(Observation GleasonScore) {
-            Procedure n_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period(context);
-            Procedure[] o_ = [
-                n_,
-            ];
-
-            bool? p_(Procedure FirstProstateCancerTreatment) {
-                DataType t_ = GleasonScore?.Effective;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-
-                object x_() {
-
-                    bool ah_() {
-                        DataType al_ = FirstProstateCancerTreatment?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        bool an_ = am_ is CqlDateTime;
-                        return an_;
-                    }
-
-
-                    bool ai_() {
-                        DataType ao_ = FirstProstateCancerTreatment?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        bool aq_ = ap_ is CqlInterval<CqlDateTime>;
-                        return aq_;
-                    }
-
-
-                    bool aj_() {
-                        DataType ar_ = FirstProstateCancerTreatment?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlQuantity;
-                        return at_;
-                    }
-
-
-                    bool ak_() {
-                        DataType au_ = FirstProstateCancerTreatment?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlInterval<CqlQuantity>;
-                        return aw_;
-                    }
-
-                    if (ah_())
-                    {
-                        DataType ax_ = FirstProstateCancerTreatment?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        return (ay_ as CqlDateTime) as object;
-                    }
-                    else if (ai_())
-                    {
-                        DataType az_ = FirstProstateCancerTreatment?.Performed;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        return (ba_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aj_())
-                    {
-                        DataType bb_ = FirstProstateCancerTreatment?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        return (bc_ as CqlQuantity) as object;
-                    }
-                    else if (ak_())
-                    {
-                        DataType bd_ = FirstProstateCancerTreatment?.Performed;
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        return (be_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
-                CqlDateTime z_ = context.Operators.Start(y_);
-                bool? aa_ = context.Operators.Before(w_, z_, (string)default);
-                Code<ObservationStatus> ab_ = GleasonScore?.StatusElement;
-                ObservationStatus? ac_ = ab_?.Value;
-                string ad_ = context.Operators.Convert<string>(ac_);
-                string[] ae_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                bool? af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
-                bool? ag_ = context.Operators.And(aa_, af_);
-                return ag_;
-            }
-
-            IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)o_, p_);
-            Observation r_(Procedure FirstProstateCancerTreatment) => GleasonScore;
-            IEnumerable<Observation> s_ = context.Operators.Select<Procedure, Observation>(q_, r_);
-            return s_;
-        }
-
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
-
-        object f_(Observation @this) {
-            DataType bf_ = @this?.Effective;
-            object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-            CqlInterval<CqlDateTime> bh_ = QICoreCommon_4_0_000.Instance.toInterval(context, bg_);
-            CqlDateTime bi_ = context.Operators.Start(bh_);
-            return bi_;
-        }
-
-        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-        Observation h_ = context.Operators.Last<Observation>(g_);
-        Observation[] i_ = [
-            h_,
-        ];
-
         bool? j_(Observation LastGleasonScore) {
-            DataType bj_ = LastGleasonScore?.Value;
-            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-            bool? bl_ = context.Operators.LessOrEqual(bk_ as int?, 6);
-            return bl_;
+            DataType bi_ = LastGleasonScore?.Value;
+            object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+            bool? bk_ = context.Operators.LessOrEqual(bj_ as int?, 6);
+            return bk_;
         }
 
         IEnumerable<bool?> k_ = context.Operators.Select<Observation, bool?>((IEnumerable<Observation>)i_, j_);
@@ -856,46 +853,45 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
         CqlValueSet a_ = this.Bone_Scan(context);
         IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
-        IEnumerable<Observation> c_(Observation BoneScan) {
+        bool? c_(Observation BoneScan) {
             IEnumerable<Condition> g_ = this.Prostate_Cancer_Diagnosis(context);
 
             bool? h_(Condition ActiveProstateCancer) {
-                DataType l_ = BoneScan?.Effective;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as Condition);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                bool? r_ = context.Operators.After(o_, q_, (string)default);
-                return r_;
+                DataType k_ = BoneScan?.Effective;
+                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as Condition);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                bool? q_ = context.Operators.After(n_, p_, (string)default);
+                return q_;
             }
 
             IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
-            Observation j_(Condition ActiveProstateCancer) => BoneScan;
-            IEnumerable<Observation> k_ = context.Operators.Select<Condition, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Condition>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
         bool? e_(Observation BoneScan) {
-            DataType s_ = BoneScan?.Effective;
-            object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
-            CqlDateTime v_ = context.Operators.End(u_);
-            CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-            bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, "day");
-            Code<ObservationStatus> y_ = BoneScan?.StatusElement;
-            ObservationStatus? z_ = y_?.Value;
-            string aa_ = context.Operators.Convert<string>(z_);
-            string[] ab_ = [
+            DataType r_ = BoneScan?.Effective;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
+            CqlDateTime u_ = context.Operators.End(t_);
+            CqlInterval<CqlDateTime> v_ = this.Measurement_Period(context);
+            bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, "day");
+            Code<ObservationStatus> x_ = BoneScan?.StatusElement;
+            ObservationStatus? y_ = x_?.Value;
+            string z_ = context.Operators.Convert<string>(y_);
+            string[] aa_ = [
                 "final",
                 "amended",
                 "corrected",
             ];
-            bool? ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-            bool? ad_ = context.Operators.And(x_, ac_);
-            return ad_;
+            bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
+            bool? ac_ = context.Operators.And(w_, ab_);
+            return ac_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
@@ -931,27 +927,26 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
         IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
         IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
 
-        IEnumerable<Condition> f_(Condition ProstateCancerPain) {
+        bool? f_(Condition ProstateCancerPain) {
             IEnumerable<Condition> i_ = this.Prostate_Cancer_Diagnosis(context);
 
             bool? j_(Condition ActiveProstateCancer) {
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ProstateCancerPain);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as Condition);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                bool? r_ = context.Operators.After(o_, q_, (string)default);
-                bool? s_ = this.isVerified(context, ProstateCancerPain);
-                bool? t_ = context.Operators.And(r_, s_);
-                return t_;
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ProstateCancerPain);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as Condition);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                bool? q_ = context.Operators.After(n_, p_, (string)default);
+                bool? r_ = this.isVerified(context, ProstateCancerPain);
+                bool? s_ = context.Operators.And(q_, r_);
+                return s_;
             }
 
             IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
-            Condition l_(Condition ActiveProstateCancer) => ProstateCancerPain;
-            IEnumerable<Condition> m_ = context.Operators.Select<Condition, Condition>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Condition>(k_);
+            return l_;
         }
 
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
         bool? h_ = context.Operators.Exists<Condition>(g_);
         return h_;
     }
@@ -968,67 +963,67 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
         CqlValueSet a_ = this.Salvage_Therapy(context);
         IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> c_(Procedure SalvageTherapy) {
+        bool? c_(Procedure SalvageTherapy) {
             IEnumerable<Condition> f_ = this.Prostate_Cancer_Diagnosis(context);
 
             bool? g_(Condition ActiveProstateCancer) {
 
-                object k_() {
+                object j_() {
+
+                    bool u_() {
+                        DataType y_ = SalvageTherapy?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlDateTime;
+                        return aa_;
+                    }
+
 
                     bool v_() {
-                        DataType z_ = SalvageTherapy?.Performed;
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlDateTime;
-                        return ab_;
+                        DataType ab_ = SalvageTherapy?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlInterval<CqlDateTime>;
+                        return ad_;
                     }
 
 
                     bool w_() {
-                        DataType ac_ = SalvageTherapy?.Performed;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlInterval<CqlDateTime>;
-                        return ae_;
+                        DataType ae_ = SalvageTherapy?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlQuantity;
+                        return ag_;
                     }
 
 
                     bool x_() {
-                        DataType af_ = SalvageTherapy?.Performed;
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlQuantity;
-                        return ah_;
+                        DataType ah_ = SalvageTherapy?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        bool aj_ = ai_ is CqlInterval<CqlQuantity>;
+                        return aj_;
                     }
 
-
-                    bool y_() {
-                        DataType ai_ = SalvageTherapy?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        bool ak_ = aj_ is CqlInterval<CqlQuantity>;
-                        return ak_;
-                    }
-
-                    if (v_())
+                    if (u_())
                     {
-                        DataType al_ = SalvageTherapy?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlDateTime) as object;
+                        DataType ak_ = SalvageTherapy?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlDateTime) as object;
+                    }
+                    else if (v_())
+                    {
+                        DataType am_ = SalvageTherapy?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (w_())
                     {
-                        DataType an_ = SalvageTherapy?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ao_ = SalvageTherapy?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlQuantity) as object;
                     }
                     else if (x_())
                     {
-                        DataType ap_ = SalvageTherapy?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlQuantity) as object;
-                    }
-                    else if (y_())
-                    {
-                        DataType ar_ = SalvageTherapy?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlInterval<CqlQuantity>) as object;
+                        DataType aq_ = SalvageTherapy?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1036,26 +1031,25 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                     };
                 }
 
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                CqlDateTime m_ = context.Operators.Start(l_);
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as Condition);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                bool? p_ = context.Operators.After(m_, o_, (string)default);
-                Code<EventStatus> q_ = SalvageTherapy?.StatusElement;
-                EventStatus? r_ = q_?.Value;
-                string s_ = context.Operators.Convert<string>(r_);
-                bool? t_ = context.Operators.Equal(s_, "completed");
-                bool? u_ = context.Operators.And(p_, t_);
-                return u_;
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                CqlDateTime l_ = context.Operators.Start(k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as Condition);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                bool? o_ = context.Operators.After(l_, n_, (string)default);
+                Code<EventStatus> p_ = SalvageTherapy?.StatusElement;
+                EventStatus? q_ = p_?.Value;
+                string r_ = context.Operators.Convert<string>(q_);
+                bool? s_ = context.Operators.Equal(r_, "completed");
+                bool? t_ = context.Operators.And(o_, s_);
+                return t_;
             }
 
             IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
-            Procedure i_(Condition ActiveProstateCancer) => SalvageTherapy;
-            IEnumerable<Procedure> j_ = context.Operators.Select<Condition, Procedure>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Condition>(h_);
+            return i_;
         }
 
-        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
         bool? e_ = context.Operators.Exists<Procedure>(d_);
         return e_;
     }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS133FHIRCataracts2040BCVA90Days-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS133FHIRCataracts2040BCVA90Days-1.0.000.g.cs
@@ -551,7 +551,7 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Procedure> a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period(context);
 
-        IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed) {
+        bool? b_(Procedure CataractSurgeryPerformed) {
             CqlValueSet d_ = this.Acute_and_Subacute_Iridocyclitis(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
@@ -828,64 +828,64 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
             IEnumerable<Condition> lt_ = context.Operators.Union<Condition>(ln_, ls_);
 
             bool? lu_(Condition ComorbidDiagnosis) {
-                CqlInterval<CqlDateTime> ly_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ComorbidDiagnosis);
+                CqlInterval<CqlDateTime> lx_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ComorbidDiagnosis);
 
-                object lz_() {
+                object ly_() {
+
+                    bool md_() {
+                        DataType mh_ = CataractSurgeryPerformed?.Performed;
+                        object mi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mh_);
+                        bool mj_ = mi_ is CqlDateTime;
+                        return mj_;
+                    }
+
 
                     bool me_() {
-                        DataType mi_ = CataractSurgeryPerformed?.Performed;
-                        object mj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mi_);
-                        bool mk_ = mj_ is CqlDateTime;
-                        return mk_;
+                        DataType mk_ = CataractSurgeryPerformed?.Performed;
+                        object ml_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mk_);
+                        bool mm_ = ml_ is CqlInterval<CqlDateTime>;
+                        return mm_;
                     }
 
 
                     bool mf_() {
-                        DataType ml_ = CataractSurgeryPerformed?.Performed;
-                        object mm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ml_);
-                        bool mn_ = mm_ is CqlInterval<CqlDateTime>;
-                        return mn_;
+                        DataType mn_ = CataractSurgeryPerformed?.Performed;
+                        object mo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mn_);
+                        bool mp_ = mo_ is CqlQuantity;
+                        return mp_;
                     }
 
 
                     bool mg_() {
-                        DataType mo_ = CataractSurgeryPerformed?.Performed;
-                        object mp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mo_);
-                        bool mq_ = mp_ is CqlQuantity;
-                        return mq_;
+                        DataType mq_ = CataractSurgeryPerformed?.Performed;
+                        object mr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mq_);
+                        bool ms_ = mr_ is CqlInterval<CqlQuantity>;
+                        return ms_;
                     }
 
-
-                    bool mh_() {
-                        DataType mr_ = CataractSurgeryPerformed?.Performed;
-                        object ms_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mr_);
-                        bool mt_ = ms_ is CqlInterval<CqlQuantity>;
-                        return mt_;
-                    }
-
-                    if (me_())
+                    if (md_())
                     {
-                        DataType mu_ = CataractSurgeryPerformed?.Performed;
-                        object mv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mu_);
-                        return (mv_ as CqlDateTime) as object;
+                        DataType mt_ = CataractSurgeryPerformed?.Performed;
+                        object mu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mt_);
+                        return (mu_ as CqlDateTime) as object;
+                    }
+                    else if (me_())
+                    {
+                        DataType mv_ = CataractSurgeryPerformed?.Performed;
+                        object mw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mv_);
+                        return (mw_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (mf_())
                     {
-                        DataType mw_ = CataractSurgeryPerformed?.Performed;
-                        object mx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mw_);
-                        return (mx_ as CqlInterval<CqlDateTime>) as object;
+                        DataType mx_ = CataractSurgeryPerformed?.Performed;
+                        object my_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mx_);
+                        return (my_ as CqlQuantity) as object;
                     }
                     else if (mg_())
                     {
-                        DataType my_ = CataractSurgeryPerformed?.Performed;
-                        object mz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, my_);
-                        return (mz_ as CqlQuantity) as object;
-                    }
-                    else if (mh_())
-                    {
-                        DataType na_ = CataractSurgeryPerformed?.Performed;
-                        object nb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, na_);
-                        return (nb_ as CqlInterval<CqlQuantity>) as object;
+                        DataType mz_ = CataractSurgeryPerformed?.Performed;
+                        object na_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mz_);
+                        return (na_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -893,20 +893,19 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
                     };
                 }
 
-                CqlInterval<CqlDateTime> ma_ = QICoreCommon_4_0_000.Instance.toInterval(context, lz_());
-                bool? mb_ = context.Operators.OverlapsBefore(ly_, ma_, "day");
-                bool? mc_ = this.isVerified(context, ComorbidDiagnosis);
-                bool? md_ = context.Operators.And(mb_, mc_);
-                return md_;
+                CqlInterval<CqlDateTime> lz_ = QICoreCommon_4_0_000.Instance.toInterval(context, ly_());
+                bool? ma_ = context.Operators.OverlapsBefore(lx_, lz_, "day");
+                bool? mb_ = this.isVerified(context, ComorbidDiagnosis);
+                bool? mc_ = context.Operators.And(ma_, mb_);
+                return mc_;
             }
 
             IEnumerable<Condition> lv_ = context.Operators.Where<Condition>(lt_, lu_);
-            Procedure lw_(Condition ComorbidDiagnosis) => CataractSurgeryPerformed;
-            IEnumerable<Procedure> lx_ = context.Operators.Select<Condition, Procedure>(lv_, lw_);
-            return lx_;
+            bool? lw_ = context.Operators.Exists<Condition>(lv_);
+            return lw_;
         }
 
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
         return c_;
     }
 
@@ -934,7 +933,7 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Procedure> a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period(context);
 
-        IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed) {
+        bool? b_(Procedure CataractSurgeryPerformed) {
             CqlCode d_ = this.Best_corrected_visual_acuity__observable_entity_(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
@@ -943,67 +942,67 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
             IEnumerable<Observation> i_ = context.Operators.Union<Observation>(f_, h_);
 
             bool? j_(Observation VisualAcuityExamPerformed) {
-                DataType n_ = VisualAcuityExamPerformed?.Effective;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                CqlDateTime q_ = context.Operators.Start(p_);
+                DataType m_ = VisualAcuityExamPerformed?.Effective;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                CqlDateTime p_ = context.Operators.Start(o_);
 
-                object r_() {
+                object q_() {
+
+                    bool aq_() {
+                        DataType au_ = CataractSurgeryPerformed?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlDateTime;
+                        return aw_;
+                    }
+
 
                     bool ar_() {
-                        DataType av_ = CataractSurgeryPerformed?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlDateTime;
-                        return ax_;
+                        DataType ax_ = CataractSurgeryPerformed?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlInterval<CqlDateTime>;
+                        return az_;
                     }
 
 
                     bool as_() {
-                        DataType ay_ = CataractSurgeryPerformed?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlInterval<CqlDateTime>;
-                        return ba_;
+                        DataType ba_ = CataractSurgeryPerformed?.Performed;
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlQuantity;
+                        return bc_;
                     }
 
 
                     bool at_() {
-                        DataType bb_ = CataractSurgeryPerformed?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlQuantity;
-                        return bd_;
+                        DataType bd_ = CataractSurgeryPerformed?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        bool bf_ = be_ is CqlInterval<CqlQuantity>;
+                        return bf_;
                     }
 
-
-                    bool au_() {
-                        DataType be_ = CataractSurgeryPerformed?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        bool bg_ = bf_ is CqlInterval<CqlQuantity>;
-                        return bg_;
-                    }
-
-                    if (ar_())
+                    if (aq_())
                     {
-                        DataType bh_ = CataractSurgeryPerformed?.Performed;
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        return (bi_ as CqlDateTime) as object;
+                        DataType bg_ = CataractSurgeryPerformed?.Performed;
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        return (bh_ as CqlDateTime) as object;
+                    }
+                    else if (ar_())
+                    {
+                        DataType bi_ = CataractSurgeryPerformed?.Performed;
+                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                        return (bj_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (as_())
                     {
-                        DataType bj_ = CataractSurgeryPerformed?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        return (bk_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bk_ = CataractSurgeryPerformed?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        return (bl_ as CqlQuantity) as object;
                     }
                     else if (at_())
                     {
-                        DataType bl_ = CataractSurgeryPerformed?.Performed;
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        return (bm_ as CqlQuantity) as object;
-                    }
-                    else if (au_())
-                    {
-                        DataType bn_ = CataractSurgeryPerformed?.Performed;
-                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                        return (bo_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bm_ = CataractSurgeryPerformed?.Performed;
+                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                        return (bn_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1011,65 +1010,65 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
                     };
                 }
 
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
-                CqlDateTime t_ = context.Operators.End(s_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
+                CqlDateTime s_ = context.Operators.End(r_);
 
-                object u_() {
+                object t_() {
+
+                    bool bo_() {
+                        DataType bs_ = CataractSurgeryPerformed?.Performed;
+                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                        bool bu_ = bt_ is CqlDateTime;
+                        return bu_;
+                    }
+
 
                     bool bp_() {
-                        DataType bt_ = CataractSurgeryPerformed?.Performed;
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        bool bv_ = bu_ is CqlDateTime;
-                        return bv_;
+                        DataType bv_ = CataractSurgeryPerformed?.Performed;
+                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                        bool bx_ = bw_ is CqlInterval<CqlDateTime>;
+                        return bx_;
                     }
 
 
                     bool bq_() {
-                        DataType bw_ = CataractSurgeryPerformed?.Performed;
-                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                        bool by_ = bx_ is CqlInterval<CqlDateTime>;
-                        return by_;
+                        DataType by_ = CataractSurgeryPerformed?.Performed;
+                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
+                        bool ca_ = bz_ is CqlQuantity;
+                        return ca_;
                     }
 
 
                     bool br_() {
-                        DataType bz_ = CataractSurgeryPerformed?.Performed;
-                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                        bool cb_ = ca_ is CqlQuantity;
-                        return cb_;
+                        DataType cb_ = CataractSurgeryPerformed?.Performed;
+                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+                        bool cd_ = cc_ is CqlInterval<CqlQuantity>;
+                        return cd_;
                     }
 
-
-                    bool bs_() {
-                        DataType cc_ = CataractSurgeryPerformed?.Performed;
-                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        bool ce_ = cd_ is CqlInterval<CqlQuantity>;
-                        return ce_;
-                    }
-
-                    if (bp_())
+                    if (bo_())
                     {
-                        DataType cf_ = CataractSurgeryPerformed?.Performed;
-                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                        return (cg_ as CqlDateTime) as object;
+                        DataType ce_ = CataractSurgeryPerformed?.Performed;
+                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                        return (cf_ as CqlDateTime) as object;
+                    }
+                    else if (bp_())
+                    {
+                        DataType cg_ = CataractSurgeryPerformed?.Performed;
+                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                        return (ch_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bq_())
                     {
-                        DataType ch_ = CataractSurgeryPerformed?.Performed;
-                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                        return (ci_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ci_ = CataractSurgeryPerformed?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        return (cj_ as CqlQuantity) as object;
                     }
                     else if (br_())
                     {
-                        DataType cj_ = CataractSurgeryPerformed?.Performed;
-                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                        return (ck_ as CqlQuantity) as object;
-                    }
-                    else if (bs_())
-                    {
-                        DataType cl_ = CataractSurgeryPerformed?.Performed;
-                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                        return (cm_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ck_ = CataractSurgeryPerformed?.Performed;
+                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+                        return (cl_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1077,69 +1076,69 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
                     };
                 }
 
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.End(v_);
-                CqlQuantity x_ = context.Operators.Quantity(90m, "days");
-                CqlDateTime y_ = context.Operators.Add(w_, x_);
-                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(t_, y_, false, true);
-                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.End(u_);
+                CqlQuantity w_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime x_ = context.Operators.Add(v_, w_);
+                CqlInterval<CqlDateTime> y_ = context.Operators.Interval(s_, x_, false, true);
+                bool? z_ = context.Operators.In<CqlDateTime>(p_, y_, "day");
 
-                object ab_() {
+                object aa_() {
+
+                    bool cm_() {
+                        DataType cq_ = CataractSurgeryPerformed?.Performed;
+                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                        bool cs_ = cr_ is CqlDateTime;
+                        return cs_;
+                    }
+
 
                     bool cn_() {
-                        DataType cr_ = CataractSurgeryPerformed?.Performed;
-                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
-                        bool ct_ = cs_ is CqlDateTime;
-                        return ct_;
+                        DataType ct_ = CataractSurgeryPerformed?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        bool cv_ = cu_ is CqlInterval<CqlDateTime>;
+                        return cv_;
                     }
 
 
                     bool co_() {
-                        DataType cu_ = CataractSurgeryPerformed?.Performed;
-                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
-                        bool cw_ = cv_ is CqlInterval<CqlDateTime>;
-                        return cw_;
+                        DataType cw_ = CataractSurgeryPerformed?.Performed;
+                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                        bool cy_ = cx_ is CqlQuantity;
+                        return cy_;
                     }
 
 
                     bool cp_() {
-                        DataType cx_ = CataractSurgeryPerformed?.Performed;
-                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
-                        bool cz_ = cy_ is CqlQuantity;
-                        return cz_;
+                        DataType cz_ = CataractSurgeryPerformed?.Performed;
+                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
+                        bool db_ = da_ is CqlInterval<CqlQuantity>;
+                        return db_;
                     }
 
-
-                    bool cq_() {
-                        DataType da_ = CataractSurgeryPerformed?.Performed;
-                        object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-                        bool dc_ = db_ is CqlInterval<CqlQuantity>;
-                        return dc_;
-                    }
-
-                    if (cn_())
+                    if (cm_())
                     {
-                        DataType dd_ = CataractSurgeryPerformed?.Performed;
-                        object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
-                        return (de_ as CqlDateTime) as object;
+                        DataType dc_ = CataractSurgeryPerformed?.Performed;
+                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
+                        return (dd_ as CqlDateTime) as object;
+                    }
+                    else if (cn_())
+                    {
+                        DataType de_ = CataractSurgeryPerformed?.Performed;
+                        object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                        return (df_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (co_())
                     {
-                        DataType df_ = CataractSurgeryPerformed?.Performed;
-                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                        return (dg_ as CqlInterval<CqlDateTime>) as object;
+                        DataType dg_ = CataractSurgeryPerformed?.Performed;
+                        object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
+                        return (dh_ as CqlQuantity) as object;
                     }
                     else if (cp_())
                     {
-                        DataType dh_ = CataractSurgeryPerformed?.Performed;
-                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
-                        return (di_ as CqlQuantity) as object;
-                    }
-                    else if (cq_())
-                    {
-                        DataType dj_ = CataractSurgeryPerformed?.Performed;
-                        object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
-                        return (dk_ as CqlInterval<CqlQuantity>) as object;
+                        DataType di_ = CataractSurgeryPerformed?.Performed;
+                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+                        return (dj_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1147,35 +1146,34 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
                     };
                 }
 
-                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_());
-                CqlDateTime ad_ = context.Operators.End(ac_);
-                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
-                bool? af_ = context.Operators.And(aa_, ae_);
-                Code<ObservationStatus> ag_ = VisualAcuityExamPerformed?.StatusElement;
-                ObservationStatus? ah_ = ag_?.Value;
-                string ai_ = context.Operators.Convert<string>(ah_);
-                string[] aj_ = [
+                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_());
+                CqlDateTime ac_ = context.Operators.End(ab_);
+                bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+                bool? ae_ = context.Operators.And(z_, ad_);
+                Code<ObservationStatus> af_ = VisualAcuityExamPerformed?.StatusElement;
+                ObservationStatus? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                string[] ai_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-                bool? al_ = context.Operators.And(af_, ak_);
-                DataType am_ = VisualAcuityExamPerformed?.Value;
-                object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                CqlValueSet ao_ = this.Visual_Acuity_20_40_or_Better(context);
-                bool? ap_ = context.Operators.ConceptInValueSet(an_ as CqlConcept, ao_);
-                bool? aq_ = context.Operators.And(al_, ap_);
-                return aq_;
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+                bool? ak_ = context.Operators.And(ae_, aj_);
+                DataType al_ = VisualAcuityExamPerformed?.Value;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                CqlValueSet an_ = this.Visual_Acuity_20_40_or_Better(context);
+                bool? ao_ = context.Operators.ConceptInValueSet(am_ as CqlConcept, an_);
+                bool? ap_ = context.Operators.And(ak_, ao_);
+                return ap_;
             }
 
             IEnumerable<Observation> k_ = context.Operators.Where<Observation>(i_, j_);
-            Procedure l_(Observation VisualAcuityExamPerformed) => CataractSurgeryPerformed;
-            IEnumerable<Procedure> m_ = context.Operators.Select<Observation, Procedure>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Observation>(k_);
+            return l_;
         }
 
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
@@ -357,87 +357,85 @@ public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISinglet
         IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
         IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
 
-        IEnumerable<Condition> f_(Condition PregnancyDiagnosis) {
+        bool? f_(Condition PregnancyDiagnosis) {
             IEnumerable<Encounter> n_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? o_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyDiagnosis);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                Period u_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(9m, "months");
-                CqlDateTime y_ = context.Operators.Subtract(w_, x_);
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, true);
-                bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
-                CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime ag_ = context.Operators.Start(af_);
-                bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
-                bool? ai_ = context.Operators.And(ad_, ah_);
-                bool? aj_ = AHAOverall_4_1_000.Instance.isVerified(context, PregnancyDiagnosis);
-                bool? ak_ = context.Operators.And(ai_, aj_);
-                return ak_;
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyDiagnosis);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                Period t_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlQuantity w_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime x_ = context.Operators.Subtract(v_, w_);
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(x_, aa_, true, true);
+                bool? ac_ = context.Operators.In<CqlDateTime>(s_, ab_, (string)default);
+                CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime af_ = context.Operators.Start(ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ac_, ag_);
+                bool? ai_ = AHAOverall_4_1_000.Instance.isVerified(context, PregnancyDiagnosis);
+                bool? aj_ = context.Operators.And(ah_, ai_);
+                return aj_;
             }
 
             IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
-            Condition q_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => PregnancyDiagnosis;
-            IEnumerable<Condition> r_ = context.Operators.Select<Encounter, Condition>(p_, q_);
-            return r_;
+            bool? q_ = context.Operators.Exists<Encounter>(p_);
+            return q_;
         }
 
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
         bool? h_ = context.Operators.Exists<Condition>(g_);
         IEnumerable<Observation> i_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancystatus"));
 
-        IEnumerable<Observation> j_(Observation PregnantObservation) {
-            IEnumerable<Encounter> al_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
+        bool? j_(Observation PregnantObservation) {
+            IEnumerable<Encounter> ak_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
-            bool? am_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
-                DataType aq_ = PregnantObservation?.Effective;
-                CqlDateTime ar_ = context.Operators.LateBoundProperty<CqlDateTime>(aq_, "value");
-                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_ as object);
-                CqlDateTime at_ = context.Operators.Start(as_);
-                Period au_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
-                CqlDateTime aw_ = context.Operators.Start(av_);
-                CqlQuantity ax_ = context.Operators.Quantity(9m, "months");
-                CqlDateTime ay_ = context.Operators.Subtract(aw_, ax_);
-                CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
-                CqlDateTime bb_ = context.Operators.Start(ba_);
-                CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(ay_, bb_, true, true);
-                bool? bd_ = context.Operators.In<CqlDateTime>(at_, bc_, (string)default);
-                CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
-                CqlDateTime bg_ = context.Operators.Start(bf_);
-                bool? bh_ = context.Operators.Not((bool?)(bg_ is null));
-                bool? bi_ = context.Operators.And(bd_, bh_);
-                DataType bj_ = PregnantObservation?.Value;
-                CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_ as CodeableConcept);
-                CqlValueSet bl_ = this.Pregnancy(context);
-                bool? bm_ = context.Operators.ConceptInValueSet(bk_, bl_);
-                Code<ObservationStatus> bn_ = PregnantObservation?.StatusElement;
-                ObservationStatus? bo_ = bn_?.Value;
-                Code<ObservationStatus> bp_ = context.Operators.Convert<Code<ObservationStatus>>(bo_);
-                string bq_ = context.Operators.Convert<string>(bp_);
-                string[] br_ = [
+            bool? al_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
+                DataType ao_ = PregnantObservation?.Effective;
+                CqlDateTime ap_ = context.Operators.LateBoundProperty<CqlDateTime>(ao_, "value");
+                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_ as object);
+                CqlDateTime ar_ = context.Operators.Start(aq_);
+                Period as_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
+                CqlDateTime au_ = context.Operators.Start(at_);
+                CqlQuantity av_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime aw_ = context.Operators.Subtract(au_, av_);
+                CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+                CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(aw_, az_, true, true);
+                bool? bb_ = context.Operators.In<CqlDateTime>(ar_, ba_, (string)default);
+                CqlInterval<CqlDateTime> bd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
+                CqlDateTime be_ = context.Operators.Start(bd_);
+                bool? bf_ = context.Operators.Not((bool?)(be_ is null));
+                bool? bg_ = context.Operators.And(bb_, bf_);
+                DataType bh_ = PregnantObservation?.Value;
+                CqlConcept bi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bh_ as CodeableConcept);
+                CqlValueSet bj_ = this.Pregnancy(context);
+                bool? bk_ = context.Operators.ConceptInValueSet(bi_, bj_);
+                Code<ObservationStatus> bl_ = PregnantObservation?.StatusElement;
+                ObservationStatus? bm_ = bl_?.Value;
+                Code<ObservationStatus> bn_ = context.Operators.Convert<Code<ObservationStatus>>(bm_);
+                string bo_ = context.Operators.Convert<string>(bn_);
+                string[] bp_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
-                bool? bt_ = context.Operators.And(bm_, bs_);
-                bool? bu_ = context.Operators.And(bi_, bt_);
-                return bu_;
+                bool? bq_ = context.Operators.In<string>(bo_, (IEnumerable<string>)bp_);
+                bool? br_ = context.Operators.And(bk_, bq_);
+                bool? bs_ = context.Operators.And(bg_, br_);
+                return bs_;
             }
 
-            IEnumerable<Encounter> an_ = context.Operators.Where<Encounter>(al_, am_);
-            Observation ao_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => PregnantObservation;
-            IEnumerable<Observation> ap_ = context.Operators.Select<Encounter, Observation>(an_, ao_);
-            return ap_;
+            IEnumerable<Encounter> am_ = context.Operators.Where<Encounter>(ak_, al_);
+            bool? an_ = context.Operators.Exists<Encounter>(am_);
+            return an_;
         }
 
-        IEnumerable<Observation> k_ = context.Operators.SelectMany<Observation, Observation>(i_, j_);
+        IEnumerable<Observation> k_ = context.Operators.Where<Observation>(i_, j_);
         bool? l_ = context.Operators.Exists<Observation>(k_);
         bool? m_ = context.Operators.Or(h_, l_);
         return m_;

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
@@ -238,96 +238,235 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
-            IEnumerable<Medication> ej_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? d_(MedicationRequest MR) {
+            IEnumerable<Medication> bu_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ek_(Medication M) {
-                object eo_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ep_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> eq_ = context.Operators.Split((string)ep_, "/");
-                string er_ = context.Operators.Last<string>(eq_);
-                bool? es_ = context.Operators.Equal(eo_, er_);
-                CodeableConcept et_ = M?.Code;
-                CqlConcept eu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, et_);
-                CqlValueSet ev_ = this.Atomoxetine(context);
-                bool? ew_ = context.Operators.ConceptInValueSet(eu_, ev_);
-                bool? ex_ = context.Operators.And(es_, ew_);
-                return ex_;
+            bool? bv_(Medication M) {
+                object by_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object bz_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ca_ = context.Operators.Split((string)bz_, "/");
+                string cb_ = context.Operators.Last<string>(ca_);
+                bool? cc_ = context.Operators.Equal(by_, cb_);
+                CodeableConcept cd_ = M?.Code;
+                CqlConcept ce_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cd_);
+                CqlValueSet cf_ = this.Atomoxetine(context);
+                bool? cg_ = context.Operators.ConceptInValueSet(ce_, cf_);
+                bool? ch_ = context.Operators.And(cc_, cg_);
+                return ch_;
             }
 
-            IEnumerable<Medication> el_ = context.Operators.Where<Medication>(ej_, ek_);
-            MedicationRequest em_(Medication M) => MR;
-            IEnumerable<MedicationRequest> en_ = context.Operators.Select<Medication, MedicationRequest>(el_, em_);
-            return en_;
+            IEnumerable<Medication> bw_ = context.Operators.Where<Medication>(bu_, bv_);
+            bool? bx_ = context.Operators.Exists<Medication>(bw_);
+            return bx_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         CqlValueSet g_ = this.Clonidine(context);
         IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> j_(MedicationRequest MR) {
-            IEnumerable<Medication> ey_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? j_(MedicationRequest MR) {
+            IEnumerable<Medication> ci_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ez_(Medication M) {
-                object fd_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object fe_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ff_ = context.Operators.Split((string)fe_, "/");
-                string fg_ = context.Operators.Last<string>(ff_);
-                bool? fh_ = context.Operators.Equal(fd_, fg_);
-                CodeableConcept fi_ = M?.Code;
-                CqlConcept fj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fi_);
-                CqlValueSet fk_ = this.Clonidine(context);
-                bool? fl_ = context.Operators.ConceptInValueSet(fj_, fk_);
-                bool? fm_ = context.Operators.And(fh_, fl_);
-                return fm_;
+            bool? cj_(Medication M) {
+                object cm_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> co_ = context.Operators.Split((string)cn_, "/");
+                string cp_ = context.Operators.Last<string>(co_);
+                bool? cq_ = context.Operators.Equal(cm_, cp_);
+                CodeableConcept cr_ = M?.Code;
+                CqlConcept cs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cr_);
+                CqlValueSet ct_ = this.Clonidine(context);
+                bool? cu_ = context.Operators.ConceptInValueSet(cs_, ct_);
+                bool? cv_ = context.Operators.And(cq_, cu_);
+                return cv_;
             }
 
-            IEnumerable<Medication> fa_ = context.Operators.Where<Medication>(ey_, ez_);
-            MedicationRequest fb_(Medication M) => MR;
-            IEnumerable<MedicationRequest> fc_ = context.Operators.Select<Medication, MedicationRequest>(fa_, fb_);
-            return fc_;
+            IEnumerable<Medication> ck_ = context.Operators.Where<Medication>(ci_, cj_);
+            bool? cl_ = context.Operators.Exists<Medication>(ck_);
+            return cl_;
         }
 
-        IEnumerable<MedicationRequest> k_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, j_);
+        IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(c_, j_);
         IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(h_, k_);
         IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(f_, l_);
         CqlValueSet n_ = this.Dexmethylphenidate(context);
         IEnumerable<MedicationRequest> o_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> q_(MedicationRequest MR) {
-            IEnumerable<Medication> fn_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? q_(MedicationRequest MR) {
+            IEnumerable<Medication> cw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? fo_(Medication M) {
-                object fs_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ft_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fu_ = context.Operators.Split((string)ft_, "/");
-                string fv_ = context.Operators.Last<string>(fu_);
-                bool? fw_ = context.Operators.Equal(fs_, fv_);
-                CodeableConcept fx_ = M?.Code;
-                CqlConcept fy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fx_);
-                CqlValueSet fz_ = this.Dexmethylphenidate(context);
-                bool? ga_ = context.Operators.ConceptInValueSet(fy_, fz_);
-                bool? gb_ = context.Operators.And(fw_, ga_);
-                return gb_;
+            bool? cx_(Medication M) {
+                object da_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object db_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> dc_ = context.Operators.Split((string)db_, "/");
+                string dd_ = context.Operators.Last<string>(dc_);
+                bool? de_ = context.Operators.Equal(da_, dd_);
+                CodeableConcept df_ = M?.Code;
+                CqlConcept dg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, df_);
+                CqlValueSet dh_ = this.Dexmethylphenidate(context);
+                bool? di_ = context.Operators.ConceptInValueSet(dg_, dh_);
+                bool? dj_ = context.Operators.And(de_, di_);
+                return dj_;
             }
 
-            IEnumerable<Medication> fp_ = context.Operators.Where<Medication>(fn_, fo_);
-            MedicationRequest fq_(Medication M) => MR;
-            IEnumerable<MedicationRequest> fr_ = context.Operators.Select<Medication, MedicationRequest>(fp_, fq_);
-            return fr_;
+            IEnumerable<Medication> cy_ = context.Operators.Where<Medication>(cw_, cx_);
+            bool? cz_ = context.Operators.Exists<Medication>(cy_);
+            return cz_;
         }
 
-        IEnumerable<MedicationRequest> r_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, q_);
+        IEnumerable<MedicationRequest> r_ = context.Operators.Where<MedicationRequest>(c_, q_);
         IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(o_, r_);
         IEnumerable<MedicationRequest> t_ = context.Operators.Union<MedicationRequest>(m_, s_);
         CqlValueSet u_ = this.Dextroamphetamine(context);
         IEnumerable<MedicationRequest> v_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, u_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> x_(MedicationRequest MR) {
-            IEnumerable<Medication> gc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? x_(MedicationRequest MR) {
+            IEnumerable<Medication> dk_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? gd_(Medication M) {
+            bool? dl_(Medication M) {
+                object do_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object dp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> dq_ = context.Operators.Split((string)dp_, "/");
+                string dr_ = context.Operators.Last<string>(dq_);
+                bool? ds_ = context.Operators.Equal(do_, dr_);
+                CodeableConcept dt_ = M?.Code;
+                CqlConcept du_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dt_);
+                CqlValueSet dv_ = this.Dextroamphetamine(context);
+                bool? dw_ = context.Operators.ConceptInValueSet(du_, dv_);
+                bool? dx_ = context.Operators.And(ds_, dw_);
+                return dx_;
+            }
+
+            IEnumerable<Medication> dm_ = context.Operators.Where<Medication>(dk_, dl_);
+            bool? dn_ = context.Operators.Exists<Medication>(dm_);
+            return dn_;
+        }
+
+        IEnumerable<MedicationRequest> y_ = context.Operators.Where<MedicationRequest>(c_, x_);
+        IEnumerable<MedicationRequest> z_ = context.Operators.Union<MedicationRequest>(v_, y_);
+        IEnumerable<MedicationRequest> aa_ = context.Operators.Union<MedicationRequest>(t_, z_);
+        CqlValueSet ab_ = this.Lisdexamfetamine(context);
+        IEnumerable<MedicationRequest> ac_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ab_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+
+        bool? ae_(MedicationRequest MR) {
+            IEnumerable<Medication> dy_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+
+            bool? dz_(Medication M) {
+                object ec_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ed_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ee_ = context.Operators.Split((string)ed_, "/");
+                string ef_ = context.Operators.Last<string>(ee_);
+                bool? eg_ = context.Operators.Equal(ec_, ef_);
+                CodeableConcept eh_ = M?.Code;
+                CqlConcept ei_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eh_);
+                CqlValueSet ej_ = this.Lisdexamfetamine(context);
+                bool? ek_ = context.Operators.ConceptInValueSet(ei_, ej_);
+                bool? el_ = context.Operators.And(eg_, ek_);
+                return el_;
+            }
+
+            IEnumerable<Medication> ea_ = context.Operators.Where<Medication>(dy_, dz_);
+            bool? eb_ = context.Operators.Exists<Medication>(ea_);
+            return eb_;
+        }
+
+        IEnumerable<MedicationRequest> af_ = context.Operators.Where<MedicationRequest>(c_, ae_);
+        IEnumerable<MedicationRequest> ag_ = context.Operators.Union<MedicationRequest>(ac_, af_);
+        IEnumerable<MedicationRequest> ah_ = context.Operators.Union<MedicationRequest>(aa_, ag_);
+        CqlCode ai_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+        IEnumerable<CqlCode> aj_ = context.Operators.ToList<CqlCode>(ai_);
+        IEnumerable<MedicationRequest> ak_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, aj_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+
+        bool? am_(MedicationRequest MR) {
+            IEnumerable<Medication> em_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+
+            bool? en_(Medication M) {
+                object eq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object er_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> es_ = context.Operators.Split((string)er_, "/");
+                string et_ = context.Operators.Last<string>(es_);
+                bool? eu_ = context.Operators.Equal(eq_, et_);
+                CodeableConcept ev_ = M?.Code;
+                CqlConcept ew_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ev_);
+                CqlCode ex_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+                CqlConcept ey_ = context.Operators.ConvertCodeToConcept(ex_);
+                bool? ez_ = context.Operators.Equivalent(ew_, ey_);
+                bool? fa_ = context.Operators.And(eu_, ez_);
+                return fa_;
+            }
+
+            IEnumerable<Medication> eo_ = context.Operators.Where<Medication>(em_, en_);
+            bool? ep_ = context.Operators.Exists<Medication>(eo_);
+            return ep_;
+        }
+
+        IEnumerable<MedicationRequest> an_ = context.Operators.Where<MedicationRequest>(c_, am_);
+        IEnumerable<MedicationRequest> ao_ = context.Operators.Union<MedicationRequest>(ak_, an_);
+        IEnumerable<MedicationRequest> ap_ = context.Operators.Union<MedicationRequest>(ah_, ao_);
+        CqlValueSet aq_ = this.Methylphenidate(context);
+        IEnumerable<MedicationRequest> ar_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+
+        bool? at_(MedicationRequest MR) {
+            IEnumerable<Medication> fb_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+
+            bool? fc_(Medication M) {
+                object ff_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object fg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fh_ = context.Operators.Split((string)fg_, "/");
+                string fi_ = context.Operators.Last<string>(fh_);
+                bool? fj_ = context.Operators.Equal(ff_, fi_);
+                CodeableConcept fk_ = M?.Code;
+                CqlConcept fl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fk_);
+                CqlValueSet fm_ = this.Methylphenidate(context);
+                bool? fn_ = context.Operators.ConceptInValueSet(fl_, fm_);
+                bool? fo_ = context.Operators.And(fj_, fn_);
+                return fo_;
+            }
+
+            IEnumerable<Medication> fd_ = context.Operators.Where<Medication>(fb_, fc_);
+            bool? fe_ = context.Operators.Exists<Medication>(fd_);
+            return fe_;
+        }
+
+        IEnumerable<MedicationRequest> au_ = context.Operators.Where<MedicationRequest>(c_, at_);
+        IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(ar_, au_);
+        IEnumerable<MedicationRequest> aw_ = context.Operators.Union<MedicationRequest>(ap_, av_);
+        CqlValueSet ax_ = this.Guanfacine_Medications(context);
+        IEnumerable<MedicationRequest> ay_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ax_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+
+        bool? ba_(MedicationRequest MR) {
+            IEnumerable<Medication> fp_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+
+            bool? fq_(Medication M) {
+                object ft_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object fu_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fv_ = context.Operators.Split((string)fu_, "/");
+                string fw_ = context.Operators.Last<string>(fv_);
+                bool? fx_ = context.Operators.Equal(ft_, fw_);
+                CodeableConcept fy_ = M?.Code;
+                CqlConcept fz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fy_);
+                CqlValueSet ga_ = this.Guanfacine_Medications(context);
+                bool? gb_ = context.Operators.ConceptInValueSet(fz_, ga_);
+                bool? gc_ = context.Operators.And(fx_, gb_);
+                return gc_;
+            }
+
+            IEnumerable<Medication> fr_ = context.Operators.Where<Medication>(fp_, fq_);
+            bool? fs_ = context.Operators.Exists<Medication>(fr_);
+            return fs_;
+        }
+
+        IEnumerable<MedicationRequest> bb_ = context.Operators.Where<MedicationRequest>(c_, ba_);
+        IEnumerable<MedicationRequest> bc_ = context.Operators.Union<MedicationRequest>(ay_, bb_);
+        IEnumerable<MedicationRequest> bd_ = context.Operators.Union<MedicationRequest>(aw_, bc_);
+        CqlValueSet be_ = this.Viloxazine(context);
+        IEnumerable<MedicationRequest> bf_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, be_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+
+        bool? bh_(MedicationRequest MR) {
+            IEnumerable<Medication> gd_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+
+            bool? ge_(Medication M) {
                 object gh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
                 object gi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
                 IEnumerable<string> gj_ = context.Operators.Split((string)gi_, "/");
@@ -335,753 +474,330 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 bool? gl_ = context.Operators.Equal(gh_, gk_);
                 CodeableConcept gm_ = M?.Code;
                 CqlConcept gn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gm_);
-                CqlValueSet go_ = this.Dextroamphetamine(context);
+                CqlValueSet go_ = this.Viloxazine(context);
                 bool? gp_ = context.Operators.ConceptInValueSet(gn_, go_);
                 bool? gq_ = context.Operators.And(gl_, gp_);
                 return gq_;
             }
 
-            IEnumerable<Medication> ge_ = context.Operators.Where<Medication>(gc_, gd_);
-            MedicationRequest gf_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gg_ = context.Operators.Select<Medication, MedicationRequest>(ge_, gf_);
+            IEnumerable<Medication> gf_ = context.Operators.Where<Medication>(gd_, ge_);
+            bool? gg_ = context.Operators.Exists<Medication>(gf_);
             return gg_;
         }
 
-        IEnumerable<MedicationRequest> y_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, x_);
-        IEnumerable<MedicationRequest> z_ = context.Operators.Union<MedicationRequest>(v_, y_);
-        IEnumerable<MedicationRequest> aa_ = context.Operators.Union<MedicationRequest>(t_, z_);
-        CqlValueSet ab_ = this.Lisdexamfetamine(context);
-        IEnumerable<MedicationRequest> ac_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ab_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> ae_(MedicationRequest MR) {
-            IEnumerable<Medication> gr_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? gs_(Medication M) {
-                object gw_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object gx_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> gy_ = context.Operators.Split((string)gx_, "/");
-                string gz_ = context.Operators.Last<string>(gy_);
-                bool? ha_ = context.Operators.Equal(gw_, gz_);
-                CodeableConcept hb_ = M?.Code;
-                CqlConcept hc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hb_);
-                CqlValueSet hd_ = this.Lisdexamfetamine(context);
-                bool? he_ = context.Operators.ConceptInValueSet(hc_, hd_);
-                bool? hf_ = context.Operators.And(ha_, he_);
-                return hf_;
-            }
-
-            IEnumerable<Medication> gt_ = context.Operators.Where<Medication>(gr_, gs_);
-            MedicationRequest gu_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gv_ = context.Operators.Select<Medication, MedicationRequest>(gt_, gu_);
-            return gv_;
-        }
-
-        IEnumerable<MedicationRequest> af_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ae_);
-        IEnumerable<MedicationRequest> ag_ = context.Operators.Union<MedicationRequest>(ac_, af_);
-        IEnumerable<MedicationRequest> ah_ = context.Operators.Union<MedicationRequest>(aa_, ag_);
-        CqlCode ai_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-        IEnumerable<CqlCode> aj_ = context.Operators.ToList<CqlCode>(ai_);
-        IEnumerable<MedicationRequest> ak_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, aj_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> am_(MedicationRequest MR) {
-            IEnumerable<Medication> hg_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? hh_(Medication M) {
-                object hl_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hm_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hn_ = context.Operators.Split((string)hm_, "/");
-                string ho_ = context.Operators.Last<string>(hn_);
-                bool? hp_ = context.Operators.Equal(hl_, ho_);
-                CodeableConcept hq_ = M?.Code;
-                CqlConcept hr_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hq_);
-                CqlCode hs_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-                CqlConcept ht_ = context.Operators.ConvertCodeToConcept(hs_);
-                bool? hu_ = context.Operators.Equivalent(hr_, ht_);
-                bool? hv_ = context.Operators.And(hp_, hu_);
-                return hv_;
-            }
-
-            IEnumerable<Medication> hi_ = context.Operators.Where<Medication>(hg_, hh_);
-            MedicationRequest hj_(Medication M) => MR;
-            IEnumerable<MedicationRequest> hk_ = context.Operators.Select<Medication, MedicationRequest>(hi_, hj_);
-            return hk_;
-        }
-
-        IEnumerable<MedicationRequest> an_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, am_);
-        IEnumerable<MedicationRequest> ao_ = context.Operators.Union<MedicationRequest>(ak_, an_);
-        IEnumerable<MedicationRequest> ap_ = context.Operators.Union<MedicationRequest>(ah_, ao_);
-        CqlValueSet aq_ = this.Methylphenidate(context);
-        IEnumerable<MedicationRequest> ar_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> at_(MedicationRequest MR) {
-            IEnumerable<Medication> hw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? hx_(Medication M) {
-                object ib_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ic_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> id_ = context.Operators.Split((string)ic_, "/");
-                string ie_ = context.Operators.Last<string>(id_);
-                bool? if_ = context.Operators.Equal(ib_, ie_);
-                CodeableConcept ig_ = M?.Code;
-                CqlConcept ih_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ig_);
-                CqlValueSet ii_ = this.Methylphenidate(context);
-                bool? ij_ = context.Operators.ConceptInValueSet(ih_, ii_);
-                bool? ik_ = context.Operators.And(if_, ij_);
-                return ik_;
-            }
-
-            IEnumerable<Medication> hy_ = context.Operators.Where<Medication>(hw_, hx_);
-            MedicationRequest hz_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ia_ = context.Operators.Select<Medication, MedicationRequest>(hy_, hz_);
-            return ia_;
-        }
-
-        IEnumerable<MedicationRequest> au_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, at_);
-        IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(ar_, au_);
-        IEnumerable<MedicationRequest> aw_ = context.Operators.Union<MedicationRequest>(ap_, av_);
-        CqlValueSet ax_ = this.Guanfacine_Medications(context);
-        IEnumerable<MedicationRequest> ay_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ax_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> ba_(MedicationRequest MR) {
-            IEnumerable<Medication> il_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? im_(Medication M) {
-                object iq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ir_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> is_ = context.Operators.Split((string)ir_, "/");
-                string it_ = context.Operators.Last<string>(is_);
-                bool? iu_ = context.Operators.Equal(iq_, it_);
-                CodeableConcept iv_ = M?.Code;
-                CqlConcept iw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, iv_);
-                CqlValueSet ix_ = this.Guanfacine_Medications(context);
-                bool? iy_ = context.Operators.ConceptInValueSet(iw_, ix_);
-                bool? iz_ = context.Operators.And(iu_, iy_);
-                return iz_;
-            }
-
-            IEnumerable<Medication> in_ = context.Operators.Where<Medication>(il_, im_);
-            MedicationRequest io_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ip_ = context.Operators.Select<Medication, MedicationRequest>(in_, io_);
-            return ip_;
-        }
-
-        IEnumerable<MedicationRequest> bb_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ba_);
-        IEnumerable<MedicationRequest> bc_ = context.Operators.Union<MedicationRequest>(ay_, bb_);
-        IEnumerable<MedicationRequest> bd_ = context.Operators.Union<MedicationRequest>(aw_, bc_);
-        CqlValueSet be_ = this.Viloxazine(context);
-        IEnumerable<MedicationRequest> bf_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, be_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> bh_(MedicationRequest MR) {
-            IEnumerable<Medication> ja_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? jb_(Medication M) {
-                object jf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object jg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> jh_ = context.Operators.Split((string)jg_, "/");
-                string ji_ = context.Operators.Last<string>(jh_);
-                bool? jj_ = context.Operators.Equal(jf_, ji_);
-                CodeableConcept jk_ = M?.Code;
-                CqlConcept jl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jk_);
-                CqlValueSet jm_ = this.Viloxazine(context);
-                bool? jn_ = context.Operators.ConceptInValueSet(jl_, jm_);
-                bool? jo_ = context.Operators.And(jj_, jn_);
-                return jo_;
-            }
-
-            IEnumerable<Medication> jc_ = context.Operators.Where<Medication>(ja_, jb_);
-            MedicationRequest jd_(Medication M) => MR;
-            IEnumerable<MedicationRequest> je_ = context.Operators.Select<Medication, MedicationRequest>(jc_, jd_);
-            return je_;
-        }
-
-        IEnumerable<MedicationRequest> bi_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, bh_);
+        IEnumerable<MedicationRequest> bi_ = context.Operators.Where<MedicationRequest>(c_, bh_);
         IEnumerable<MedicationRequest> bj_ = context.Operators.Union<MedicationRequest>(bf_, bi_);
         IEnumerable<MedicationRequest> bk_ = context.Operators.Union<MedicationRequest>(bd_, bj_);
         IEnumerable<MedicationRequest> bl_ = Status_1_15_000.Instance.isMedicationOrder(context, bk_);
 
         bool? bm_(MedicationRequest ADHDMedications) {
-            CqlInterval<CqlDate> jp_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ADHDMedications);
-            CqlDate jq_ = context.Operators.Start(jp_);
-            CqlDateTime jr_ = context.Operators.ConvertDateToDateTime(jq_);
-            CqlInterval<CqlDateTime> js_ = this.Intake_Period(context);
-            bool? jt_ = context.Operators.In<CqlDateTime>(jr_, js_, (string)default);
-            return jt_;
+            CqlInterval<CqlDate> gr_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ADHDMedications);
+            CqlDate gs_ = context.Operators.Start(gr_);
+            CqlDateTime gt_ = context.Operators.ConvertDateToDateTime(gs_);
+            CqlInterval<CqlDateTime> gu_ = this.Intake_Period(context);
+            bool? gv_ = context.Operators.In<CqlDateTime>(gt_, gu_, (string)default);
+            return gv_;
         }
 
         IEnumerable<MedicationRequest> bn_ = context.Operators.Where<MedicationRequest>(bl_, bm_);
-        IEnumerable<MedicationRequest> bp_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> br_(MedicationRequest MR) {
-            IEnumerable<Medication> ju_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? bo_(MedicationRequest ADHDMedicationOrder) {
+            CqlValueSet gw_ = this.Atomoxetine(context);
+            IEnumerable<MedicationRequest> gx_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, gw_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> gy_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            bool? jv_(Medication M) {
-                object jz_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ka_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> kb_ = context.Operators.Split((string)ka_, "/");
-                string kc_ = context.Operators.Last<string>(kb_);
-                bool? kd_ = context.Operators.Equal(jz_, kc_);
-                CodeableConcept ke_ = M?.Code;
-                CqlConcept kf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ke_);
-                CqlValueSet kg_ = this.Atomoxetine(context);
-                bool? kh_ = context.Operators.ConceptInValueSet(kf_, kg_);
-                bool? ki_ = context.Operators.And(kd_, kh_);
-                return ki_;
-            }
+            bool? gz_(MedicationRequest MR) {
+                IEnumerable<Medication> jm_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            IEnumerable<Medication> jw_ = context.Operators.Where<Medication>(ju_, jv_);
-            MedicationRequest jx_(Medication M) => MR;
-            IEnumerable<MedicationRequest> jy_ = context.Operators.Select<Medication, MedicationRequest>(jw_, jx_);
-            return jy_;
-        }
-
-        IEnumerable<MedicationRequest> bs_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, br_);
-        IEnumerable<MedicationRequest> bt_ = context.Operators.Union<MedicationRequest>(bp_, bs_);
-        IEnumerable<MedicationRequest> bv_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> bx_(MedicationRequest MR) {
-            IEnumerable<Medication> kj_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? kk_(Medication M) {
-                object ko_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object kp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> kq_ = context.Operators.Split((string)kp_, "/");
-                string kr_ = context.Operators.Last<string>(kq_);
-                bool? ks_ = context.Operators.Equal(ko_, kr_);
-                CodeableConcept kt_ = M?.Code;
-                CqlConcept ku_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kt_);
-                CqlValueSet kv_ = this.Clonidine(context);
-                bool? kw_ = context.Operators.ConceptInValueSet(ku_, kv_);
-                bool? kx_ = context.Operators.And(ks_, kw_);
-                return kx_;
-            }
-
-            IEnumerable<Medication> kl_ = context.Operators.Where<Medication>(kj_, kk_);
-            MedicationRequest km_(Medication M) => MR;
-            IEnumerable<MedicationRequest> kn_ = context.Operators.Select<Medication, MedicationRequest>(kl_, km_);
-            return kn_;
-        }
-
-        IEnumerable<MedicationRequest> by_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, bx_);
-        IEnumerable<MedicationRequest> bz_ = context.Operators.Union<MedicationRequest>(bv_, by_);
-        IEnumerable<MedicationRequest> ca_ = context.Operators.Union<MedicationRequest>(bt_, bz_);
-        IEnumerable<MedicationRequest> cc_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> ce_(MedicationRequest MR) {
-            IEnumerable<Medication> ky_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? kz_(Medication M) {
-                object ld_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object le_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> lf_ = context.Operators.Split((string)le_, "/");
-                string lg_ = context.Operators.Last<string>(lf_);
-                bool? lh_ = context.Operators.Equal(ld_, lg_);
-                CodeableConcept li_ = M?.Code;
-                CqlConcept lj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, li_);
-                CqlValueSet lk_ = this.Dexmethylphenidate(context);
-                bool? ll_ = context.Operators.ConceptInValueSet(lj_, lk_);
-                bool? lm_ = context.Operators.And(lh_, ll_);
-                return lm_;
-            }
-
-            IEnumerable<Medication> la_ = context.Operators.Where<Medication>(ky_, kz_);
-            MedicationRequest lb_(Medication M) => MR;
-            IEnumerable<MedicationRequest> lc_ = context.Operators.Select<Medication, MedicationRequest>(la_, lb_);
-            return lc_;
-        }
-
-        IEnumerable<MedicationRequest> cf_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ce_);
-        IEnumerable<MedicationRequest> cg_ = context.Operators.Union<MedicationRequest>(cc_, cf_);
-        IEnumerable<MedicationRequest> ch_ = context.Operators.Union<MedicationRequest>(ca_, cg_);
-        IEnumerable<MedicationRequest> cj_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, u_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> cl_(MedicationRequest MR) {
-            IEnumerable<Medication> ln_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? lo_(Medication M) {
-                object ls_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object lt_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> lu_ = context.Operators.Split((string)lt_, "/");
-                string lv_ = context.Operators.Last<string>(lu_);
-                bool? lw_ = context.Operators.Equal(ls_, lv_);
-                CodeableConcept lx_ = M?.Code;
-                CqlConcept ly_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lx_);
-                CqlValueSet lz_ = this.Dextroamphetamine(context);
-                bool? ma_ = context.Operators.ConceptInValueSet(ly_, lz_);
-                bool? mb_ = context.Operators.And(lw_, ma_);
-                return mb_;
-            }
-
-            IEnumerable<Medication> lp_ = context.Operators.Where<Medication>(ln_, lo_);
-            MedicationRequest lq_(Medication M) => MR;
-            IEnumerable<MedicationRequest> lr_ = context.Operators.Select<Medication, MedicationRequest>(lp_, lq_);
-            return lr_;
-        }
-
-        IEnumerable<MedicationRequest> cm_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, cl_);
-        IEnumerable<MedicationRequest> cn_ = context.Operators.Union<MedicationRequest>(cj_, cm_);
-        IEnumerable<MedicationRequest> co_ = context.Operators.Union<MedicationRequest>(ch_, cn_);
-        IEnumerable<MedicationRequest> cq_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ab_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> cs_(MedicationRequest MR) {
-            IEnumerable<Medication> mc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? md_(Medication M) {
-                object mh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object mi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> mj_ = context.Operators.Split((string)mi_, "/");
-                string mk_ = context.Operators.Last<string>(mj_);
-                bool? ml_ = context.Operators.Equal(mh_, mk_);
-                CodeableConcept mm_ = M?.Code;
-                CqlConcept mn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mm_);
-                CqlValueSet mo_ = this.Lisdexamfetamine(context);
-                bool? mp_ = context.Operators.ConceptInValueSet(mn_, mo_);
-                bool? mq_ = context.Operators.And(ml_, mp_);
-                return mq_;
-            }
-
-            IEnumerable<Medication> me_ = context.Operators.Where<Medication>(mc_, md_);
-            MedicationRequest mf_(Medication M) => MR;
-            IEnumerable<MedicationRequest> mg_ = context.Operators.Select<Medication, MedicationRequest>(me_, mf_);
-            return mg_;
-        }
-
-        IEnumerable<MedicationRequest> ct_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, cs_);
-        IEnumerable<MedicationRequest> cu_ = context.Operators.Union<MedicationRequest>(cq_, ct_);
-        IEnumerable<MedicationRequest> cv_ = context.Operators.Union<MedicationRequest>(co_, cu_);
-        IEnumerable<CqlCode> cx_ = context.Operators.ToList<CqlCode>(ai_);
-        IEnumerable<MedicationRequest> cy_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, cx_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> da_(MedicationRequest MR) {
-            IEnumerable<Medication> mr_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? ms_(Medication M) {
-                object mw_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object mx_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> my_ = context.Operators.Split((string)mx_, "/");
-                string mz_ = context.Operators.Last<string>(my_);
-                bool? na_ = context.Operators.Equal(mw_, mz_);
-                CodeableConcept nb_ = M?.Code;
-                CqlConcept nc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, nb_);
-                CqlCode nd_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-                CqlConcept ne_ = context.Operators.ConvertCodeToConcept(nd_);
-                bool? nf_ = context.Operators.Equivalent(nc_, ne_);
-                bool? ng_ = context.Operators.And(na_, nf_);
-                return ng_;
-            }
-
-            IEnumerable<Medication> mt_ = context.Operators.Where<Medication>(mr_, ms_);
-            MedicationRequest mu_(Medication M) => MR;
-            IEnumerable<MedicationRequest> mv_ = context.Operators.Select<Medication, MedicationRequest>(mt_, mu_);
-            return mv_;
-        }
-
-        IEnumerable<MedicationRequest> db_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, da_);
-        IEnumerable<MedicationRequest> dc_ = context.Operators.Union<MedicationRequest>(cy_, db_);
-        IEnumerable<MedicationRequest> dd_ = context.Operators.Union<MedicationRequest>(cv_, dc_);
-        IEnumerable<MedicationRequest> df_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> dh_(MedicationRequest MR) {
-            IEnumerable<Medication> nh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? ni_(Medication M) {
-                object nm_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object nn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> no_ = context.Operators.Split((string)nn_, "/");
-                string np_ = context.Operators.Last<string>(no_);
-                bool? nq_ = context.Operators.Equal(nm_, np_);
-                CodeableConcept nr_ = M?.Code;
-                CqlConcept ns_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, nr_);
-                CqlValueSet nt_ = this.Methylphenidate(context);
-                bool? nu_ = context.Operators.ConceptInValueSet(ns_, nt_);
-                bool? nv_ = context.Operators.And(nq_, nu_);
-                return nv_;
-            }
-
-            IEnumerable<Medication> nj_ = context.Operators.Where<Medication>(nh_, ni_);
-            MedicationRequest nk_(Medication M) => MR;
-            IEnumerable<MedicationRequest> nl_ = context.Operators.Select<Medication, MedicationRequest>(nj_, nk_);
-            return nl_;
-        }
-
-        IEnumerable<MedicationRequest> di_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, dh_);
-        IEnumerable<MedicationRequest> dj_ = context.Operators.Union<MedicationRequest>(df_, di_);
-        IEnumerable<MedicationRequest> dk_ = context.Operators.Union<MedicationRequest>(dd_, dj_);
-        IEnumerable<MedicationRequest> dm_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ax_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> do_(MedicationRequest MR) {
-            IEnumerable<Medication> nw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? nx_(Medication M) {
-                object ob_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object oc_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> od_ = context.Operators.Split((string)oc_, "/");
-                string oe_ = context.Operators.Last<string>(od_);
-                bool? of_ = context.Operators.Equal(ob_, oe_);
-                CodeableConcept og_ = M?.Code;
-                CqlConcept oh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, og_);
-                CqlValueSet oi_ = this.Guanfacine_Medications(context);
-                bool? oj_ = context.Operators.ConceptInValueSet(oh_, oi_);
-                bool? ok_ = context.Operators.And(of_, oj_);
-                return ok_;
-            }
-
-            IEnumerable<Medication> ny_ = context.Operators.Where<Medication>(nw_, nx_);
-            MedicationRequest nz_(Medication M) => MR;
-            IEnumerable<MedicationRequest> oa_ = context.Operators.Select<Medication, MedicationRequest>(ny_, nz_);
-            return oa_;
-        }
-
-        IEnumerable<MedicationRequest> dp_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, do_);
-        IEnumerable<MedicationRequest> dq_ = context.Operators.Union<MedicationRequest>(dm_, dp_);
-        IEnumerable<MedicationRequest> dr_ = context.Operators.Union<MedicationRequest>(dk_, dq_);
-        IEnumerable<MedicationRequest> dt_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, be_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-        IEnumerable<MedicationRequest> dv_(MedicationRequest MR) {
-            IEnumerable<Medication> ol_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-            bool? om_(Medication M) {
-                object oq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object or_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> os_ = context.Operators.Split((string)or_, "/");
-                string ot_ = context.Operators.Last<string>(os_);
-                bool? ou_ = context.Operators.Equal(oq_, ot_);
-                CodeableConcept ov_ = M?.Code;
-                CqlConcept ow_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ov_);
-                CqlValueSet ox_ = this.Viloxazine(context);
-                bool? oy_ = context.Operators.ConceptInValueSet(ow_, ox_);
-                bool? oz_ = context.Operators.And(ou_, oy_);
-                return oz_;
-            }
-
-            IEnumerable<Medication> on_ = context.Operators.Where<Medication>(ol_, om_);
-            MedicationRequest oo_(Medication M) => MR;
-            IEnumerable<MedicationRequest> op_ = context.Operators.Select<Medication, MedicationRequest>(on_, oo_);
-            return op_;
-        }
-
-        IEnumerable<MedicationRequest> dw_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, dv_);
-        IEnumerable<MedicationRequest> dx_ = context.Operators.Union<MedicationRequest>(dt_, dw_);
-        IEnumerable<MedicationRequest> dy_ = context.Operators.Union<MedicationRequest>(dr_, dx_);
-        IEnumerable<MedicationRequest> dz_ = Status_1_15_000.Instance.isMedicationOrder(context, dy_);
-
-        bool? ea_(MedicationRequest ADHDMedications) {
-            CqlInterval<CqlDate> pa_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ADHDMedications);
-            CqlDate pb_ = context.Operators.Start(pa_);
-            CqlDateTime pc_ = context.Operators.ConvertDateToDateTime(pb_);
-            CqlInterval<CqlDateTime> pd_ = this.Intake_Period(context);
-            bool? pe_ = context.Operators.In<CqlDateTime>(pc_, pd_, (string)default);
-            return pe_;
-        }
-
-        IEnumerable<MedicationRequest> eb_ = context.Operators.Where<MedicationRequest>(dz_, ea_);
-
-        IEnumerable<MedicationRequest> ec_(MedicationRequest ADHDMedicationOrder) {
-            CqlValueSet pf_ = this.Atomoxetine(context);
-            IEnumerable<MedicationRequest> pg_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, pf_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> ph_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-
-            IEnumerable<MedicationRequest> pi_(MedicationRequest MR) {
-                IEnumerable<Medication> rv_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-                bool? rw_(Medication M) {
-                    object sa_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object sb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> sc_ = context.Operators.Split((string)sb_, "/");
-                    string sd_ = context.Operators.Last<string>(sc_);
-                    bool? se_ = context.Operators.Equal(sa_, sd_);
-                    CodeableConcept sf_ = M?.Code;
-                    CqlConcept sg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, sf_);
-                    CqlValueSet sh_ = this.Atomoxetine(context);
-                    bool? si_ = context.Operators.ConceptInValueSet(sg_, sh_);
-                    bool? sj_ = context.Operators.And(se_, si_);
-                    return sj_;
+                bool? jn_(Medication M) {
+                    object jq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object jr_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> js_ = context.Operators.Split((string)jr_, "/");
+                    string jt_ = context.Operators.Last<string>(js_);
+                    bool? ju_ = context.Operators.Equal(jq_, jt_);
+                    CodeableConcept jv_ = M?.Code;
+                    CqlConcept jw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jv_);
+                    CqlValueSet jx_ = this.Atomoxetine(context);
+                    bool? jy_ = context.Operators.ConceptInValueSet(jw_, jx_);
+                    bool? jz_ = context.Operators.And(ju_, jy_);
+                    return jz_;
                 }
 
-                IEnumerable<Medication> rx_ = context.Operators.Where<Medication>(rv_, rw_);
-                MedicationRequest ry_(Medication M) => MR;
-                IEnumerable<MedicationRequest> rz_ = context.Operators.Select<Medication, MedicationRequest>(rx_, ry_);
-                return rz_;
+                IEnumerable<Medication> jo_ = context.Operators.Where<Medication>(jm_, jn_);
+                bool? jp_ = context.Operators.Exists<Medication>(jo_);
+                return jp_;
             }
 
-            IEnumerable<MedicationRequest> pj_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, pi_);
-            IEnumerable<MedicationRequest> pk_ = context.Operators.Union<MedicationRequest>(pg_, pj_);
-            CqlValueSet pl_ = this.Clonidine(context);
-            IEnumerable<MedicationRequest> pm_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, pl_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> ha_ = context.Operators.Where<MedicationRequest>(gy_, gz_);
+            IEnumerable<MedicationRequest> hb_ = context.Operators.Union<MedicationRequest>(gx_, ha_);
+            CqlValueSet hc_ = this.Clonidine(context);
+            IEnumerable<MedicationRequest> hd_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, hc_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> po_(MedicationRequest MR) {
-                IEnumerable<Medication> sk_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? hf_(MedicationRequest MR) {
+                IEnumerable<Medication> ka_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? sl_(Medication M) {
-                    object sp_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object sq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> sr_ = context.Operators.Split((string)sq_, "/");
-                    string ss_ = context.Operators.Last<string>(sr_);
-                    bool? st_ = context.Operators.Equal(sp_, ss_);
-                    CodeableConcept su_ = M?.Code;
-                    CqlConcept sv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, su_);
-                    CqlValueSet sw_ = this.Clonidine(context);
-                    bool? sx_ = context.Operators.ConceptInValueSet(sv_, sw_);
-                    bool? sy_ = context.Operators.And(st_, sx_);
-                    return sy_;
+                bool? kb_(Medication M) {
+                    object ke_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object kf_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> kg_ = context.Operators.Split((string)kf_, "/");
+                    string kh_ = context.Operators.Last<string>(kg_);
+                    bool? ki_ = context.Operators.Equal(ke_, kh_);
+                    CodeableConcept kj_ = M?.Code;
+                    CqlConcept kk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kj_);
+                    CqlValueSet kl_ = this.Clonidine(context);
+                    bool? km_ = context.Operators.ConceptInValueSet(kk_, kl_);
+                    bool? kn_ = context.Operators.And(ki_, km_);
+                    return kn_;
                 }
 
-                IEnumerable<Medication> sm_ = context.Operators.Where<Medication>(sk_, sl_);
-                MedicationRequest sn_(Medication M) => MR;
-                IEnumerable<MedicationRequest> so_ = context.Operators.Select<Medication, MedicationRequest>(sm_, sn_);
-                return so_;
+                IEnumerable<Medication> kc_ = context.Operators.Where<Medication>(ka_, kb_);
+                bool? kd_ = context.Operators.Exists<Medication>(kc_);
+                return kd_;
             }
 
-            IEnumerable<MedicationRequest> pp_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, po_);
-            IEnumerable<MedicationRequest> pq_ = context.Operators.Union<MedicationRequest>(pm_, pp_);
-            IEnumerable<MedicationRequest> pr_ = context.Operators.Union<MedicationRequest>(pk_, pq_);
-            CqlValueSet ps_ = this.Dexmethylphenidate(context);
-            IEnumerable<MedicationRequest> pt_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ps_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> hg_ = context.Operators.Where<MedicationRequest>(gy_, hf_);
+            IEnumerable<MedicationRequest> hh_ = context.Operators.Union<MedicationRequest>(hd_, hg_);
+            IEnumerable<MedicationRequest> hi_ = context.Operators.Union<MedicationRequest>(hb_, hh_);
+            CqlValueSet hj_ = this.Dexmethylphenidate(context);
+            IEnumerable<MedicationRequest> hk_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, hj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> pv_(MedicationRequest MR) {
-                IEnumerable<Medication> sz_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? hm_(MedicationRequest MR) {
+                IEnumerable<Medication> ko_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? ta_(Medication M) {
-                    object te_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object tf_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> tg_ = context.Operators.Split((string)tf_, "/");
-                    string th_ = context.Operators.Last<string>(tg_);
-                    bool? ti_ = context.Operators.Equal(te_, th_);
-                    CodeableConcept tj_ = M?.Code;
-                    CqlConcept tk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, tj_);
-                    CqlValueSet tl_ = this.Dexmethylphenidate(context);
-                    bool? tm_ = context.Operators.ConceptInValueSet(tk_, tl_);
-                    bool? tn_ = context.Operators.And(ti_, tm_);
-                    return tn_;
+                bool? kp_(Medication M) {
+                    object ks_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object kt_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> ku_ = context.Operators.Split((string)kt_, "/");
+                    string kv_ = context.Operators.Last<string>(ku_);
+                    bool? kw_ = context.Operators.Equal(ks_, kv_);
+                    CodeableConcept kx_ = M?.Code;
+                    CqlConcept ky_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kx_);
+                    CqlValueSet kz_ = this.Dexmethylphenidate(context);
+                    bool? la_ = context.Operators.ConceptInValueSet(ky_, kz_);
+                    bool? lb_ = context.Operators.And(kw_, la_);
+                    return lb_;
                 }
 
-                IEnumerable<Medication> tb_ = context.Operators.Where<Medication>(sz_, ta_);
-                MedicationRequest tc_(Medication M) => MR;
-                IEnumerable<MedicationRequest> td_ = context.Operators.Select<Medication, MedicationRequest>(tb_, tc_);
-                return td_;
+                IEnumerable<Medication> kq_ = context.Operators.Where<Medication>(ko_, kp_);
+                bool? kr_ = context.Operators.Exists<Medication>(kq_);
+                return kr_;
             }
 
-            IEnumerable<MedicationRequest> pw_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, pv_);
-            IEnumerable<MedicationRequest> px_ = context.Operators.Union<MedicationRequest>(pt_, pw_);
-            IEnumerable<MedicationRequest> py_ = context.Operators.Union<MedicationRequest>(pr_, px_);
-            CqlValueSet pz_ = this.Dextroamphetamine(context);
-            IEnumerable<MedicationRequest> qa_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, pz_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> hn_ = context.Operators.Where<MedicationRequest>(gy_, hm_);
+            IEnumerable<MedicationRequest> ho_ = context.Operators.Union<MedicationRequest>(hk_, hn_);
+            IEnumerable<MedicationRequest> hp_ = context.Operators.Union<MedicationRequest>(hi_, ho_);
+            CqlValueSet hq_ = this.Dextroamphetamine(context);
+            IEnumerable<MedicationRequest> hr_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, hq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> qc_(MedicationRequest MR) {
-                IEnumerable<Medication> to_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? ht_(MedicationRequest MR) {
+                IEnumerable<Medication> lc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? tp_(Medication M) {
-                    object tt_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object tu_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> tv_ = context.Operators.Split((string)tu_, "/");
-                    string tw_ = context.Operators.Last<string>(tv_);
-                    bool? tx_ = context.Operators.Equal(tt_, tw_);
-                    CodeableConcept ty_ = M?.Code;
-                    CqlConcept tz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ty_);
-                    CqlValueSet ua_ = this.Dextroamphetamine(context);
-                    bool? ub_ = context.Operators.ConceptInValueSet(tz_, ua_);
-                    bool? uc_ = context.Operators.And(tx_, ub_);
-                    return uc_;
+                bool? ld_(Medication M) {
+                    object lg_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object lh_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> li_ = context.Operators.Split((string)lh_, "/");
+                    string lj_ = context.Operators.Last<string>(li_);
+                    bool? lk_ = context.Operators.Equal(lg_, lj_);
+                    CodeableConcept ll_ = M?.Code;
+                    CqlConcept lm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ll_);
+                    CqlValueSet ln_ = this.Dextroamphetamine(context);
+                    bool? lo_ = context.Operators.ConceptInValueSet(lm_, ln_);
+                    bool? lp_ = context.Operators.And(lk_, lo_);
+                    return lp_;
                 }
 
-                IEnumerable<Medication> tq_ = context.Operators.Where<Medication>(to_, tp_);
-                MedicationRequest tr_(Medication M) => MR;
-                IEnumerable<MedicationRequest> ts_ = context.Operators.Select<Medication, MedicationRequest>(tq_, tr_);
-                return ts_;
+                IEnumerable<Medication> le_ = context.Operators.Where<Medication>(lc_, ld_);
+                bool? lf_ = context.Operators.Exists<Medication>(le_);
+                return lf_;
             }
 
-            IEnumerable<MedicationRequest> qd_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, qc_);
-            IEnumerable<MedicationRequest> qe_ = context.Operators.Union<MedicationRequest>(qa_, qd_);
-            IEnumerable<MedicationRequest> qf_ = context.Operators.Union<MedicationRequest>(py_, qe_);
-            CqlValueSet qg_ = this.Lisdexamfetamine(context);
-            IEnumerable<MedicationRequest> qh_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, qg_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> hu_ = context.Operators.Where<MedicationRequest>(gy_, ht_);
+            IEnumerable<MedicationRequest> hv_ = context.Operators.Union<MedicationRequest>(hr_, hu_);
+            IEnumerable<MedicationRequest> hw_ = context.Operators.Union<MedicationRequest>(hp_, hv_);
+            CqlValueSet hx_ = this.Lisdexamfetamine(context);
+            IEnumerable<MedicationRequest> hy_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, hx_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> qj_(MedicationRequest MR) {
-                IEnumerable<Medication> ud_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? ia_(MedicationRequest MR) {
+                IEnumerable<Medication> lq_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? ue_(Medication M) {
-                    object ui_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object uj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> uk_ = context.Operators.Split((string)uj_, "/");
-                    string ul_ = context.Operators.Last<string>(uk_);
-                    bool? um_ = context.Operators.Equal(ui_, ul_);
-                    CodeableConcept un_ = M?.Code;
-                    CqlConcept uo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, un_);
-                    CqlValueSet up_ = this.Lisdexamfetamine(context);
-                    bool? uq_ = context.Operators.ConceptInValueSet(uo_, up_);
-                    bool? ur_ = context.Operators.And(um_, uq_);
-                    return ur_;
+                bool? lr_(Medication M) {
+                    object lu_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object lv_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> lw_ = context.Operators.Split((string)lv_, "/");
+                    string lx_ = context.Operators.Last<string>(lw_);
+                    bool? ly_ = context.Operators.Equal(lu_, lx_);
+                    CodeableConcept lz_ = M?.Code;
+                    CqlConcept ma_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lz_);
+                    CqlValueSet mb_ = this.Lisdexamfetamine(context);
+                    bool? mc_ = context.Operators.ConceptInValueSet(ma_, mb_);
+                    bool? md_ = context.Operators.And(ly_, mc_);
+                    return md_;
                 }
 
-                IEnumerable<Medication> uf_ = context.Operators.Where<Medication>(ud_, ue_);
-                MedicationRequest ug_(Medication M) => MR;
-                IEnumerable<MedicationRequest> uh_ = context.Operators.Select<Medication, MedicationRequest>(uf_, ug_);
-                return uh_;
+                IEnumerable<Medication> ls_ = context.Operators.Where<Medication>(lq_, lr_);
+                bool? lt_ = context.Operators.Exists<Medication>(ls_);
+                return lt_;
             }
 
-            IEnumerable<MedicationRequest> qk_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, qj_);
-            IEnumerable<MedicationRequest> ql_ = context.Operators.Union<MedicationRequest>(qh_, qk_);
-            IEnumerable<MedicationRequest> qm_ = context.Operators.Union<MedicationRequest>(qf_, ql_);
-            CqlCode qn_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-            IEnumerable<CqlCode> qo_ = context.Operators.ToList<CqlCode>(qn_);
-            IEnumerable<MedicationRequest> qp_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, qo_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> ib_ = context.Operators.Where<MedicationRequest>(gy_, ia_);
+            IEnumerable<MedicationRequest> ic_ = context.Operators.Union<MedicationRequest>(hy_, ib_);
+            IEnumerable<MedicationRequest> id_ = context.Operators.Union<MedicationRequest>(hw_, ic_);
+            CqlCode ie_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+            IEnumerable<CqlCode> if_ = context.Operators.ToList<CqlCode>(ie_);
+            IEnumerable<MedicationRequest> ig_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, if_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> qr_(MedicationRequest MR) {
-                IEnumerable<Medication> us_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? ii_(MedicationRequest MR) {
+                IEnumerable<Medication> me_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? ut_(Medication M) {
-                    object ux_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object uy_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> uz_ = context.Operators.Split((string)uy_, "/");
-                    string va_ = context.Operators.Last<string>(uz_);
-                    bool? vb_ = context.Operators.Equal(ux_, va_);
-                    CodeableConcept vc_ = M?.Code;
-                    CqlConcept vd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, vc_);
-                    CqlCode ve_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-                    CqlConcept vf_ = context.Operators.ConvertCodeToConcept(ve_);
-                    bool? vg_ = context.Operators.Equivalent(vd_, vf_);
-                    bool? vh_ = context.Operators.And(vb_, vg_);
-                    return vh_;
+                bool? mf_(Medication M) {
+                    object mi_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object mj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> mk_ = context.Operators.Split((string)mj_, "/");
+                    string ml_ = context.Operators.Last<string>(mk_);
+                    bool? mm_ = context.Operators.Equal(mi_, ml_);
+                    CodeableConcept mn_ = M?.Code;
+                    CqlConcept mo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mn_);
+                    CqlCode mp_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+                    CqlConcept mq_ = context.Operators.ConvertCodeToConcept(mp_);
+                    bool? mr_ = context.Operators.Equivalent(mo_, mq_);
+                    bool? ms_ = context.Operators.And(mm_, mr_);
+                    return ms_;
                 }
 
-                IEnumerable<Medication> uu_ = context.Operators.Where<Medication>(us_, ut_);
-                MedicationRequest uv_(Medication M) => MR;
-                IEnumerable<MedicationRequest> uw_ = context.Operators.Select<Medication, MedicationRequest>(uu_, uv_);
-                return uw_;
+                IEnumerable<Medication> mg_ = context.Operators.Where<Medication>(me_, mf_);
+                bool? mh_ = context.Operators.Exists<Medication>(mg_);
+                return mh_;
             }
 
-            IEnumerable<MedicationRequest> qs_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, qr_);
-            IEnumerable<MedicationRequest> qt_ = context.Operators.Union<MedicationRequest>(qp_, qs_);
-            IEnumerable<MedicationRequest> qu_ = context.Operators.Union<MedicationRequest>(qm_, qt_);
-            CqlValueSet qv_ = this.Methylphenidate(context);
-            IEnumerable<MedicationRequest> qw_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, qv_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> ij_ = context.Operators.Where<MedicationRequest>(gy_, ii_);
+            IEnumerable<MedicationRequest> ik_ = context.Operators.Union<MedicationRequest>(ig_, ij_);
+            IEnumerable<MedicationRequest> il_ = context.Operators.Union<MedicationRequest>(id_, ik_);
+            CqlValueSet im_ = this.Methylphenidate(context);
+            IEnumerable<MedicationRequest> in_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, im_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> qy_(MedicationRequest MR) {
-                IEnumerable<Medication> vi_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? ip_(MedicationRequest MR) {
+                IEnumerable<Medication> mt_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? vj_(Medication M) {
-                    object vn_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object vo_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> vp_ = context.Operators.Split((string)vo_, "/");
-                    string vq_ = context.Operators.Last<string>(vp_);
-                    bool? vr_ = context.Operators.Equal(vn_, vq_);
-                    CodeableConcept vs_ = M?.Code;
-                    CqlConcept vt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, vs_);
-                    CqlValueSet vu_ = this.Methylphenidate(context);
-                    bool? vv_ = context.Operators.ConceptInValueSet(vt_, vu_);
-                    bool? vw_ = context.Operators.And(vr_, vv_);
-                    return vw_;
+                bool? mu_(Medication M) {
+                    object mx_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object my_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> mz_ = context.Operators.Split((string)my_, "/");
+                    string na_ = context.Operators.Last<string>(mz_);
+                    bool? nb_ = context.Operators.Equal(mx_, na_);
+                    CodeableConcept nc_ = M?.Code;
+                    CqlConcept nd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, nc_);
+                    CqlValueSet ne_ = this.Methylphenidate(context);
+                    bool? nf_ = context.Operators.ConceptInValueSet(nd_, ne_);
+                    bool? ng_ = context.Operators.And(nb_, nf_);
+                    return ng_;
                 }
 
-                IEnumerable<Medication> vk_ = context.Operators.Where<Medication>(vi_, vj_);
-                MedicationRequest vl_(Medication M) => MR;
-                IEnumerable<MedicationRequest> vm_ = context.Operators.Select<Medication, MedicationRequest>(vk_, vl_);
-                return vm_;
+                IEnumerable<Medication> mv_ = context.Operators.Where<Medication>(mt_, mu_);
+                bool? mw_ = context.Operators.Exists<Medication>(mv_);
+                return mw_;
             }
 
-            IEnumerable<MedicationRequest> qz_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, qy_);
-            IEnumerable<MedicationRequest> ra_ = context.Operators.Union<MedicationRequest>(qw_, qz_);
-            IEnumerable<MedicationRequest> rb_ = context.Operators.Union<MedicationRequest>(qu_, ra_);
-            CqlValueSet rc_ = this.Guanfacine_Medications(context);
-            IEnumerable<MedicationRequest> rd_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, rc_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> iq_ = context.Operators.Where<MedicationRequest>(gy_, ip_);
+            IEnumerable<MedicationRequest> ir_ = context.Operators.Union<MedicationRequest>(in_, iq_);
+            IEnumerable<MedicationRequest> is_ = context.Operators.Union<MedicationRequest>(il_, ir_);
+            CqlValueSet it_ = this.Guanfacine_Medications(context);
+            IEnumerable<MedicationRequest> iu_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, it_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> rf_(MedicationRequest MR) {
-                IEnumerable<Medication> vx_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? iw_(MedicationRequest MR) {
+                IEnumerable<Medication> nh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? vy_(Medication M) {
-                    object wc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object wd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> we_ = context.Operators.Split((string)wd_, "/");
-                    string wf_ = context.Operators.Last<string>(we_);
-                    bool? wg_ = context.Operators.Equal(wc_, wf_);
-                    CodeableConcept wh_ = M?.Code;
-                    CqlConcept wi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, wh_);
-                    CqlValueSet wj_ = this.Guanfacine_Medications(context);
-                    bool? wk_ = context.Operators.ConceptInValueSet(wi_, wj_);
-                    bool? wl_ = context.Operators.And(wg_, wk_);
-                    return wl_;
+                bool? ni_(Medication M) {
+                    object nl_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object nm_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> nn_ = context.Operators.Split((string)nm_, "/");
+                    string no_ = context.Operators.Last<string>(nn_);
+                    bool? np_ = context.Operators.Equal(nl_, no_);
+                    CodeableConcept nq_ = M?.Code;
+                    CqlConcept nr_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, nq_);
+                    CqlValueSet ns_ = this.Guanfacine_Medications(context);
+                    bool? nt_ = context.Operators.ConceptInValueSet(nr_, ns_);
+                    bool? nu_ = context.Operators.And(np_, nt_);
+                    return nu_;
                 }
 
-                IEnumerable<Medication> vz_ = context.Operators.Where<Medication>(vx_, vy_);
-                MedicationRequest wa_(Medication M) => MR;
-                IEnumerable<MedicationRequest> wb_ = context.Operators.Select<Medication, MedicationRequest>(vz_, wa_);
-                return wb_;
+                IEnumerable<Medication> nj_ = context.Operators.Where<Medication>(nh_, ni_);
+                bool? nk_ = context.Operators.Exists<Medication>(nj_);
+                return nk_;
             }
 
-            IEnumerable<MedicationRequest> rg_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, rf_);
-            IEnumerable<MedicationRequest> rh_ = context.Operators.Union<MedicationRequest>(rd_, rg_);
-            IEnumerable<MedicationRequest> ri_ = context.Operators.Union<MedicationRequest>(rb_, rh_);
-            CqlValueSet rj_ = this.Viloxazine(context);
-            IEnumerable<MedicationRequest> rk_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, rj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> ix_ = context.Operators.Where<MedicationRequest>(gy_, iw_);
+            IEnumerable<MedicationRequest> iy_ = context.Operators.Union<MedicationRequest>(iu_, ix_);
+            IEnumerable<MedicationRequest> iz_ = context.Operators.Union<MedicationRequest>(is_, iy_);
+            CqlValueSet ja_ = this.Viloxazine(context);
+            IEnumerable<MedicationRequest> jb_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ja_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> rm_(MedicationRequest MR) {
-                IEnumerable<Medication> wm_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? jd_(MedicationRequest MR) {
+                IEnumerable<Medication> nv_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? wn_(Medication M) {
-                    object wr_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object ws_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> wt_ = context.Operators.Split((string)ws_, "/");
-                    string wu_ = context.Operators.Last<string>(wt_);
-                    bool? wv_ = context.Operators.Equal(wr_, wu_);
-                    CodeableConcept ww_ = M?.Code;
-                    CqlConcept wx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ww_);
-                    CqlValueSet wy_ = this.Viloxazine(context);
-                    bool? wz_ = context.Operators.ConceptInValueSet(wx_, wy_);
-                    bool? xa_ = context.Operators.And(wv_, wz_);
-                    return xa_;
+                bool? nw_(Medication M) {
+                    object nz_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object oa_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> ob_ = context.Operators.Split((string)oa_, "/");
+                    string oc_ = context.Operators.Last<string>(ob_);
+                    bool? od_ = context.Operators.Equal(nz_, oc_);
+                    CodeableConcept oe_ = M?.Code;
+                    CqlConcept of_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, oe_);
+                    CqlValueSet og_ = this.Viloxazine(context);
+                    bool? oh_ = context.Operators.ConceptInValueSet(of_, og_);
+                    bool? oi_ = context.Operators.And(od_, oh_);
+                    return oi_;
                 }
 
-                IEnumerable<Medication> wo_ = context.Operators.Where<Medication>(wm_, wn_);
-                MedicationRequest wp_(Medication M) => MR;
-                IEnumerable<MedicationRequest> wq_ = context.Operators.Select<Medication, MedicationRequest>(wo_, wp_);
-                return wq_;
+                IEnumerable<Medication> nx_ = context.Operators.Where<Medication>(nv_, nw_);
+                bool? ny_ = context.Operators.Exists<Medication>(nx_);
+                return ny_;
             }
 
-            IEnumerable<MedicationRequest> rn_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ph_, rm_);
-            IEnumerable<MedicationRequest> ro_ = context.Operators.Union<MedicationRequest>(rk_, rn_);
-            IEnumerable<MedicationRequest> rp_ = context.Operators.Union<MedicationRequest>(ri_, ro_);
-            IEnumerable<MedicationRequest> rq_ = Status_1_15_000.Instance.isMedicationActive(context, rp_);
+            IEnumerable<MedicationRequest> je_ = context.Operators.Where<MedicationRequest>(gy_, jd_);
+            IEnumerable<MedicationRequest> jf_ = context.Operators.Union<MedicationRequest>(jb_, je_);
+            IEnumerable<MedicationRequest> jg_ = context.Operators.Union<MedicationRequest>(iz_, jf_);
+            IEnumerable<MedicationRequest> jh_ = Status_1_15_000.Instance.isMedicationActive(context, jg_);
 
-            bool? rr_(MedicationRequest ActiveADHDMedication) {
-                CqlInterval<CqlDate> xb_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveADHDMedication);
-                CqlInterval<CqlDate> xc_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ADHDMedicationOrder);
-                CqlDate xd_ = context.Operators.Start(xc_);
-                CqlDateTime xe_ = context.Operators.ConvertDateToDateTime(xd_);
-                CqlDate xf_ = context.Operators.DateFrom(xe_);
-                CqlQuantity xg_ = context.Operators.Quantity(120m, "days");
-                CqlDate xh_ = context.Operators.Subtract(xf_, xg_);
-                CqlDate xj_ = context.Operators.Start(xc_);
-                CqlDateTime xk_ = context.Operators.ConvertDateToDateTime(xj_);
-                CqlDate xl_ = context.Operators.DateFrom(xk_);
-                CqlInterval<CqlDate> xm_ = context.Operators.Interval(xh_, xl_, true, false);
-                bool? xn_ = context.Operators.Overlaps(xb_, xm_, (string)default);
-                return xn_;
+            bool? ji_(MedicationRequest ActiveADHDMedication) {
+                CqlInterval<CqlDate> oj_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveADHDMedication);
+                CqlInterval<CqlDate> ok_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ADHDMedicationOrder);
+                CqlDate ol_ = context.Operators.Start(ok_);
+                CqlDateTime om_ = context.Operators.ConvertDateToDateTime(ol_);
+                CqlDate on_ = context.Operators.DateFrom(om_);
+                CqlQuantity oo_ = context.Operators.Quantity(120m, "days");
+                CqlDate op_ = context.Operators.Subtract(on_, oo_);
+                CqlDate or_ = context.Operators.Start(ok_);
+                CqlDateTime os_ = context.Operators.ConvertDateToDateTime(or_);
+                CqlDate ot_ = context.Operators.DateFrom(os_);
+                CqlInterval<CqlDate> ou_ = context.Operators.Interval(op_, ot_, true, false);
+                bool? ov_ = context.Operators.Overlaps(oj_, ou_, (string)default);
+                return ov_;
             }
 
-            IEnumerable<MedicationRequest> rs_ = context.Operators.Where<MedicationRequest>(rq_, rr_);
-            MedicationRequest rt_(MedicationRequest ActiveADHDMedication) => ADHDMedicationOrder;
-            IEnumerable<MedicationRequest> ru_ = context.Operators.Select<MedicationRequest, MedicationRequest>(rs_, rt_);
-            return ru_;
+            IEnumerable<MedicationRequest> jj_ = context.Operators.Where<MedicationRequest>(jh_, ji_);
+            bool? jk_ = context.Operators.Exists<MedicationRequest>(jj_);
+            bool? jl_ = context.Operators.Not(jk_);
+            return jl_;
         }
 
-        IEnumerable<MedicationRequest> ed_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(eb_, ec_);
-        IEnumerable<MedicationRequest> ee_ = context.Operators.Except<MedicationRequest>(bn_, ed_);
+        IEnumerable<MedicationRequest> bp_ = context.Operators.Where<MedicationRequest>(bn_, bo_);
 
-        (CqlTupleMetadata, CqlDate startDate)? ef_(MedicationRequest QualifyingMed) {
-            CqlInterval<CqlDate> xo_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, QualifyingMed);
-            CqlDate xp_ = context.Operators.Start(xo_);
-            (CqlTupleMetadata, CqlDate startDate)? xq_ = (CqlTupleMetadata_CVELXTjiMTaGQEjMfJXBdUHjW, xp_);
-            return xq_;
+        (CqlTupleMetadata, CqlDate startDate)? bq_(MedicationRequest QualifyingMed) {
+            CqlInterval<CqlDate> ow_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, QualifyingMed);
+            CqlDate ox_ = context.Operators.Start(ow_);
+            (CqlTupleMetadata, CqlDate startDate)? oy_ = (CqlTupleMetadata_CVELXTjiMTaGQEjMfJXBdUHjW, ox_);
+            return oy_;
         }
 
-        IEnumerable<(CqlTupleMetadata, CqlDate startDate)?> eg_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlDate startDate)?>(ee_, ef_);
+        IEnumerable<(CqlTupleMetadata, CqlDate startDate)?> br_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlDate startDate)?>(bp_, bq_);
 
-        object eh_((CqlTupleMetadata, CqlDate startDate)? @this) {
-            CqlDate xr_ = @this?.startDate;
-            return xr_;
+        object bs_((CqlTupleMetadata, CqlDate startDate)? @this) {
+            CqlDate oz_ = @this?.startDate;
+            return oz_;
         }
 
-        IEnumerable<(CqlTupleMetadata, CqlDate startDate)?> ei_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDate startDate)?>(eg_, eh_, System.ComponentModel.ListSortDirection.Ascending);
-        return ei_;
+        IEnumerable<(CqlTupleMetadata, CqlDate startDate)?> bt_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDate startDate)?>(br_, bs_, System.ComponentModel.ListSortDirection.Ascending);
+        return bt_;
     }
 
 
@@ -1444,60 +1160,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> ez_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? fa_(Medication M) {
-                object fe_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ff_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fg_ = context.Operators.Split((string)ff_, "/");
-                string fh_ = context.Operators.Last<string>(fg_);
-                bool? fi_ = context.Operators.Equal(fe_, fh_);
-                CodeableConcept fj_ = M?.Code;
-                CqlConcept fk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fj_);
-                CqlValueSet fl_ = this.Atomoxetine(context);
-                bool? fm_ = context.Operators.ConceptInValueSet(fk_, fl_);
-                bool? fn_ = context.Operators.And(fi_, fm_);
-                return fn_;
+                object fd_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object fe_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ff_ = context.Operators.Split((string)fe_, "/");
+                string fg_ = context.Operators.Last<string>(ff_);
+                bool? fh_ = context.Operators.Equal(fd_, fg_);
+                CodeableConcept fi_ = M?.Code;
+                CqlConcept fj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fi_);
+                CqlValueSet fk_ = this.Atomoxetine(context);
+                bool? fl_ = context.Operators.ConceptInValueSet(fj_, fk_);
+                bool? fm_ = context.Operators.And(fh_, fl_);
+                return fm_;
             }
 
             IEnumerable<Medication> fb_ = context.Operators.Where<Medication>(ez_, fa_);
-            MedicationRequest fc_(Medication M) => MR;
-            IEnumerable<MedicationRequest> fd_ = context.Operators.Select<Medication, MedicationRequest>(fb_, fc_);
-            return fd_;
+            bool? fc_ = context.Operators.Exists<Medication>(fb_);
+            return fc_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationOrder(context, f_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? h_(MedicationRequest AtomoxetineMed) {
-            CqlInterval<CqlDate> fo_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AtomoxetineMed);
-            CqlDate fq_ = context.Operators.Start(fo_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? fr_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, fo_, fq_);
-            return fr_;
+            CqlInterval<CqlDate> fn_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AtomoxetineMed);
+            CqlDate fp_ = context.Operators.Start(fn_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? fq_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, fn_, fp_);
+            return fq_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> i_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(g_, h_);
 
         object j_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate fs_ = @this?.periodStart;
-            return fs_;
+            CqlDate fr_ = @this?.periodStart;
+            return fr_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> k_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? l_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> ft_ = @this?.period;
-            bool? fu_ = context.Operators.Not((bool?)(ft_ is null));
-            return fu_;
+            CqlInterval<CqlDate> fs_ = @this?.period;
+            bool? ft_ = context.Operators.Not((bool?)(fs_ is null));
+            return ft_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> m_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(k_, l_);
 
         CqlInterval<CqlDate> n_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> fv_ = @this?.period;
-            return fv_;
+            CqlInterval<CqlDate> fu_ = @this?.period;
+            return fu_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> o_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(m_, n_);
@@ -1505,60 +1220,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlValueSet q_ = this.Clonidine(context);
         IEnumerable<MedicationRequest> r_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, q_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> t_(MedicationRequest MR) {
-            IEnumerable<Medication> fw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? t_(MedicationRequest MR) {
+            IEnumerable<Medication> fv_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? fx_(Medication M) {
-                object gb_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object gc_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> gd_ = context.Operators.Split((string)gc_, "/");
-                string ge_ = context.Operators.Last<string>(gd_);
-                bool? gf_ = context.Operators.Equal(gb_, ge_);
-                CodeableConcept gg_ = M?.Code;
-                CqlConcept gh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gg_);
-                CqlValueSet gi_ = this.Clonidine(context);
-                bool? gj_ = context.Operators.ConceptInValueSet(gh_, gi_);
-                bool? gk_ = context.Operators.And(gf_, gj_);
-                return gk_;
+            bool? fw_(Medication M) {
+                object fz_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ga_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gb_ = context.Operators.Split((string)ga_, "/");
+                string gc_ = context.Operators.Last<string>(gb_);
+                bool? gd_ = context.Operators.Equal(fz_, gc_);
+                CodeableConcept ge_ = M?.Code;
+                CqlConcept gf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ge_);
+                CqlValueSet gg_ = this.Clonidine(context);
+                bool? gh_ = context.Operators.ConceptInValueSet(gf_, gg_);
+                bool? gi_ = context.Operators.And(gd_, gh_);
+                return gi_;
             }
 
-            IEnumerable<Medication> fy_ = context.Operators.Where<Medication>(fw_, fx_);
-            MedicationRequest fz_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ga_ = context.Operators.Select<Medication, MedicationRequest>(fy_, fz_);
-            return ga_;
+            IEnumerable<Medication> fx_ = context.Operators.Where<Medication>(fv_, fw_);
+            bool? fy_ = context.Operators.Exists<Medication>(fx_);
+            return fy_;
         }
 
-        IEnumerable<MedicationRequest> u_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, t_);
+        IEnumerable<MedicationRequest> u_ = context.Operators.Where<MedicationRequest>(c_, t_);
         IEnumerable<MedicationRequest> v_ = context.Operators.Union<MedicationRequest>(r_, u_);
         IEnumerable<MedicationRequest> w_ = Status_1_15_000.Instance.isMedicationOrder(context, v_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? x_(MedicationRequest ClonidineMed) {
-            CqlInterval<CqlDate> gl_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ClonidineMed);
-            CqlDate gn_ = context.Operators.Start(gl_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? go_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, gl_, gn_);
-            return go_;
+            CqlInterval<CqlDate> gj_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ClonidineMed);
+            CqlDate gl_ = context.Operators.Start(gj_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? gm_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, gj_, gl_);
+            return gm_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> y_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(w_, x_);
 
         object z_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate gp_ = @this?.periodStart;
-            return gp_;
+            CqlDate gn_ = @this?.periodStart;
+            return gn_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> aa_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(y_, z_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? ab_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> gq_ = @this?.period;
-            bool? gr_ = context.Operators.Not((bool?)(gq_ is null));
-            return gr_;
+            CqlInterval<CqlDate> go_ = @this?.period;
+            bool? gp_ = context.Operators.Not((bool?)(go_ is null));
+            return gp_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> ac_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(aa_, ab_);
 
         CqlInterval<CqlDate> ad_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> gs_ = @this?.period;
-            return gs_;
+            CqlInterval<CqlDate> gq_ = @this?.period;
+            return gq_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> ae_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(ac_, ad_);
@@ -1567,60 +1281,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlValueSet ah_ = this.Dexmethylphenidate(context);
         IEnumerable<MedicationRequest> ai_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ak_(MedicationRequest MR) {
-            IEnumerable<Medication> gt_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ak_(MedicationRequest MR) {
+            IEnumerable<Medication> gr_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? gu_(Medication M) {
-                object gy_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object gz_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ha_ = context.Operators.Split((string)gz_, "/");
-                string hb_ = context.Operators.Last<string>(ha_);
-                bool? hc_ = context.Operators.Equal(gy_, hb_);
-                CodeableConcept hd_ = M?.Code;
-                CqlConcept he_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hd_);
-                CqlValueSet hf_ = this.Dexmethylphenidate(context);
-                bool? hg_ = context.Operators.ConceptInValueSet(he_, hf_);
-                bool? hh_ = context.Operators.And(hc_, hg_);
-                return hh_;
+            bool? gs_(Medication M) {
+                object gv_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object gw_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gx_ = context.Operators.Split((string)gw_, "/");
+                string gy_ = context.Operators.Last<string>(gx_);
+                bool? gz_ = context.Operators.Equal(gv_, gy_);
+                CodeableConcept ha_ = M?.Code;
+                CqlConcept hb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ha_);
+                CqlValueSet hc_ = this.Dexmethylphenidate(context);
+                bool? hd_ = context.Operators.ConceptInValueSet(hb_, hc_);
+                bool? he_ = context.Operators.And(gz_, hd_);
+                return he_;
             }
 
-            IEnumerable<Medication> gv_ = context.Operators.Where<Medication>(gt_, gu_);
-            MedicationRequest gw_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gx_ = context.Operators.Select<Medication, MedicationRequest>(gv_, gw_);
-            return gx_;
+            IEnumerable<Medication> gt_ = context.Operators.Where<Medication>(gr_, gs_);
+            bool? gu_ = context.Operators.Exists<Medication>(gt_);
+            return gu_;
         }
 
-        IEnumerable<MedicationRequest> al_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ak_);
+        IEnumerable<MedicationRequest> al_ = context.Operators.Where<MedicationRequest>(c_, ak_);
         IEnumerable<MedicationRequest> am_ = context.Operators.Union<MedicationRequest>(ai_, al_);
         IEnumerable<MedicationRequest> an_ = Status_1_15_000.Instance.isMedicationOrder(context, am_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? ao_(MedicationRequest DexmethylphenidateMed) {
-            CqlInterval<CqlDate> hi_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DexmethylphenidateMed);
-            CqlDate hk_ = context.Operators.Start(hi_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? hl_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, hi_, hk_);
-            return hl_;
+            CqlInterval<CqlDate> hf_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DexmethylphenidateMed);
+            CqlDate hh_ = context.Operators.Start(hf_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? hi_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, hf_, hh_);
+            return hi_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> ap_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(an_, ao_);
 
         object aq_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate hm_ = @this?.periodStart;
-            return hm_;
+            CqlDate hj_ = @this?.periodStart;
+            return hj_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> ar_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? as_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> hn_ = @this?.period;
-            bool? ho_ = context.Operators.Not((bool?)(hn_ is null));
-            return ho_;
+            CqlInterval<CqlDate> hk_ = @this?.period;
+            bool? hl_ = context.Operators.Not((bool?)(hk_ is null));
+            return hl_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> at_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(ar_, as_);
 
         CqlInterval<CqlDate> au_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> hp_ = @this?.period;
-            return hp_;
+            CqlInterval<CqlDate> hm_ = @this?.period;
+            return hm_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> av_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(at_, au_);
@@ -1628,60 +1341,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlValueSet ax_ = this.Dextroamphetamine(context);
         IEnumerable<MedicationRequest> ay_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ax_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ba_(MedicationRequest MR) {
-            IEnumerable<Medication> hq_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ba_(MedicationRequest MR) {
+            IEnumerable<Medication> hn_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? hr_(Medication M) {
-                object hv_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hw_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hx_ = context.Operators.Split((string)hw_, "/");
-                string hy_ = context.Operators.Last<string>(hx_);
-                bool? hz_ = context.Operators.Equal(hv_, hy_);
-                CodeableConcept ia_ = M?.Code;
-                CqlConcept ib_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ia_);
-                CqlValueSet ic_ = this.Dextroamphetamine(context);
-                bool? id_ = context.Operators.ConceptInValueSet(ib_, ic_);
-                bool? ie_ = context.Operators.And(hz_, id_);
-                return ie_;
+            bool? ho_(Medication M) {
+                object hr_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object hs_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ht_ = context.Operators.Split((string)hs_, "/");
+                string hu_ = context.Operators.Last<string>(ht_);
+                bool? hv_ = context.Operators.Equal(hr_, hu_);
+                CodeableConcept hw_ = M?.Code;
+                CqlConcept hx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hw_);
+                CqlValueSet hy_ = this.Dextroamphetamine(context);
+                bool? hz_ = context.Operators.ConceptInValueSet(hx_, hy_);
+                bool? ia_ = context.Operators.And(hv_, hz_);
+                return ia_;
             }
 
-            IEnumerable<Medication> hs_ = context.Operators.Where<Medication>(hq_, hr_);
-            MedicationRequest ht_(Medication M) => MR;
-            IEnumerable<MedicationRequest> hu_ = context.Operators.Select<Medication, MedicationRequest>(hs_, ht_);
-            return hu_;
+            IEnumerable<Medication> hp_ = context.Operators.Where<Medication>(hn_, ho_);
+            bool? hq_ = context.Operators.Exists<Medication>(hp_);
+            return hq_;
         }
 
-        IEnumerable<MedicationRequest> bb_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ba_);
+        IEnumerable<MedicationRequest> bb_ = context.Operators.Where<MedicationRequest>(c_, ba_);
         IEnumerable<MedicationRequest> bc_ = context.Operators.Union<MedicationRequest>(ay_, bb_);
         IEnumerable<MedicationRequest> bd_ = Status_1_15_000.Instance.isMedicationOrder(context, bc_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? be_(MedicationRequest DextroamphetamineMed) {
-            CqlInterval<CqlDate> if_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DextroamphetamineMed);
-            CqlDate ih_ = context.Operators.Start(if_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? ii_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, if_, ih_);
-            return ii_;
+            CqlInterval<CqlDate> ib_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DextroamphetamineMed);
+            CqlDate id_ = context.Operators.Start(ib_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? ie_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, ib_, id_);
+            return ie_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> bf_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(bd_, be_);
 
         object bg_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate ij_ = @this?.periodStart;
-            return ij_;
+            CqlDate if_ = @this?.periodStart;
+            return if_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> bh_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? bi_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> ik_ = @this?.period;
-            bool? il_ = context.Operators.Not((bool?)(ik_ is null));
-            return il_;
+            CqlInterval<CqlDate> ig_ = @this?.period;
+            bool? ih_ = context.Operators.Not((bool?)(ig_ is null));
+            return ih_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> bj_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(bh_, bi_);
 
         CqlInterval<CqlDate> bk_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> im_ = @this?.period;
-            return im_;
+            CqlInterval<CqlDate> ii_ = @this?.period;
+            return ii_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> bl_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(bj_, bk_);
@@ -1691,60 +1403,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlValueSet bp_ = this.Lisdexamfetamine(context);
         IEnumerable<MedicationRequest> bq_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, bp_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> bs_(MedicationRequest MR) {
-            IEnumerable<Medication> in_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? bs_(MedicationRequest MR) {
+            IEnumerable<Medication> ij_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? io_(Medication M) {
-                object is_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object it_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> iu_ = context.Operators.Split((string)it_, "/");
-                string iv_ = context.Operators.Last<string>(iu_);
-                bool? iw_ = context.Operators.Equal(is_, iv_);
-                CodeableConcept ix_ = M?.Code;
-                CqlConcept iy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ix_);
-                CqlValueSet iz_ = this.Lisdexamfetamine(context);
-                bool? ja_ = context.Operators.ConceptInValueSet(iy_, iz_);
-                bool? jb_ = context.Operators.And(iw_, ja_);
-                return jb_;
+            bool? ik_(Medication M) {
+                object in_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object io_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ip_ = context.Operators.Split((string)io_, "/");
+                string iq_ = context.Operators.Last<string>(ip_);
+                bool? ir_ = context.Operators.Equal(in_, iq_);
+                CodeableConcept is_ = M?.Code;
+                CqlConcept it_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, is_);
+                CqlValueSet iu_ = this.Lisdexamfetamine(context);
+                bool? iv_ = context.Operators.ConceptInValueSet(it_, iu_);
+                bool? iw_ = context.Operators.And(ir_, iv_);
+                return iw_;
             }
 
-            IEnumerable<Medication> ip_ = context.Operators.Where<Medication>(in_, io_);
-            MedicationRequest iq_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ir_ = context.Operators.Select<Medication, MedicationRequest>(ip_, iq_);
-            return ir_;
+            IEnumerable<Medication> il_ = context.Operators.Where<Medication>(ij_, ik_);
+            bool? im_ = context.Operators.Exists<Medication>(il_);
+            return im_;
         }
 
-        IEnumerable<MedicationRequest> bt_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, bs_);
+        IEnumerable<MedicationRequest> bt_ = context.Operators.Where<MedicationRequest>(c_, bs_);
         IEnumerable<MedicationRequest> bu_ = context.Operators.Union<MedicationRequest>(bq_, bt_);
         IEnumerable<MedicationRequest> bv_ = Status_1_15_000.Instance.isMedicationOrder(context, bu_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? bw_(MedicationRequest LisdexamfetamineMed) {
-            CqlInterval<CqlDate> jc_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, LisdexamfetamineMed);
-            CqlDate je_ = context.Operators.Start(jc_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? jf_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, jc_, je_);
-            return jf_;
+            CqlInterval<CqlDate> ix_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, LisdexamfetamineMed);
+            CqlDate iz_ = context.Operators.Start(ix_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? ja_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, ix_, iz_);
+            return ja_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> bx_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(bv_, bw_);
 
         object by_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate jg_ = @this?.periodStart;
-            return jg_;
+            CqlDate jb_ = @this?.periodStart;
+            return jb_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> bz_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(bx_, by_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? ca_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> jh_ = @this?.period;
-            bool? ji_ = context.Operators.Not((bool?)(jh_ is null));
-            return ji_;
+            CqlInterval<CqlDate> jc_ = @this?.period;
+            bool? jd_ = context.Operators.Not((bool?)(jc_ is null));
+            return jd_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> cb_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(bz_, ca_);
 
         CqlInterval<CqlDate> cc_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> jj_ = @this?.period;
-            return jj_;
+            CqlInterval<CqlDate> je_ = @this?.period;
+            return je_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> cd_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(cb_, cc_);
@@ -1752,60 +1463,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlValueSet cf_ = this.Methylphenidate(context);
         IEnumerable<MedicationRequest> cg_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, cf_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ci_(MedicationRequest MR) {
-            IEnumerable<Medication> jk_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ci_(MedicationRequest MR) {
+            IEnumerable<Medication> jf_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? jl_(Medication M) {
-                object jp_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object jq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> jr_ = context.Operators.Split((string)jq_, "/");
-                string js_ = context.Operators.Last<string>(jr_);
-                bool? jt_ = context.Operators.Equal(jp_, js_);
-                CodeableConcept ju_ = M?.Code;
-                CqlConcept jv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ju_);
-                CqlValueSet jw_ = this.Methylphenidate(context);
-                bool? jx_ = context.Operators.ConceptInValueSet(jv_, jw_);
-                bool? jy_ = context.Operators.And(jt_, jx_);
-                return jy_;
+            bool? jg_(Medication M) {
+                object jj_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object jk_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> jl_ = context.Operators.Split((string)jk_, "/");
+                string jm_ = context.Operators.Last<string>(jl_);
+                bool? jn_ = context.Operators.Equal(jj_, jm_);
+                CodeableConcept jo_ = M?.Code;
+                CqlConcept jp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jo_);
+                CqlValueSet jq_ = this.Methylphenidate(context);
+                bool? jr_ = context.Operators.ConceptInValueSet(jp_, jq_);
+                bool? js_ = context.Operators.And(jn_, jr_);
+                return js_;
             }
 
-            IEnumerable<Medication> jm_ = context.Operators.Where<Medication>(jk_, jl_);
-            MedicationRequest jn_(Medication M) => MR;
-            IEnumerable<MedicationRequest> jo_ = context.Operators.Select<Medication, MedicationRequest>(jm_, jn_);
-            return jo_;
+            IEnumerable<Medication> jh_ = context.Operators.Where<Medication>(jf_, jg_);
+            bool? ji_ = context.Operators.Exists<Medication>(jh_);
+            return ji_;
         }
 
-        IEnumerable<MedicationRequest> cj_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ci_);
+        IEnumerable<MedicationRequest> cj_ = context.Operators.Where<MedicationRequest>(c_, ci_);
         IEnumerable<MedicationRequest> ck_ = context.Operators.Union<MedicationRequest>(cg_, cj_);
         IEnumerable<MedicationRequest> cl_ = Status_1_15_000.Instance.isMedicationOrder(context, ck_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? cm_(MedicationRequest MethylphenidateMed) {
-            CqlInterval<CqlDate> jz_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, MethylphenidateMed);
-            CqlDate kb_ = context.Operators.Start(jz_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? kc_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, jz_, kb_);
-            return kc_;
+            CqlInterval<CqlDate> jt_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, MethylphenidateMed);
+            CqlDate jv_ = context.Operators.Start(jt_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? jw_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, jt_, jv_);
+            return jw_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> cn_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(cl_, cm_);
 
         object co_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate kd_ = @this?.periodStart;
-            return kd_;
+            CqlDate jx_ = @this?.periodStart;
+            return jx_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> cp_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(cn_, co_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? cq_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> ke_ = @this?.period;
-            bool? kf_ = context.Operators.Not((bool?)(ke_ is null));
-            return kf_;
+            CqlInterval<CqlDate> jy_ = @this?.period;
+            bool? jz_ = context.Operators.Not((bool?)(jy_ is null));
+            return jz_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> cr_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(cp_, cq_);
 
         CqlInterval<CqlDate> cs_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> kg_ = @this?.period;
-            return kg_;
+            CqlInterval<CqlDate> ka_ = @this?.period;
+            return ka_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> ct_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(cr_, cs_);
@@ -1815,60 +1525,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlValueSet cx_ = this.Guanfacine_Medications(context);
         IEnumerable<MedicationRequest> cy_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, cx_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> da_(MedicationRequest MR) {
-            IEnumerable<Medication> kh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? da_(MedicationRequest MR) {
+            IEnumerable<Medication> kb_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ki_(Medication M) {
-                object km_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object kn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ko_ = context.Operators.Split((string)kn_, "/");
-                string kp_ = context.Operators.Last<string>(ko_);
-                bool? kq_ = context.Operators.Equal(km_, kp_);
-                CodeableConcept kr_ = M?.Code;
-                CqlConcept ks_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kr_);
-                CqlValueSet kt_ = this.Guanfacine_Medications(context);
-                bool? ku_ = context.Operators.ConceptInValueSet(ks_, kt_);
-                bool? kv_ = context.Operators.And(kq_, ku_);
-                return kv_;
+            bool? kc_(Medication M) {
+                object kf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object kg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> kh_ = context.Operators.Split((string)kg_, "/");
+                string ki_ = context.Operators.Last<string>(kh_);
+                bool? kj_ = context.Operators.Equal(kf_, ki_);
+                CodeableConcept kk_ = M?.Code;
+                CqlConcept kl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kk_);
+                CqlValueSet km_ = this.Guanfacine_Medications(context);
+                bool? kn_ = context.Operators.ConceptInValueSet(kl_, km_);
+                bool? ko_ = context.Operators.And(kj_, kn_);
+                return ko_;
             }
 
-            IEnumerable<Medication> kj_ = context.Operators.Where<Medication>(kh_, ki_);
-            MedicationRequest kk_(Medication M) => MR;
-            IEnumerable<MedicationRequest> kl_ = context.Operators.Select<Medication, MedicationRequest>(kj_, kk_);
-            return kl_;
+            IEnumerable<Medication> kd_ = context.Operators.Where<Medication>(kb_, kc_);
+            bool? ke_ = context.Operators.Exists<Medication>(kd_);
+            return ke_;
         }
 
-        IEnumerable<MedicationRequest> db_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, da_);
+        IEnumerable<MedicationRequest> db_ = context.Operators.Where<MedicationRequest>(c_, da_);
         IEnumerable<MedicationRequest> dc_ = context.Operators.Union<MedicationRequest>(cy_, db_);
         IEnumerable<MedicationRequest> dd_ = Status_1_15_000.Instance.isMedicationOrder(context, dc_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? de_(MedicationRequest GuanfacineMed) {
-            CqlInterval<CqlDate> kw_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, GuanfacineMed);
-            CqlDate ky_ = context.Operators.Start(kw_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? kz_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, kw_, ky_);
-            return kz_;
+            CqlInterval<CqlDate> kp_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, GuanfacineMed);
+            CqlDate kr_ = context.Operators.Start(kp_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? ks_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, kp_, kr_);
+            return ks_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> df_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(dd_, de_);
 
         object dg_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate la_ = @this?.periodStart;
-            return la_;
+            CqlDate kt_ = @this?.periodStart;
+            return kt_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> dh_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(df_, dg_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? di_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> lb_ = @this?.period;
-            bool? lc_ = context.Operators.Not((bool?)(lb_ is null));
-            return lc_;
+            CqlInterval<CqlDate> ku_ = @this?.period;
+            bool? kv_ = context.Operators.Not((bool?)(ku_ is null));
+            return kv_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> dj_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(dh_, di_);
 
         CqlInterval<CqlDate> dk_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> ld_ = @this?.period;
-            return ld_;
+            CqlInterval<CqlDate> kw_ = @this?.period;
+            return kw_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> dl_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(dj_, dk_);
@@ -1877,61 +1586,60 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         IEnumerable<CqlCode> do_ = context.Operators.ToList<CqlCode>(dn_);
         IEnumerable<MedicationRequest> dp_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, do_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> dr_(MedicationRequest MR) {
-            IEnumerable<Medication> le_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? dr_(MedicationRequest MR) {
+            IEnumerable<Medication> kx_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? lf_(Medication M) {
-                object lj_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object lk_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ll_ = context.Operators.Split((string)lk_, "/");
-                string lm_ = context.Operators.Last<string>(ll_);
-                bool? ln_ = context.Operators.Equal(lj_, lm_);
-                CodeableConcept lo_ = M?.Code;
-                CqlConcept lp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lo_);
-                CqlCode lq_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-                CqlConcept lr_ = context.Operators.ConvertCodeToConcept(lq_);
-                bool? ls_ = context.Operators.Equivalent(lp_, lr_);
-                bool? lt_ = context.Operators.And(ln_, ls_);
-                return lt_;
+            bool? ky_(Medication M) {
+                object lb_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object lc_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ld_ = context.Operators.Split((string)lc_, "/");
+                string le_ = context.Operators.Last<string>(ld_);
+                bool? lf_ = context.Operators.Equal(lb_, le_);
+                CodeableConcept lg_ = M?.Code;
+                CqlConcept lh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lg_);
+                CqlCode li_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+                CqlConcept lj_ = context.Operators.ConvertCodeToConcept(li_);
+                bool? lk_ = context.Operators.Equivalent(lh_, lj_);
+                bool? ll_ = context.Operators.And(lf_, lk_);
+                return ll_;
             }
 
-            IEnumerable<Medication> lg_ = context.Operators.Where<Medication>(le_, lf_);
-            MedicationRequest lh_(Medication M) => MR;
-            IEnumerable<MedicationRequest> li_ = context.Operators.Select<Medication, MedicationRequest>(lg_, lh_);
-            return li_;
+            IEnumerable<Medication> kz_ = context.Operators.Where<Medication>(kx_, ky_);
+            bool? la_ = context.Operators.Exists<Medication>(kz_);
+            return la_;
         }
 
-        IEnumerable<MedicationRequest> ds_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, dr_);
+        IEnumerable<MedicationRequest> ds_ = context.Operators.Where<MedicationRequest>(c_, dr_);
         IEnumerable<MedicationRequest> dt_ = context.Operators.Union<MedicationRequest>(dp_, ds_);
         IEnumerable<MedicationRequest> du_ = Status_1_15_000.Instance.isMedicationOrder(context, dt_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? dv_(MedicationRequest MethamphetamineMed) {
-            CqlInterval<CqlDate> lu_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, MethamphetamineMed);
-            CqlDate lw_ = context.Operators.Start(lu_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? lx_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, lu_, lw_);
-            return lx_;
+            CqlInterval<CqlDate> lm_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, MethamphetamineMed);
+            CqlDate lo_ = context.Operators.Start(lm_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? lp_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, lm_, lo_);
+            return lp_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> dw_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(du_, dv_);
 
         object dx_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate ly_ = @this?.periodStart;
-            return ly_;
+            CqlDate lq_ = @this?.periodStart;
+            return lq_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> dy_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(dw_, dx_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? dz_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> lz_ = @this?.period;
-            bool? ma_ = context.Operators.Not((bool?)(lz_ is null));
-            return ma_;
+            CqlInterval<CqlDate> lr_ = @this?.period;
+            bool? ls_ = context.Operators.Not((bool?)(lr_ is null));
+            return ls_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> ea_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(dy_, dz_);
 
         CqlInterval<CqlDate> eb_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> mb_ = @this?.period;
-            return mb_;
+            CqlInterval<CqlDate> lt_ = @this?.period;
+            return lt_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> ec_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(ea_, eb_);
@@ -1941,60 +1649,59 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlValueSet eg_ = this.Viloxazine(context);
         IEnumerable<MedicationRequest> eh_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, eg_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ej_(MedicationRequest MR) {
-            IEnumerable<Medication> mc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ej_(MedicationRequest MR) {
+            IEnumerable<Medication> lu_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? md_(Medication M) {
-                object mh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object mi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> mj_ = context.Operators.Split((string)mi_, "/");
-                string mk_ = context.Operators.Last<string>(mj_);
-                bool? ml_ = context.Operators.Equal(mh_, mk_);
-                CodeableConcept mm_ = M?.Code;
-                CqlConcept mn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mm_);
-                CqlValueSet mo_ = this.Viloxazine(context);
-                bool? mp_ = context.Operators.ConceptInValueSet(mn_, mo_);
-                bool? mq_ = context.Operators.And(ml_, mp_);
-                return mq_;
+            bool? lv_(Medication M) {
+                object ly_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object lz_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ma_ = context.Operators.Split((string)lz_, "/");
+                string mb_ = context.Operators.Last<string>(ma_);
+                bool? mc_ = context.Operators.Equal(ly_, mb_);
+                CodeableConcept md_ = M?.Code;
+                CqlConcept me_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, md_);
+                CqlValueSet mf_ = this.Viloxazine(context);
+                bool? mg_ = context.Operators.ConceptInValueSet(me_, mf_);
+                bool? mh_ = context.Operators.And(mc_, mg_);
+                return mh_;
             }
 
-            IEnumerable<Medication> me_ = context.Operators.Where<Medication>(mc_, md_);
-            MedicationRequest mf_(Medication M) => MR;
-            IEnumerable<MedicationRequest> mg_ = context.Operators.Select<Medication, MedicationRequest>(me_, mf_);
-            return mg_;
+            IEnumerable<Medication> lw_ = context.Operators.Where<Medication>(lu_, lv_);
+            bool? lx_ = context.Operators.Exists<Medication>(lw_);
+            return lx_;
         }
 
-        IEnumerable<MedicationRequest> ek_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ej_);
+        IEnumerable<MedicationRequest> ek_ = context.Operators.Where<MedicationRequest>(c_, ej_);
         IEnumerable<MedicationRequest> el_ = context.Operators.Union<MedicationRequest>(eh_, ek_);
         IEnumerable<MedicationRequest> em_ = Status_1_15_000.Instance.isMedicationOrder(context, el_);
 
         (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? en_(MedicationRequest ViloxazineMed) {
-            CqlInterval<CqlDate> mr_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ViloxazineMed);
-            CqlDate mt_ = context.Operators.Start(mr_);
-            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? mu_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, mr_, mt_);
-            return mu_;
+            CqlInterval<CqlDate> mi_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ViloxazineMed);
+            CqlDate mk_ = context.Operators.Start(mi_);
+            (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? ml_ = (CqlTupleMetadata_EhMLLfWeOaeVhYfBZeiQfaefD, mi_, mk_);
+            return ml_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> eo_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(em_, en_);
 
         object ep_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlDate mv_ = @this?.periodStart;
-            return mv_;
+            CqlDate mm_ = @this?.periodStart;
+            return mm_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> eq_ = context.Operators.SortBy<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
 
         bool? er_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> mw_ = @this?.period;
-            bool? mx_ = context.Operators.Not((bool?)(mw_ is null));
-            return mx_;
+            CqlInterval<CqlDate> mn_ = @this?.period;
+            bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
+            return mo_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?> es_ = context.Operators.Where<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?>(eq_, er_);
 
         CqlInterval<CqlDate> et_((CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)? @this) {
-            CqlInterval<CqlDate> my_ = @this?.period;
-            return my_;
+            CqlInterval<CqlDate> mp_ = @this?.period;
+            return mp_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> eu_ = context.Operators.Select<(CqlTupleMetadata, CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(es_, et_);
@@ -2002,12 +1709,12 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         IEnumerable<CqlInterval<CqlDate>> ew_ = context.Operators.Union<CqlInterval<CqlDate>>(ef_, ev_);
 
         CqlInterval<CqlDate> ex_(CqlInterval<CqlDate> ADHDMedication) {
-            CqlDate mz_ = this.IPSD(context);
-            CqlQuantity nb_ = context.Operators.Quantity(300m, "days");
-            CqlDate nc_ = context.Operators.Add(mz_, nb_);
-            CqlInterval<CqlDate> nd_ = context.Operators.Interval(mz_, nc_, true, true);
-            CqlInterval<CqlDate> ne_ = context.Operators.Intersect<CqlDate>(ADHDMedication, nd_);
-            return ne_;
+            CqlDate mq_ = this.IPSD(context);
+            CqlQuantity ms_ = context.Operators.Quantity(300m, "days");
+            CqlDate mt_ = context.Operators.Add(mq_, ms_);
+            CqlInterval<CqlDate> mu_ = context.Operators.Interval(mq_, mt_, true, true);
+            CqlInterval<CqlDate> mv_ = context.Operators.Intersect<CqlDate>(ADHDMedication, mu_);
+            return mv_;
         }
 
         IEnumerable<CqlInterval<CqlDate>> ey_ = context.Operators.Select<CqlInterval<CqlDate>, CqlInterval<CqlDate>>(ew_, ex_);
@@ -2240,26 +1947,25 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         bool? c_ = this.Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
         IEnumerable<CqlDate> d_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
 
-        IEnumerable<CqlDate> e_(CqlDate Encounter1) {
+        bool? e_(CqlDate Encounter1) {
             IEnumerable<CqlDate> j_ = this.Virtual_Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
 
             bool? k_(CqlDate Encounter2) {
-                bool? o_ = context.Operators.Not((bool?)(Encounter1 is null));
-                bool? p_ = context.Operators.Not((bool?)(Encounter2 is null));
-                bool? q_ = context.Operators.And(o_, p_);
-                bool? r_ = context.Operators.Equivalent(Encounter1, Encounter2);
-                bool? s_ = context.Operators.Not(r_);
-                bool? t_ = context.Operators.And(q_, s_);
-                return t_;
+                bool? n_ = context.Operators.Not((bool?)(Encounter1 is null));
+                bool? o_ = context.Operators.Not((bool?)(Encounter2 is null));
+                bool? p_ = context.Operators.And(n_, o_);
+                bool? q_ = context.Operators.Equivalent(Encounter1, Encounter2);
+                bool? r_ = context.Operators.Not(q_);
+                bool? s_ = context.Operators.And(p_, r_);
+                return s_;
             }
 
             IEnumerable<CqlDate> l_ = context.Operators.Where<CqlDate>(j_, k_);
-            CqlDate m_(CqlDate Encounter2) => Encounter1;
-            IEnumerable<CqlDate> n_ = context.Operators.Select<CqlDate, CqlDate>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<CqlDate>(l_);
+            return m_;
         }
 
-        IEnumerable<CqlDate> f_ = context.Operators.SelectMany<CqlDate, CqlDate>(d_, e_);
+        IEnumerable<CqlDate> f_ = context.Operators.Where<CqlDate>(d_, e_);
         bool? g_ = context.Operators.Exists<CqlDate>(f_);
         bool? h_ = context.Operators.Or(c_, g_);
         bool? i_ = context.Operators.And(b_, h_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
@@ -162,7 +162,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounters(context);
 
-        IEnumerable<Encounter> b_(Encounter ValidEncounters) {
+        bool? b_(Encounter ValidEncounters) {
             CqlValueSet k_ = this.Substance_Use_Disorder(context);
             IEnumerable<Condition> l_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, k_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             Condition m_(Condition X) => X as Condition;
@@ -170,47 +170,46 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
             IEnumerable<Condition> o_ = Status_1_15_000.Instance.verified(context, n_);
 
             bool? p_(Condition SUDDiagnosis) {
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                Period u_ = ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, (string)default);
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SUDDiagnosis);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                bool? ab_ = context.Operators.In<CqlDateTime>(y_, aa_, (string)default);
-                bool? ac_ = context.Operators.And(w_, ab_);
-                CqlDateTime ae_ = context.Operators.Start(x_);
-                CqlDateTime ag_ = context.Operators.End(t_);
-                CqlQuantity ah_ = context.Operators.Quantity(47m, "days");
-                CqlDateTime ai_ = context.Operators.Subtract(ag_, ah_);
-                bool? aj_ = context.Operators.SameOrBefore(ae_, ai_, "day");
-                bool? ak_ = context.Operators.And(ac_, aj_);
-                return ak_;
+                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
+                Period t_ = ValidEncounters?.Period;
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(s_, u_, (string)default);
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SUDDiagnosis);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, (string)default);
+                bool? ab_ = context.Operators.And(v_, aa_);
+                CqlDateTime ad_ = context.Operators.Start(w_);
+                CqlDateTime af_ = context.Operators.End(s_);
+                CqlQuantity ag_ = context.Operators.Quantity(47m, "days");
+                CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+                bool? ai_ = context.Operators.SameOrBefore(ad_, ah_, "day");
+                bool? aj_ = context.Operators.And(ab_, ai_);
+                return aj_;
             }
 
             IEnumerable<Condition> q_ = context.Operators.Where<Condition>(o_, p_);
-            Encounter r_(Condition SUDDiagnosis) => ValidEncounters;
-            IEnumerable<Encounter> s_ = context.Operators.Select<Condition, Encounter>(q_, r_);
-            return s_;
+            bool? r_ = context.Operators.Exists<Condition>(q_);
+            return r_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? d_(Encounter ValidEncounters) {
-            Period al_ = ValidEncounters?.Period;
-            CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-            CqlDateTime an_ = context.Operators.Start(am_);
-            CqlDate ao_ = context.Operators.DateFrom(an_);
-            (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? ap_ = (CqlTupleMetadata_GYLjjJGJTORTXhCHiKcLEBBaJ, ao_, ValidEncounters);
-            return ap_;
+            Period ak_ = ValidEncounters?.Period;
+            CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
+            CqlDateTime am_ = context.Operators.Start(al_);
+            CqlDate an_ = context.Operators.DateFrom(am_);
+            (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? ao_ = (CqlTupleMetadata_GYLjjJGJTORTXhCHiKcLEBBaJ, an_, ValidEncounters);
+            return ao_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?> e_ = context.Operators.Select<Encounter, (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?>(c_, d_);
         IEnumerable<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?> f_ = context.Operators.Distinct<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?>(e_);
 
         object g_((CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? @this) {
-            CqlDate aq_ = @this?.ValidEncounterDate;
-            return aq_;
+            CqlDate ap_ = @this?.ValidEncounterDate;
+            return ap_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?> h_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
@@ -259,7 +258,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<Procedure> k_ = context.Operators.Union<Procedure>(e_, j_);
         IEnumerable<Procedure> l_ = Status_1_15_000.Instance.isInterventionPerformed(context, k_);
 
-        IEnumerable<Procedure> m_(Procedure Interventions) {
+        bool? m_(Procedure Interventions) {
             Encounter an_ = this.First_SUD_Episode_During_Measurement_Period(context);
             Encounter[] ao_ = [
                 an_,
@@ -267,62 +266,62 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
 
             bool? ap_(Encounter FirstSUDEpisode) {
 
-                object at_() {
+                object as_() {
+
+                    bool db_() {
+                        DataType df_ = Interventions?.Performed;
+                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                        bool dh_ = dg_ is CqlDateTime;
+                        return dh_;
+                    }
+
 
                     bool dc_() {
-                        DataType dg_ = Interventions?.Performed;
-                        object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
-                        bool di_ = dh_ is CqlDateTime;
-                        return di_;
+                        DataType di_ = Interventions?.Performed;
+                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+                        bool dk_ = dj_ is CqlInterval<CqlDateTime>;
+                        return dk_;
                     }
 
 
                     bool dd_() {
-                        DataType dj_ = Interventions?.Performed;
-                        object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
-                        bool dl_ = dk_ is CqlInterval<CqlDateTime>;
-                        return dl_;
+                        DataType dl_ = Interventions?.Performed;
+                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+                        bool dn_ = dm_ is CqlQuantity;
+                        return dn_;
                     }
 
 
                     bool de_() {
-                        DataType dm_ = Interventions?.Performed;
-                        object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
-                        bool do_ = dn_ is CqlQuantity;
-                        return do_;
+                        DataType do_ = Interventions?.Performed;
+                        object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
+                        bool dq_ = dp_ is CqlInterval<CqlQuantity>;
+                        return dq_;
                     }
 
-
-                    bool df_() {
-                        DataType dp_ = Interventions?.Performed;
-                        object dq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dp_);
-                        bool dr_ = dq_ is CqlInterval<CqlQuantity>;
-                        return dr_;
-                    }
-
-                    if (dc_())
+                    if (db_())
                     {
-                        DataType ds_ = Interventions?.Performed;
-                        object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
-                        return (dt_ as CqlDateTime) as object;
+                        DataType dr_ = Interventions?.Performed;
+                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                        return (ds_ as CqlDateTime) as object;
+                    }
+                    else if (dc_())
+                    {
+                        DataType dt_ = Interventions?.Performed;
+                        object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                        return (du_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (dd_())
                     {
-                        DataType du_ = Interventions?.Performed;
-                        object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                        return (dv_ as CqlInterval<CqlDateTime>) as object;
+                        DataType dv_ = Interventions?.Performed;
+                        object dw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dv_);
+                        return (dw_ as CqlQuantity) as object;
                     }
                     else if (de_())
                     {
-                        DataType dw_ = Interventions?.Performed;
-                        object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                        return (dx_ as CqlQuantity) as object;
-                    }
-                    else if (df_())
-                    {
-                        DataType dy_ = Interventions?.Performed;
-                        object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
-                        return (dz_ as CqlInterval<CqlQuantity>) as object;
+                        DataType dx_ = Interventions?.Performed;
+                        object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
+                        return (dy_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -330,289 +329,284 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     };
                 }
 
-                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_());
-                CqlDateTime av_ = context.Operators.Start(au_);
-                Period aw_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime ay_ = context.Operators.Start(ax_);
-                CqlDate az_ = context.Operators.DateFrom(ay_);
-                CqlQuantity ba_ = context.Operators.Quantity(60m, "days");
-                CqlDate bb_ = context.Operators.Subtract(az_, ba_);
-                CqlInterval<CqlDateTime> bd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime be_ = context.Operators.Start(bd_);
-                CqlDate bf_ = context.Operators.DateFrom(be_);
-                CqlInterval<CqlDate> bg_ = context.Operators.Interval(bb_, bf_, true, false);
-                CqlDate bh_ = bg_?.low;
-                CqlDateTime bi_ = context.Operators.ConvertDateToDateTime(bh_);
-                CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime bl_ = context.Operators.Start(bk_);
-                CqlDate bm_ = context.Operators.DateFrom(bl_);
-                CqlDate bo_ = context.Operators.Subtract(bm_, ba_);
-                CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime br_ = context.Operators.Start(bq_);
-                CqlDate bs_ = context.Operators.DateFrom(br_);
-                CqlInterval<CqlDate> bt_ = context.Operators.Interval(bo_, bs_, true, false);
-                CqlDate bu_ = bt_?.high;
-                CqlDateTime bv_ = context.Operators.ConvertDateToDateTime(bu_);
-                CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime by_ = context.Operators.Start(bx_);
-                CqlDate bz_ = context.Operators.DateFrom(by_);
-                CqlDate cb_ = context.Operators.Subtract(bz_, ba_);
-                CqlInterval<CqlDateTime> cd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime ce_ = context.Operators.Start(cd_);
-                CqlDate cf_ = context.Operators.DateFrom(ce_);
-                CqlInterval<CqlDate> cg_ = context.Operators.Interval(cb_, cf_, true, false);
-                bool? ch_ = cg_?.lowClosed;
-                CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime ck_ = context.Operators.Start(cj_);
-                CqlDate cl_ = context.Operators.DateFrom(ck_);
-                CqlDate cn_ = context.Operators.Subtract(cl_, ba_);
-                CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime cq_ = context.Operators.Start(cp_);
-                CqlDate cr_ = context.Operators.DateFrom(cq_);
-                CqlInterval<CqlDate> cs_ = context.Operators.Interval(cn_, cr_, true, false);
-                bool? ct_ = cs_?.highClosed;
-                CqlInterval<CqlDateTime> cu_ = context.Operators.Interval(bi_, bv_, ch_, ct_);
-                bool? cv_ = context.Operators.In<CqlDateTime>(av_, cu_, "day");
-                CqlInterval<CqlDateTime> cx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime cy_ = context.Operators.Start(cx_);
-                CqlDate cz_ = context.Operators.DateFrom(cy_);
-                bool? da_ = context.Operators.Not((bool?)(cz_ is null));
-                bool? db_ = context.Operators.And(cv_, da_);
-                return db_;
+                CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_());
+                CqlDateTime au_ = context.Operators.Start(at_);
+                Period av_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime ax_ = context.Operators.Start(aw_);
+                CqlDate ay_ = context.Operators.DateFrom(ax_);
+                CqlQuantity az_ = context.Operators.Quantity(60m, "days");
+                CqlDate ba_ = context.Operators.Subtract(ay_, az_);
+                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                CqlDate be_ = context.Operators.DateFrom(bd_);
+                CqlInterval<CqlDate> bf_ = context.Operators.Interval(ba_, be_, true, false);
+                CqlDate bg_ = bf_?.low;
+                CqlDateTime bh_ = context.Operators.ConvertDateToDateTime(bg_);
+                CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime bk_ = context.Operators.Start(bj_);
+                CqlDate bl_ = context.Operators.DateFrom(bk_);
+                CqlDate bn_ = context.Operators.Subtract(bl_, az_);
+                CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime bq_ = context.Operators.Start(bp_);
+                CqlDate br_ = context.Operators.DateFrom(bq_);
+                CqlInterval<CqlDate> bs_ = context.Operators.Interval(bn_, br_, true, false);
+                CqlDate bt_ = bs_?.high;
+                CqlDateTime bu_ = context.Operators.ConvertDateToDateTime(bt_);
+                CqlInterval<CqlDateTime> bw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime bx_ = context.Operators.Start(bw_);
+                CqlDate by_ = context.Operators.DateFrom(bx_);
+                CqlDate ca_ = context.Operators.Subtract(by_, az_);
+                CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime cd_ = context.Operators.Start(cc_);
+                CqlDate ce_ = context.Operators.DateFrom(cd_);
+                CqlInterval<CqlDate> cf_ = context.Operators.Interval(ca_, ce_, true, false);
+                bool? cg_ = cf_?.lowClosed;
+                CqlInterval<CqlDateTime> ci_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime cj_ = context.Operators.Start(ci_);
+                CqlDate ck_ = context.Operators.DateFrom(cj_);
+                CqlDate cm_ = context.Operators.Subtract(ck_, az_);
+                CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime cp_ = context.Operators.Start(co_);
+                CqlDate cq_ = context.Operators.DateFrom(cp_);
+                CqlInterval<CqlDate> cr_ = context.Operators.Interval(cm_, cq_, true, false);
+                bool? cs_ = cr_?.highClosed;
+                CqlInterval<CqlDateTime> ct_ = context.Operators.Interval(bh_, bu_, cg_, cs_);
+                bool? cu_ = context.Operators.In<CqlDateTime>(au_, ct_, "day");
+                CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+                CqlDateTime cx_ = context.Operators.Start(cw_);
+                CqlDate cy_ = context.Operators.DateFrom(cx_);
+                bool? cz_ = context.Operators.Not((bool?)(cy_ is null));
+                bool? da_ = context.Operators.And(cu_, cz_);
+                return da_;
             }
 
             IEnumerable<Encounter> aq_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)ao_, ap_);
-            Procedure ar_(Encounter FirstSUDEpisode) => Interventions;
-            IEnumerable<Procedure> as_ = context.Operators.Select<Encounter, Procedure>(aq_, ar_);
-            return as_;
+            bool? ar_ = context.Operators.Exists<Encounter>(aq_);
+            return ar_;
         }
 
-        IEnumerable<Procedure> n_ = context.Operators.SelectMany<Procedure, Procedure>(l_, m_);
+        IEnumerable<Procedure> n_ = context.Operators.Where<Procedure>(l_, m_);
         IEnumerable<Encounter> o_ = this.Qualifying_Encounters(context);
         IEnumerable<Encounter> p_ = this.Emergency_Department_or_Detoxification_Visit(context);
         IEnumerable<Encounter> q_ = context.Operators.Except<Encounter>(o_, p_);
 
         bool? r_(Encounter QualifyingEncounter) {
-            IEnumerable<Condition> ea_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
+            IEnumerable<Condition> dz_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
 
-            bool? eb_(Condition @this) {
-                CodeableConcept eh_ = @this?.Code;
-                CqlConcept ei_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eh_);
-                bool? ej_ = context.Operators.Not((bool?)(ei_ is null));
-                return ej_;
+            bool? ea_(Condition @this) {
+                CodeableConcept eg_ = @this?.Code;
+                CqlConcept eh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eg_);
+                bool? ei_ = context.Operators.Not((bool?)(eh_ is null));
+                return ei_;
             }
 
-            IEnumerable<Condition> ec_ = context.Operators.Where<Condition>(ea_, eb_);
+            IEnumerable<Condition> eb_ = context.Operators.Where<Condition>(dz_, ea_);
 
-            CqlConcept ed_(Condition @this) {
-                CodeableConcept ek_ = @this?.Code;
-                CqlConcept el_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ek_);
-                return el_;
+            CqlConcept ec_(Condition @this) {
+                CodeableConcept ej_ = @this?.Code;
+                CqlConcept ek_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ej_);
+                return ek_;
             }
 
-            IEnumerable<CqlConcept> ee_ = context.Operators.Select<Condition, CqlConcept>(ec_, ed_);
-            CqlValueSet ef_ = this.Substance_Use_Disorder(context);
-            bool? eg_ = context.Operators.ConceptsInValueSet(ee_, ef_);
-            return eg_;
+            IEnumerable<CqlConcept> ed_ = context.Operators.Select<Condition, CqlConcept>(eb_, ec_);
+            CqlValueSet ee_ = this.Substance_Use_Disorder(context);
+            bool? ef_ = context.Operators.ConceptsInValueSet(ed_, ee_);
+            return ef_;
         }
 
         IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
 
-        IEnumerable<Encounter> t_(Encounter SUDEncounterDx) {
-            Encounter em_ = this.First_SUD_Episode_During_Measurement_Period(context);
-            Encounter[] en_ = [
-                em_,
+        bool? t_(Encounter SUDEncounterDx) {
+            Encounter el_ = this.First_SUD_Episode_During_Measurement_Period(context);
+            Encounter[] em_ = [
+                el_,
             ];
 
-            bool? eo_(Encounter FirstSUDEpisode) {
-                Period es_ = SUDEncounterDx?.Period;
-                CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, es_);
-                CqlDateTime eu_ = context.Operators.Start(et_);
-                Period ev_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime ex_ = context.Operators.Start(ew_);
-                CqlDate ey_ = context.Operators.DateFrom(ex_);
-                CqlQuantity ez_ = context.Operators.Quantity(60m, "days");
-                CqlDate fa_ = context.Operators.Subtract(ey_, ez_);
-                CqlInterval<CqlDateTime> fc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime fd_ = context.Operators.Start(fc_);
-                CqlDate fe_ = context.Operators.DateFrom(fd_);
-                CqlInterval<CqlDate> ff_ = context.Operators.Interval(fa_, fe_, true, false);
-                CqlDate fg_ = ff_?.low;
-                CqlDateTime fh_ = context.Operators.ConvertDateToDateTime(fg_);
-                CqlInterval<CqlDateTime> fj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime fk_ = context.Operators.Start(fj_);
-                CqlDate fl_ = context.Operators.DateFrom(fk_);
-                CqlDate fn_ = context.Operators.Subtract(fl_, ez_);
-                CqlInterval<CqlDateTime> fp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime fq_ = context.Operators.Start(fp_);
-                CqlDate fr_ = context.Operators.DateFrom(fq_);
-                CqlInterval<CqlDate> fs_ = context.Operators.Interval(fn_, fr_, true, false);
-                CqlDate ft_ = fs_?.high;
-                CqlDateTime fu_ = context.Operators.ConvertDateToDateTime(ft_);
-                CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime fx_ = context.Operators.Start(fw_);
-                CqlDate fy_ = context.Operators.DateFrom(fx_);
-                CqlDate ga_ = context.Operators.Subtract(fy_, ez_);
-                CqlInterval<CqlDateTime> gc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime gd_ = context.Operators.Start(gc_);
-                CqlDate ge_ = context.Operators.DateFrom(gd_);
-                CqlInterval<CqlDate> gf_ = context.Operators.Interval(ga_, ge_, true, false);
-                bool? gg_ = gf_?.lowClosed;
-                CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime gj_ = context.Operators.Start(gi_);
-                CqlDate gk_ = context.Operators.DateFrom(gj_);
-                CqlDate gm_ = context.Operators.Subtract(gk_, ez_);
-                CqlInterval<CqlDateTime> go_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime gp_ = context.Operators.Start(go_);
-                CqlDate gq_ = context.Operators.DateFrom(gp_);
-                CqlInterval<CqlDate> gr_ = context.Operators.Interval(gm_, gq_, true, false);
-                bool? gs_ = gr_?.highClosed;
-                CqlInterval<CqlDateTime> gt_ = context.Operators.Interval(fh_, fu_, gg_, gs_);
-                bool? gu_ = context.Operators.In<CqlDateTime>(eu_, gt_, "day");
-                CqlInterval<CqlDateTime> gw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
-                CqlDateTime gx_ = context.Operators.Start(gw_);
-                CqlDate gy_ = context.Operators.DateFrom(gx_);
-                bool? gz_ = context.Operators.Not((bool?)(gy_ is null));
-                bool? ha_ = context.Operators.And(gu_, gz_);
-                return ha_;
+            bool? en_(Encounter FirstSUDEpisode) {
+                Period eq_ = SUDEncounterDx?.Period;
+                CqlInterval<CqlDateTime> er_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eq_);
+                CqlDateTime es_ = context.Operators.Start(er_);
+                Period et_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> eu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime ev_ = context.Operators.Start(eu_);
+                CqlDate ew_ = context.Operators.DateFrom(ev_);
+                CqlQuantity ex_ = context.Operators.Quantity(60m, "days");
+                CqlDate ey_ = context.Operators.Subtract(ew_, ex_);
+                CqlInterval<CqlDateTime> fa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime fb_ = context.Operators.Start(fa_);
+                CqlDate fc_ = context.Operators.DateFrom(fb_);
+                CqlInterval<CqlDate> fd_ = context.Operators.Interval(ey_, fc_, true, false);
+                CqlDate fe_ = fd_?.low;
+                CqlDateTime ff_ = context.Operators.ConvertDateToDateTime(fe_);
+                CqlInterval<CqlDateTime> fh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime fi_ = context.Operators.Start(fh_);
+                CqlDate fj_ = context.Operators.DateFrom(fi_);
+                CqlDate fl_ = context.Operators.Subtract(fj_, ex_);
+                CqlInterval<CqlDateTime> fn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime fo_ = context.Operators.Start(fn_);
+                CqlDate fp_ = context.Operators.DateFrom(fo_);
+                CqlInterval<CqlDate> fq_ = context.Operators.Interval(fl_, fp_, true, false);
+                CqlDate fr_ = fq_?.high;
+                CqlDateTime fs_ = context.Operators.ConvertDateToDateTime(fr_);
+                CqlInterval<CqlDateTime> fu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime fv_ = context.Operators.Start(fu_);
+                CqlDate fw_ = context.Operators.DateFrom(fv_);
+                CqlDate fy_ = context.Operators.Subtract(fw_, ex_);
+                CqlInterval<CqlDateTime> ga_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime gb_ = context.Operators.Start(ga_);
+                CqlDate gc_ = context.Operators.DateFrom(gb_);
+                CqlInterval<CqlDate> gd_ = context.Operators.Interval(fy_, gc_, true, false);
+                bool? ge_ = gd_?.lowClosed;
+                CqlInterval<CqlDateTime> gg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime gh_ = context.Operators.Start(gg_);
+                CqlDate gi_ = context.Operators.DateFrom(gh_);
+                CqlDate gk_ = context.Operators.Subtract(gi_, ex_);
+                CqlInterval<CqlDateTime> gm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime gn_ = context.Operators.Start(gm_);
+                CqlDate go_ = context.Operators.DateFrom(gn_);
+                CqlInterval<CqlDate> gp_ = context.Operators.Interval(gk_, go_, true, false);
+                bool? gq_ = gp_?.highClosed;
+                CqlInterval<CqlDateTime> gr_ = context.Operators.Interval(ff_, fs_, ge_, gq_);
+                bool? gs_ = context.Operators.In<CqlDateTime>(es_, gr_, "day");
+                CqlInterval<CqlDateTime> gu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
+                CqlDateTime gv_ = context.Operators.Start(gu_);
+                CqlDate gw_ = context.Operators.DateFrom(gv_);
+                bool? gx_ = context.Operators.Not((bool?)(gw_ is null));
+                bool? gy_ = context.Operators.And(gs_, gx_);
+                return gy_;
             }
 
-            IEnumerable<Encounter> ep_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)en_, eo_);
-            Encounter eq_(Encounter FirstSUDEpisode) => SUDEncounterDx;
-            IEnumerable<Encounter> er_ = context.Operators.Select<Encounter, Encounter>(ep_, eq_);
-            return er_;
+            IEnumerable<Encounter> eo_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)em_, en_);
+            bool? ep_ = context.Operators.Exists<Encounter>(eo_);
+            return ep_;
         }
 
-        IEnumerable<Encounter> u_ = context.Operators.SelectMany<Encounter, Encounter>(s_, t_);
+        IEnumerable<Encounter> u_ = context.Operators.Where<Encounter>(s_, t_);
         IEnumerable<object> v_ = context.Operators.Union<object>(n_ as IEnumerable<object>, u_ as IEnumerable<object>);
         CqlValueSet w_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
         IEnumerable<MedicationRequest> x_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, w_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> y_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> z_(MedicationRequest MR) {
-            IEnumerable<Medication> hb_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? z_(MedicationRequest MR) {
+            IEnumerable<Medication> gz_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? hc_(Medication M) {
-                object hg_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hh_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hi_ = context.Operators.Split((string)hh_, "/");
-                string hj_ = context.Operators.Last<string>(hi_);
-                bool? hk_ = context.Operators.Equal(hg_, hj_);
-                CodeableConcept hl_ = M?.Code;
-                CqlConcept hm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hl_);
-                CqlValueSet hn_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
-                bool? ho_ = context.Operators.ConceptInValueSet(hm_, hn_);
-                bool? hp_ = context.Operators.And(hk_, ho_);
-                return hp_;
+            bool? ha_(Medication M) {
+                object hd_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object he_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> hf_ = context.Operators.Split((string)he_, "/");
+                string hg_ = context.Operators.Last<string>(hf_);
+                bool? hh_ = context.Operators.Equal(hd_, hg_);
+                CodeableConcept hi_ = M?.Code;
+                CqlConcept hj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hi_);
+                CqlValueSet hk_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
+                bool? hl_ = context.Operators.ConceptInValueSet(hj_, hk_);
+                bool? hm_ = context.Operators.And(hh_, hl_);
+                return hm_;
             }
 
-            IEnumerable<Medication> hd_ = context.Operators.Where<Medication>(hb_, hc_);
-            MedicationRequest he_(Medication M) => MR;
-            IEnumerable<MedicationRequest> hf_ = context.Operators.Select<Medication, MedicationRequest>(hd_, he_);
-            return hf_;
+            IEnumerable<Medication> hb_ = context.Operators.Where<Medication>(gz_, ha_);
+            bool? hc_ = context.Operators.Exists<Medication>(hb_);
+            return hc_;
         }
 
-        IEnumerable<MedicationRequest> aa_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(y_, z_);
+        IEnumerable<MedicationRequest> aa_ = context.Operators.Where<MedicationRequest>(y_, z_);
         IEnumerable<MedicationRequest> ab_ = context.Operators.Union<MedicationRequest>(x_, aa_);
         CqlValueSet ac_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
         IEnumerable<MedicationRequest> ad_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ac_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> af_(MedicationRequest MR) {
-            IEnumerable<Medication> hq_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? af_(MedicationRequest MR) {
+            IEnumerable<Medication> hn_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? hr_(Medication M) {
-                object hv_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hw_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hx_ = context.Operators.Split((string)hw_, "/");
-                string hy_ = context.Operators.Last<string>(hx_);
-                bool? hz_ = context.Operators.Equal(hv_, hy_);
-                CodeableConcept ia_ = M?.Code;
-                CqlConcept ib_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ia_);
-                CqlValueSet ic_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
-                bool? id_ = context.Operators.ConceptInValueSet(ib_, ic_);
-                bool? ie_ = context.Operators.And(hz_, id_);
-                return ie_;
+            bool? ho_(Medication M) {
+                object hr_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object hs_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ht_ = context.Operators.Split((string)hs_, "/");
+                string hu_ = context.Operators.Last<string>(ht_);
+                bool? hv_ = context.Operators.Equal(hr_, hu_);
+                CodeableConcept hw_ = M?.Code;
+                CqlConcept hx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hw_);
+                CqlValueSet hy_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
+                bool? hz_ = context.Operators.ConceptInValueSet(hx_, hy_);
+                bool? ia_ = context.Operators.And(hv_, hz_);
+                return ia_;
             }
 
-            IEnumerable<Medication> hs_ = context.Operators.Where<Medication>(hq_, hr_);
-            MedicationRequest ht_(Medication M) => MR;
-            IEnumerable<MedicationRequest> hu_ = context.Operators.Select<Medication, MedicationRequest>(hs_, ht_);
-            return hu_;
+            IEnumerable<Medication> hp_ = context.Operators.Where<Medication>(hn_, ho_);
+            bool? hq_ = context.Operators.Exists<Medication>(hp_);
+            return hq_;
         }
 
-        IEnumerable<MedicationRequest> ag_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(y_, af_);
+        IEnumerable<MedicationRequest> ag_ = context.Operators.Where<MedicationRequest>(y_, af_);
         IEnumerable<MedicationRequest> ah_ = context.Operators.Union<MedicationRequest>(ad_, ag_);
         IEnumerable<MedicationRequest> ai_ = context.Operators.Union<MedicationRequest>(ab_, ah_);
         IEnumerable<MedicationRequest> aj_ = Status_1_15_000.Instance.isMedicationOrder(context, ai_);
 
-        IEnumerable<MedicationRequest> ak_(MedicationRequest SUDMedication) {
-            Encounter if_ = this.First_SUD_Episode_During_Measurement_Period(context);
-            Encounter[] ig_ = [
-                if_,
+        bool? ak_(MedicationRequest SUDMedication) {
+            Encounter ib_ = this.First_SUD_Episode_During_Measurement_Period(context);
+            Encounter[] ic_ = [
+                ib_,
             ];
 
-            bool? ih_(Encounter FirstSUDEpisode) {
-                FhirDateTime il_ = SUDMedication?.AuthoredOnElement;
-                CqlDateTime im_ = context.Operators.Convert<CqlDateTime>(il_);
-                Period in_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> io_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime ip_ = context.Operators.Start(io_);
-                CqlDate iq_ = context.Operators.DateFrom(ip_);
-                CqlQuantity ir_ = context.Operators.Quantity(60m, "days");
-                CqlDate is_ = context.Operators.Subtract(iq_, ir_);
-                CqlInterval<CqlDateTime> iu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime iv_ = context.Operators.Start(iu_);
-                CqlDate iw_ = context.Operators.DateFrom(iv_);
-                CqlInterval<CqlDate> ix_ = context.Operators.Interval(is_, iw_, true, false);
-                CqlDate iy_ = ix_?.low;
-                CqlDateTime iz_ = context.Operators.ConvertDateToDateTime(iy_);
-                CqlInterval<CqlDateTime> jb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime jc_ = context.Operators.Start(jb_);
-                CqlDate jd_ = context.Operators.DateFrom(jc_);
-                CqlDate jf_ = context.Operators.Subtract(jd_, ir_);
-                CqlInterval<CqlDateTime> jh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime ji_ = context.Operators.Start(jh_);
-                CqlDate jj_ = context.Operators.DateFrom(ji_);
-                CqlInterval<CqlDate> jk_ = context.Operators.Interval(jf_, jj_, true, false);
-                CqlDate jl_ = jk_?.high;
-                CqlDateTime jm_ = context.Operators.ConvertDateToDateTime(jl_);
-                CqlInterval<CqlDateTime> jo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime jp_ = context.Operators.Start(jo_);
-                CqlDate jq_ = context.Operators.DateFrom(jp_);
-                CqlDate js_ = context.Operators.Subtract(jq_, ir_);
-                CqlInterval<CqlDateTime> ju_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime jv_ = context.Operators.Start(ju_);
-                CqlDate jw_ = context.Operators.DateFrom(jv_);
-                CqlInterval<CqlDate> jx_ = context.Operators.Interval(js_, jw_, true, false);
-                bool? jy_ = jx_?.lowClosed;
-                CqlInterval<CqlDateTime> ka_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime kb_ = context.Operators.Start(ka_);
-                CqlDate kc_ = context.Operators.DateFrom(kb_);
-                CqlDate ke_ = context.Operators.Subtract(kc_, ir_);
-                CqlInterval<CqlDateTime> kg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime kh_ = context.Operators.Start(kg_);
-                CqlDate ki_ = context.Operators.DateFrom(kh_);
-                CqlInterval<CqlDate> kj_ = context.Operators.Interval(ke_, ki_, true, false);
-                bool? kk_ = kj_?.highClosed;
-                CqlInterval<CqlDateTime> kl_ = context.Operators.Interval(iz_, jm_, jy_, kk_);
-                bool? km_ = context.Operators.In<CqlDateTime>(im_, kl_, "day");
-                CqlInterval<CqlDateTime> ko_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, in_);
-                CqlDateTime kp_ = context.Operators.Start(ko_);
-                CqlDate kq_ = context.Operators.DateFrom(kp_);
-                bool? kr_ = context.Operators.Not((bool?)(kq_ is null));
-                bool? ks_ = context.Operators.And(km_, kr_);
-                return ks_;
+            bool? id_(Encounter FirstSUDEpisode) {
+                FhirDateTime ig_ = SUDMedication?.AuthoredOnElement;
+                CqlDateTime ih_ = context.Operators.Convert<CqlDateTime>(ig_);
+                Period ii_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> ij_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime ik_ = context.Operators.Start(ij_);
+                CqlDate il_ = context.Operators.DateFrom(ik_);
+                CqlQuantity im_ = context.Operators.Quantity(60m, "days");
+                CqlDate in_ = context.Operators.Subtract(il_, im_);
+                CqlInterval<CqlDateTime> ip_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime iq_ = context.Operators.Start(ip_);
+                CqlDate ir_ = context.Operators.DateFrom(iq_);
+                CqlInterval<CqlDate> is_ = context.Operators.Interval(in_, ir_, true, false);
+                CqlDate it_ = is_?.low;
+                CqlDateTime iu_ = context.Operators.ConvertDateToDateTime(it_);
+                CqlInterval<CqlDateTime> iw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime ix_ = context.Operators.Start(iw_);
+                CqlDate iy_ = context.Operators.DateFrom(ix_);
+                CqlDate ja_ = context.Operators.Subtract(iy_, im_);
+                CqlInterval<CqlDateTime> jc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime jd_ = context.Operators.Start(jc_);
+                CqlDate je_ = context.Operators.DateFrom(jd_);
+                CqlInterval<CqlDate> jf_ = context.Operators.Interval(ja_, je_, true, false);
+                CqlDate jg_ = jf_?.high;
+                CqlDateTime jh_ = context.Operators.ConvertDateToDateTime(jg_);
+                CqlInterval<CqlDateTime> jj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime jk_ = context.Operators.Start(jj_);
+                CqlDate jl_ = context.Operators.DateFrom(jk_);
+                CqlDate jn_ = context.Operators.Subtract(jl_, im_);
+                CqlInterval<CqlDateTime> jp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime jq_ = context.Operators.Start(jp_);
+                CqlDate jr_ = context.Operators.DateFrom(jq_);
+                CqlInterval<CqlDate> js_ = context.Operators.Interval(jn_, jr_, true, false);
+                bool? jt_ = js_?.lowClosed;
+                CqlInterval<CqlDateTime> jv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime jw_ = context.Operators.Start(jv_);
+                CqlDate jx_ = context.Operators.DateFrom(jw_);
+                CqlDate jz_ = context.Operators.Subtract(jx_, im_);
+                CqlInterval<CqlDateTime> kb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime kc_ = context.Operators.Start(kb_);
+                CqlDate kd_ = context.Operators.DateFrom(kc_);
+                CqlInterval<CqlDate> ke_ = context.Operators.Interval(jz_, kd_, true, false);
+                bool? kf_ = ke_?.highClosed;
+                CqlInterval<CqlDateTime> kg_ = context.Operators.Interval(iu_, jh_, jt_, kf_);
+                bool? kh_ = context.Operators.In<CqlDateTime>(ih_, kg_, "day");
+                CqlInterval<CqlDateTime> kj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
+                CqlDateTime kk_ = context.Operators.Start(kj_);
+                CqlDate kl_ = context.Operators.DateFrom(kk_);
+                bool? km_ = context.Operators.Not((bool?)(kl_ is null));
+                bool? kn_ = context.Operators.And(kh_, km_);
+                return kn_;
             }
 
-            IEnumerable<Encounter> ii_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)ig_, ih_);
-            MedicationRequest ij_(Encounter FirstSUDEpisode) => SUDMedication;
-            IEnumerable<MedicationRequest> ik_ = context.Operators.Select<Encounter, MedicationRequest>(ii_, ij_);
-            return ik_;
+            IEnumerable<Encounter> ie_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)ic_, id_);
+            bool? if_ = context.Operators.Exists<Encounter>(ie_);
+            return if_;
         }
 
-        IEnumerable<MedicationRequest> al_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(aj_, ak_);
+        IEnumerable<MedicationRequest> al_ = context.Operators.Where<MedicationRequest>(aj_, ak_);
         IEnumerable<object> am_ = context.Operators.Union<object>(v_ as IEnumerable<object>, al_ as IEnumerable<object>);
         return am_;
     }
@@ -733,7 +727,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<object> a_ = this.Psychosocial_Visit(context);
 
-        IEnumerable<object> b_(object PsychosocialVisitProcedure) {
+        bool? b_(object PsychosocialVisitProcedure) {
             Encounter l_ = this.First_SUD_Episode_During_Measurement_Period(context);
             Encounter[] m_ = [
                 l_,
@@ -741,62 +735,62 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
 
             bool? n_(Encounter FirstSUDEpisode) {
 
-                object r_() {
+                object q_() {
+
+                    bool an_() {
+                        object ar_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        bool at_ = as_ is CqlDateTime;
+                        return at_;
+                    }
+
 
                     bool ao_() {
-                        object as_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        bool au_ = at_ is CqlDateTime;
-                        return au_;
+                        object au_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
+                        return aw_;
                     }
 
 
                     bool ap_() {
-                        object av_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlInterval<CqlDateTime>;
-                        return ax_;
+                        object ax_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlQuantity;
+                        return az_;
                     }
 
 
                     bool aq_() {
-                        object ay_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlQuantity;
-                        return ba_;
+                        object ba_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlInterval<CqlQuantity>;
+                        return bc_;
                     }
 
-
-                    bool ar_() {
-                        object bb_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlInterval<CqlQuantity>;
-                        return bd_;
-                    }
-
-                    if (ao_())
+                    if (an_())
                     {
-                        object be_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        return (bf_ as CqlDateTime) as object;
+                        object bd_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        return (be_ as CqlDateTime) as object;
+                    }
+                    else if (ao_())
+                    {
+                        object bf_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        return (bg_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ap_())
                     {
-                        object bg_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        return (bh_ as CqlInterval<CqlDateTime>) as object;
+                        object bh_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        return (bi_ as CqlQuantity) as object;
                     }
                     else if (aq_())
                     {
-                        object bi_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        return (bj_ as CqlQuantity) as object;
-                    }
-                    else if (ar_())
-                    {
-                        object bk_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        return (bl_ as CqlInterval<CqlQuantity>) as object;
+                        object bj_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        return (bk_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -804,96 +798,95 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     };
                 }
 
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
-                CqlDateTime t_ = context.Operators.Start(s_);
-                CqlDate u_ = context.Operators.DateFrom(t_);
-                Period v_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                CqlDate y_ = context.Operators.DateFrom(x_);
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlDate ac_ = context.Operators.DateFrom(ab_);
-                CqlQuantity ad_ = context.Operators.Quantity(14m, "days");
-                CqlDate ae_ = context.Operators.Add(ac_, ad_);
-                CqlInterval<CqlDate> af_ = context.Operators.Interval(y_, ae_, true, false);
-                bool? ag_ = context.Operators.In<CqlDate>(u_, af_, (string)default);
-                object ah_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "id");
-                string ai_ = context.Operators.LateBoundProperty<string>(ah_, "value");
-                Id aj_ = FirstSUDEpisode?.IdElement;
-                string ak_ = aj_?.Value;
-                bool? al_ = context.Operators.Equivalent(ai_, ak_);
-                bool? am_ = context.Operators.Not(al_);
-                bool? an_ = context.Operators.And(ag_, am_);
-                return an_;
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlDate t_ = context.Operators.DateFrom(s_);
+                Period u_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlDate x_ = context.Operators.DateFrom(w_);
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlDate ab_ = context.Operators.DateFrom(aa_);
+                CqlQuantity ac_ = context.Operators.Quantity(14m, "days");
+                CqlDate ad_ = context.Operators.Add(ab_, ac_);
+                CqlInterval<CqlDate> ae_ = context.Operators.Interval(x_, ad_, true, false);
+                bool? af_ = context.Operators.In<CqlDate>(t_, ae_, (string)default);
+                object ag_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "id");
+                string ah_ = context.Operators.LateBoundProperty<string>(ag_, "value");
+                Id ai_ = FirstSUDEpisode?.IdElement;
+                string aj_ = ai_?.Value;
+                bool? ak_ = context.Operators.Equivalent(ah_, aj_);
+                bool? al_ = context.Operators.Not(ak_);
+                bool? am_ = context.Operators.And(af_, al_);
+                return am_;
             }
 
             IEnumerable<Encounter> o_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)m_, n_);
-            object p_(Encounter FirstSUDEpisode) => PsychosocialVisitProcedure;
-            IEnumerable<object> q_ = context.Operators.Select<Encounter, object>(o_, p_);
-            return q_;
+            bool? p_ = context.Operators.Exists<Encounter>(o_);
+            return p_;
         }
 
-        IEnumerable<object> c_ = context.Operators.SelectMany<object, object>(a_, b_);
+        IEnumerable<object> c_ = context.Operators.Where<object>(a_, b_);
 
         CqlDate d_(object PsychosocialVisitProcedure) {
 
-            object bm_() {
+            object bl_() {
+
+                bool bp_() {
+                    object bt_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                    bool bv_ = bu_ is CqlDateTime;
+                    return bv_;
+                }
+
 
                 bool bq_() {
-                    object bu_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                    bool bw_ = bv_ is CqlDateTime;
-                    return bw_;
+                    object bw_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+                    bool by_ = bx_ is CqlInterval<CqlDateTime>;
+                    return by_;
                 }
 
 
                 bool br_() {
-                    object bx_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                    bool bz_ = by_ is CqlInterval<CqlDateTime>;
-                    return bz_;
+                    object bz_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                    bool cb_ = ca_ is CqlQuantity;
+                    return cb_;
                 }
 
 
                 bool bs_() {
-                    object ca_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                    bool cc_ = cb_ is CqlQuantity;
-                    return cc_;
+                    object cc_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
+                    bool ce_ = cd_ is CqlInterval<CqlQuantity>;
+                    return ce_;
                 }
 
-
-                bool bt_() {
-                    object cd_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
-                    bool cf_ = ce_ is CqlInterval<CqlQuantity>;
-                    return cf_;
-                }
-
-                if (bq_())
+                if (bp_())
                 {
-                    object cg_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
-                    return (ch_ as CqlDateTime) as object;
+                    object cf_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                    return (cg_ as CqlDateTime) as object;
+                }
+                else if (bq_())
+                {
+                    object ch_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                    return (ci_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (br_())
                 {
-                    object ci_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                    return (cj_ as CqlInterval<CqlDateTime>) as object;
+                    object cj_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                    return (ck_ as CqlQuantity) as object;
                 }
                 else if (bs_())
                 {
-                    object ck_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                    return (cl_ as CqlQuantity) as object;
-                }
-                else if (bt_())
-                {
-                    object cm_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                    object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                    return (cn_ as CqlInterval<CqlQuantity>) as object;
+                    object cl_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                    return (cm_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -901,60 +894,59 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 };
             }
 
-            CqlInterval<CqlDateTime> bn_ = QICoreCommon_4_0_000.Instance.toInterval(context, bm_());
-            CqlDateTime bo_ = context.Operators.Start(bn_);
-            CqlDate bp_ = context.Operators.DateFrom(bo_);
-            return bp_;
+            CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_());
+            CqlDateTime bn_ = context.Operators.Start(bm_);
+            CqlDate bo_ = context.Operators.DateFrom(bn_);
+            return bo_;
         }
 
         IEnumerable<CqlDate> e_ = context.Operators.Select<object, CqlDate>(c_, d_);
 
-        IEnumerable<object> g_(object PsychosocialVisitEncounter) {
-            Encounter co_ = this.First_SUD_Episode_During_Measurement_Period(context);
-            Encounter[] cp_ = [
-                co_,
+        bool? g_(object PsychosocialVisitEncounter) {
+            Encounter cn_ = this.First_SUD_Episode_During_Measurement_Period(context);
+            Encounter[] co_ = [
+                cn_,
             ];
 
-            bool? cq_(Encounter FirstSUDEpisode) {
-                object cu_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "period");
-                CqlInterval<CqlDateTime> cv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cu_ as Period);
-                CqlDateTime cw_ = context.Operators.Start(cv_);
-                CqlDate cx_ = context.Operators.DateFrom(cw_);
-                Period cy_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> cz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cy_);
-                CqlDateTime da_ = context.Operators.Start(cz_);
-                CqlDate db_ = context.Operators.DateFrom(da_);
-                CqlInterval<CqlDateTime> dd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cy_);
-                CqlDateTime de_ = context.Operators.Start(dd_);
-                CqlDate df_ = context.Operators.DateFrom(de_);
-                CqlQuantity dg_ = context.Operators.Quantity(14m, "days");
-                CqlDate dh_ = context.Operators.Add(df_, dg_);
-                CqlInterval<CqlDate> di_ = context.Operators.Interval(db_, dh_, true, false);
-                bool? dj_ = context.Operators.In<CqlDate>(cx_, di_, (string)default);
-                object dk_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "id");
-                string dl_ = context.Operators.LateBoundProperty<string>(dk_, "value");
-                Id dm_ = FirstSUDEpisode?.IdElement;
-                string dn_ = dm_?.Value;
-                bool? do_ = context.Operators.Equivalent(dl_, dn_);
-                bool? dp_ = context.Operators.Not(do_);
-                bool? dq_ = context.Operators.And(dj_, dp_);
-                return dq_;
+            bool? cp_(Encounter FirstSUDEpisode) {
+                object cs_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "period");
+                CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cs_ as Period);
+                CqlDateTime cu_ = context.Operators.Start(ct_);
+                CqlDate cv_ = context.Operators.DateFrom(cu_);
+                Period cw_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> cx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cw_);
+                CqlDateTime cy_ = context.Operators.Start(cx_);
+                CqlDate cz_ = context.Operators.DateFrom(cy_);
+                CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cw_);
+                CqlDateTime dc_ = context.Operators.Start(db_);
+                CqlDate dd_ = context.Operators.DateFrom(dc_);
+                CqlQuantity de_ = context.Operators.Quantity(14m, "days");
+                CqlDate df_ = context.Operators.Add(dd_, de_);
+                CqlInterval<CqlDate> dg_ = context.Operators.Interval(cz_, df_, true, false);
+                bool? dh_ = context.Operators.In<CqlDate>(cv_, dg_, (string)default);
+                object di_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "id");
+                string dj_ = context.Operators.LateBoundProperty<string>(di_, "value");
+                Id dk_ = FirstSUDEpisode?.IdElement;
+                string dl_ = dk_?.Value;
+                bool? dm_ = context.Operators.Equivalent(dj_, dl_);
+                bool? dn_ = context.Operators.Not(dm_);
+                bool? do_ = context.Operators.And(dh_, dn_);
+                return do_;
             }
 
-            IEnumerable<Encounter> cr_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)cp_, cq_);
-            object cs_(Encounter FirstSUDEpisode) => PsychosocialVisitEncounter;
-            IEnumerable<object> ct_ = context.Operators.Select<Encounter, object>(cr_, cs_);
-            return ct_;
+            IEnumerable<Encounter> cq_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)co_, cp_);
+            bool? cr_ = context.Operators.Exists<Encounter>(cq_);
+            return cr_;
         }
 
-        IEnumerable<object> h_ = context.Operators.SelectMany<object, object>(a_, g_);
+        IEnumerable<object> h_ = context.Operators.Where<object>(a_, g_);
 
         CqlDate i_(object PsychosocialVisitEncounter) {
-            object dr_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "period");
-            CqlInterval<CqlDateTime> ds_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dr_ as Period);
-            CqlDateTime dt_ = context.Operators.Start(ds_);
-            CqlDate du_ = context.Operators.DateFrom(dt_);
-            return du_;
+            object dp_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "period");
+            CqlInterval<CqlDateTime> dq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dp_ as Period);
+            CqlDateTime dr_ = context.Operators.Start(dq_);
+            CqlDate ds_ = context.Operators.DateFrom(dr_);
+            return ds_;
         }
 
         IEnumerable<CqlDate> j_ = context.Operators.Select<object, CqlDate>(h_, i_);
@@ -975,103 +967,100 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> ad_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? ae_(Medication M) {
-                object ai_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object aj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ak_ = context.Operators.Split((string)aj_, "/");
-                string al_ = context.Operators.Last<string>(ak_);
-                bool? am_ = context.Operators.Equal(ai_, al_);
-                CodeableConcept an_ = M?.Code;
-                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, an_);
-                CqlValueSet ap_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
-                bool? aq_ = context.Operators.ConceptInValueSet(ao_, ap_);
-                bool? ar_ = context.Operators.And(am_, aq_);
-                return ar_;
+                object ah_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ai_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> aj_ = context.Operators.Split((string)ai_, "/");
+                string ak_ = context.Operators.Last<string>(aj_);
+                bool? al_ = context.Operators.Equal(ah_, ak_);
+                CodeableConcept am_ = M?.Code;
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
+                CqlValueSet ao_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
+                bool? ap_ = context.Operators.ConceptInValueSet(an_, ao_);
+                bool? aq_ = context.Operators.And(al_, ap_);
+                return aq_;
             }
 
             IEnumerable<Medication> af_ = context.Operators.Where<Medication>(ad_, ae_);
-            MedicationRequest ag_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ah_ = context.Operators.Select<Medication, MedicationRequest>(af_, ag_);
-            return ah_;
+            bool? ag_ = context.Operators.Exists<Medication>(af_);
+            return ag_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         CqlValueSet g_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
         IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> j_(MedicationRequest MR) {
-            IEnumerable<Medication> as_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? j_(MedicationRequest MR) {
+            IEnumerable<Medication> ar_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? at_(Medication M) {
-                object ax_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ay_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> az_ = context.Operators.Split((string)ay_, "/");
-                string ba_ = context.Operators.Last<string>(az_);
-                bool? bb_ = context.Operators.Equal(ax_, ba_);
-                CodeableConcept bc_ = M?.Code;
-                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_);
-                CqlValueSet be_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
-                bool? bf_ = context.Operators.ConceptInValueSet(bd_, be_);
-                bool? bg_ = context.Operators.And(bb_, bf_);
-                return bg_;
+            bool? as_(Medication M) {
+                object av_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object aw_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ax_ = context.Operators.Split((string)aw_, "/");
+                string ay_ = context.Operators.Last<string>(ax_);
+                bool? az_ = context.Operators.Equal(av_, ay_);
+                CodeableConcept ba_ = M?.Code;
+                CqlConcept bb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ba_);
+                CqlValueSet bc_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
+                bool? bd_ = context.Operators.ConceptInValueSet(bb_, bc_);
+                bool? be_ = context.Operators.And(az_, bd_);
+                return be_;
             }
 
-            IEnumerable<Medication> au_ = context.Operators.Where<Medication>(as_, at_);
-            MedicationRequest av_(Medication M) => MR;
-            IEnumerable<MedicationRequest> aw_ = context.Operators.Select<Medication, MedicationRequest>(au_, av_);
-            return aw_;
+            IEnumerable<Medication> at_ = context.Operators.Where<Medication>(ar_, as_);
+            bool? au_ = context.Operators.Exists<Medication>(at_);
+            return au_;
         }
 
-        IEnumerable<MedicationRequest> k_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, j_);
+        IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(c_, j_);
         IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(h_, k_);
         IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(f_, l_);
         IEnumerable<MedicationRequest> n_ = Status_1_15_000.Instance.isMedicationOrder(context, m_);
 
-        IEnumerable<MedicationRequest> o_(MedicationRequest SUDMedication) {
-            Encounter bh_ = this.First_SUD_Episode_During_Measurement_Period(context);
-            Encounter[] bi_ = [
-                bh_,
+        bool? o_(MedicationRequest SUDMedication) {
+            Encounter bf_ = this.First_SUD_Episode_During_Measurement_Period(context);
+            Encounter[] bg_ = [
+                bf_,
             ];
 
-            bool? bj_(Encounter FirstSUDEpisode) {
-                FhirDateTime bn_ = SUDMedication?.AuthoredOnElement;
-                CqlDateTime bo_ = context.Operators.Convert<CqlDateTime>(bn_);
-                CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_ as object);
-                CqlDateTime bq_ = context.Operators.Start(bp_);
-                CqlDate br_ = context.Operators.DateFrom(bq_);
-                Period bs_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
-                CqlDateTime bu_ = context.Operators.Start(bt_);
-                CqlDate bv_ = context.Operators.DateFrom(bu_);
-                CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
-                CqlDateTime by_ = context.Operators.Start(bx_);
-                CqlDate bz_ = context.Operators.DateFrom(by_);
-                CqlQuantity ca_ = context.Operators.Quantity(14m, "days");
-                CqlDate cb_ = context.Operators.Add(bz_, ca_);
-                CqlInterval<CqlDate> cc_ = context.Operators.Interval(bv_, cb_, true, false);
-                bool? cd_ = context.Operators.In<CqlDate>(br_, cc_, (string)default);
-                return cd_;
+            bool? bh_(Encounter FirstSUDEpisode) {
+                FhirDateTime bk_ = SUDMedication?.AuthoredOnElement;
+                CqlDateTime bl_ = context.Operators.Convert<CqlDateTime>(bk_);
+                CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_ as object);
+                CqlDateTime bn_ = context.Operators.Start(bm_);
+                CqlDate bo_ = context.Operators.DateFrom(bn_);
+                Period bp_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bp_);
+                CqlDateTime br_ = context.Operators.Start(bq_);
+                CqlDate bs_ = context.Operators.DateFrom(br_);
+                CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bp_);
+                CqlDateTime bv_ = context.Operators.Start(bu_);
+                CqlDate bw_ = context.Operators.DateFrom(bv_);
+                CqlQuantity bx_ = context.Operators.Quantity(14m, "days");
+                CqlDate by_ = context.Operators.Add(bw_, bx_);
+                CqlInterval<CqlDate> bz_ = context.Operators.Interval(bs_, by_, true, false);
+                bool? ca_ = context.Operators.In<CqlDate>(bo_, bz_, (string)default);
+                return ca_;
             }
 
-            IEnumerable<Encounter> bk_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)bi_, bj_);
-            MedicationRequest bl_(Encounter FirstSUDEpisode) => SUDMedication;
-            IEnumerable<MedicationRequest> bm_ = context.Operators.Select<Encounter, MedicationRequest>(bk_, bl_);
-            return bm_;
+            IEnumerable<Encounter> bi_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)bg_, bh_);
+            bool? bj_ = context.Operators.Exists<Encounter>(bi_);
+            return bj_;
         }
 
-        IEnumerable<MedicationRequest> p_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(n_, o_);
+        IEnumerable<MedicationRequest> p_ = context.Operators.Where<MedicationRequest>(n_, o_);
 
         CqlDate q_(MedicationRequest SUDMedication) {
-            FhirDateTime ce_ = SUDMedication?.AuthoredOnElement;
-            CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-            CqlInterval<CqlDateTime> cg_ = QICoreCommon_4_0_000.Instance.toInterval(context, cf_ as object);
-            CqlDateTime ch_ = context.Operators.Start(cg_);
-            CqlDate ci_ = context.Operators.DateFrom(ch_);
-            return ci_;
+            FhirDateTime cb_ = SUDMedication?.AuthoredOnElement;
+            CqlDateTime cc_ = context.Operators.Convert<CqlDateTime>(cb_);
+            CqlInterval<CqlDateTime> cd_ = QICoreCommon_4_0_000.Instance.toInterval(context, cc_ as object);
+            CqlDateTime ce_ = context.Operators.Start(cd_);
+            CqlDate cf_ = context.Operators.DateFrom(ce_);
+            return cf_;
         }
 
         IEnumerable<CqlDate> r_ = context.Operators.Select<MedicationRequest, CqlDate>(p_, q_);
@@ -1082,70 +1071,70 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<Procedure> w_ = context.Operators.Union<Procedure>(t_, v_);
         IEnumerable<Procedure> x_ = Status_1_15_000.Instance.isProcedurePerformed(context, w_);
 
-        IEnumerable<Procedure> y_(Procedure SUDMedAdministration) {
-            Encounter cj_ = this.First_SUD_Episode_During_Measurement_Period(context);
-            Encounter[] ck_ = [
-                cj_,
+        bool? y_(Procedure SUDMedAdministration) {
+            Encounter cg_ = this.First_SUD_Episode_During_Measurement_Period(context);
+            Encounter[] ch_ = [
+                cg_,
             ];
 
-            bool? cl_(Encounter FirstSUDEpisode) {
+            bool? ci_(Encounter FirstSUDEpisode) {
 
-                object cp_() {
+                object cl_() {
 
-                    bool df_() {
-                        DataType dj_ = SUDMedAdministration?.Performed;
-                        object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
-                        bool dl_ = dk_ is CqlDateTime;
-                        return dl_;
+                    bool db_() {
+                        DataType df_ = SUDMedAdministration?.Performed;
+                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                        bool dh_ = dg_ is CqlDateTime;
+                        return dh_;
                     }
 
 
-                    bool dg_() {
-                        DataType dm_ = SUDMedAdministration?.Performed;
-                        object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
-                        bool do_ = dn_ is CqlInterval<CqlDateTime>;
-                        return do_;
+                    bool dc_() {
+                        DataType di_ = SUDMedAdministration?.Performed;
+                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+                        bool dk_ = dj_ is CqlInterval<CqlDateTime>;
+                        return dk_;
                     }
 
 
-                    bool dh_() {
-                        DataType dp_ = SUDMedAdministration?.Performed;
-                        object dq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dp_);
-                        bool dr_ = dq_ is CqlQuantity;
-                        return dr_;
+                    bool dd_() {
+                        DataType dl_ = SUDMedAdministration?.Performed;
+                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+                        bool dn_ = dm_ is CqlQuantity;
+                        return dn_;
                     }
 
 
-                    bool di_() {
-                        DataType ds_ = SUDMedAdministration?.Performed;
-                        object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
-                        bool du_ = dt_ is CqlInterval<CqlQuantity>;
-                        return du_;
+                    bool de_() {
+                        DataType do_ = SUDMedAdministration?.Performed;
+                        object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
+                        bool dq_ = dp_ is CqlInterval<CqlQuantity>;
+                        return dq_;
                     }
 
-                    if (df_())
+                    if (db_())
+                    {
+                        DataType dr_ = SUDMedAdministration?.Performed;
+                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                        return (ds_ as CqlDateTime) as object;
+                    }
+                    else if (dc_())
+                    {
+                        DataType dt_ = SUDMedAdministration?.Performed;
+                        object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                        return (du_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (dd_())
                     {
                         DataType dv_ = SUDMedAdministration?.Performed;
                         object dw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dv_);
-                        return (dw_ as CqlDateTime) as object;
+                        return (dw_ as CqlQuantity) as object;
                     }
-                    else if (dg_())
+                    else if (de_())
                     {
                         DataType dx_ = SUDMedAdministration?.Performed;
                         object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
-                        return (dy_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (dh_())
-                    {
-                        DataType dz_ = SUDMedAdministration?.Performed;
-                        object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
-                        return (ea_ as CqlQuantity) as object;
-                    }
-                    else if (di_())
-                    {
-                        DataType eb_ = SUDMedAdministration?.Performed;
-                        object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
-                        return (ec_ as CqlInterval<CqlQuantity>) as object;
+                        return (dy_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1153,89 +1142,88 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     };
                 }
 
-                CqlInterval<CqlDateTime> cq_ = QICoreCommon_4_0_000.Instance.toInterval(context, cp_());
+                CqlInterval<CqlDateTime> cm_ = QICoreCommon_4_0_000.Instance.toInterval(context, cl_());
+                CqlDateTime cn_ = context.Operators.Start(cm_);
+                CqlDate co_ = context.Operators.DateFrom(cn_);
+                Period cp_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
                 CqlDateTime cr_ = context.Operators.Start(cq_);
                 CqlDate cs_ = context.Operators.DateFrom(cr_);
-                Period ct_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
+                CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
                 CqlDateTime cv_ = context.Operators.Start(cu_);
                 CqlDate cw_ = context.Operators.DateFrom(cv_);
-                CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
-                CqlDateTime cz_ = context.Operators.Start(cy_);
-                CqlDate da_ = context.Operators.DateFrom(cz_);
-                CqlQuantity db_ = context.Operators.Quantity(14m, "days");
-                CqlDate dc_ = context.Operators.Add(da_, db_);
-                CqlInterval<CqlDate> dd_ = context.Operators.Interval(cw_, dc_, true, false);
-                bool? de_ = context.Operators.In<CqlDate>(cs_, dd_, (string)default);
-                return de_;
+                CqlQuantity cx_ = context.Operators.Quantity(14m, "days");
+                CqlDate cy_ = context.Operators.Add(cw_, cx_);
+                CqlInterval<CqlDate> cz_ = context.Operators.Interval(cs_, cy_, true, false);
+                bool? da_ = context.Operators.In<CqlDate>(co_, cz_, (string)default);
+                return da_;
             }
 
-            IEnumerable<Encounter> cm_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)ck_, cl_);
-            Procedure cn_(Encounter FirstSUDEpisode) => SUDMedAdministration;
-            IEnumerable<Procedure> co_ = context.Operators.Select<Encounter, Procedure>(cm_, cn_);
-            return co_;
+            IEnumerable<Encounter> cj_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)ch_, ci_);
+            bool? ck_ = context.Operators.Exists<Encounter>(cj_);
+            return ck_;
         }
 
-        IEnumerable<Procedure> z_ = context.Operators.SelectMany<Procedure, Procedure>(x_, y_);
+        IEnumerable<Procedure> z_ = context.Operators.Where<Procedure>(x_, y_);
 
         CqlDate aa_(Procedure SUDMedAdministration) {
 
-            object ed_() {
+            object dz_() {
 
-                bool eh_() {
-                    DataType el_ = SUDMedAdministration?.Performed;
-                    object em_ = FHIRHelpers_4_4_000.Instance.ToValue(context, el_);
-                    bool en_ = em_ is CqlDateTime;
-                    return en_;
+                bool ed_() {
+                    DataType eh_ = SUDMedAdministration?.Performed;
+                    object ei_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eh_);
+                    bool ej_ = ei_ is CqlDateTime;
+                    return ej_;
                 }
 
 
-                bool ei_() {
-                    DataType eo_ = SUDMedAdministration?.Performed;
-                    object ep_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eo_);
-                    bool eq_ = ep_ is CqlInterval<CqlDateTime>;
-                    return eq_;
+                bool ee_() {
+                    DataType ek_ = SUDMedAdministration?.Performed;
+                    object el_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ek_);
+                    bool em_ = el_ is CqlInterval<CqlDateTime>;
+                    return em_;
                 }
 
 
-                bool ej_() {
-                    DataType er_ = SUDMedAdministration?.Performed;
-                    object es_ = FHIRHelpers_4_4_000.Instance.ToValue(context, er_);
-                    bool et_ = es_ is CqlQuantity;
-                    return et_;
+                bool ef_() {
+                    DataType en_ = SUDMedAdministration?.Performed;
+                    object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
+                    bool ep_ = eo_ is CqlQuantity;
+                    return ep_;
                 }
 
 
-                bool ek_() {
-                    DataType eu_ = SUDMedAdministration?.Performed;
-                    object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
-                    bool ew_ = ev_ is CqlInterval<CqlQuantity>;
-                    return ew_;
+                bool eg_() {
+                    DataType eq_ = SUDMedAdministration?.Performed;
+                    object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+                    bool es_ = er_ is CqlInterval<CqlQuantity>;
+                    return es_;
                 }
 
-                if (eh_())
+                if (ed_())
+                {
+                    DataType et_ = SUDMedAdministration?.Performed;
+                    object eu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, et_);
+                    return (eu_ as CqlDateTime) as object;
+                }
+                else if (ee_())
+                {
+                    DataType ev_ = SUDMedAdministration?.Performed;
+                    object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
+                    return (ew_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ef_())
                 {
                     DataType ex_ = SUDMedAdministration?.Performed;
                     object ey_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ex_);
-                    return (ey_ as CqlDateTime) as object;
+                    return (ey_ as CqlQuantity) as object;
                 }
-                else if (ei_())
+                else if (eg_())
                 {
                     DataType ez_ = SUDMedAdministration?.Performed;
                     object fa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ez_);
-                    return (fa_ as CqlInterval<CqlDateTime>) as object;
-                }
-                else if (ej_())
-                {
-                    DataType fb_ = SUDMedAdministration?.Performed;
-                    object fc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fb_);
-                    return (fc_ as CqlQuantity) as object;
-                }
-                else if (ek_())
-                {
-                    DataType fd_ = SUDMedAdministration?.Performed;
-                    object fe_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fd_);
-                    return (fe_ as CqlInterval<CqlQuantity>) as object;
+                    return (fa_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -1243,10 +1231,10 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 };
             }
 
-            CqlInterval<CqlDateTime> ee_ = QICoreCommon_4_0_000.Instance.toInterval(context, ed_());
-            CqlDateTime ef_ = context.Operators.Start(ee_);
-            CqlDate eg_ = context.Operators.DateFrom(ef_);
-            return eg_;
+            CqlInterval<CqlDateTime> ea_ = QICoreCommon_4_0_000.Instance.toInterval(context, dz_());
+            CqlDateTime eb_ = context.Operators.Start(ea_);
+            CqlDate ec_ = context.Operators.DateFrom(eb_);
+            return ec_;
         }
 
         IEnumerable<CqlDate> ab_ = context.Operators.Select<Procedure, CqlDate>(z_, aa_);
@@ -1286,7 +1274,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<Procedure> d_ = Status_1_15_000.Instance.isProcedurePerformed(context, c_);
         IEnumerable<object> e_ = context.Operators.Union<object>(a_ as IEnumerable<object>, d_ as IEnumerable<object>);
 
-        IEnumerable<object> f_(object ShortActingTreatment) {
+        bool? f_(object ShortActingTreatment) {
             IEnumerable<CqlDate> x_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
             IEnumerable<CqlDate> y_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
             IEnumerable<CqlDate> z_ = context.Operators.Union<CqlDate>(x_, y_);
@@ -1297,62 +1285,62 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
 
             bool? ac_(CqlDate InitiationTreatmentDate) {
 
-                object ag_() {
+                object af_() {
+
+                    bool ba_() {
+                        object be_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+                        bool bg_ = bf_ is CqlDateTime;
+                        return bg_;
+                    }
+
 
                     bool bb_() {
-                        object bf_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                        bool bh_ = bg_ is CqlDateTime;
-                        return bh_;
+                        object bh_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        bool bj_ = bi_ is CqlInterval<CqlDateTime>;
+                        return bj_;
                     }
 
 
                     bool bc_() {
-                        object bi_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        bool bk_ = bj_ is CqlInterval<CqlDateTime>;
-                        return bk_;
+                        object bk_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        bool bm_ = bl_ is CqlQuantity;
+                        return bm_;
                     }
 
 
                     bool bd_() {
-                        object bl_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        bool bn_ = bm_ is CqlQuantity;
-                        return bn_;
+                        object bn_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                        bool bp_ = bo_ is CqlInterval<CqlQuantity>;
+                        return bp_;
                     }
 
-
-                    bool be_() {
-                        object bo_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
-                        bool bq_ = bp_ is CqlInterval<CqlQuantity>;
-                        return bq_;
-                    }
-
-                    if (bb_())
+                    if (ba_())
                     {
-                        object br_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
-                        return (bs_ as CqlDateTime) as object;
+                        object bq_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                        return (br_ as CqlDateTime) as object;
+                    }
+                    else if (bb_())
+                    {
+                        object bs_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                        return (bt_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bc_())
                     {
-                        object bt_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        return (bu_ as CqlInterval<CqlDateTime>) as object;
+                        object bu_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                        return (bv_ as CqlQuantity) as object;
                     }
                     else if (bd_())
                     {
-                        object bv_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        return (bw_ as CqlQuantity) as object;
-                    }
-                    else if (be_())
-                    {
-                        object bx_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                        return (by_ as CqlInterval<CqlQuantity>) as object;
+                        object bw_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+                        return (bx_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1360,98 +1348,95 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     };
                 }
 
-                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_());
-                CqlDateTime ai_ = context.Operators.Start(ah_);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(34m, "days");
-                CqlDate al_ = context.Operators.Add(InitiationTreatmentDate, ak_);
-                CqlInterval<CqlDate> am_ = context.Operators.Interval(InitiationTreatmentDate, al_, false, true);
-                bool? an_ = context.Operators.In<CqlDate>(aj_, am_, (string)default);
-                bool? ao_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
-                bool? ap_ = context.Operators.And(an_, ao_);
-                object aq_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "period");
-                CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aq_ as Period);
-                CqlDateTime as_ = context.Operators.Start(ar_);
-                CqlDate at_ = context.Operators.DateFrom(as_);
-                CqlDate av_ = context.Operators.Add(InitiationTreatmentDate, ak_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitiationTreatmentDate, av_, false, true);
-                bool? ax_ = context.Operators.In<CqlDate>(at_, aw_, (string)default);
-                bool? az_ = context.Operators.And(ax_, ao_);
-                bool? ba_ = context.Operators.Or(ap_, az_);
-                return ba_;
+                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_());
+                CqlDateTime ah_ = context.Operators.Start(ag_);
+                CqlDate ai_ = context.Operators.DateFrom(ah_);
+                CqlQuantity aj_ = context.Operators.Quantity(34m, "days");
+                CqlDate ak_ = context.Operators.Add(InitiationTreatmentDate, aj_);
+                CqlInterval<CqlDate> al_ = context.Operators.Interval(InitiationTreatmentDate, ak_, false, true);
+                bool? am_ = context.Operators.In<CqlDate>(ai_, al_, (string)default);
+                bool? an_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
+                bool? ao_ = context.Operators.And(am_, an_);
+                object ap_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "period");
+                CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_ as Period);
+                CqlDateTime ar_ = context.Operators.Start(aq_);
+                CqlDate as_ = context.Operators.DateFrom(ar_);
+                CqlDate au_ = context.Operators.Add(InitiationTreatmentDate, aj_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitiationTreatmentDate, au_, false, true);
+                bool? aw_ = context.Operators.In<CqlDate>(as_, av_, (string)default);
+                bool? ay_ = context.Operators.And(aw_, an_);
+                bool? az_ = context.Operators.Or(ao_, ay_);
+                return az_;
             }
 
             IEnumerable<CqlDate> ad_ = context.Operators.Where<CqlDate>((IEnumerable<CqlDate>)ab_, ac_);
-            object ae_(CqlDate InitiationTreatmentDate) => ShortActingTreatment;
-            IEnumerable<object> af_ = context.Operators.Select<CqlDate, object>(ad_, ae_);
-            return af_;
+            bool? ae_ = context.Operators.Exists<CqlDate>(ad_);
+            return ae_;
         }
 
-        IEnumerable<object> g_ = context.Operators.SelectMany<object, object>(e_, f_);
+        IEnumerable<object> g_ = context.Operators.Where<object>(e_, f_);
         object h_(object ShortActingTreatment) => ShortActingTreatment;
         IEnumerable<object> i_ = context.Operators.Select<object, object>(g_, h_);
         CqlValueSet j_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
         IEnumerable<MedicationRequest> k_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, j_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> l_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> m_(MedicationRequest MR) {
-            IEnumerable<Medication> bz_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? m_(MedicationRequest MR) {
+            IEnumerable<Medication> by_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ca_(Medication M) {
-                object ce_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object cf_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> cg_ = context.Operators.Split((string)cf_, "/");
-                string ch_ = context.Operators.Last<string>(cg_);
-                bool? ci_ = context.Operators.Equal(ce_, ch_);
-                CodeableConcept cj_ = M?.Code;
-                CqlConcept ck_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cj_);
-                CqlValueSet cl_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
-                bool? cm_ = context.Operators.ConceptInValueSet(ck_, cl_);
-                bool? cn_ = context.Operators.And(ci_, cm_);
-                return cn_;
+            bool? bz_(Medication M) {
+                object cc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ce_ = context.Operators.Split((string)cd_, "/");
+                string cf_ = context.Operators.Last<string>(ce_);
+                bool? cg_ = context.Operators.Equal(cc_, cf_);
+                CodeableConcept ch_ = M?.Code;
+                CqlConcept ci_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ch_);
+                CqlValueSet cj_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
+                bool? ck_ = context.Operators.ConceptInValueSet(ci_, cj_);
+                bool? cl_ = context.Operators.And(cg_, ck_);
+                return cl_;
             }
 
-            IEnumerable<Medication> cb_ = context.Operators.Where<Medication>(bz_, ca_);
-            MedicationRequest cc_(Medication M) => MR;
-            IEnumerable<MedicationRequest> cd_ = context.Operators.Select<Medication, MedicationRequest>(cb_, cc_);
-            return cd_;
+            IEnumerable<Medication> ca_ = context.Operators.Where<Medication>(by_, bz_);
+            bool? cb_ = context.Operators.Exists<Medication>(ca_);
+            return cb_;
         }
 
-        IEnumerable<MedicationRequest> n_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(l_, m_);
+        IEnumerable<MedicationRequest> n_ = context.Operators.Where<MedicationRequest>(l_, m_);
         IEnumerable<MedicationRequest> o_ = context.Operators.Union<MedicationRequest>(k_, n_);
         IEnumerable<MedicationRequest> p_ = Status_1_15_000.Instance.isMedicationOrder(context, o_);
 
-        IEnumerable<MedicationRequest> q_(MedicationRequest ShortActingMedOrder) {
-            IEnumerable<CqlDate> co_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
-            IEnumerable<CqlDate> cp_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
-            IEnumerable<CqlDate> cq_ = context.Operators.Union<CqlDate>(co_, cp_);
-            CqlDate cr_ = context.Operators.Min<CqlDate>(cq_);
-            CqlDate[] cs_ = [
-                cr_,
+        bool? q_(MedicationRequest ShortActingMedOrder) {
+            IEnumerable<CqlDate> cm_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
+            IEnumerable<CqlDate> cn_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
+            IEnumerable<CqlDate> co_ = context.Operators.Union<CqlDate>(cm_, cn_);
+            CqlDate cp_ = context.Operators.Min<CqlDate>(co_);
+            CqlDate[] cq_ = [
+                cp_,
             ];
 
-            bool? ct_(CqlDate InitiationTreatmentDate) {
-                FhirDateTime cx_ = ShortActingMedOrder?.AuthoredOnElement;
-                CqlDateTime cy_ = context.Operators.Convert<CqlDateTime>(cx_);
-                CqlInterval<CqlDateTime> cz_ = QICoreCommon_4_0_000.Instance.toInterval(context, cy_ as object);
-                CqlDateTime da_ = context.Operators.Start(cz_);
-                CqlDate db_ = context.Operators.DateFrom(da_);
-                CqlQuantity dc_ = context.Operators.Quantity(34m, "days");
-                CqlDate dd_ = context.Operators.Add(InitiationTreatmentDate, dc_);
-                CqlInterval<CqlDate> de_ = context.Operators.Interval(InitiationTreatmentDate, dd_, false, true);
-                bool? df_ = context.Operators.In<CqlDate>(db_, de_, (string)default);
-                bool? dg_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
-                bool? dh_ = context.Operators.And(df_, dg_);
-                return dh_;
+            bool? cr_(CqlDate InitiationTreatmentDate) {
+                FhirDateTime cu_ = ShortActingMedOrder?.AuthoredOnElement;
+                CqlDateTime cv_ = context.Operators.Convert<CqlDateTime>(cu_);
+                CqlInterval<CqlDateTime> cw_ = QICoreCommon_4_0_000.Instance.toInterval(context, cv_ as object);
+                CqlDateTime cx_ = context.Operators.Start(cw_);
+                CqlDate cy_ = context.Operators.DateFrom(cx_);
+                CqlQuantity cz_ = context.Operators.Quantity(34m, "days");
+                CqlDate da_ = context.Operators.Add(InitiationTreatmentDate, cz_);
+                CqlInterval<CqlDate> db_ = context.Operators.Interval(InitiationTreatmentDate, da_, false, true);
+                bool? dc_ = context.Operators.In<CqlDate>(cy_, db_, (string)default);
+                bool? dd_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
+                bool? de_ = context.Operators.And(dc_, dd_);
+                return de_;
             }
 
-            IEnumerable<CqlDate> cu_ = context.Operators.Where<CqlDate>((IEnumerable<CqlDate>)cs_, ct_);
-            MedicationRequest cv_(CqlDate InitiationTreatmentDate) => ShortActingMedOrder;
-            IEnumerable<MedicationRequest> cw_ = context.Operators.Select<CqlDate, MedicationRequest>(cu_, cv_);
-            return cw_;
+            IEnumerable<CqlDate> cs_ = context.Operators.Where<CqlDate>((IEnumerable<CqlDate>)cq_, cr_);
+            bool? ct_ = context.Operators.Exists<CqlDate>(cs_);
+            return ct_;
         }
 
-        IEnumerable<MedicationRequest> r_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(p_, q_);
+        IEnumerable<MedicationRequest> r_ = context.Operators.Where<MedicationRequest>(p_, q_);
         MedicationRequest s_(MedicationRequest ShortActingMedOrder) => ShortActingMedOrder;
         IEnumerable<MedicationRequest> t_ = context.Operators.Select<MedicationRequest, MedicationRequest>(r_, s_);
         IEnumerable<object> u_ = context.Operators.Union<object>(i_ as IEnumerable<object>, t_ as IEnumerable<object>);
@@ -1473,135 +1458,133 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> q_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? r_(Medication M) {
-                object v_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object w_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> x_ = context.Operators.Split((string)w_, "/");
-                string y_ = context.Operators.Last<string>(x_);
-                bool? z_ = context.Operators.Equal(v_, y_);
-                CodeableConcept aa_ = M?.Code;
-                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
-                CqlValueSet ac_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
-                bool? ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
-                bool? ae_ = context.Operators.And(z_, ad_);
-                return ae_;
+                object u_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object v_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> w_ = context.Operators.Split((string)v_, "/");
+                string x_ = context.Operators.Last<string>(w_);
+                bool? y_ = context.Operators.Equal(u_, x_);
+                CodeableConcept z_ = M?.Code;
+                CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
+                CqlValueSet ab_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
+                bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+                bool? ad_ = context.Operators.And(y_, ac_);
+                return ad_;
             }
 
             IEnumerable<Medication> s_ = context.Operators.Where<Medication>(q_, r_);
-            MedicationRequest t_(Medication M) => MR;
-            IEnumerable<MedicationRequest> u_ = context.Operators.Select<Medication, MedicationRequest>(s_, t_);
-            return u_;
+            bool? t_ = context.Operators.Exists<Medication>(s_);
+            return t_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationOrder(context, f_);
 
-        IEnumerable<MedicationRequest> h_(MedicationRequest LongActingMedOrder) {
-            IEnumerable<CqlDate> af_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
-            IEnumerable<CqlDate> ag_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
-            IEnumerable<CqlDate> ah_ = context.Operators.Union<CqlDate>(af_, ag_);
-            CqlDate ai_ = context.Operators.Min<CqlDate>(ah_);
-            CqlDate[] aj_ = [
-                ai_,
+        bool? h_(MedicationRequest LongActingMedOrder) {
+            IEnumerable<CqlDate> ae_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
+            IEnumerable<CqlDate> af_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
+            IEnumerable<CqlDate> ag_ = context.Operators.Union<CqlDate>(ae_, af_);
+            CqlDate ah_ = context.Operators.Min<CqlDate>(ag_);
+            CqlDate[] ai_ = [
+                ah_,
             ];
 
-            bool? ak_(CqlDate InitiationTreatmentDate) {
-                FhirDateTime ao_ = LongActingMedOrder?.AuthoredOnElement;
-                CqlDateTime ap_ = context.Operators.Convert<CqlDateTime>(ao_);
-                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_ as object);
-                CqlDateTime ar_ = context.Operators.Start(aq_);
-                CqlDate as_ = context.Operators.DateFrom(ar_);
-                CqlQuantity at_ = context.Operators.Quantity(34m, "days");
-                CqlDate au_ = context.Operators.Add(InitiationTreatmentDate, at_);
-                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitiationTreatmentDate, au_, false, true);
-                bool? aw_ = context.Operators.In<CqlDate>(as_, av_, (string)default);
-                bool? ax_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
-                bool? ay_ = context.Operators.And(aw_, ax_);
-                return ay_;
+            bool? aj_(CqlDate InitiationTreatmentDate) {
+                FhirDateTime am_ = LongActingMedOrder?.AuthoredOnElement;
+                CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(am_);
+                CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_ as object);
+                CqlDateTime ap_ = context.Operators.Start(ao_);
+                CqlDate aq_ = context.Operators.DateFrom(ap_);
+                CqlQuantity ar_ = context.Operators.Quantity(34m, "days");
+                CqlDate as_ = context.Operators.Add(InitiationTreatmentDate, ar_);
+                CqlInterval<CqlDate> at_ = context.Operators.Interval(InitiationTreatmentDate, as_, false, true);
+                bool? au_ = context.Operators.In<CqlDate>(aq_, at_, (string)default);
+                bool? av_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
+                bool? aw_ = context.Operators.And(au_, av_);
+                return aw_;
             }
 
-            IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>((IEnumerable<CqlDate>)aj_, ak_);
-            MedicationRequest am_(CqlDate InitiationTreatmentDate) => LongActingMedOrder;
-            IEnumerable<MedicationRequest> an_ = context.Operators.Select<CqlDate, MedicationRequest>(al_, am_);
-            return an_;
+            IEnumerable<CqlDate> ak_ = context.Operators.Where<CqlDate>((IEnumerable<CqlDate>)ai_, aj_);
+            bool? al_ = context.Operators.Exists<CqlDate>(ak_);
+            return al_;
         }
 
-        IEnumerable<MedicationRequest> i_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(g_, h_);
+        IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
         CqlValueSet j_ = this.Substance_Use_Disorder_Long_Acting_Medication_Administration(context);
         IEnumerable<Procedure> k_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, j_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
         IEnumerable<Procedure> l_ = Status_1_15_000.Instance.isProcedurePerformed(context, k_);
 
-        IEnumerable<Procedure> m_(Procedure LongActingTreatment) {
-            IEnumerable<CqlDate> az_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
-            IEnumerable<CqlDate> ba_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
-            IEnumerable<CqlDate> bb_ = context.Operators.Union<CqlDate>(az_, ba_);
-            CqlDate bc_ = context.Operators.Min<CqlDate>(bb_);
-            CqlDate[] bd_ = [
-                bc_,
+        bool? m_(Procedure LongActingTreatment) {
+            IEnumerable<CqlDate> ax_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
+            IEnumerable<CqlDate> ay_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
+            IEnumerable<CqlDate> az_ = context.Operators.Union<CqlDate>(ax_, ay_);
+            CqlDate ba_ = context.Operators.Min<CqlDate>(az_);
+            CqlDate[] bb_ = [
+                ba_,
             ];
 
-            bool? be_(CqlDate InitiationTreatmentDate) {
+            bool? bc_(CqlDate InitiationTreatmentDate) {
 
-                object bi_() {
+                object bf_() {
 
-                    bool bs_() {
+                    bool bp_() {
+                        DataType bt_ = LongActingTreatment?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        bool bv_ = bu_ is CqlDateTime;
+                        return bv_;
+                    }
+
+
+                    bool bq_() {
                         DataType bw_ = LongActingTreatment?.Performed;
                         object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                        bool by_ = bx_ is CqlDateTime;
+                        bool by_ = bx_ is CqlInterval<CqlDateTime>;
                         return by_;
                     }
 
 
-                    bool bt_() {
+                    bool br_() {
                         DataType bz_ = LongActingTreatment?.Performed;
                         object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                        bool cb_ = ca_ is CqlInterval<CqlDateTime>;
+                        bool cb_ = ca_ is CqlQuantity;
                         return cb_;
                     }
 
 
-                    bool bu_() {
+                    bool bs_() {
                         DataType cc_ = LongActingTreatment?.Performed;
                         object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        bool ce_ = cd_ is CqlQuantity;
+                        bool ce_ = cd_ is CqlInterval<CqlQuantity>;
                         return ce_;
                     }
 
-
-                    bool bv_() {
+                    if (bp_())
+                    {
                         DataType cf_ = LongActingTreatment?.Performed;
                         object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                        bool ch_ = cg_ is CqlInterval<CqlQuantity>;
-                        return ch_;
+                        return (cg_ as CqlDateTime) as object;
                     }
-
-                    if (bs_())
+                    else if (bq_())
                     {
-                        DataType ci_ = LongActingTreatment?.Performed;
-                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                        return (cj_ as CqlDateTime) as object;
+                        DataType ch_ = LongActingTreatment?.Performed;
+                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                        return (ci_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (bt_())
+                    else if (br_())
                     {
-                        DataType ck_ = LongActingTreatment?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        return (cl_ as CqlInterval<CqlDateTime>) as object;
+                        DataType cj_ = LongActingTreatment?.Performed;
+                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                        return (ck_ as CqlQuantity) as object;
                     }
-                    else if (bu_())
+                    else if (bs_())
                     {
-                        DataType cm_ = LongActingTreatment?.Performed;
-                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                        return (cn_ as CqlQuantity) as object;
-                    }
-                    else if (bv_())
-                    {
-                        DataType co_ = LongActingTreatment?.Performed;
-                        object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
-                        return (cp_ as CqlInterval<CqlQuantity>) as object;
+                        DataType cl_ = LongActingTreatment?.Performed;
+                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                        return (cm_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1609,25 +1592,24 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     };
                 }
 
-                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_());
-                CqlDateTime bk_ = context.Operators.Start(bj_);
-                CqlDate bl_ = context.Operators.DateFrom(bk_);
-                CqlQuantity bm_ = context.Operators.Quantity(34m, "days");
-                CqlDate bn_ = context.Operators.Add(InitiationTreatmentDate, bm_);
-                CqlInterval<CqlDate> bo_ = context.Operators.Interval(InitiationTreatmentDate, bn_, false, true);
-                bool? bp_ = context.Operators.In<CqlDate>(bl_, bo_, (string)default);
-                bool? bq_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
-                bool? br_ = context.Operators.And(bp_, bq_);
-                return br_;
+                CqlInterval<CqlDateTime> bg_ = QICoreCommon_4_0_000.Instance.toInterval(context, bf_());
+                CqlDateTime bh_ = context.Operators.Start(bg_);
+                CqlDate bi_ = context.Operators.DateFrom(bh_);
+                CqlQuantity bj_ = context.Operators.Quantity(34m, "days");
+                CqlDate bk_ = context.Operators.Add(InitiationTreatmentDate, bj_);
+                CqlInterval<CqlDate> bl_ = context.Operators.Interval(InitiationTreatmentDate, bk_, false, true);
+                bool? bm_ = context.Operators.In<CqlDate>(bi_, bl_, (string)default);
+                bool? bn_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
+                bool? bo_ = context.Operators.And(bm_, bn_);
+                return bo_;
             }
 
-            IEnumerable<CqlDate> bf_ = context.Operators.Where<CqlDate>((IEnumerable<CqlDate>)bd_, be_);
-            Procedure bg_(CqlDate InitiationTreatmentDate) => LongActingTreatment;
-            IEnumerable<Procedure> bh_ = context.Operators.Select<CqlDate, Procedure>(bf_, bg_);
-            return bh_;
+            IEnumerable<CqlDate> bd_ = context.Operators.Where<CqlDate>((IEnumerable<CqlDate>)bb_, bc_);
+            bool? be_ = context.Operators.Exists<CqlDate>(bd_);
+            return be_;
         }
 
-        IEnumerable<Procedure> n_ = context.Operators.SelectMany<Procedure, Procedure>(l_, m_);
+        IEnumerable<Procedure> n_ = context.Operators.Where<Procedure>(l_, m_);
         IEnumerable<object> o_ = context.Operators.Union<object>(i_ as IEnumerable<object>, n_ as IEnumerable<object>);
         bool? p_ = context.Operators.Exists<object>(o_);
         return p_;

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS138FHIRTobaccoScrnCessation-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS138FHIRTobaccoScrnCessation-1.0.000.g.cs
@@ -723,62 +723,61 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> j_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? k_(Medication M) {
-                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
-                string r_ = context.Operators.Last<string>(q_);
-                bool? s_ = context.Operators.Equal(o_, r_);
-                CodeableConcept t_ = M?.Code;
-                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                CqlValueSet v_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
-                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
-                bool? x_ = context.Operators.And(s_, w_);
-                return x_;
+                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
+                string q_ = context.Operators.Last<string>(p_);
+                bool? r_ = context.Operators.Equal(n_, q_);
+                CodeableConcept s_ = M?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                CqlValueSet u_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
+                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+                bool? w_ = context.Operators.And(r_, v_);
+                return w_;
             }
 
             IEnumerable<Medication> l_ = context.Operators.Where<Medication>(j_, k_);
-            MedicationRequest m_(Medication M) => MR;
-            IEnumerable<MedicationRequest> n_ = context.Operators.Select<Medication, MedicationRequest>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Medication>(l_);
+            return m_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationOrder(context, f_);
 
         bool? h_(MedicationRequest CessationPharmacotherapyOrdered) {
-            FhirDateTime y_ = CessationPharmacotherapyOrdered?.AuthoredOnElement;
-            CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
-            CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
-            CqlDateTime ab_ = context.Operators.Start(aa_);
-            CqlQuantity ac_ = context.Operators.Quantity(6m, "months");
-            CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
-            CqlDateTime af_ = context.Operators.End(aa_);
-            CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ad_, af_, true, true);
-            bool? ah_ = context.Operators.In<CqlDateTime>(z_, ag_, "day");
-            IEnumerable<Task> ai_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+            FhirDateTime x_ = CessationPharmacotherapyOrdered?.AuthoredOnElement;
+            CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(x_);
+            CqlInterval<CqlDateTime> z_ = this.Measurement_Period(context);
+            CqlDateTime aa_ = context.Operators.Start(z_);
+            CqlQuantity ab_ = context.Operators.Quantity(6m, "months");
+            CqlDateTime ac_ = context.Operators.Subtract(aa_, ab_);
+            CqlDateTime ae_ = context.Operators.End(z_);
+            CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ac_, ae_, true, true);
+            bool? ag_ = context.Operators.In<CqlDateTime>(y_, af_, "day");
+            IEnumerable<Task> ah_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            bool? aj_(Task TaskReject) {
-                ResourceReference ao_ = TaskReject?.Focus;
-                bool? ap_ = QICoreCommon_4_0_000.Instance.references(context, ao_, CessationPharmacotherapyOrdered);
-                CodeableConcept aq_ = TaskReject?.Code;
-                CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
-                CqlCode as_ = this.fulfill(context);
-                CqlConcept at_ = context.Operators.ConvertCodeToConcept(as_);
-                bool? au_ = context.Operators.Equivalent(ar_, at_);
-                bool? av_ = context.Operators.And(ap_, au_);
-                return av_;
+            bool? ai_(Task TaskReject) {
+                ResourceReference an_ = TaskReject?.Focus;
+                bool? ao_ = QICoreCommon_4_0_000.Instance.references(context, an_, CessationPharmacotherapyOrdered);
+                CodeableConcept ap_ = TaskReject?.Code;
+                CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
+                CqlCode ar_ = this.fulfill(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                bool? at_ = context.Operators.Equivalent(aq_, as_);
+                bool? au_ = context.Operators.And(ao_, at_);
+                return au_;
             }
 
-            IEnumerable<Task> ak_ = context.Operators.Where<Task>(ai_, aj_);
-            bool? al_ = context.Operators.Exists<Task>(ak_);
-            bool? am_ = context.Operators.Not(al_);
-            bool? an_ = context.Operators.And(ah_, am_);
-            return an_;
+            IEnumerable<Task> aj_ = context.Operators.Where<Task>(ah_, ai_);
+            bool? ak_ = context.Operators.Exists<Task>(aj_);
+            bool? al_ = context.Operators.Not(ak_);
+            bool? am_ = context.Operators.And(ag_, al_);
+            return am_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
@@ -798,50 +797,49 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> j_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? k_(Medication M) {
-                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
-                string r_ = context.Operators.Last<string>(q_);
-                bool? s_ = context.Operators.Equal(o_, r_);
-                CodeableConcept t_ = M?.Code;
-                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                CqlValueSet v_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
-                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
-                bool? x_ = context.Operators.And(s_, w_);
-                return x_;
+                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
+                string q_ = context.Operators.Last<string>(p_);
+                bool? r_ = context.Operators.Equal(n_, q_);
+                CodeableConcept s_ = M?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                CqlValueSet u_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
+                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+                bool? w_ = context.Operators.And(r_, v_);
+                return w_;
             }
 
             IEnumerable<Medication> l_ = context.Operators.Where<Medication>(j_, k_);
-            MedicationRequest m_(Medication M) => MR;
-            IEnumerable<MedicationRequest> n_ = context.Operators.Select<Medication, MedicationRequest>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Medication>(l_);
+            return m_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationActive(context, f_);
 
         bool? h_(MedicationRequest TakingCessationPharmacotherapy) {
-            CqlInterval<CqlDateTime> y_ = this.Measurement_Period(context);
-            CqlDateTime z_ = context.Operators.Start(y_);
-            CqlQuantity aa_ = context.Operators.Quantity(6m, "months");
-            CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
-            CqlDateTime ad_ = context.Operators.End(y_);
-            CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ab_, ad_, true, true);
-            CqlInterval<CqlDate> af_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, TakingCessationPharmacotherapy);
-            CqlDate ag_ = af_?.low;
-            CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
-            CqlDate aj_ = af_?.high;
-            CqlDateTime ak_ = context.Operators.ConvertDateToDateTime(aj_);
-            bool? am_ = af_?.lowClosed;
-            bool? ao_ = af_?.highClosed;
-            CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ah_, ak_, am_, ao_);
-            bool? aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ap_, "day");
-            return aq_;
+            CqlInterval<CqlDateTime> x_ = this.Measurement_Period(context);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlQuantity z_ = context.Operators.Quantity(6m, "months");
+            CqlDateTime aa_ = context.Operators.Subtract(y_, z_);
+            CqlDateTime ac_ = context.Operators.End(x_);
+            CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(aa_, ac_, true, true);
+            CqlInterval<CqlDate> ae_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, TakingCessationPharmacotherapy);
+            CqlDate af_ = ae_?.low;
+            CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(af_);
+            CqlDate ai_ = ae_?.high;
+            CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
+            bool? al_ = ae_?.lowClosed;
+            bool? an_ = ae_?.highClosed;
+            CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ag_, aj_, al_, an_);
+            bool? ap_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ad_, ao_, "day");
+            return ap_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
@@ -271,29 +271,28 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter) {
+        bool? b_(Encounter ValidQualifyingEncounter) {
             CqlValueSet d_ = this.Diabetic_Retinopathy(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_ as IEnumerable<Condition>, g_ as IEnumerable<Condition>);
 
             bool? i_(Condition DiabeticRetinopathy) {
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabeticRetinopathy);
-                Period n_ = ValidQualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                bool? p_ = context.Operators.Overlaps(m_, o_, "day");
-                bool? q_ = this.isVerified(context, DiabeticRetinopathy);
-                bool? r_ = context.Operators.And(p_, q_);
-                return r_;
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabeticRetinopathy);
+                Period m_ = ValidQualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                bool? o_ = context.Operators.Overlaps(l_, n_, "day");
+                bool? p_ = this.isVerified(context, DiabeticRetinopathy);
+                bool? q_ = context.Operators.And(o_, p_);
+                return q_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
-            Encounter k_(Condition DiabeticRetinopathy) => ValidQualifyingEncounter;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Condition, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -333,42 +332,41 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Macular_Exam(context);
         IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
-        IEnumerable<Observation> c_(Observation MacularExam) {
+        bool? c_(Observation MacularExam) {
             IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter(context);
 
             bool? h_(Encounter EncounterDiabeticRetinopathy) {
-                Period l_ = EncounterDiabeticRetinopathy?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                DataType n_ = MacularExam?.Effective;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
-                return q_;
+                Period k_ = EncounterDiabeticRetinopathy?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                DataType m_ = MacularExam?.Effective;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, (string)default);
+                return p_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter EncounterDiabeticRetinopathy) => MacularExam;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
         bool? e_(Observation MacularExam) {
-            DataType r_ = MacularExam?.Value;
-            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-            bool? t_ = context.Operators.Not((bool?)(s_ is null));
-            Code<ObservationStatus> u_ = MacularExam?.StatusElement;
-            ObservationStatus? v_ = u_?.Value;
-            string w_ = context.Operators.Convert<string>(v_);
-            string[] x_ = [
+            DataType q_ = MacularExam?.Value;
+            object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+            bool? s_ = context.Operators.Not((bool?)(r_ is null));
+            Code<ObservationStatus> t_ = MacularExam?.StatusElement;
+            ObservationStatus? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
                 "final",
                 "amended",
                 "corrected",
             ];
-            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-            bool? z_ = context.Operators.And(t_, y_);
-            return z_;
+            bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            bool? y_ = context.Operators.And(s_, x_);
+            return y_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
@@ -403,37 +401,36 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Level_of_Severity_of_Retinopathy_Findings(context);
         IEnumerable<Communication> b_ = context.Operators.Retrieve<Communication>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication"));
 
-        IEnumerable<Communication> c_(Communication LevelOfSeverityCommunicated) {
+        bool? c_(Communication LevelOfSeverityCommunicated) {
             IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter(context);
 
             bool? h_(Encounter EncounterDiabeticRetinopathy) {
-                FhirDateTime l_ = LevelOfSeverityCommunicated?.SentElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                Period n_ = EncounterDiabeticRetinopathy?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.Start(o_);
-                bool? q_ = context.Operators.After(m_, p_, (string)default);
-                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
-                bool? v_ = context.Operators.And(q_, u_);
-                return v_;
+                FhirDateTime k_ = LevelOfSeverityCommunicated?.SentElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                Period m_ = EncounterDiabeticRetinopathy?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.Start(n_);
+                bool? p_ = context.Operators.After(l_, o_, (string)default);
+                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
+                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
+                bool? u_ = context.Operators.And(p_, t_);
+                return u_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Communication j_(Encounter EncounterDiabeticRetinopathy) => LevelOfSeverityCommunicated;
-            IEnumerable<Communication> k_ = context.Operators.Select<Encounter, Communication>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Communication> d_ = context.Operators.SelectMany<Communication, Communication>(b_, c_);
+        IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication LevelOfSeverityCommunicated) {
-            Code<EventStatus> w_ = LevelOfSeverityCommunicated?.StatusElement;
-            EventStatus? x_ = w_?.Value;
-            string y_ = context.Operators.Convert<string>(x_);
-            bool? z_ = context.Operators.Equal(y_, "completed");
-            return z_;
+            Code<EventStatus> v_ = LevelOfSeverityCommunicated?.StatusElement;
+            EventStatus? w_ = v_?.Value;
+            string x_ = context.Operators.Convert<string>(w_);
+            bool? y_ = context.Operators.Equal(x_, "completed");
+            return y_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -452,37 +449,36 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Macular_Edema_Findings_Absent(context);
         IEnumerable<Communication> b_ = context.Operators.Retrieve<Communication>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication"));
 
-        IEnumerable<Communication> c_(Communication MacularEdemaAbsentCommunicated) {
+        bool? c_(Communication MacularEdemaAbsentCommunicated) {
             IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter(context);
 
             bool? h_(Encounter EncounterDiabeticRetinopathy) {
-                FhirDateTime l_ = MacularEdemaAbsentCommunicated?.SentElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                Period n_ = EncounterDiabeticRetinopathy?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.Start(o_);
-                bool? q_ = context.Operators.After(m_, p_, (string)default);
-                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
-                bool? v_ = context.Operators.And(q_, u_);
-                return v_;
+                FhirDateTime k_ = MacularEdemaAbsentCommunicated?.SentElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                Period m_ = EncounterDiabeticRetinopathy?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.Start(n_);
+                bool? p_ = context.Operators.After(l_, o_, (string)default);
+                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
+                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
+                bool? u_ = context.Operators.And(p_, t_);
+                return u_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Communication j_(Encounter EncounterDiabeticRetinopathy) => MacularEdemaAbsentCommunicated;
-            IEnumerable<Communication> k_ = context.Operators.Select<Encounter, Communication>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Communication> d_ = context.Operators.SelectMany<Communication, Communication>(b_, c_);
+        IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication MacularEdemaAbsentCommunicated) {
-            Code<EventStatus> w_ = MacularEdemaAbsentCommunicated?.StatusElement;
-            EventStatus? x_ = w_?.Value;
-            string y_ = context.Operators.Convert<string>(x_);
-            bool? z_ = context.Operators.Equal(y_, "completed");
-            return z_;
+            Code<EventStatus> v_ = MacularEdemaAbsentCommunicated?.StatusElement;
+            EventStatus? w_ = v_?.Value;
+            string x_ = context.Operators.Convert<string>(w_);
+            bool? y_ = context.Operators.Equal(x_, "completed");
+            return y_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -501,37 +497,36 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Macular_Edema_Findings_Present(context);
         IEnumerable<Communication> b_ = context.Operators.Retrieve<Communication>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication"));
 
-        IEnumerable<Communication> c_(Communication MacularEdemaPresentCommunicated) {
+        bool? c_(Communication MacularEdemaPresentCommunicated) {
             IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter(context);
 
             bool? h_(Encounter EncounterDiabeticRetinopathy) {
-                FhirDateTime l_ = MacularEdemaPresentCommunicated?.SentElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                Period n_ = EncounterDiabeticRetinopathy?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.Start(o_);
-                bool? q_ = context.Operators.After(m_, p_, (string)default);
-                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, (string)default);
-                bool? v_ = context.Operators.And(q_, u_);
-                return v_;
+                FhirDateTime k_ = MacularEdemaPresentCommunicated?.SentElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                Period m_ = EncounterDiabeticRetinopathy?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.Start(n_);
+                bool? p_ = context.Operators.After(l_, o_, (string)default);
+                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
+                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
+                bool? u_ = context.Operators.And(p_, t_);
+                return u_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Communication j_(Encounter EncounterDiabeticRetinopathy) => MacularEdemaPresentCommunicated;
-            IEnumerable<Communication> k_ = context.Operators.Select<Encounter, Communication>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Communication> d_ = context.Operators.SelectMany<Communication, Communication>(b_, c_);
+        IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication MacularEdemaPresentCommunicated) {
-            Code<EventStatus> w_ = MacularEdemaPresentCommunicated?.StatusElement;
-            EventStatus? x_ = w_?.Value;
-            string y_ = context.Operators.Convert<string>(x_);
-            bool? z_ = context.Operators.Equal(y_, "completed");
-            return z_;
+            Code<EventStatus> v_ = MacularEdemaPresentCommunicated?.StatusElement;
+            EventStatus? w_ = v_?.Value;
+            string x_ = context.Operators.Convert<string>(w_);
+            bool? y_ = context.Operators.Equal(x_, "completed");
+            return y_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -570,55 +565,54 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Level_of_Severity_of_Retinopathy_Findings(context);
         IEnumerable<Communication> b_ = context.Operators.Retrieve<Communication>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone"));
 
-        IEnumerable<Communication> c_(Communication LevelOfSeverityNotCommunicated) {
+        bool? c_(Communication LevelOfSeverityNotCommunicated) {
             IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter(context);
 
             bool? h_(Encounter EncounterDiabeticRetinopathy) {
 
-                bool? l_(Extension @this) {
-                    FhirUri v_ = @this?.UrlElement;
-                    string w_ = FHIRHelpers_4_4_000.Instance.ToString(context, v_);
-                    bool? x_ = context.Operators.Equal(w_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                bool? k_(Extension @this) {
+                    FhirUri u_ = @this?.UrlElement;
+                    string v_ = FHIRHelpers_4_4_000.Instance.ToString(context, u_);
+                    bool? w_ = context.Operators.Equal(v_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return w_;
+                }
+
+                IEnumerable<Extension> l_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(LevelOfSeverityNotCommunicated is DomainResource
+                    ? (LevelOfSeverityNotCommunicated as DomainResource).Extension
+                    : default), k_);
+
+                DataType m_(Extension @this) {
+                    DataType x_ = @this?.Value;
                     return x_;
                 }
 
-                IEnumerable<Extension> m_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(LevelOfSeverityNotCommunicated is DomainResource
-                    ? (LevelOfSeverityNotCommunicated as DomainResource).Extension
-                    : default), l_);
-
-                DataType n_(Extension @this) {
-                    DataType y_ = @this?.Value;
-                    return y_;
-                }
-
-                IEnumerable<DataType> o_ = context.Operators.Select<Extension, DataType>(m_, n_);
-                DataType p_ = context.Operators.SingletonFrom<DataType>(o_);
-                FhirDateTime q_ = context.Operators.Convert<FhirDateTime>(p_);
-                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
-                Period s_ = EncounterDiabeticRetinopathy?.Period;
-                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                bool? u_ = context.Operators.In<CqlDateTime>(r_, t_, "day");
-                return u_;
+                IEnumerable<DataType> n_ = context.Operators.Select<Extension, DataType>(l_, m_);
+                DataType o_ = context.Operators.SingletonFrom<DataType>(n_);
+                FhirDateTime p_ = context.Operators.Convert<FhirDateTime>(o_);
+                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+                Period r_ = EncounterDiabeticRetinopathy?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
+                return t_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Communication j_(Encounter EncounterDiabeticRetinopathy) => LevelOfSeverityNotCommunicated;
-            IEnumerable<Communication> k_ = context.Operators.Select<Encounter, Communication>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Communication> d_ = context.Operators.SelectMany<Communication, Communication>(b_, c_);
+        IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication LevelOfSeverityNotCommunicated) {
-            CodeableConcept z_ = LevelOfSeverityNotCommunicated?.StatusReason;
-            CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-            CqlValueSet ab_ = this.Medical_Reason(context);
-            bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
-            CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-            CqlValueSet af_ = this.Patient_Reason(context);
-            bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-            bool? ah_ = context.Operators.Or(ac_, ag_);
-            return ah_;
+            CodeableConcept y_ = LevelOfSeverityNotCommunicated?.StatusReason;
+            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+            CqlValueSet aa_ = this.Medical_Reason(context);
+            bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+            CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+            CqlValueSet ae_ = this.Patient_Reason(context);
+            bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+            bool? ag_ = context.Operators.Or(ab_, af_);
+            return ag_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -637,55 +631,54 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Macular_Edema_Findings_Absent(context);
         IEnumerable<Communication> b_ = context.Operators.Retrieve<Communication>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone"));
 
-        IEnumerable<Communication> c_(Communication MacularEdemaAbsentNotCommunicated) {
+        bool? c_(Communication MacularEdemaAbsentNotCommunicated) {
             IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter(context);
 
             bool? h_(Encounter EncounterDiabeticRetinopathy) {
 
-                bool? l_(Extension @this) {
-                    FhirUri v_ = @this?.UrlElement;
-                    string w_ = FHIRHelpers_4_4_000.Instance.ToString(context, v_);
-                    bool? x_ = context.Operators.Equal(w_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                bool? k_(Extension @this) {
+                    FhirUri u_ = @this?.UrlElement;
+                    string v_ = FHIRHelpers_4_4_000.Instance.ToString(context, u_);
+                    bool? w_ = context.Operators.Equal(v_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return w_;
+                }
+
+                IEnumerable<Extension> l_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(MacularEdemaAbsentNotCommunicated is DomainResource
+                    ? (MacularEdemaAbsentNotCommunicated as DomainResource).Extension
+                    : default), k_);
+
+                DataType m_(Extension @this) {
+                    DataType x_ = @this?.Value;
                     return x_;
                 }
 
-                IEnumerable<Extension> m_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(MacularEdemaAbsentNotCommunicated is DomainResource
-                    ? (MacularEdemaAbsentNotCommunicated as DomainResource).Extension
-                    : default), l_);
-
-                DataType n_(Extension @this) {
-                    DataType y_ = @this?.Value;
-                    return y_;
-                }
-
-                IEnumerable<DataType> o_ = context.Operators.Select<Extension, DataType>(m_, n_);
-                DataType p_ = context.Operators.SingletonFrom<DataType>(o_);
-                FhirDateTime q_ = context.Operators.Convert<FhirDateTime>(p_);
-                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
-                Period s_ = EncounterDiabeticRetinopathy?.Period;
-                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                bool? u_ = context.Operators.In<CqlDateTime>(r_, t_, "day");
-                return u_;
+                IEnumerable<DataType> n_ = context.Operators.Select<Extension, DataType>(l_, m_);
+                DataType o_ = context.Operators.SingletonFrom<DataType>(n_);
+                FhirDateTime p_ = context.Operators.Convert<FhirDateTime>(o_);
+                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+                Period r_ = EncounterDiabeticRetinopathy?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
+                return t_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Communication j_(Encounter EncounterDiabeticRetinopathy) => MacularEdemaAbsentNotCommunicated;
-            IEnumerable<Communication> k_ = context.Operators.Select<Encounter, Communication>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Communication> d_ = context.Operators.SelectMany<Communication, Communication>(b_, c_);
+        IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication MacularEdemaAbsentNotCommunicated) {
-            CodeableConcept z_ = MacularEdemaAbsentNotCommunicated?.StatusReason;
-            CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-            CqlValueSet ab_ = this.Medical_Reason(context);
-            bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
-            CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-            CqlValueSet af_ = this.Patient_Reason(context);
-            bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-            bool? ah_ = context.Operators.Or(ac_, ag_);
-            return ah_;
+            CodeableConcept y_ = MacularEdemaAbsentNotCommunicated?.StatusReason;
+            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+            CqlValueSet aa_ = this.Medical_Reason(context);
+            bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+            CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+            CqlValueSet ae_ = this.Patient_Reason(context);
+            bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+            bool? ag_ = context.Operators.Or(ab_, af_);
+            return ag_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -704,55 +697,54 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Macular_Edema_Findings_Present(context);
         IEnumerable<Communication> b_ = context.Operators.Retrieve<Communication>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone"));
 
-        IEnumerable<Communication> c_(Communication MacularEdemaPresentNotCommunicated) {
+        bool? c_(Communication MacularEdemaPresentNotCommunicated) {
             IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter(context);
 
             bool? h_(Encounter EncounterDiabeticRetinopathy) {
 
-                bool? l_(Extension @this) {
-                    FhirUri v_ = @this?.UrlElement;
-                    string w_ = FHIRHelpers_4_4_000.Instance.ToString(context, v_);
-                    bool? x_ = context.Operators.Equal(w_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                bool? k_(Extension @this) {
+                    FhirUri u_ = @this?.UrlElement;
+                    string v_ = FHIRHelpers_4_4_000.Instance.ToString(context, u_);
+                    bool? w_ = context.Operators.Equal(v_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return w_;
+                }
+
+                IEnumerable<Extension> l_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(MacularEdemaPresentNotCommunicated is DomainResource
+                    ? (MacularEdemaPresentNotCommunicated as DomainResource).Extension
+                    : default), k_);
+
+                DataType m_(Extension @this) {
+                    DataType x_ = @this?.Value;
                     return x_;
                 }
 
-                IEnumerable<Extension> m_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(MacularEdemaPresentNotCommunicated is DomainResource
-                    ? (MacularEdemaPresentNotCommunicated as DomainResource).Extension
-                    : default), l_);
-
-                DataType n_(Extension @this) {
-                    DataType y_ = @this?.Value;
-                    return y_;
-                }
-
-                IEnumerable<DataType> o_ = context.Operators.Select<Extension, DataType>(m_, n_);
-                DataType p_ = context.Operators.SingletonFrom<DataType>(o_);
-                FhirDateTime q_ = context.Operators.Convert<FhirDateTime>(p_);
-                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
-                Period s_ = EncounterDiabeticRetinopathy?.Period;
-                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                bool? u_ = context.Operators.In<CqlDateTime>(r_, t_, "day");
-                return u_;
+                IEnumerable<DataType> n_ = context.Operators.Select<Extension, DataType>(l_, m_);
+                DataType o_ = context.Operators.SingletonFrom<DataType>(n_);
+                FhirDateTime p_ = context.Operators.Convert<FhirDateTime>(o_);
+                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+                Period r_ = EncounterDiabeticRetinopathy?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
+                return t_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Communication j_(Encounter EncounterDiabeticRetinopathy) => MacularEdemaPresentNotCommunicated;
-            IEnumerable<Communication> k_ = context.Operators.Select<Encounter, Communication>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Communication> d_ = context.Operators.SelectMany<Communication, Communication>(b_, c_);
+        IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication MacularEdemaPresentNotCommunicated) {
-            CodeableConcept z_ = MacularEdemaPresentNotCommunicated?.StatusReason;
-            CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-            CqlValueSet ab_ = this.Medical_Reason(context);
-            bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
-            CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-            CqlValueSet af_ = this.Patient_Reason(context);
-            bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-            bool? ah_ = context.Operators.Or(ac_, ag_);
-            return ah_;
+            CodeableConcept y_ = MacularEdemaPresentNotCommunicated?.StatusReason;
+            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+            CqlValueSet aa_ = this.Medical_Reason(context);
+            bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+            CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+            CqlValueSet ae_ = this.Patient_Reason(context);
+            bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+            bool? ag_ = context.Operators.Or(ab_, af_);
+            return ag_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS143FHIRPOAGOpticNerveEval-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS143FHIRPOAGOpticNerveEval-1.0.000.g.cs
@@ -249,29 +249,28 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter) {
+        bool? b_(Encounter ValidQualifyingEncounter) {
             CqlValueSet d_ = this.Primary_Open_Angle_Glaucoma(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_ as IEnumerable<Condition>, g_ as IEnumerable<Condition>);
 
             bool? i_(Condition PrimaryOpenAngleGlaucoma) {
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PrimaryOpenAngleGlaucoma);
-                Period n_ = ValidQualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                bool? p_ = context.Operators.Overlaps(m_, o_, "day");
-                bool? q_ = this.isVerified(context, PrimaryOpenAngleGlaucoma);
-                bool? r_ = context.Operators.And(p_, q_);
-                return r_;
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PrimaryOpenAngleGlaucoma);
+                Period m_ = ValidQualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                bool? o_ = context.Operators.Overlaps(l_, n_, "day");
+                bool? p_ = this.isVerified(context, PrimaryOpenAngleGlaucoma);
+                bool? q_ = context.Operators.And(o_, p_);
+                return q_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
-            Encounter k_(Condition PrimaryOpenAngleGlaucoma) => ValidQualifyingEncounter;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Condition, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -326,51 +325,50 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
         IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
         IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 
-        IEnumerable<Observation> f_(Observation CupToDiscExamNotPerformed) {
+        bool? f_(Observation CupToDiscExamNotPerformed) {
             IEnumerable<Encounter> j_ = this.Primary_Open_Angle_Glaucoma_Encounter(context);
 
             bool? k_(Encounter EncounterWithPOAG) {
-                Instant o_ = CupToDiscExamNotPerformed?.IssuedElement;
-                DateTimeOffset? p_ = o_?.Value;
-                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                Period r_ = EncounterWithPOAG?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
-                return t_;
+                Instant n_ = CupToDiscExamNotPerformed?.IssuedElement;
+                DateTimeOffset? o_ = n_?.Value;
+                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+                Period q_ = EncounterWithPOAG?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
+                return s_;
             }
 
             IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
-            Observation m_(Encounter EncounterWithPOAG) => CupToDiscExamNotPerformed;
-            IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Encounter>(l_);
+            return m_;
         }
 
-        IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
 
         bool? h_(Observation CupToDiscExamNotPerformed) {
 
-            bool? u_(Extension @this) {
-                FhirUri ac_ = @this?.UrlElement;
-                string ad_ = FHIRHelpers_4_4_000.Instance.ToString(context, ac_);
-                bool? ae_ = context.Operators.Equal(ad_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            bool? t_(Extension @this) {
+                FhirUri ab_ = @this?.UrlElement;
+                string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
+                bool? ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return ad_;
+            }
+
+            IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(CupToDiscExamNotPerformed is DomainResource
+                ? (CupToDiscExamNotPerformed as DomainResource).Extension
+                : default), t_);
+
+            object v_(Extension @this) {
+                DataType ae_ = @this?.Value;
                 return ae_;
             }
 
-            IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(CupToDiscExamNotPerformed is DomainResource
-                ? (CupToDiscExamNotPerformed as DomainResource).Extension
-                : default), u_);
-
-            object w_(Extension @this) {
-                DataType af_ = @this?.Value;
-                return af_;
-            }
-
-            IEnumerable<object> x_ = context.Operators.Select<Extension, object>(v_, w_);
-            object y_ = context.Operators.SingletonFrom<object>(x_);
-            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_ as CodeableConcept);
-            CqlValueSet aa_ = this.Medical_Reason(context);
-            bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-            return ab_;
+            IEnumerable<object> w_ = context.Operators.Select<Extension, object>(u_, v_);
+            object x_ = context.Operators.SingletonFrom<object>(w_);
+            CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
+            CqlValueSet z_ = this.Medical_Reason(context);
+            bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
+            return aa_;
         }
 
         IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -391,51 +389,50 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
         IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
         IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 
-        IEnumerable<Observation> f_(Observation OpticDiscExamNotPerformed) {
+        bool? f_(Observation OpticDiscExamNotPerformed) {
             IEnumerable<Encounter> j_ = this.Primary_Open_Angle_Glaucoma_Encounter(context);
 
             bool? k_(Encounter EncounterWithPOAG) {
-                Instant o_ = OpticDiscExamNotPerformed?.IssuedElement;
-                DateTimeOffset? p_ = o_?.Value;
-                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                Period r_ = EncounterWithPOAG?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
-                return t_;
+                Instant n_ = OpticDiscExamNotPerformed?.IssuedElement;
+                DateTimeOffset? o_ = n_?.Value;
+                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+                Period q_ = EncounterWithPOAG?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
+                return s_;
             }
 
             IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
-            Observation m_(Encounter EncounterWithPOAG) => OpticDiscExamNotPerformed;
-            IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Encounter>(l_);
+            return m_;
         }
 
-        IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
 
         bool? h_(Observation OpticDiscExamNotPerformed) {
 
-            bool? u_(Extension @this) {
-                FhirUri ac_ = @this?.UrlElement;
-                string ad_ = FHIRHelpers_4_4_000.Instance.ToString(context, ac_);
-                bool? ae_ = context.Operators.Equal(ad_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            bool? t_(Extension @this) {
+                FhirUri ab_ = @this?.UrlElement;
+                string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
+                bool? ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return ad_;
+            }
+
+            IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(OpticDiscExamNotPerformed is DomainResource
+                ? (OpticDiscExamNotPerformed as DomainResource).Extension
+                : default), t_);
+
+            object v_(Extension @this) {
+                DataType ae_ = @this?.Value;
                 return ae_;
             }
 
-            IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(OpticDiscExamNotPerformed is DomainResource
-                ? (OpticDiscExamNotPerformed as DomainResource).Extension
-                : default), u_);
-
-            object w_(Extension @this) {
-                DataType af_ = @this?.Value;
-                return af_;
-            }
-
-            IEnumerable<object> x_ = context.Operators.Select<Extension, object>(v_, w_);
-            object y_ = context.Operators.SingletonFrom<object>(x_);
-            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_ as CodeableConcept);
-            CqlValueSet aa_ = this.Medical_Reason(context);
-            bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-            return ab_;
+            IEnumerable<object> w_ = context.Operators.Select<Extension, object>(u_, v_);
+            object x_ = context.Operators.SingletonFrom<object>(w_);
+            CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
+            CqlValueSet z_ = this.Medical_Reason(context);
+            bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
+            return aa_;
         }
 
         IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -471,42 +468,41 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
         CqlValueSet a_ = this.Cup_to_Disc_Ratio(context);
         IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
-        IEnumerable<Observation> c_(Observation CupToDiscExamPerformed) {
+        bool? c_(Observation CupToDiscExamPerformed) {
             IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter(context);
 
             bool? h_(Encounter EncounterWithPOAG) {
-                Period l_ = EncounterWithPOAG?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                DataType n_ = CupToDiscExamPerformed?.Effective;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
-                return q_;
+                Period k_ = EncounterWithPOAG?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                DataType m_ = CupToDiscExamPerformed?.Effective;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
+                return p_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter EncounterWithPOAG) => CupToDiscExamPerformed;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
         bool? e_(Observation CupToDiscExamPerformed) {
-            DataType r_ = CupToDiscExamPerformed?.Value;
-            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-            bool? t_ = context.Operators.Not((bool?)(s_ is null));
-            Code<ObservationStatus> u_ = CupToDiscExamPerformed?.StatusElement;
-            ObservationStatus? v_ = u_?.Value;
-            string w_ = context.Operators.Convert<string>(v_);
-            string[] x_ = [
+            DataType q_ = CupToDiscExamPerformed?.Value;
+            object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+            bool? s_ = context.Operators.Not((bool?)(r_ is null));
+            Code<ObservationStatus> t_ = CupToDiscExamPerformed?.StatusElement;
+            ObservationStatus? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
                 "final",
                 "amended",
                 "corrected",
             ];
-            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-            bool? z_ = context.Operators.And(t_, y_);
-            return z_;
+            bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            bool? y_ = context.Operators.And(s_, x_);
+            return y_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
@@ -525,42 +521,41 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
         CqlValueSet a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities(context);
         IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
-        IEnumerable<Observation> c_(Observation OpticDiscExamPerformed) {
+        bool? c_(Observation OpticDiscExamPerformed) {
             IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter(context);
 
             bool? h_(Encounter EncounterWithPOAG) {
-                Period l_ = EncounterWithPOAG?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                DataType n_ = OpticDiscExamPerformed?.Effective;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
-                return q_;
+                Period k_ = EncounterWithPOAG?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                DataType m_ = OpticDiscExamPerformed?.Effective;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
+                return p_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter EncounterWithPOAG) => OpticDiscExamPerformed;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
         bool? e_(Observation OpticDiscExamPerformed) {
-            DataType r_ = OpticDiscExamPerformed?.Value;
-            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-            bool? t_ = context.Operators.Not((bool?)(s_ is null));
-            Code<ObservationStatus> u_ = OpticDiscExamPerformed?.StatusElement;
-            ObservationStatus? v_ = u_?.Value;
-            string w_ = context.Operators.Convert<string>(v_);
-            string[] x_ = [
+            DataType q_ = OpticDiscExamPerformed?.Value;
+            object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+            bool? s_ = context.Operators.Not((bool?)(r_ is null));
+            Code<ObservationStatus> t_ = OpticDiscExamPerformed?.StatusElement;
+            ObservationStatus? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
                 "final",
                 "amended",
                 "corrected",
             ];
-            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-            bool? z_ = context.Operators.And(t_, y_);
-            return z_;
+            bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            bool? y_ = context.Operators.And(s_, x_);
+            return y_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
@@ -208,35 +208,34 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> j_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? k_(Medication M) {
-                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
-                string r_ = context.Operators.Last<string>(q_);
-                bool? s_ = context.Operators.Equal(o_, r_);
-                CodeableConcept t_ = M?.Code;
-                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                CqlValueSet v_ = this.Beta_Blocker_Therapy_for_LVSD(context);
-                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
-                bool? x_ = context.Operators.And(s_, w_);
-                return x_;
+                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
+                string q_ = context.Operators.Last<string>(p_);
+                bool? r_ = context.Operators.Equal(n_, q_);
+                CodeableConcept s_ = M?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                CqlValueSet u_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+                bool? w_ = context.Operators.And(r_, v_);
+                return w_;
             }
 
             IEnumerable<Medication> l_ = context.Operators.Where<Medication>(j_, k_);
-            MedicationRequest m_(Medication M) => MR;
-            IEnumerable<MedicationRequest> n_ = context.Operators.Select<Medication, MedicationRequest>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Medication>(l_);
+            return m_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest ActiveBetaBlocker) {
-            bool? y_ = AHAOverall_4_1_000.Instance.overlapsAfterHeartFailureOutpatientEncounter(context, ActiveBetaBlocker);
-            return y_;
+            bool? x_ = AHAOverall_4_1_000.Instance.overlapsAfterHeartFailureOutpatientEncounter(context, ActiveBetaBlocker);
+            return x_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -359,48 +358,47 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
         CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested"));
 
-        IEnumerable<MedicationRequest> c_(MedicationRequest NoBetaBlockerOrdered) {
+        bool? c_(MedicationRequest NoBetaBlockerOrdered) {
             IEnumerable<Encounter> h_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
-                FhirDateTime m_ = NoBetaBlockerOrdered?.AuthoredOnElement;
-                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
-                Period o_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
-                return q_;
+                FhirDateTime l_ = NoBetaBlockerOrdered?.AuthoredOnElement;
+                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+                Period n_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, "day");
+                return p_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            MedicationRequest k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => NoBetaBlockerOrdered;
-            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
 
         bool? e_(MedicationRequest NoBetaBlockerOrdered) {
-            List<CodeableConcept> r_ = NoBetaBlockerOrdered?.ReasonCode;
+            List<CodeableConcept> q_ = NoBetaBlockerOrdered?.ReasonCode;
 
-            CqlConcept s_(CodeableConcept @this) {
+            CqlConcept r_(CodeableConcept @this) {
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ab_;
+            }
+
+            IEnumerable<CqlConcept> s_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)q_, r_);
+            CqlValueSet t_ = this.Medical_Reason(context);
+            bool? u_ = context.Operators.ConceptsInValueSet(s_, t_);
+
+            CqlConcept w_(CodeableConcept @this) {
                 CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                 return ac_;
             }
 
-            IEnumerable<CqlConcept> t_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)r_, s_);
-            CqlValueSet u_ = this.Medical_Reason(context);
-            bool? v_ = context.Operators.ConceptsInValueSet(t_, u_);
-
-            CqlConcept x_(CodeableConcept @this) {
-                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return ad_;
-            }
-
-            IEnumerable<CqlConcept> y_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)r_, x_);
-            CqlValueSet z_ = this.Patient_Reason(context);
-            bool? aa_ = context.Operators.ConceptsInValueSet(y_, z_);
-            bool? ab_ = context.Operators.Or(v_, aa_);
-            return ab_;
+            IEnumerable<CqlConcept> x_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)q_, w_);
+            CqlValueSet y_ = this.Patient_Reason(context);
+            bool? z_ = context.Operators.ConceptsInValueSet(x_, y_);
+            bool? aa_ = context.Operators.Or(u_, z_);
+            return aa_;
         }
 
         IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
@@ -656,67 +654,67 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
         CqlValueSet a_ = this.Cardiac_Pacer(context);
         IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer) {
+        bool? c_(Procedure ImplantedCardiacPacer) {
             IEnumerable<Encounter> h_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
 
-                object m_() {
+                object l_() {
+
+                    bool s_() {
+                        DataType w_ = ImplantedCardiacPacer?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
 
                     bool t_() {
-                        DataType x_ = ImplantedCardiacPacer?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
+                        DataType z_ = ImplantedCardiacPacer?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        DataType aa_ = ImplantedCardiacPacer?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        DataType ac_ = ImplantedCardiacPacer?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
                     }
 
 
                     bool v_() {
-                        DataType ad_ = ImplantedCardiacPacer?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
+                        DataType af_ = ImplantedCardiacPacer?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
                     }
 
-
-                    bool w_() {
-                        DataType ag_ = ImplantedCardiacPacer?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
+                    if (s_())
                     {
-                        DataType aj_ = ImplantedCardiacPacer?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
+                        DataType ai_ = ImplantedCardiacPacer?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = ImplantedCardiacPacer?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
-                        DataType al_ = ImplantedCardiacPacer?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        DataType am_ = ImplantedCardiacPacer?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
-                        DataType an_ = ImplantedCardiacPacer?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = ImplantedCardiacPacer?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ao_ = ImplantedCardiacPacer?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -724,29 +722,28 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
                     };
                 }
 
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
-                CqlDateTime o_ = context.Operators.Start(n_);
-                Period p_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.End(q_);
-                bool? s_ = context.Operators.Before(o_, r_, (string)default);
-                return s_;
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
+                CqlDateTime n_ = context.Operators.Start(m_);
+                Period o_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                bool? r_ = context.Operators.Before(n_, q_, (string)default);
+                return r_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            Procedure k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => ImplantedCardiacPacer;
-            IEnumerable<Procedure> l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 
         bool? e_(Procedure ImplantedCardiacPacer) {
-            Code<EventStatus> ar_ = ImplantedCardiacPacer?.StatusElement;
-            EventStatus? as_ = ar_?.Value;
-            string at_ = context.Operators.Convert<string>(as_);
-            bool? au_ = context.Operators.Equal(at_, "completed");
-            return au_;
+            Code<EventStatus> aq_ = ImplantedCardiacPacer?.StatusElement;
+            EventStatus? ar_ = aq_?.Value;
+            string as_ = context.Operators.Convert<string>(ar_);
+            bool? at_ = context.Operators.Equal(as_, "completed");
+            return at_;
         }
 
         IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
@@ -326,24 +326,23 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Outpatient_Encounter_During_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter) {
+        bool? b_(Encounter ValidQualifyingEncounter) {
             CqlValueSet d_ = this.Coronary_Artery_Disease_No_MI(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_ as IEnumerable<Condition>, g_ as IEnumerable<Condition>);
 
             bool? i_(Condition CoronaryArteryDisease) {
-                bool? m_ = this.overlapsDayOfEncounter(context, CoronaryArteryDisease as Condition, ValidQualifyingEncounter);
-                return m_;
+                bool? l_ = this.overlapsDayOfEncounter(context, CoronaryArteryDisease as Condition, ValidQualifyingEncounter);
+                return l_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
-            Encounter k_(Condition CoronaryArteryDisease) => ValidQualifyingEncounter;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Condition, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -358,68 +357,68 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Outpatient_Encounter_During_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter) {
+        bool? b_(Encounter ValidQualifyingEncounter) {
             CqlValueSet d_ = this.Cardiac_Surgery(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure CardiacSurgeryProcedure) {
 
-                object j_() {
+                object i_() {
+
+                    bool u_() {
+                        DataType y_ = CardiacSurgeryProcedure?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlDateTime;
+                        return aa_;
+                    }
+
 
                     bool v_() {
-                        DataType z_ = CardiacSurgeryProcedure?.Performed;
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlDateTime;
-                        return ab_;
+                        DataType ab_ = CardiacSurgeryProcedure?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlInterval<CqlDateTime>;
+                        return ad_;
                     }
 
 
                     bool w_() {
-                        DataType ac_ = CardiacSurgeryProcedure?.Performed;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlInterval<CqlDateTime>;
-                        return ae_;
+                        DataType ae_ = CardiacSurgeryProcedure?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlQuantity;
+                        return ag_;
                     }
 
 
                     bool x_() {
-                        DataType af_ = CardiacSurgeryProcedure?.Performed;
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlQuantity;
-                        return ah_;
+                        DataType ah_ = CardiacSurgeryProcedure?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        bool aj_ = ai_ is CqlInterval<CqlQuantity>;
+                        return aj_;
                     }
 
-
-                    bool y_() {
-                        DataType ai_ = CardiacSurgeryProcedure?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        bool ak_ = aj_ is CqlInterval<CqlQuantity>;
-                        return ak_;
-                    }
-
-                    if (v_())
+                    if (u_())
                     {
-                        DataType al_ = CardiacSurgeryProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlDateTime) as object;
+                        DataType ak_ = CardiacSurgeryProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlDateTime) as object;
+                    }
+                    else if (v_())
+                    {
+                        DataType am_ = CardiacSurgeryProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (w_())
                     {
-                        DataType an_ = CardiacSurgeryProcedure?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ao_ = CardiacSurgeryProcedure?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlQuantity) as object;
                     }
                     else if (x_())
                     {
-                        DataType ap_ = CardiacSurgeryProcedure?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlQuantity) as object;
-                    }
-                    else if (y_())
-                    {
-                        DataType ar_ = CardiacSurgeryProcedure?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlInterval<CqlQuantity>) as object;
+                        DataType aq_ = CardiacSurgeryProcedure?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -427,27 +426,26 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
-                CqlDateTime l_ = context.Operators.Start(k_);
-                Period m_ = ValidQualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime o_ = context.Operators.End(n_);
-                bool? p_ = context.Operators.Before(l_, o_, (string)default);
-                Code<EventStatus> q_ = CardiacSurgeryProcedure?.StatusElement;
-                EventStatus? r_ = q_?.Value;
-                string s_ = context.Operators.Convert<string>(r_);
-                bool? t_ = context.Operators.Equal(s_, "completed");
-                bool? u_ = context.Operators.And(p_, t_);
-                return u_;
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
+                CqlDateTime k_ = context.Operators.Start(j_);
+                Period l_ = ValidQualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.End(m_);
+                bool? o_ = context.Operators.Before(k_, n_, (string)default);
+                Code<EventStatus> p_ = CardiacSurgeryProcedure?.StatusElement;
+                EventStatus? q_ = p_?.Value;
+                string r_ = context.Operators.Convert<string>(q_);
+                bool? s_ = context.Operators.Equal(r_, "completed");
+                bool? t_ = context.Operators.And(o_, s_);
+                return t_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure CardiacSurgeryProcedure) => ValidQualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -486,26 +484,25 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
         IEnumerable<Encounter> j_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
-        IEnumerable<Encounter> k_(Encounter Encounter1) {
+        bool? k_(Encounter Encounter1) {
             IEnumerable<Encounter> r_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? s_(Encounter Encounter2) {
-                Id w_ = Encounter2?.IdElement;
-                string x_ = w_?.Value;
-                Id y_ = Encounter1?.IdElement;
-                string z_ = y_?.Value;
-                bool? aa_ = context.Operators.Equivalent(x_, z_);
-                bool? ab_ = context.Operators.Not(aa_);
-                return ab_;
+                Id v_ = Encounter2?.IdElement;
+                string w_ = v_?.Value;
+                Id x_ = Encounter1?.IdElement;
+                string y_ = x_?.Value;
+                bool? z_ = context.Operators.Equivalent(w_, y_);
+                bool? aa_ = context.Operators.Not(z_);
+                return aa_;
             }
 
             IEnumerable<Encounter> t_ = context.Operators.Where<Encounter>(r_, s_);
-            Encounter u_(Encounter Encounter2) => Encounter1;
-            IEnumerable<Encounter> v_ = context.Operators.Select<Encounter, Encounter>(t_, u_);
-            return v_;
+            bool? u_ = context.Operators.Exists<Encounter>(t_);
+            return u_;
         }
 
-        IEnumerable<Encounter> l_ = context.Operators.SelectMany<Encounter, Encounter>(j_, k_);
+        IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
         bool? m_ = context.Operators.Exists<Encounter>(l_);
         bool? n_ = context.Operators.And(i_, m_);
         IEnumerable<Encounter> o_ = this.Qualifying_CAD_Encounter(context);
@@ -525,44 +522,43 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Qualifying_CAD_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithCADProxy) {
+        bool? b_(Encounter EncounterWithCADProxy) {
             CqlValueSet d_ = this.Myocardial_Infarction(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_ as IEnumerable<Condition>, g_ as IEnumerable<Condition>);
 
             bool? i_(Condition MyocardialInfarction) {
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MyocardialInfarction);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                Period o_ = EncounterWithCADProxy?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                CqlQuantity r_ = context.Operators.Quantity(3m, "years");
-                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
-                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                CqlDateTime v_ = context.Operators.Start(u_);
-                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, false);
-                bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, "day");
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                CqlDateTime aa_ = context.Operators.Start(z_);
-                bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
-                bool? ac_ = context.Operators.And(x_, ab_);
-                IEnumerable<object> ad_ = AHAOverall_4_1_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
-                bool? ae_ = context.Operators.Exists<object>(ad_);
-                bool? af_ = context.Operators.Not(ae_);
-                bool? ag_ = context.Operators.And(ac_, af_);
-                bool? ah_ = AHAOverall_4_1_000.Instance.isVerified(context, MyocardialInfarction);
-                bool? ai_ = context.Operators.And(ag_, ah_);
-                return ai_;
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MyocardialInfarction);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                Period n_ = EncounterWithCADProxy?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                CqlQuantity q_ = context.Operators.Quantity(3m, "years");
+                CqlDateTime r_ = context.Operators.Subtract(p_, q_);
+                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime u_ = context.Operators.Start(t_);
+                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
+                bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, "day");
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                bool? aa_ = context.Operators.Not((bool?)(z_ is null));
+                bool? ab_ = context.Operators.And(w_, aa_);
+                IEnumerable<object> ac_ = AHAOverall_4_1_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
+                bool? ad_ = context.Operators.Exists<object>(ac_);
+                bool? ae_ = context.Operators.Not(ad_);
+                bool? af_ = context.Operators.And(ab_, ae_);
+                bool? ag_ = AHAOverall_4_1_000.Instance.isVerified(context, MyocardialInfarction);
+                bool? ah_ = context.Operators.And(af_, ag_);
+                return ah_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
-            Encounter k_(Condition MyocardialInfarction) => EncounterWithCADProxy;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Condition, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -640,67 +636,67 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Cardiac_Pacer(context);
         IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer) {
+        bool? c_(Procedure ImplantedCardiacPacer) {
             IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
 
             bool? g_(Encounter CADEncounterMI) {
 
-                object k_() {
+                object j_() {
+
+                    bool v_() {
+                        DataType z_ = ImplantedCardiacPacer?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlDateTime;
+                        return ab_;
+                    }
+
 
                     bool w_() {
-                        DataType aa_ = ImplantedCardiacPacer?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlDateTime;
-                        return ac_;
+                        DataType ac_ = ImplantedCardiacPacer?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlDateTime>;
+                        return ae_;
                     }
 
 
                     bool x_() {
-                        DataType ad_ = ImplantedCardiacPacer?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlInterval<CqlDateTime>;
-                        return af_;
+                        DataType af_ = ImplantedCardiacPacer?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlQuantity;
+                        return ah_;
                     }
 
 
                     bool y_() {
-                        DataType ag_ = ImplantedCardiacPacer?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlQuantity;
-                        return ai_;
+                        DataType ai_ = ImplantedCardiacPacer?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        bool ak_ = aj_ is CqlInterval<CqlQuantity>;
+                        return ak_;
                     }
 
-
-                    bool z_() {
-                        DataType aj_ = ImplantedCardiacPacer?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        bool al_ = ak_ is CqlInterval<CqlQuantity>;
-                        return al_;
-                    }
-
-                    if (w_())
+                    if (v_())
                     {
-                        DataType am_ = ImplantedCardiacPacer?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlDateTime) as object;
+                        DataType al_ = ImplantedCardiacPacer?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlDateTime) as object;
+                    }
+                    else if (w_())
+                    {
+                        DataType an_ = ImplantedCardiacPacer?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (x_())
                     {
-                        DataType ao_ = ImplantedCardiacPacer?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ap_ = ImplantedCardiacPacer?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        return (aq_ as CqlQuantity) as object;
                     }
                     else if (y_())
                     {
-                        DataType aq_ = ImplantedCardiacPacer?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        return (ar_ as CqlQuantity) as object;
-                    }
-                    else if (z_())
-                    {
-                        DataType as_ = ImplantedCardiacPacer?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        return (at_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ar_ = ImplantedCardiacPacer?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        return (as_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -708,27 +704,26 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                CqlDateTime m_ = context.Operators.Start(l_);
-                Period n_ = CADEncounterMI?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                bool? q_ = context.Operators.Before(m_, p_, (string)default);
-                Code<EventStatus> r_ = ImplantedCardiacPacer?.StatusElement;
-                EventStatus? s_ = r_?.Value;
-                string t_ = context.Operators.Convert<string>(s_);
-                bool? u_ = context.Operators.Equal(t_, "completed");
-                bool? v_ = context.Operators.And(q_, u_);
-                return v_;
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                CqlDateTime l_ = context.Operators.Start(k_);
+                Period m_ = CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                bool? p_ = context.Operators.Before(l_, o_, (string)default);
+                Code<EventStatus> q_ = ImplantedCardiacPacer?.StatusElement;
+                EventStatus? r_ = q_?.Value;
+                string s_ = context.Operators.Convert<string>(r_);
+                bool? t_ = context.Operators.Equal(s_, "completed");
+                bool? u_ = context.Operators.And(p_, t_);
+                return u_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
-            Procedure i_(Encounter CADEncounterMI) => ImplantedCardiacPacer;
-            IEnumerable<Procedure> j_ = context.Operators.Select<Encounter, Procedure>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Encounter>(h_);
+            return i_;
         }
 
-        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
         bool? e_ = context.Operators.Exists<Procedure>(d_);
         return e_;
     }
@@ -868,29 +863,28 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Qualifying_CAD_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterWithCADProxy) {
+        bool? b_(Encounter EncounterWithCADProxy) {
             IEnumerable<object> d_ = AHAOverall_4_1_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
 
             bool? e_(object LVSDFindings) {
-                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LVSDFindings as Condition);
-                object j_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
-                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
-                CqlDateTime m_ = context.Operators.Start(i_ ?? l_);
-                Period n_ = EncounterWithCADProxy?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                bool? q_ = context.Operators.Before(m_, p_, (string)default);
-                return q_;
+                CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LVSDFindings as Condition);
+                object i_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
+                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
+                CqlDateTime l_ = context.Operators.Start(h_ ?? k_);
+                Period m_ = EncounterWithCADProxy?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                bool? p_ = context.Operators.Before(l_, o_, (string)default);
+                return p_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object LVSDFindings) => EncounterWithCADProxy;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1008,111 +1002,110 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> c_(MedicationRequest ActiveBetaBlockerForLVSD) {
+        bool? c_(MedicationRequest ActiveBetaBlockerForLVSD) {
             IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? i_(Encounter CADEncounterModerateOrSevereLVSD) {
-                List<Dosage> m_ = ActiveBetaBlockerForLVSD?.DosageInstruction;
+                List<Dosage> l_ = ActiveBetaBlockerForLVSD?.DosageInstruction;
 
-                bool? n_(Dosage @this) {
-                    Timing aj_ = @this?.Timing;
-                    bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+                bool? m_(Dosage @this) {
+                    Timing ai_ = @this?.Timing;
+                    bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
+                    return aj_;
+                }
+
+                IEnumerable<Dosage> n_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)l_, m_);
+
+                Timing o_(Dosage @this) {
+                    Timing ak_ = @this?.Timing;
                     return ak_;
                 }
 
-                IEnumerable<Dosage> o_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)m_, n_);
+                IEnumerable<Timing> p_ = context.Operators.Select<Dosage, Timing>(n_, o_);
 
-                Timing p_(Dosage @this) {
-                    Timing al_ = @this?.Timing;
-                    return al_;
+                bool? q_(Timing @this) {
+                    Timing.RepeatComponent al_ = @this?.Repeat;
+                    bool? am_ = context.Operators.Not((bool?)(al_ is null));
+                    return am_;
                 }
 
-                IEnumerable<Timing> q_ = context.Operators.Select<Dosage, Timing>(o_, p_);
+                IEnumerable<Timing> r_ = context.Operators.Where<Timing>(p_, q_);
 
-                bool? r_(Timing @this) {
-                    Timing.RepeatComponent am_ = @this?.Repeat;
-                    bool? an_ = context.Operators.Not((bool?)(am_ is null));
+                Timing.RepeatComponent s_(Timing @this) {
+                    Timing.RepeatComponent an_ = @this?.Repeat;
                     return an_;
                 }
 
-                IEnumerable<Timing> s_ = context.Operators.Where<Timing>(q_, r_);
+                IEnumerable<Timing.RepeatComponent> t_ = context.Operators.Select<Timing, Timing.RepeatComponent>(r_, s_);
 
-                Timing.RepeatComponent t_(Timing @this) {
-                    Timing.RepeatComponent ao_ = @this?.Repeat;
-                    return ao_;
+                bool? u_(Timing.RepeatComponent @this) {
+                    DataType ao_ = @this?.Bounds;
+                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                    bool? aq_ = context.Operators.Not((bool?)(ap_ is null));
+                    return aq_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> u_ = context.Operators.Select<Timing, Timing.RepeatComponent>(s_, t_);
+                IEnumerable<Timing.RepeatComponent> v_ = context.Operators.Where<Timing.RepeatComponent>(t_, u_);
 
-                bool? v_(Timing.RepeatComponent @this) {
-                    DataType ap_ = @this?.Bounds;
-                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                    bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
-                    return ar_;
+                object w_(Timing.RepeatComponent @this) {
+                    DataType ar_ = @this?.Bounds;
+                    object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                    return as_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> w_ = context.Operators.Where<Timing.RepeatComponent>(u_, v_);
+                IEnumerable<object> x_ = context.Operators.Select<Timing.RepeatComponent, object>(v_, w_);
 
-                object x_(Timing.RepeatComponent @this) {
-                    DataType as_ = @this?.Bounds;
-                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                CqlInterval<CqlDateTime> y_(object DoseTime) {
+                    CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
                     return at_;
                 }
 
-                IEnumerable<object> y_ = context.Operators.Select<Timing.RepeatComponent, object>(w_, x_);
+                IEnumerable<CqlInterval<CqlDateTime>> z_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(x_, y_);
+                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(z_);
+                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Collapse(aa_, (string)default);
 
-                CqlInterval<CqlDateTime> z_(object DoseTime) {
-                    CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+                object ac_(CqlInterval<CqlDateTime> @this) {
+                    CqlDateTime au_ = context.Operators.Start(@this);
                     return au_;
                 }
 
-                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
-                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
-                IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, (string)default);
-
-                object ad_(CqlInterval<CqlDateTime> @this) {
-                    CqlDateTime av_ = context.Operators.Start(@this);
-                    return av_;
-                }
-
-                IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ac_, ad_, System.ComponentModel.ListSortDirection.Ascending);
-                CqlInterval<CqlDateTime> af_ = context.Operators.First<CqlInterval<CqlDateTime>>(ae_);
-                Period ag_ = CADEncounterModerateOrSevereLVSD?.Period;
-                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                bool? ai_ = context.Operators.OverlapsAfter(af_, ah_, "day");
-                return ai_;
+                IEnumerable<CqlInterval<CqlDateTime>> ad_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> ae_ = context.Operators.First<CqlInterval<CqlDateTime>>(ad_);
+                Period af_ = CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
+                bool? ah_ = context.Operators.OverlapsAfter(ae_, ag_, "day");
+                return ah_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            MedicationRequest k_(Encounter CADEncounterModerateOrSevereLVSD) => ActiveBetaBlockerForLVSD;
-            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
 
         bool? e_(MedicationRequest ActiveBetaBlockerForLVSD) {
-            Code<MedicationRequest.MedicationrequestStatus> aw_ = ActiveBetaBlockerForLVSD?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ax_ = aw_?.Value;
-            string ay_ = context.Operators.Convert<string>(ax_);
-            string[] az_ = [
+            Code<MedicationRequest.MedicationrequestStatus> av_ = ActiveBetaBlockerForLVSD?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aw_ = av_?.Value;
+            string ax_ = context.Operators.Convert<string>(aw_);
+            string[] ay_ = [
                 "active",
                 "completed",
             ];
-            bool? ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
-            Code<MedicationRequest.MedicationRequestIntent> bb_ = ActiveBetaBlockerForLVSD?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? bc_ = bb_?.Value;
-            string bd_ = context.Operators.Convert<string>(bc_);
-            string[] be_ = [
+            bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
+            Code<MedicationRequest.MedicationRequestIntent> ba_ = ActiveBetaBlockerForLVSD?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bb_ = ba_?.Value;
+            string bc_ = context.Operators.Convert<string>(bb_);
+            string[] bd_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
-            bool? bg_ = context.Operators.And(ba_, bf_);
-            return bg_;
+            bool? be_ = context.Operators.In<string>(bc_, (IEnumerable<string>)bd_);
+            bool? bf_ = context.Operators.And(az_, be_);
+            return bf_;
         }
 
         IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
@@ -1170,111 +1163,110 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Beta_Blocker_Therapy(context);
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> c_(MedicationRequest ActiveBetaBlocker) {
+        bool? c_(MedicationRequest ActiveBetaBlocker) {
             IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
 
             bool? i_(Encounter CADEncounterMI) {
-                List<Dosage> m_ = ActiveBetaBlocker?.DosageInstruction;
+                List<Dosage> l_ = ActiveBetaBlocker?.DosageInstruction;
 
-                bool? n_(Dosage @this) {
-                    Timing aj_ = @this?.Timing;
-                    bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+                bool? m_(Dosage @this) {
+                    Timing ai_ = @this?.Timing;
+                    bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
+                    return aj_;
+                }
+
+                IEnumerable<Dosage> n_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)l_, m_);
+
+                Timing o_(Dosage @this) {
+                    Timing ak_ = @this?.Timing;
                     return ak_;
                 }
 
-                IEnumerable<Dosage> o_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)m_, n_);
+                IEnumerable<Timing> p_ = context.Operators.Select<Dosage, Timing>(n_, o_);
 
-                Timing p_(Dosage @this) {
-                    Timing al_ = @this?.Timing;
-                    return al_;
+                bool? q_(Timing @this) {
+                    Timing.RepeatComponent al_ = @this?.Repeat;
+                    bool? am_ = context.Operators.Not((bool?)(al_ is null));
+                    return am_;
                 }
 
-                IEnumerable<Timing> q_ = context.Operators.Select<Dosage, Timing>(o_, p_);
+                IEnumerable<Timing> r_ = context.Operators.Where<Timing>(p_, q_);
 
-                bool? r_(Timing @this) {
-                    Timing.RepeatComponent am_ = @this?.Repeat;
-                    bool? an_ = context.Operators.Not((bool?)(am_ is null));
+                Timing.RepeatComponent s_(Timing @this) {
+                    Timing.RepeatComponent an_ = @this?.Repeat;
                     return an_;
                 }
 
-                IEnumerable<Timing> s_ = context.Operators.Where<Timing>(q_, r_);
+                IEnumerable<Timing.RepeatComponent> t_ = context.Operators.Select<Timing, Timing.RepeatComponent>(r_, s_);
 
-                Timing.RepeatComponent t_(Timing @this) {
-                    Timing.RepeatComponent ao_ = @this?.Repeat;
-                    return ao_;
+                bool? u_(Timing.RepeatComponent @this) {
+                    DataType ao_ = @this?.Bounds;
+                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                    bool? aq_ = context.Operators.Not((bool?)(ap_ is null));
+                    return aq_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> u_ = context.Operators.Select<Timing, Timing.RepeatComponent>(s_, t_);
+                IEnumerable<Timing.RepeatComponent> v_ = context.Operators.Where<Timing.RepeatComponent>(t_, u_);
 
-                bool? v_(Timing.RepeatComponent @this) {
-                    DataType ap_ = @this?.Bounds;
-                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                    bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
-                    return ar_;
+                object w_(Timing.RepeatComponent @this) {
+                    DataType ar_ = @this?.Bounds;
+                    object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                    return as_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> w_ = context.Operators.Where<Timing.RepeatComponent>(u_, v_);
+                IEnumerable<object> x_ = context.Operators.Select<Timing.RepeatComponent, object>(v_, w_);
 
-                object x_(Timing.RepeatComponent @this) {
-                    DataType as_ = @this?.Bounds;
-                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                CqlInterval<CqlDateTime> y_(object DoseTime) {
+                    CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
                     return at_;
                 }
 
-                IEnumerable<object> y_ = context.Operators.Select<Timing.RepeatComponent, object>(w_, x_);
+                IEnumerable<CqlInterval<CqlDateTime>> z_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(x_, y_);
+                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(z_);
+                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Collapse(aa_, (string)default);
 
-                CqlInterval<CqlDateTime> z_(object DoseTime) {
-                    CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+                object ac_(CqlInterval<CqlDateTime> @this) {
+                    CqlDateTime au_ = context.Operators.Start(@this);
                     return au_;
                 }
 
-                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
-                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
-                IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, (string)default);
-
-                object ad_(CqlInterval<CqlDateTime> @this) {
-                    CqlDateTime av_ = context.Operators.Start(@this);
-                    return av_;
-                }
-
-                IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ac_, ad_, System.ComponentModel.ListSortDirection.Ascending);
-                CqlInterval<CqlDateTime> af_ = context.Operators.First<CqlInterval<CqlDateTime>>(ae_);
-                Period ag_ = CADEncounterMI?.Period;
-                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                bool? ai_ = context.Operators.OverlapsAfter(af_, ah_, "day");
-                return ai_;
+                IEnumerable<CqlInterval<CqlDateTime>> ad_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> ae_ = context.Operators.First<CqlInterval<CqlDateTime>>(ad_);
+                Period af_ = CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
+                bool? ah_ = context.Operators.OverlapsAfter(ae_, ag_, "day");
+                return ah_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            MedicationRequest k_(Encounter CADEncounterMI) => ActiveBetaBlocker;
-            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
 
         bool? e_(MedicationRequest ActiveBetaBlocker) {
-            Code<MedicationRequest.MedicationrequestStatus> aw_ = ActiveBetaBlocker?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ax_ = aw_?.Value;
-            string ay_ = context.Operators.Convert<string>(ax_);
-            string[] az_ = [
+            Code<MedicationRequest.MedicationrequestStatus> av_ = ActiveBetaBlocker?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aw_ = av_?.Value;
+            string ax_ = context.Operators.Convert<string>(aw_);
+            string[] ay_ = [
                 "active",
                 "completed",
             ];
-            bool? ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
-            Code<MedicationRequest.MedicationRequestIntent> bb_ = ActiveBetaBlocker?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? bc_ = bb_?.Value;
-            string bd_ = context.Operators.Convert<string>(bc_);
-            string[] be_ = [
+            bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
+            Code<MedicationRequest.MedicationRequestIntent> ba_ = ActiveBetaBlocker?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bb_ = ba_?.Value;
+            string bc_ = context.Operators.Convert<string>(bb_);
+            string[] bd_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
-            bool? bg_ = context.Operators.And(ba_, bf_);
-            return bg_;
+            bool? be_ = context.Operators.In<string>(bc_, (IEnumerable<string>)bd_);
+            bool? bf_ = context.Operators.And(az_, be_);
+            return bf_;
         }
 
         IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
@@ -1423,67 +1415,67 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Cardiac_Pacer(context);
         IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer) {
+        bool? c_(Procedure ImplantedCardiacPacer) {
             IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? g_(Encounter CADEncounterModerateOrSevereLVSD) {
 
-                object k_() {
+                object j_() {
+
+                    bool q_() {
+                        DataType u_ = ImplantedCardiacPacer?.Performed;
+                        object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                        bool w_ = v_ is CqlDateTime;
+                        return w_;
+                    }
+
 
                     bool r_() {
-                        DataType v_ = ImplantedCardiacPacer?.Performed;
-                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                        bool x_ = w_ is CqlDateTime;
-                        return x_;
+                        DataType x_ = ImplantedCardiacPacer?.Performed;
+                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                        bool z_ = y_ is CqlInterval<CqlDateTime>;
+                        return z_;
                     }
 
 
                     bool s_() {
-                        DataType y_ = ImplantedCardiacPacer?.Performed;
-                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                        bool aa_ = z_ is CqlInterval<CqlDateTime>;
-                        return aa_;
+                        DataType aa_ = ImplantedCardiacPacer?.Performed;
+                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                        bool ac_ = ab_ is CqlQuantity;
+                        return ac_;
                     }
 
 
                     bool t_() {
-                        DataType ab_ = ImplantedCardiacPacer?.Performed;
-                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-                        bool ad_ = ac_ is CqlQuantity;
-                        return ad_;
+                        DataType ad_ = ImplantedCardiacPacer?.Performed;
+                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                        bool af_ = ae_ is CqlInterval<CqlQuantity>;
+                        return af_;
                     }
 
-
-                    bool u_() {
-                        DataType ae_ = ImplantedCardiacPacer?.Performed;
-                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
-                        return ag_;
-                    }
-
-                    if (r_())
+                    if (q_())
                     {
-                        DataType ah_ = ImplantedCardiacPacer?.Performed;
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        return (ai_ as CqlDateTime) as object;
+                        DataType ag_ = ImplantedCardiacPacer?.Performed;
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        return (ah_ as CqlDateTime) as object;
+                    }
+                    else if (r_())
+                    {
+                        DataType ai_ = ImplantedCardiacPacer?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (s_())
                     {
-                        DataType aj_ = ImplantedCardiacPacer?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ak_ = ImplantedCardiacPacer?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlQuantity) as object;
                     }
                     else if (t_())
                     {
-                        DataType al_ = ImplantedCardiacPacer?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlQuantity) as object;
-                    }
-                    else if (u_())
-                    {
-                        DataType an_ = ImplantedCardiacPacer?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlInterval<CqlQuantity>) as object;
+                        DataType am_ = ImplantedCardiacPacer?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1491,22 +1483,21 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                CqlDateTime m_ = context.Operators.Start(l_);
-                Period n_ = CADEncounterModerateOrSevereLVSD?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                bool? q_ = context.Operators.Before(m_, p_, (string)default);
-                return q_;
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                CqlDateTime l_ = context.Operators.Start(k_);
+                Period m_ = CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                bool? p_ = context.Operators.Before(l_, o_, (string)default);
+                return p_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
-            Procedure i_(Encounter CADEncounterModerateOrSevereLVSD) => ImplantedCardiacPacer;
-            IEnumerable<Procedure> j_ = context.Operators.Select<Encounter, Procedure>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Encounter>(h_);
+            return i_;
         }
 
-        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
         bool? e_ = context.Operators.Exists<Procedure>(d_);
         return e_;
     }
@@ -2002,69 +1993,68 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested"));
 
-        IEnumerable<MedicationRequest> c_(MedicationRequest NoBetaBlockerForLVSDOrdered) {
+        bool? c_(MedicationRequest NoBetaBlockerForLVSDOrdered) {
             IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
 
             bool? i_(Encounter LVSDVisit) {
-                FhirDateTime m_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
-                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
-                Period o_ = LVSDVisit?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
-                return q_;
+                FhirDateTime l_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
+                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+                Period n_ = LVSDVisit?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, "day");
+                return p_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            MedicationRequest k_(Encounter LVSDVisit) => NoBetaBlockerForLVSDOrdered;
-            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
 
         bool? e_(MedicationRequest NoBetaBlockerForLVSDOrdered) {
-            Code<MedicationRequest.MedicationrequestStatus> r_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? s_ = r_?.Value;
-            string t_ = context.Operators.Convert<string>(s_);
-            string[] u_ = [
+            Code<MedicationRequest.MedicationrequestStatus> q_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            string[] t_ = [
                 "active",
                 "completed",
             ];
-            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
-            Code<MedicationRequest.MedicationRequestIntent> w_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? x_ = w_?.Value;
-            string y_ = context.Operators.Convert<string>(x_);
-            string[] z_ = [
+            bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+            Code<MedicationRequest.MedicationRequestIntent> v_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? w_ = v_?.Value;
+            string x_ = context.Operators.Convert<string>(w_);
+            string[] y_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
-            bool? ab_ = context.Operators.And(v_, aa_);
-            List<CodeableConcept> ac_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
+            bool? aa_ = context.Operators.And(u_, z_);
+            List<CodeableConcept> ab_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
 
-            CqlConcept ad_(CodeableConcept @this) {
+            CqlConcept ac_(CodeableConcept @this) {
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return an_;
+            }
+
+            IEnumerable<CqlConcept> ad_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ab_, ac_);
+            CqlValueSet ae_ = this.Medical_Reason(context);
+            bool? af_ = context.Operators.ConceptsInValueSet(ad_, ae_);
+
+            CqlConcept ah_(CodeableConcept @this) {
                 CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                 return ao_;
             }
 
-            IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
-            CqlValueSet af_ = this.Medical_Reason(context);
-            bool? ag_ = context.Operators.ConceptsInValueSet(ae_, af_);
-
-            CqlConcept ai_(CodeableConcept @this) {
-                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return ap_;
-            }
-
-            IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ai_);
-            CqlValueSet ak_ = this.Patient_Reason(context);
-            bool? al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
-            bool? am_ = context.Operators.Or(ag_, al_);
-            bool? an_ = context.Operators.And(ab_, am_);
-            return an_;
+            IEnumerable<CqlConcept> ai_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ab_, ah_);
+            CqlValueSet aj_ = this.Patient_Reason(context);
+            bool? ak_ = context.Operators.ConceptsInValueSet(ai_, aj_);
+            bool? al_ = context.Operators.Or(af_, ak_);
+            bool? am_ = context.Operators.And(aa_, al_);
+            return am_;
         }
 
         IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
@@ -2113,69 +2103,68 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested"));
 
-        IEnumerable<MedicationRequest> c_(MedicationRequest NoBetaBlockerForLVSDOrdered) {
+        bool? c_(MedicationRequest NoBetaBlockerForLVSDOrdered) {
             IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
 
             bool? i_(Encounter PriorMIVisit) {
-                FhirDateTime m_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
-                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
-                Period o_ = PriorMIVisit?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
-                return q_;
+                FhirDateTime l_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
+                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+                Period n_ = PriorMIVisit?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, "day");
+                return p_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            MedicationRequest k_(Encounter PriorMIVisit) => NoBetaBlockerForLVSDOrdered;
-            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
 
         bool? e_(MedicationRequest NoBetaBlockerForLVSDOrdered) {
-            Code<MedicationRequest.MedicationrequestStatus> r_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? s_ = r_?.Value;
-            string t_ = context.Operators.Convert<string>(s_);
-            string[] u_ = [
+            Code<MedicationRequest.MedicationrequestStatus> q_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            string[] t_ = [
                 "active",
                 "completed",
             ];
-            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
-            Code<MedicationRequest.MedicationRequestIntent> w_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? x_ = w_?.Value;
-            string y_ = context.Operators.Convert<string>(x_);
-            string[] z_ = [
+            bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+            Code<MedicationRequest.MedicationRequestIntent> v_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? w_ = v_?.Value;
+            string x_ = context.Operators.Convert<string>(w_);
+            string[] y_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
-            bool? ab_ = context.Operators.And(v_, aa_);
-            List<CodeableConcept> ac_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
+            bool? aa_ = context.Operators.And(u_, z_);
+            List<CodeableConcept> ab_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
 
-            CqlConcept ad_(CodeableConcept @this) {
+            CqlConcept ac_(CodeableConcept @this) {
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return an_;
+            }
+
+            IEnumerable<CqlConcept> ad_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ab_, ac_);
+            CqlValueSet ae_ = this.Medical_Reason(context);
+            bool? af_ = context.Operators.ConceptsInValueSet(ad_, ae_);
+
+            CqlConcept ah_(CodeableConcept @this) {
                 CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                 return ao_;
             }
 
-            IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
-            CqlValueSet af_ = this.Medical_Reason(context);
-            bool? ag_ = context.Operators.ConceptsInValueSet(ae_, af_);
-
-            CqlConcept ai_(CodeableConcept @this) {
-                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return ap_;
-            }
-
-            IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ai_);
-            CqlValueSet ak_ = this.Patient_Reason(context);
-            bool? al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
-            bool? am_ = context.Operators.Or(ag_, al_);
-            bool? an_ = context.Operators.And(ab_, am_);
-            return an_;
+            IEnumerable<CqlConcept> ai_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ab_, ah_);
+            CqlValueSet aj_ = this.Patient_Reason(context);
+            bool? ak_ = context.Operators.ConceptsInValueSet(ai_, aj_);
+            bool? al_ = context.Operators.Or(af_, ak_);
+            bool? am_ = context.Operators.And(aa_, al_);
+            return am_;
         }
 
         IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
@@ -305,63 +305,61 @@ public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounters(context);
 
-        IEnumerable<Encounter> b_(Encounter EDOrAmbulatoryVisit) {
+        bool? b_(Encounter EDOrAmbulatoryVisit) {
             CqlValueSet d_ = this.Antibiotic_Medications_for_Pharyngitis(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> o_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? p_(Medication M) {
-                    object t_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object u_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> v_ = context.Operators.Split((string)u_, "/");
-                    string w_ = context.Operators.Last<string>(v_);
-                    bool? x_ = context.Operators.Equal(t_, w_);
-                    CodeableConcept y_ = M?.Code;
-                    CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                    CqlValueSet aa_ = this.Antibiotic_Medications_for_Pharyngitis(context);
-                    bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-                    bool? ac_ = context.Operators.And(x_, ab_);
-                    return ac_;
+                bool? o_(Medication M) {
+                    object r_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object s_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> t_ = context.Operators.Split((string)s_, "/");
+                    string u_ = context.Operators.Last<string>(t_);
+                    bool? v_ = context.Operators.Equal(r_, u_);
+                    CodeableConcept w_ = M?.Code;
+                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
+                    CqlValueSet y_ = this.Antibiotic_Medications_for_Pharyngitis(context);
+                    bool? z_ = context.Operators.ConceptInValueSet(x_, y_);
+                    bool? aa_ = context.Operators.And(v_, z_);
+                    return aa_;
                 }
 
-                IEnumerable<Medication> q_ = context.Operators.Where<Medication>(o_, p_);
-                MedicationRequest r_(Medication M) => MR;
-                IEnumerable<MedicationRequest> s_ = context.Operators.Select<Medication, MedicationRequest>(q_, r_);
-                return s_;
+                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
+                bool? q_ = context.Operators.Exists<Medication>(p_);
+                return q_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
             IEnumerable<MedicationRequest> j_ = Status_1_15_000.Instance.isMedicationOrder(context, i_);
 
             bool? k_(MedicationRequest AntibioticOrdered) {
-                Period ad_ = EDOrAmbulatoryVisit?.Period;
-                CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_ as object);
-                CqlDateTime ag_ = context.Operators.Start(af_);
-                FhirDateTime ah_ = AntibioticOrdered?.AuthoredOnElement;
-                CqlDateTime ai_ = context.Operators.Convert<CqlDateTime>(ah_);
-                CqlQuantity aj_ = context.Operators.Quantity(3m, "days");
-                CqlDateTime ak_ = context.Operators.Subtract(ai_, aj_);
-                CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(ah_);
-                CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ak_, am_, true, true);
-                bool? ao_ = context.Operators.In<CqlDateTime>(ag_, an_, "day");
-                CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(ah_);
-                bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
-                bool? as_ = context.Operators.And(ao_, ar_);
-                return as_;
+                Period ab_ = EDOrAmbulatoryVisit?.Period;
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_ as object);
+                CqlDateTime ae_ = context.Operators.Start(ad_);
+                FhirDateTime af_ = AntibioticOrdered?.AuthoredOnElement;
+                CqlDateTime ag_ = context.Operators.Convert<CqlDateTime>(af_);
+                CqlQuantity ah_ = context.Operators.Quantity(3m, "days");
+                CqlDateTime ai_ = context.Operators.Subtract(ag_, ah_);
+                CqlDateTime ak_ = context.Operators.Convert<CqlDateTime>(af_);
+                CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ai_, ak_, true, true);
+                bool? am_ = context.Operators.In<CqlDateTime>(ae_, al_, "day");
+                CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(af_);
+                bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
+                bool? aq_ = context.Operators.And(am_, ap_);
+                return aq_;
             }
 
             IEnumerable<MedicationRequest> l_ = context.Operators.Where<MedicationRequest>(j_, k_);
-            Encounter m_(MedicationRequest AntibioticOrdered) => EDOrAmbulatoryVisit;
-            IEnumerable<Encounter> n_ = context.Operators.Select<MedicationRequest, Encounter>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<MedicationRequest>(l_);
+            return m_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -508,30 +506,29 @@ public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> n_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, m_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> o_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> p_(MedicationRequest MR) {
+        bool? p_(MedicationRequest MR) {
             IEnumerable<Medication> af_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? ag_(Medication M) {
-                object ak_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object al_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> am_ = context.Operators.Split((string)al_, "/");
-                string an_ = context.Operators.Last<string>(am_);
-                bool? ao_ = context.Operators.Equal(ak_, an_);
-                CodeableConcept ap_ = M?.Code;
-                CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
-                CqlValueSet ar_ = this.Antibiotic_Medications_for_Pharyngitis(context);
-                bool? as_ = context.Operators.ConceptInValueSet(aq_, ar_);
-                bool? at_ = context.Operators.And(ao_, as_);
-                return at_;
+                object aj_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ak_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> al_ = context.Operators.Split((string)ak_, "/");
+                string am_ = context.Operators.Last<string>(al_);
+                bool? an_ = context.Operators.Equal(aj_, am_);
+                CodeableConcept ao_ = M?.Code;
+                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ao_);
+                CqlValueSet aq_ = this.Antibiotic_Medications_for_Pharyngitis(context);
+                bool? ar_ = context.Operators.ConceptInValueSet(ap_, aq_);
+                bool? as_ = context.Operators.And(an_, ar_);
+                return as_;
             }
 
             IEnumerable<Medication> ah_ = context.Operators.Where<Medication>(af_, ag_);
-            MedicationRequest ai_(Medication M) => MR;
-            IEnumerable<MedicationRequest> aj_ = context.Operators.Select<Medication, MedicationRequest>(ah_, ai_);
-            return aj_;
+            bool? ai_ = context.Operators.Exists<Medication>(ah_);
+            return ai_;
         }
 
-        IEnumerable<MedicationRequest> q_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(o_, p_);
+        IEnumerable<MedicationRequest> q_ = context.Operators.Where<MedicationRequest>(o_, p_);
         IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(n_, q_);
         IEnumerable<MedicationRequest> s_ = Status_1_15_000.Instance.isMedicationActive(context, r_);
         IEnumerable<Encounter> t_ = Antibiotic_1_11_000.Instance.Encounter_with_Antibiotic_Medication_History(context, b_, s_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS149FHIRDementiaCognitiveAssess-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS149FHIRDementiaCognitiveAssess-1.0.000.g.cs
@@ -209,42 +209,41 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Encounter> a_ = this.Encounter_to_Assess_Cognition(context);
 
-        IEnumerable<Encounter> b_(Encounter EncounterAssessCognition) {
+        bool? b_(Encounter EncounterAssessCognition) {
             CqlValueSet d_ = this.Dementia__and__Mental_Degenerations(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_ as IEnumerable<Condition>, g_ as IEnumerable<Condition>);
 
             bool? i_(Condition Dementia) {
-                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                Period n_ = EncounterAssessCognition?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Dementia);
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                bool? t_ = context.Operators.Overlaps(q_, s_, "day");
-                bool? u_ = context.Operators.And(p_, t_);
-                DataType v_ = Dementia?.Abatement;
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.End(z_);
-                CqlDateTime ac_ = context.Operators.End(m_);
-                bool? ad_ = context.Operators.After(aa_, ac_, "day");
-                bool? ae_ = context.Operators.Or((bool?)(w_ is null), ad_);
-                bool? af_ = context.Operators.And(u_, ae_);
-                bool? ag_ = this.isVerified(context, Dementia);
-                bool? ah_ = context.Operators.And(af_, ag_);
-                return ah_;
+                CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+                Period m_ = EncounterAssessCognition?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, "day");
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Dementia);
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                bool? s_ = context.Operators.Overlaps(p_, r_, "day");
+                bool? t_ = context.Operators.And(o_, s_);
+                DataType u_ = Dementia?.Abatement;
+                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+                CqlDateTime z_ = context.Operators.End(y_);
+                CqlDateTime ab_ = context.Operators.End(l_);
+                bool? ac_ = context.Operators.After(z_, ab_, "day");
+                bool? ad_ = context.Operators.Or((bool?)(v_ is null), ac_);
+                bool? ae_ = context.Operators.And(t_, ad_);
+                bool? af_ = this.isVerified(context, Dementia);
+                bool? ag_ = context.Operators.And(ae_, af_);
+                return ag_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
-            Encounter k_(Condition Dementia) => EncounterAssessCognition;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Condition, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -325,53 +324,52 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
         IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
         IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 
-        IEnumerable<Observation> f_(Observation CognitiveAssessment) {
+        bool? f_(Observation CognitiveAssessment) {
             IEnumerable<Encounter> j_ = this.Dementia_Encounter_During_Measurement_Period(context);
 
             bool? k_(Encounter EncounterDementia) {
-                DataType o_ = CognitiveAssessment?.Effective;
-                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                Period s_ = EncounterDementia?.Period;
-                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                CqlDateTime u_ = context.Operators.End(t_);
-                CqlQuantity v_ = context.Operators.Quantity(12m, "months");
-                CqlDateTime w_ = context.Operators.Subtract(u_, v_);
-                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                CqlDateTime z_ = context.Operators.End(y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, true);
-                bool? ab_ = context.Operators.In<CqlDateTime>(r_, aa_, "day");
-                CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                CqlDateTime ae_ = context.Operators.End(ad_);
-                bool? af_ = context.Operators.Not((bool?)(ae_ is null));
-                bool? ag_ = context.Operators.And(ab_, af_);
-                return ag_;
+                DataType n_ = CognitiveAssessment?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                Period r_ = EncounterDementia?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.End(s_);
+                CqlQuantity u_ = context.Operators.Quantity(12m, "months");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime y_ = context.Operators.End(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime ad_ = context.Operators.End(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                return af_;
             }
 
             IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
-            Observation m_(Encounter EncounterDementia) => CognitiveAssessment;
-            IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Encounter>(l_);
+            return m_;
         }
 
-        IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
 
         bool? h_(Observation CognitiveAssessment) {
-            DataType ah_ = CognitiveAssessment?.Value;
-            object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-            bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
-            Code<ObservationStatus> ak_ = CognitiveAssessment?.StatusElement;
-            ObservationStatus? al_ = ak_?.Value;
-            string am_ = context.Operators.Convert<string>(al_);
-            string[] an_ = [
+            DataType ag_ = CognitiveAssessment?.Value;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+            Code<ObservationStatus> aj_ = CognitiveAssessment?.StatusElement;
+            ObservationStatus? ak_ = aj_?.Value;
+            string al_ = context.Operators.Convert<string>(ak_);
+            string[] am_ = [
                 "final",
                 "amended",
                 "corrected",
             ];
-            bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
-            bool? ap_ = context.Operators.And(aj_, ao_);
-            return ap_;
+            bool? an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
+            bool? ao_ = context.Operators.And(ai_, an_);
+            return ao_;
         }
 
         IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -407,51 +405,50 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
         IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
         IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 
-        IEnumerable<Observation> f_(Observation NoCognitiveAssessment) {
+        bool? f_(Observation NoCognitiveAssessment) {
             IEnumerable<Encounter> j_ = this.Dementia_Encounter_During_Measurement_Period(context);
 
             bool? k_(Encounter EncounterDementia) {
-                Instant o_ = NoCognitiveAssessment?.IssuedElement;
-                DateTimeOffset? p_ = o_?.Value;
-                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                Period r_ = EncounterDementia?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
-                return t_;
+                Instant n_ = NoCognitiveAssessment?.IssuedElement;
+                DateTimeOffset? o_ = n_?.Value;
+                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+                Period q_ = EncounterDementia?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
+                return s_;
             }
 
             IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
-            Observation m_(Encounter EncounterDementia) => NoCognitiveAssessment;
-            IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Encounter>(l_);
+            return m_;
         }
 
-        IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
 
         bool? h_(Observation NoCognitiveAssessment) {
 
-            bool? u_(Extension @this) {
-                FhirUri ac_ = @this?.UrlElement;
-                string ad_ = FHIRHelpers_4_4_000.Instance.ToString(context, ac_);
-                bool? ae_ = context.Operators.Equal(ad_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            bool? t_(Extension @this) {
+                FhirUri ab_ = @this?.UrlElement;
+                string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
+                bool? ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return ad_;
+            }
+
+            IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoCognitiveAssessment is DomainResource
+                ? (NoCognitiveAssessment as DomainResource).Extension
+                : default), t_);
+
+            object v_(Extension @this) {
+                DataType ae_ = @this?.Value;
                 return ae_;
             }
 
-            IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoCognitiveAssessment is DomainResource
-                ? (NoCognitiveAssessment as DomainResource).Extension
-                : default), u_);
-
-            object w_(Extension @this) {
-                DataType af_ = @this?.Value;
-                return af_;
-            }
-
-            IEnumerable<object> x_ = context.Operators.Select<Extension, object>(v_, w_);
-            object y_ = context.Operators.SingletonFrom<object>(x_);
-            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_ as CodeableConcept);
-            CqlValueSet aa_ = this.Patient_Reason(context);
-            bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-            return ab_;
+            IEnumerable<object> w_ = context.Operators.Select<Extension, object>(u_, v_);
+            object x_ = context.Operators.SingletonFrom<object>(w_);
+            CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
+            CqlValueSet z_ = this.Patient_Reason(context);
+            bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
+            return aa_;
         }
 
         IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
@@ -376,45 +376,44 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> k_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? l_(Medication M) {
-                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
-                string s_ = context.Operators.Last<string>(r_);
-                bool? t_ = context.Operators.Equal(p_, s_);
-                CodeableConcept u_ = M?.Code;
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                CqlValueSet w_ = this.Contraceptive_Medications(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
+                string r_ = context.Operators.Last<string>(q_);
+                bool? s_ = context.Operators.Equal(o_, r_);
+                CodeableConcept t_ = M?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlValueSet v_ = this.Contraceptive_Medications(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Medication> m_ = context.Operators.Where<Medication>(k_, l_);
-            MedicationRequest n_(Medication M) => MR;
-            IEnumerable<MedicationRequest> o_ = context.Operators.Select<Medication, MedicationRequest>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Medication>(m_);
+            return n_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationActive(context, f_);
 
         bool? h_(MedicationRequest ActiveContraceptives) {
-            CqlInterval<CqlDate> z_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveContraceptives);
-            CqlDate aa_ = z_?.low;
-            CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(aa_);
-            CqlDate ad_ = z_?.high;
-            CqlDateTime ae_ = context.Operators.ConvertDateToDateTime(ad_);
-            bool? ag_ = z_?.lowClosed;
-            bool? ai_ = z_?.highClosed;
-            CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ab_, ae_, ag_, ai_);
-            CqlInterval<CqlDateTime> ak_ = this.Measurement_Period(context);
-            bool? al_ = context.Operators.Overlaps(aj_, ak_, (string)default);
-            return al_;
+            CqlInterval<CqlDate> y_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveContraceptives);
+            CqlDate z_ = y_?.low;
+            CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+            CqlDate ac_ = y_?.high;
+            CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(ac_);
+            bool? af_ = y_?.lowClosed;
+            bool? ah_ = y_?.highClosed;
+            CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(aa_, ad_, af_, ah_);
+            CqlInterval<CqlDateTime> aj_ = this.Measurement_Period(context);
+            bool? ak_ = context.Operators.Overlaps(ai_, aj_, (string)default);
+            return ak_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
@@ -435,40 +434,39 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> k_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? l_(Medication M) {
-                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
-                string s_ = context.Operators.Last<string>(r_);
-                bool? t_ = context.Operators.Equal(p_, s_);
-                CodeableConcept u_ = M?.Code;
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                CqlValueSet w_ = this.Contraceptive_Medications(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
+                string r_ = context.Operators.Last<string>(q_);
+                bool? s_ = context.Operators.Equal(o_, r_);
+                CodeableConcept t_ = M?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlValueSet v_ = this.Contraceptive_Medications(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Medication> m_ = context.Operators.Where<Medication>(k_, l_);
-            MedicationRequest n_(Medication M) => MR;
-            IEnumerable<MedicationRequest> o_ = context.Operators.Select<Medication, MedicationRequest>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Medication>(m_);
+            return n_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationOrder(context, f_);
 
         bool? h_(MedicationRequest OrderedContraceptives) {
-            CqlInterval<CqlDateTime> z_ = this.Measurement_Period(context);
-            FhirDateTime aa_ = OrderedContraceptives?.AuthoredOnElement;
-            CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-            CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_ as object);
-            bool? ad_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ac_, "day");
-            return ad_;
+            CqlInterval<CqlDateTime> y_ = this.Measurement_Period(context);
+            FhirDateTime z_ = OrderedContraceptives?.AuthoredOnElement;
+            CqlDateTime aa_ = context.Operators.Convert<CqlDateTime>(z_);
+            CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_ as object);
+            bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, ab_, "day");
+            return ac_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
@@ -758,127 +756,124 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
         IEnumerable<ServiceRequest> b_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
         IEnumerable<ServiceRequest> c_ = Status_1_15_000.Instance.isLaboratoryTestOrder(context, b_);
 
-        IEnumerable<ServiceRequest> d_(ServiceRequest PregnancyTest) {
+        bool? d_(ServiceRequest PregnancyTest) {
             CqlValueSet q_ = this.XRay_Study(context);
             IEnumerable<ServiceRequest> r_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, q_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
             IEnumerable<ServiceRequest> s_ = Status_1_15_000.Instance.isDiagnosticStudyOrder(context, r_);
 
             bool? t_(ServiceRequest XrayOrder) {
-                FhirDateTime x_ = XrayOrder?.AuthoredOnElement;
-                CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(x_);
-                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_ as object);
-                CqlDateTime aa_ = context.Operators.Start(z_);
-                FhirDateTime ab_ = PregnancyTest?.AuthoredOnElement;
-                CqlDateTime ac_ = context.Operators.Convert<CqlDateTime>(ab_);
-                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_ as object);
-                CqlDateTime ae_ = context.Operators.End(ad_);
-                CqlDateTime ag_ = context.Operators.Convert<CqlDateTime>(ab_);
-                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_ as object);
-                CqlDateTime ai_ = context.Operators.End(ah_);
-                CqlQuantity aj_ = context.Operators.Quantity(6m, "days");
-                CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
-                CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ae_, ak_, true, true);
-                bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, "day");
-                CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(ab_);
-                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_ as object);
-                CqlDateTime aq_ = context.Operators.End(ap_);
-                bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
-                bool? as_ = context.Operators.And(am_, ar_);
-                return as_;
+                FhirDateTime w_ = XrayOrder?.AuthoredOnElement;
+                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_ as object);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                FhirDateTime aa_ = PregnancyTest?.AuthoredOnElement;
+                CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_ as object);
+                CqlDateTime ad_ = context.Operators.End(ac_);
+                CqlDateTime af_ = context.Operators.Convert<CqlDateTime>(aa_);
+                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_ as object);
+                CqlDateTime ah_ = context.Operators.End(ag_);
+                CqlQuantity ai_ = context.Operators.Quantity(6m, "days");
+                CqlDateTime aj_ = context.Operators.Add(ah_, ai_);
+                CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ad_, aj_, true, true);
+                bool? al_ = context.Operators.In<CqlDateTime>(z_, ak_, "day");
+                CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(aa_);
+                CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_ as object);
+                CqlDateTime ap_ = context.Operators.End(ao_);
+                bool? aq_ = context.Operators.Not((bool?)(ap_ is null));
+                bool? ar_ = context.Operators.And(al_, aq_);
+                return ar_;
             }
 
             IEnumerable<ServiceRequest> u_ = context.Operators.Where<ServiceRequest>(s_, t_);
-            ServiceRequest v_(ServiceRequest XrayOrder) => PregnancyTest;
-            IEnumerable<ServiceRequest> w_ = context.Operators.Select<ServiceRequest, ServiceRequest>(u_, v_);
-            return w_;
+            bool? v_ = context.Operators.Exists<ServiceRequest>(u_);
+            return v_;
         }
 
-        IEnumerable<ServiceRequest> e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
+        IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
 
         bool? f_(ServiceRequest PregnancyTest) {
-            CqlInterval<CqlDateTime> at_ = this.Measurement_Period(context);
-            FhirDateTime au_ = PregnancyTest?.AuthoredOnElement;
-            CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(au_);
-            CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_ as object);
-            bool? ax_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(at_, aw_, (string)default);
-            return ax_;
+            CqlInterval<CqlDateTime> as_ = this.Measurement_Period(context);
+            FhirDateTime at_ = PregnancyTest?.AuthoredOnElement;
+            CqlDateTime au_ = context.Operators.Convert<CqlDateTime>(at_);
+            CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.toInterval(context, au_ as object);
+            bool? aw_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(as_, av_, (string)default);
+            return aw_;
         }
 
         IEnumerable<ServiceRequest> g_ = context.Operators.Where<ServiceRequest>(e_, f_);
         IEnumerable<ServiceRequest> i_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
         IEnumerable<ServiceRequest> j_ = Status_1_15_000.Instance.isLaboratoryTestOrder(context, i_);
 
-        IEnumerable<ServiceRequest> k_(ServiceRequest PregnancyTestOrder) {
-            CqlValueSet ay_ = this.Isotretinoin(context);
-            IEnumerable<MedicationRequest> az_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ay_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> ba_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? k_(ServiceRequest PregnancyTestOrder) {
+            CqlValueSet ax_ = this.Isotretinoin(context);
+            IEnumerable<MedicationRequest> ay_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ax_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> az_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> bb_(MedicationRequest MR) {
-                IEnumerable<Medication> bj_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? ba_(MedicationRequest MR) {
+                IEnumerable<Medication> bh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? bk_(Medication M) {
-                    object bo_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object bp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> bq_ = context.Operators.Split((string)bp_, "/");
-                    string br_ = context.Operators.Last<string>(bq_);
-                    bool? bs_ = context.Operators.Equal(bo_, br_);
-                    CodeableConcept bt_ = M?.Code;
-                    CqlConcept bu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bt_);
-                    CqlValueSet bv_ = this.Isotretinoin(context);
-                    bool? bw_ = context.Operators.ConceptInValueSet(bu_, bv_);
-                    bool? bx_ = context.Operators.And(bs_, bw_);
-                    return bx_;
+                bool? bi_(Medication M) {
+                    object bl_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object bm_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> bn_ = context.Operators.Split((string)bm_, "/");
+                    string bo_ = context.Operators.Last<string>(bn_);
+                    bool? bp_ = context.Operators.Equal(bl_, bo_);
+                    CodeableConcept bq_ = M?.Code;
+                    CqlConcept br_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
+                    CqlValueSet bs_ = this.Isotretinoin(context);
+                    bool? bt_ = context.Operators.ConceptInValueSet(br_, bs_);
+                    bool? bu_ = context.Operators.And(bp_, bt_);
+                    return bu_;
                 }
 
-                IEnumerable<Medication> bl_ = context.Operators.Where<Medication>(bj_, bk_);
-                MedicationRequest bm_(Medication M) => MR;
-                IEnumerable<MedicationRequest> bn_ = context.Operators.Select<Medication, MedicationRequest>(bl_, bm_);
-                return bn_;
+                IEnumerable<Medication> bj_ = context.Operators.Where<Medication>(bh_, bi_);
+                bool? bk_ = context.Operators.Exists<Medication>(bj_);
+                return bk_;
             }
 
-            IEnumerable<MedicationRequest> bc_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(ba_, bb_);
-            IEnumerable<MedicationRequest> bd_ = context.Operators.Union<MedicationRequest>(az_, bc_);
-            IEnumerable<MedicationRequest> be_ = Status_1_15_000.Instance.isMedicationOrder(context, bd_);
+            IEnumerable<MedicationRequest> bb_ = context.Operators.Where<MedicationRequest>(az_, ba_);
+            IEnumerable<MedicationRequest> bc_ = context.Operators.Union<MedicationRequest>(ay_, bb_);
+            IEnumerable<MedicationRequest> bd_ = Status_1_15_000.Instance.isMedicationOrder(context, bc_);
 
-            bool? bf_(MedicationRequest AccutaneOrder) {
-                FhirDateTime by_ = AccutaneOrder?.AuthoredOnElement;
-                CqlDateTime bz_ = context.Operators.Convert<CqlDateTime>(by_);
-                CqlInterval<CqlDateTime> ca_ = QICoreCommon_4_0_000.Instance.toInterval(context, bz_ as object);
-                CqlDateTime cb_ = context.Operators.Start(ca_);
-                FhirDateTime cc_ = PregnancyTestOrder?.AuthoredOnElement;
-                CqlDateTime cd_ = context.Operators.Convert<CqlDateTime>(cc_);
-                CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.toInterval(context, cd_ as object);
-                CqlDateTime cf_ = context.Operators.End(ce_);
-                CqlDateTime ch_ = context.Operators.Convert<CqlDateTime>(cc_);
-                CqlInterval<CqlDateTime> ci_ = QICoreCommon_4_0_000.Instance.toInterval(context, ch_ as object);
-                CqlDateTime cj_ = context.Operators.End(ci_);
-                CqlQuantity ck_ = context.Operators.Quantity(6m, "days");
-                CqlDateTime cl_ = context.Operators.Add(cj_, ck_);
-                CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(cf_, cl_, true, true);
-                bool? cn_ = context.Operators.In<CqlDateTime>(cb_, cm_, "day");
-                CqlDateTime cp_ = context.Operators.Convert<CqlDateTime>(cc_);
-                CqlInterval<CqlDateTime> cq_ = QICoreCommon_4_0_000.Instance.toInterval(context, cp_ as object);
-                CqlDateTime cr_ = context.Operators.End(cq_);
-                bool? cs_ = context.Operators.Not((bool?)(cr_ is null));
-                bool? ct_ = context.Operators.And(cn_, cs_);
-                return ct_;
+            bool? be_(MedicationRequest AccutaneOrder) {
+                FhirDateTime bv_ = AccutaneOrder?.AuthoredOnElement;
+                CqlDateTime bw_ = context.Operators.Convert<CqlDateTime>(bv_);
+                CqlInterval<CqlDateTime> bx_ = QICoreCommon_4_0_000.Instance.toInterval(context, bw_ as object);
+                CqlDateTime by_ = context.Operators.Start(bx_);
+                FhirDateTime bz_ = PregnancyTestOrder?.AuthoredOnElement;
+                CqlDateTime ca_ = context.Operators.Convert<CqlDateTime>(bz_);
+                CqlInterval<CqlDateTime> cb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ca_ as object);
+                CqlDateTime cc_ = context.Operators.End(cb_);
+                CqlDateTime ce_ = context.Operators.Convert<CqlDateTime>(bz_);
+                CqlInterval<CqlDateTime> cf_ = QICoreCommon_4_0_000.Instance.toInterval(context, ce_ as object);
+                CqlDateTime cg_ = context.Operators.End(cf_);
+                CqlQuantity ch_ = context.Operators.Quantity(6m, "days");
+                CqlDateTime ci_ = context.Operators.Add(cg_, ch_);
+                CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(cc_, ci_, true, true);
+                bool? ck_ = context.Operators.In<CqlDateTime>(by_, cj_, "day");
+                CqlDateTime cm_ = context.Operators.Convert<CqlDateTime>(bz_);
+                CqlInterval<CqlDateTime> cn_ = QICoreCommon_4_0_000.Instance.toInterval(context, cm_ as object);
+                CqlDateTime co_ = context.Operators.End(cn_);
+                bool? cp_ = context.Operators.Not((bool?)(co_ is null));
+                bool? cq_ = context.Operators.And(ck_, cp_);
+                return cq_;
             }
 
-            IEnumerable<MedicationRequest> bg_ = context.Operators.Where<MedicationRequest>(be_, bf_);
-            ServiceRequest bh_(MedicationRequest AccutaneOrder) => PregnancyTestOrder;
-            IEnumerable<ServiceRequest> bi_ = context.Operators.Select<MedicationRequest, ServiceRequest>(bg_, bh_);
-            return bi_;
+            IEnumerable<MedicationRequest> bf_ = context.Operators.Where<MedicationRequest>(bd_, be_);
+            bool? bg_ = context.Operators.Exists<MedicationRequest>(bf_);
+            return bg_;
         }
 
-        IEnumerable<ServiceRequest> l_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(j_, k_);
+        IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
 
         bool? m_(ServiceRequest PregnancyTestOrder) {
-            CqlInterval<CqlDateTime> cu_ = this.Measurement_Period(context);
-            FhirDateTime cv_ = PregnancyTestOrder?.AuthoredOnElement;
-            CqlDateTime cw_ = context.Operators.Convert<CqlDateTime>(cv_);
-            CqlInterval<CqlDateTime> cx_ = QICoreCommon_4_0_000.Instance.toInterval(context, cw_ as object);
-            bool? cy_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cu_, cx_, (string)default);
-            return cy_;
+            CqlInterval<CqlDateTime> cr_ = this.Measurement_Period(context);
+            FhirDateTime cs_ = PregnancyTestOrder?.AuthoredOnElement;
+            CqlDateTime ct_ = context.Operators.Convert<CqlDateTime>(cs_);
+            CqlInterval<CqlDateTime> cu_ = QICoreCommon_4_0_000.Instance.toInterval(context, ct_ as object);
+            bool? cv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cr_, cu_, (string)default);
+            return cv_;
         }
 
         IEnumerable<ServiceRequest> n_ = context.Operators.Where<ServiceRequest>(l_, m_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
@@ -424,30 +424,29 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> n_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, m_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> o_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> p_(MedicationRequest MR) {
+        bool? p_(MedicationRequest MR) {
             IEnumerable<Medication> al_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? am_(Medication M) {
-                object aq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ar_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> as_ = context.Operators.Split((string)ar_, "/");
-                string at_ = context.Operators.Last<string>(as_);
-                bool? au_ = context.Operators.Equal(aq_, at_);
-                CodeableConcept av_ = M?.Code;
-                CqlConcept aw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, av_);
-                CqlValueSet ax_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
-                bool? ay_ = context.Operators.ConceptInValueSet(aw_, ax_);
-                bool? az_ = context.Operators.And(au_, ay_);
-                return az_;
+                object ap_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object aq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ar_ = context.Operators.Split((string)aq_, "/");
+                string as_ = context.Operators.Last<string>(ar_);
+                bool? at_ = context.Operators.Equal(ap_, as_);
+                CodeableConcept au_ = M?.Code;
+                CqlConcept av_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, au_);
+                CqlValueSet aw_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
+                bool? ax_ = context.Operators.ConceptInValueSet(av_, aw_);
+                bool? ay_ = context.Operators.And(at_, ax_);
+                return ay_;
             }
 
             IEnumerable<Medication> an_ = context.Operators.Where<Medication>(al_, am_);
-            MedicationRequest ao_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ap_ = context.Operators.Select<Medication, MedicationRequest>(an_, ao_);
-            return ap_;
+            bool? ao_ = context.Operators.Exists<Medication>(an_);
+            return ao_;
         }
 
-        IEnumerable<MedicationRequest> q_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(o_, p_);
+        IEnumerable<MedicationRequest> q_ = context.Operators.Where<MedicationRequest>(o_, p_);
         IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(n_, q_);
         IEnumerable<MedicationRequest> s_ = Status_1_15_000.Instance.isMedicationActive(context, r_);
         IEnumerable<Encounter> t_ = Antibiotic_1_11_000.Instance.Encounter_with_Antibiotic_Medication_History(context, b_, s_);
@@ -479,69 +478,67 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = this.Encounter_with_Upper_Respiratory_Infection(context);
 
-        IEnumerable<Encounter> c_(Encounter EncounterWithURI) {
-            CqlValueSet i_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
-            IEnumerable<MedicationRequest> j_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> k_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? b_(Encounter EncounterWithURI) {
+            CqlValueSet g_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> i_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> l_(MedicationRequest MR) {
-                IEnumerable<Medication> t_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? j_(MedicationRequest MR) {
+                IEnumerable<Medication> r_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? u_(Medication M) {
-                    object y_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object z_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> aa_ = context.Operators.Split((string)z_, "/");
-                    string ab_ = context.Operators.Last<string>(aa_);
-                    bool? ac_ = context.Operators.Equal(y_, ab_);
-                    CodeableConcept ad_ = M?.Code;
-                    CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
-                    CqlValueSet af_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
-                    bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-                    bool? ah_ = context.Operators.And(ac_, ag_);
-                    return ah_;
+                bool? s_(Medication M) {
+                    object v_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object w_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> x_ = context.Operators.Split((string)w_, "/");
+                    string y_ = context.Operators.Last<string>(x_);
+                    bool? z_ = context.Operators.Equal(v_, y_);
+                    CodeableConcept aa_ = M?.Code;
+                    CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
+                    CqlValueSet ac_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
+                    bool? ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
+                    bool? ae_ = context.Operators.And(z_, ad_);
+                    return ae_;
                 }
 
-                IEnumerable<Medication> v_ = context.Operators.Where<Medication>(t_, u_);
-                MedicationRequest w_(Medication M) => MR;
-                IEnumerable<MedicationRequest> x_ = context.Operators.Select<Medication, MedicationRequest>(v_, w_);
-                return x_;
+                IEnumerable<Medication> t_ = context.Operators.Where<Medication>(r_, s_);
+                bool? u_ = context.Operators.Exists<Medication>(t_);
+                return u_;
             }
 
-            IEnumerable<MedicationRequest> m_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(k_, l_);
-            IEnumerable<MedicationRequest> n_ = context.Operators.Union<MedicationRequest>(j_, m_);
-            IEnumerable<MedicationRequest> o_ = Status_1_15_000.Instance.isMedicationOrder(context, n_);
+            IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
+            IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(h_, k_);
+            IEnumerable<MedicationRequest> m_ = Status_1_15_000.Instance.isMedicationOrder(context, l_);
 
-            bool? p_(MedicationRequest OrderedAntibiotic) {
-                FhirDateTime ai_ = OrderedAntibiotic?.AuthoredOnElement;
-                CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
-                Period ak_ = EncounterWithURI?.Period;
-                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
+            bool? n_(MedicationRequest OrderedAntibiotic) {
+                FhirDateTime af_ = OrderedAntibiotic?.AuthoredOnElement;
+                CqlDateTime ag_ = context.Operators.Convert<CqlDateTime>(af_);
+                Period ah_ = EncounterWithURI?.Period;
+                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
+                CqlDateTime aj_ = context.Operators.Start(ai_);
+                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
                 CqlDateTime am_ = context.Operators.Start(al_);
-                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
-                CqlDateTime ap_ = context.Operators.Start(ao_);
-                CqlQuantity aq_ = context.Operators.Quantity(3m, "days");
-                CqlDateTime ar_ = context.Operators.Add(ap_, aq_);
-                CqlInterval<CqlDateTime> as_ = context.Operators.Interval(am_, ar_, true, true);
-                bool? at_ = context.Operators.In<CqlDateTime>(aj_, as_, (string)default);
-                CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
-                CqlDateTime aw_ = context.Operators.Start(av_);
-                bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
-                bool? ay_ = context.Operators.And(at_, ax_);
-                return ay_;
+                CqlQuantity an_ = context.Operators.Quantity(3m, "days");
+                CqlDateTime ao_ = context.Operators.Add(am_, an_);
+                CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(aj_, ao_, true, true);
+                bool? aq_ = context.Operators.In<CqlDateTime>(ag_, ap_, (string)default);
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                bool? au_ = context.Operators.Not((bool?)(at_ is null));
+                bool? av_ = context.Operators.And(aq_, au_);
+                return av_;
             }
 
-            IEnumerable<MedicationRequest> q_ = context.Operators.Where<MedicationRequest>(o_, p_);
-            Encounter r_(MedicationRequest OrderedAntibiotic) => EncounterWithURI;
-            IEnumerable<Encounter> s_ = context.Operators.Select<MedicationRequest, Encounter>(q_, r_);
-            return s_;
+            IEnumerable<MedicationRequest> o_ = context.Operators.Where<MedicationRequest>(m_, n_);
+            bool? p_ = context.Operators.Exists<MedicationRequest>(o_);
+            bool? q_ = context.Operators.Not(p_);
+            return q_;
         }
 
-        IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(a_, c_);
-        IEnumerable<Encounter> e_ = context.Operators.Except<Encounter>(a_, d_);
-        Encounter f_(Encounter EncounterWithURI) => EncounterWithURI;
-        IEnumerable<Encounter> g_ = context.Operators.Select<Encounter, Encounter>(e_, f_);
-        IEnumerable<Encounter> h_ = context.Operators.Distinct<Encounter>(g_);
-        return h_;
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+        Encounter d_(Encounter EncounterWithURI) => EncounterWithURI;
+        IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+        IEnumerable<Encounter> f_ = context.Operators.Distinct<Encounter>(e_);
+        return f_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
@@ -457,71 +457,70 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<MedicationRequest> a_ = Status_1_15_000.Instance.isMedicationOrder(context, Medication);
 
-        IEnumerable<MedicationRequest> b_(MedicationRequest OrderMedication1) {
+        bool? b_(MedicationRequest OrderMedication1) {
             IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationOrder(context, Medication);
 
             bool? h_(MedicationRequest OrderMedication2) {
-                FhirDateTime l_ = OrderMedication1?.AuthoredOnElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
-                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
-                MedicationRequest.DispenseRequestComponent p_ = OrderMedication1?.DispenseRequest;
-                UnsignedInt q_ = p_?.NumberOfRepeatsAllowedElement;
-                int? r_ = q_?.Value;
-                bool? s_ = context.Operators.GreaterOrEqual(r_, 1);
-                bool? t_ = context.Operators.And(o_, s_);
-                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlDate w_ = context.Operators.DateFrom(v_);
-                FhirDateTime x_ = OrderMedication2?.AuthoredOnElement;
-                CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(x_);
-                CqlDate z_ = context.Operators.DateFrom(y_);
-                bool? aa_ = context.Operators.Equivalent(w_, z_);
-                bool? ab_ = context.Operators.Not(aa_);
-                CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(l_);
-                bool? af_ = context.Operators.In<CqlDateTime>(ad_, n_, (string)default);
-                bool? ag_ = context.Operators.And(ab_, af_);
-                CqlDateTime ai_ = context.Operators.Convert<CqlDateTime>(x_);
-                bool? ak_ = context.Operators.In<CqlDateTime>(ai_, n_, (string)default);
-                bool? al_ = context.Operators.And(ag_, ak_);
-                bool? am_ = context.Operators.Or(t_, al_);
-                CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlDate ap_ = context.Operators.DateFrom(ao_);
-                CqlDateTime ar_ = context.Operators.Convert<CqlDateTime>(x_);
-                CqlDate as_ = context.Operators.DateFrom(ar_);
-                bool? at_ = context.Operators.Equivalent(ap_, as_);
-                CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(l_);
-                bool? ax_ = context.Operators.In<CqlDateTime>(av_, n_, (string)default);
-                bool? ay_ = context.Operators.And(at_, ax_);
-                CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication1);
-                CqlDate ba_ = context.Operators.Start(az_);
-                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
-                CqlDate bc_ = context.Operators.DateFrom(bb_);
-                CqlInterval<CqlDate> bd_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication2);
-                CqlDate be_ = context.Operators.Start(bd_);
-                CqlDateTime bf_ = context.Operators.ConvertDateToDateTime(be_);
-                CqlDate bg_ = context.Operators.DateFrom(bf_);
-                bool? bh_ = context.Operators.Equivalent(bc_, bg_);
-                bool? bi_ = context.Operators.Not(bh_);
-                bool? bj_ = context.Operators.And(ay_, bi_);
-                CqlDate bl_ = context.Operators.Start(az_);
-                CqlDateTime bm_ = context.Operators.ConvertDateToDateTime(bl_);
-                bool? bo_ = context.Operators.In<CqlDateTime>(bm_, n_, (string)default);
-                bool? bp_ = context.Operators.And(bj_, bo_);
-                CqlDate br_ = context.Operators.Start(bd_);
-                CqlDateTime bs_ = context.Operators.ConvertDateToDateTime(br_);
-                bool? bu_ = context.Operators.In<CqlDateTime>(bs_, n_, (string)default);
-                bool? bv_ = context.Operators.And(bp_, bu_);
-                bool? bw_ = context.Operators.Or(am_, bv_);
-                return bw_;
+                FhirDateTime k_ = OrderMedication1?.AuthoredOnElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
+                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
+                MedicationRequest.DispenseRequestComponent o_ = OrderMedication1?.DispenseRequest;
+                UnsignedInt p_ = o_?.NumberOfRepeatsAllowedElement;
+                int? q_ = p_?.Value;
+                bool? r_ = context.Operators.GreaterOrEqual(q_, 1);
+                bool? s_ = context.Operators.And(n_, r_);
+                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlDate v_ = context.Operators.DateFrom(u_);
+                FhirDateTime w_ = OrderMedication2?.AuthoredOnElement;
+                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+                CqlDate y_ = context.Operators.DateFrom(x_);
+                bool? z_ = context.Operators.Equivalent(v_, y_);
+                bool? aa_ = context.Operators.Not(z_);
+                CqlDateTime ac_ = context.Operators.Convert<CqlDateTime>(k_);
+                bool? ae_ = context.Operators.In<CqlDateTime>(ac_, m_, (string)default);
+                bool? af_ = context.Operators.And(aa_, ae_);
+                CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(w_);
+                bool? aj_ = context.Operators.In<CqlDateTime>(ah_, m_, (string)default);
+                bool? ak_ = context.Operators.And(af_, aj_);
+                bool? al_ = context.Operators.Or(s_, ak_);
+                CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlDate ao_ = context.Operators.DateFrom(an_);
+                CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(w_);
+                CqlDate ar_ = context.Operators.DateFrom(aq_);
+                bool? as_ = context.Operators.Equivalent(ao_, ar_);
+                CqlDateTime au_ = context.Operators.Convert<CqlDateTime>(k_);
+                bool? aw_ = context.Operators.In<CqlDateTime>(au_, m_, (string)default);
+                bool? ax_ = context.Operators.And(as_, aw_);
+                CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication1);
+                CqlDate az_ = context.Operators.Start(ay_);
+                CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
+                CqlDate bb_ = context.Operators.DateFrom(ba_);
+                CqlInterval<CqlDate> bc_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication2);
+                CqlDate bd_ = context.Operators.Start(bc_);
+                CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+                CqlDate bf_ = context.Operators.DateFrom(be_);
+                bool? bg_ = context.Operators.Equivalent(bb_, bf_);
+                bool? bh_ = context.Operators.Not(bg_);
+                bool? bi_ = context.Operators.And(ax_, bh_);
+                CqlDate bk_ = context.Operators.Start(ay_);
+                CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
+                bool? bn_ = context.Operators.In<CqlDateTime>(bl_, m_, (string)default);
+                bool? bo_ = context.Operators.And(bi_, bn_);
+                CqlDate bq_ = context.Operators.Start(bc_);
+                CqlDateTime br_ = context.Operators.ConvertDateToDateTime(bq_);
+                bool? bt_ = context.Operators.In<CqlDateTime>(br_, m_, (string)default);
+                bool? bu_ = context.Operators.And(bo_, bt_);
+                bool? bv_ = context.Operators.Or(al_, bu_);
+                return bv_;
             }
 
             IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
-            MedicationRequest j_(MedicationRequest OrderMedication2) => OrderMedication1;
-            IEnumerable<MedicationRequest> k_ = context.Operators.Select<MedicationRequest, MedicationRequest>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<MedicationRequest>(i_);
+            return j_;
         }
 
-        IEnumerable<MedicationRequest> c_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(a_, b_);
+        IEnumerable<MedicationRequest> c_ = context.Operators.Where<MedicationRequest>(a_, b_);
         MedicationRequest d_(MedicationRequest OrderMedication1) => OrderMedication1;
         IEnumerable<MedicationRequest> e_ = context.Operators.Select<MedicationRequest, MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Distinct<MedicationRequest>(e_);
@@ -541,118 +540,114 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> eo_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? ep_(Medication M) {
-                object et_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object eu_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ev_ = context.Operators.Split((string)eu_, "/");
-                string ew_ = context.Operators.Last<string>(ev_);
-                bool? ex_ = context.Operators.Equal(et_, ew_);
-                CodeableConcept ey_ = M?.Code;
-                CqlConcept ez_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ey_);
-                CqlValueSet fa_ = this.Potentially_Harmful_Antihistamines_for_Older_Adults(context);
-                bool? fb_ = context.Operators.ConceptInValueSet(ez_, fa_);
-                bool? fc_ = context.Operators.And(ex_, fb_);
-                return fc_;
+                object es_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object et_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> eu_ = context.Operators.Split((string)et_, "/");
+                string ev_ = context.Operators.Last<string>(eu_);
+                bool? ew_ = context.Operators.Equal(es_, ev_);
+                CodeableConcept ex_ = M?.Code;
+                CqlConcept ey_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ex_);
+                CqlValueSet ez_ = this.Potentially_Harmful_Antihistamines_for_Older_Adults(context);
+                bool? fa_ = context.Operators.ConceptInValueSet(ey_, ez_);
+                bool? fb_ = context.Operators.And(ew_, fa_);
+                return fb_;
             }
 
             IEnumerable<Medication> eq_ = context.Operators.Where<Medication>(eo_, ep_);
-            MedicationRequest er_(Medication M) => MR;
-            IEnumerable<MedicationRequest> es_ = context.Operators.Select<Medication, MedicationRequest>(eq_, er_);
-            return es_;
+            bool? er_ = context.Operators.Exists<Medication>(eq_);
+            return er_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = this.moreThanOneOrder(context, f_);
         CqlValueSet h_ = this.Potentially_Harmful_Antiparkinsonian_Agents_for_Older_Adults(context);
         IEnumerable<MedicationRequest> i_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> k_(MedicationRequest MR) {
-            IEnumerable<Medication> fd_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? k_(MedicationRequest MR) {
+            IEnumerable<Medication> fc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? fe_(Medication M) {
-                object fi_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object fj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fk_ = context.Operators.Split((string)fj_, "/");
-                string fl_ = context.Operators.Last<string>(fk_);
-                bool? fm_ = context.Operators.Equal(fi_, fl_);
-                CodeableConcept fn_ = M?.Code;
-                CqlConcept fo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fn_);
-                CqlValueSet fp_ = this.Potentially_Harmful_Antiparkinsonian_Agents_for_Older_Adults(context);
-                bool? fq_ = context.Operators.ConceptInValueSet(fo_, fp_);
-                bool? fr_ = context.Operators.And(fm_, fq_);
-                return fr_;
+            bool? fd_(Medication M) {
+                object fg_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object fh_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fi_ = context.Operators.Split((string)fh_, "/");
+                string fj_ = context.Operators.Last<string>(fi_);
+                bool? fk_ = context.Operators.Equal(fg_, fj_);
+                CodeableConcept fl_ = M?.Code;
+                CqlConcept fm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fl_);
+                CqlValueSet fn_ = this.Potentially_Harmful_Antiparkinsonian_Agents_for_Older_Adults(context);
+                bool? fo_ = context.Operators.ConceptInValueSet(fm_, fn_);
+                bool? fp_ = context.Operators.And(fk_, fo_);
+                return fp_;
             }
 
-            IEnumerable<Medication> ff_ = context.Operators.Where<Medication>(fd_, fe_);
-            MedicationRequest fg_(Medication M) => MR;
-            IEnumerable<MedicationRequest> fh_ = context.Operators.Select<Medication, MedicationRequest>(ff_, fg_);
-            return fh_;
+            IEnumerable<Medication> fe_ = context.Operators.Where<Medication>(fc_, fd_);
+            bool? ff_ = context.Operators.Exists<Medication>(fe_);
+            return ff_;
         }
 
-        IEnumerable<MedicationRequest> l_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, k_);
+        IEnumerable<MedicationRequest> l_ = context.Operators.Where<MedicationRequest>(c_, k_);
         IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(i_, l_);
         IEnumerable<MedicationRequest> n_ = this.moreThanOneOrder(context, m_);
         IEnumerable<MedicationRequest> o_ = context.Operators.Union<MedicationRequest>(g_, n_);
         CqlValueSet p_ = this.Potentially_Harmful_Gastrointestinal_Antispasmodics_for_Older_Adults(context);
         IEnumerable<MedicationRequest> q_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, p_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> s_(MedicationRequest MR) {
-            IEnumerable<Medication> fs_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? s_(MedicationRequest MR) {
+            IEnumerable<Medication> fq_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ft_(Medication M) {
-                object fx_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object fy_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fz_ = context.Operators.Split((string)fy_, "/");
-                string ga_ = context.Operators.Last<string>(fz_);
-                bool? gb_ = context.Operators.Equal(fx_, ga_);
-                CodeableConcept gc_ = M?.Code;
-                CqlConcept gd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gc_);
-                CqlValueSet ge_ = this.Potentially_Harmful_Gastrointestinal_Antispasmodics_for_Older_Adults(context);
-                bool? gf_ = context.Operators.ConceptInValueSet(gd_, ge_);
-                bool? gg_ = context.Operators.And(gb_, gf_);
-                return gg_;
+            bool? fr_(Medication M) {
+                object fu_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object fv_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fw_ = context.Operators.Split((string)fv_, "/");
+                string fx_ = context.Operators.Last<string>(fw_);
+                bool? fy_ = context.Operators.Equal(fu_, fx_);
+                CodeableConcept fz_ = M?.Code;
+                CqlConcept ga_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fz_);
+                CqlValueSet gb_ = this.Potentially_Harmful_Gastrointestinal_Antispasmodics_for_Older_Adults(context);
+                bool? gc_ = context.Operators.ConceptInValueSet(ga_, gb_);
+                bool? gd_ = context.Operators.And(fy_, gc_);
+                return gd_;
             }
 
-            IEnumerable<Medication> fu_ = context.Operators.Where<Medication>(fs_, ft_);
-            MedicationRequest fv_(Medication M) => MR;
-            IEnumerable<MedicationRequest> fw_ = context.Operators.Select<Medication, MedicationRequest>(fu_, fv_);
-            return fw_;
+            IEnumerable<Medication> fs_ = context.Operators.Where<Medication>(fq_, fr_);
+            bool? ft_ = context.Operators.Exists<Medication>(fs_);
+            return ft_;
         }
 
-        IEnumerable<MedicationRequest> t_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, s_);
+        IEnumerable<MedicationRequest> t_ = context.Operators.Where<MedicationRequest>(c_, s_);
         IEnumerable<MedicationRequest> u_ = context.Operators.Union<MedicationRequest>(q_, t_);
         IEnumerable<MedicationRequest> v_ = this.moreThanOneOrder(context, u_);
         CqlValueSet w_ = this.Dipyridamole_Medications(context);
         IEnumerable<MedicationRequest> x_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, w_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> z_(MedicationRequest MR) {
-            IEnumerable<Medication> gh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? z_(MedicationRequest MR) {
+            IEnumerable<Medication> ge_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? gi_(Medication M) {
-                object gm_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object gn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> go_ = context.Operators.Split((string)gn_, "/");
-                string gp_ = context.Operators.Last<string>(go_);
-                bool? gq_ = context.Operators.Equal(gm_, gp_);
-                CodeableConcept gr_ = M?.Code;
-                CqlConcept gs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gr_);
-                CqlValueSet gt_ = this.Dipyridamole_Medications(context);
-                bool? gu_ = context.Operators.ConceptInValueSet(gs_, gt_);
-                bool? gv_ = context.Operators.And(gq_, gu_);
-                return gv_;
+            bool? gf_(Medication M) {
+                object gi_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object gj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gk_ = context.Operators.Split((string)gj_, "/");
+                string gl_ = context.Operators.Last<string>(gk_);
+                bool? gm_ = context.Operators.Equal(gi_, gl_);
+                CodeableConcept gn_ = M?.Code;
+                CqlConcept go_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gn_);
+                CqlValueSet gp_ = this.Dipyridamole_Medications(context);
+                bool? gq_ = context.Operators.ConceptInValueSet(go_, gp_);
+                bool? gr_ = context.Operators.And(gm_, gq_);
+                return gr_;
             }
 
-            IEnumerable<Medication> gj_ = context.Operators.Where<Medication>(gh_, gi_);
-            MedicationRequest gk_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gl_ = context.Operators.Select<Medication, MedicationRequest>(gj_, gk_);
-            return gl_;
+            IEnumerable<Medication> gg_ = context.Operators.Where<Medication>(ge_, gf_);
+            bool? gh_ = context.Operators.Exists<Medication>(gg_);
+            return gh_;
         }
 
-        IEnumerable<MedicationRequest> aa_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, z_);
+        IEnumerable<MedicationRequest> aa_ = context.Operators.Where<MedicationRequest>(c_, z_);
         IEnumerable<MedicationRequest> ab_ = context.Operators.Union<MedicationRequest>(x_, aa_);
         IEnumerable<MedicationRequest> ac_ = this.moreThanOneOrder(context, ab_);
         IEnumerable<MedicationRequest> ad_ = context.Operators.Union<MedicationRequest>(v_, ac_);
@@ -660,59 +655,57 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlValueSet af_ = this.Guanfacine_Medications(context);
         IEnumerable<MedicationRequest> ag_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, af_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ai_(MedicationRequest MR) {
-            IEnumerable<Medication> gw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ai_(MedicationRequest MR) {
+            IEnumerable<Medication> gs_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? gx_(Medication M) {
-                object hb_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hc_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hd_ = context.Operators.Split((string)hc_, "/");
-                string he_ = context.Operators.Last<string>(hd_);
-                bool? hf_ = context.Operators.Equal(hb_, he_);
-                CodeableConcept hg_ = M?.Code;
-                CqlConcept hh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hg_);
-                CqlValueSet hi_ = this.Guanfacine_Medications(context);
-                bool? hj_ = context.Operators.ConceptInValueSet(hh_, hi_);
-                bool? hk_ = context.Operators.And(hf_, hj_);
-                return hk_;
+            bool? gt_(Medication M) {
+                object gw_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object gx_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gy_ = context.Operators.Split((string)gx_, "/");
+                string gz_ = context.Operators.Last<string>(gy_);
+                bool? ha_ = context.Operators.Equal(gw_, gz_);
+                CodeableConcept hb_ = M?.Code;
+                CqlConcept hc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hb_);
+                CqlValueSet hd_ = this.Guanfacine_Medications(context);
+                bool? he_ = context.Operators.ConceptInValueSet(hc_, hd_);
+                bool? hf_ = context.Operators.And(ha_, he_);
+                return hf_;
             }
 
-            IEnumerable<Medication> gy_ = context.Operators.Where<Medication>(gw_, gx_);
-            MedicationRequest gz_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ha_ = context.Operators.Select<Medication, MedicationRequest>(gy_, gz_);
-            return ha_;
+            IEnumerable<Medication> gu_ = context.Operators.Where<Medication>(gs_, gt_);
+            bool? gv_ = context.Operators.Exists<Medication>(gu_);
+            return gv_;
         }
 
-        IEnumerable<MedicationRequest> aj_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ai_);
+        IEnumerable<MedicationRequest> aj_ = context.Operators.Where<MedicationRequest>(c_, ai_);
         IEnumerable<MedicationRequest> ak_ = context.Operators.Union<MedicationRequest>(ag_, aj_);
         IEnumerable<MedicationRequest> al_ = this.moreThanOneOrder(context, ak_);
         CqlValueSet am_ = this.Nifedipine_Medications(context);
         IEnumerable<MedicationRequest> an_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, am_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ap_(MedicationRequest MR) {
-            IEnumerable<Medication> hl_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ap_(MedicationRequest MR) {
+            IEnumerable<Medication> hg_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? hm_(Medication M) {
-                object hq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hr_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hs_ = context.Operators.Split((string)hr_, "/");
-                string ht_ = context.Operators.Last<string>(hs_);
-                bool? hu_ = context.Operators.Equal(hq_, ht_);
-                CodeableConcept hv_ = M?.Code;
-                CqlConcept hw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hv_);
-                CqlValueSet hx_ = this.Nifedipine_Medications(context);
-                bool? hy_ = context.Operators.ConceptInValueSet(hw_, hx_);
-                bool? hz_ = context.Operators.And(hu_, hy_);
-                return hz_;
+            bool? hh_(Medication M) {
+                object hk_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object hl_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> hm_ = context.Operators.Split((string)hl_, "/");
+                string hn_ = context.Operators.Last<string>(hm_);
+                bool? ho_ = context.Operators.Equal(hk_, hn_);
+                CodeableConcept hp_ = M?.Code;
+                CqlConcept hq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hp_);
+                CqlValueSet hr_ = this.Nifedipine_Medications(context);
+                bool? hs_ = context.Operators.ConceptInValueSet(hq_, hr_);
+                bool? ht_ = context.Operators.And(ho_, hs_);
+                return ht_;
             }
 
-            IEnumerable<Medication> hn_ = context.Operators.Where<Medication>(hl_, hm_);
-            MedicationRequest ho_(Medication M) => MR;
-            IEnumerable<MedicationRequest> hp_ = context.Operators.Select<Medication, MedicationRequest>(hn_, ho_);
-            return hp_;
+            IEnumerable<Medication> hi_ = context.Operators.Where<Medication>(hg_, hh_);
+            bool? hj_ = context.Operators.Exists<Medication>(hi_);
+            return hj_;
         }
 
-        IEnumerable<MedicationRequest> aq_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ap_);
+        IEnumerable<MedicationRequest> aq_ = context.Operators.Where<MedicationRequest>(c_, ap_);
         IEnumerable<MedicationRequest> ar_ = context.Operators.Union<MedicationRequest>(an_, aq_);
         IEnumerable<MedicationRequest> as_ = this.moreThanOneOrder(context, ar_);
         IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(al_, as_);
@@ -720,59 +713,57 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlValueSet av_ = this.Potentially_Harmful_Antidepressants_for_Older_Adults(context);
         IEnumerable<MedicationRequest> aw_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, av_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ay_(MedicationRequest MR) {
-            IEnumerable<Medication> ia_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ay_(MedicationRequest MR) {
+            IEnumerable<Medication> hu_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ib_(Medication M) {
-                object if_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ig_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ih_ = context.Operators.Split((string)ig_, "/");
-                string ii_ = context.Operators.Last<string>(ih_);
-                bool? ij_ = context.Operators.Equal(if_, ii_);
-                CodeableConcept ik_ = M?.Code;
-                CqlConcept il_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ik_);
-                CqlValueSet im_ = this.Potentially_Harmful_Antidepressants_for_Older_Adults(context);
-                bool? in_ = context.Operators.ConceptInValueSet(il_, im_);
-                bool? io_ = context.Operators.And(ij_, in_);
-                return io_;
+            bool? hv_(Medication M) {
+                object hy_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object hz_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ia_ = context.Operators.Split((string)hz_, "/");
+                string ib_ = context.Operators.Last<string>(ia_);
+                bool? ic_ = context.Operators.Equal(hy_, ib_);
+                CodeableConcept id_ = M?.Code;
+                CqlConcept ie_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, id_);
+                CqlValueSet if_ = this.Potentially_Harmful_Antidepressants_for_Older_Adults(context);
+                bool? ig_ = context.Operators.ConceptInValueSet(ie_, if_);
+                bool? ih_ = context.Operators.And(ic_, ig_);
+                return ih_;
             }
 
-            IEnumerable<Medication> ic_ = context.Operators.Where<Medication>(ia_, ib_);
-            MedicationRequest id_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ie_ = context.Operators.Select<Medication, MedicationRequest>(ic_, id_);
-            return ie_;
+            IEnumerable<Medication> hw_ = context.Operators.Where<Medication>(hu_, hv_);
+            bool? hx_ = context.Operators.Exists<Medication>(hw_);
+            return hx_;
         }
 
-        IEnumerable<MedicationRequest> az_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ay_);
+        IEnumerable<MedicationRequest> az_ = context.Operators.Where<MedicationRequest>(c_, ay_);
         IEnumerable<MedicationRequest> ba_ = context.Operators.Union<MedicationRequest>(aw_, az_);
         IEnumerable<MedicationRequest> bb_ = this.moreThanOneOrder(context, ba_);
         CqlValueSet bc_ = this.Potentially_Harmful_Barbiturates_for_Older_Adults(context);
         IEnumerable<MedicationRequest> bd_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, bc_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> bf_(MedicationRequest MR) {
-            IEnumerable<Medication> ip_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? bf_(MedicationRequest MR) {
+            IEnumerable<Medication> ii_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? iq_(Medication M) {
-                object iu_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object iv_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> iw_ = context.Operators.Split((string)iv_, "/");
-                string ix_ = context.Operators.Last<string>(iw_);
-                bool? iy_ = context.Operators.Equal(iu_, ix_);
-                CodeableConcept iz_ = M?.Code;
-                CqlConcept ja_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, iz_);
-                CqlValueSet jb_ = this.Potentially_Harmful_Barbiturates_for_Older_Adults(context);
-                bool? jc_ = context.Operators.ConceptInValueSet(ja_, jb_);
-                bool? jd_ = context.Operators.And(iy_, jc_);
-                return jd_;
+            bool? ij_(Medication M) {
+                object im_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object in_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> io_ = context.Operators.Split((string)in_, "/");
+                string ip_ = context.Operators.Last<string>(io_);
+                bool? iq_ = context.Operators.Equal(im_, ip_);
+                CodeableConcept ir_ = M?.Code;
+                CqlConcept is_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ir_);
+                CqlValueSet it_ = this.Potentially_Harmful_Barbiturates_for_Older_Adults(context);
+                bool? iu_ = context.Operators.ConceptInValueSet(is_, it_);
+                bool? iv_ = context.Operators.And(iq_, iu_);
+                return iv_;
             }
 
-            IEnumerable<Medication> ir_ = context.Operators.Where<Medication>(ip_, iq_);
-            MedicationRequest is_(Medication M) => MR;
-            IEnumerable<MedicationRequest> it_ = context.Operators.Select<Medication, MedicationRequest>(ir_, is_);
-            return it_;
+            IEnumerable<Medication> ik_ = context.Operators.Where<Medication>(ii_, ij_);
+            bool? il_ = context.Operators.Exists<Medication>(ik_);
+            return il_;
         }
 
-        IEnumerable<MedicationRequest> bg_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, bf_);
+        IEnumerable<MedicationRequest> bg_ = context.Operators.Where<MedicationRequest>(c_, bf_);
         IEnumerable<MedicationRequest> bh_ = context.Operators.Union<MedicationRequest>(bd_, bg_);
         IEnumerable<MedicationRequest> bi_ = this.moreThanOneOrder(context, bh_);
         IEnumerable<MedicationRequest> bj_ = context.Operators.Union<MedicationRequest>(bb_, bi_);
@@ -781,60 +772,58 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<CqlCode> bm_ = context.Operators.ToList<CqlCode>(bl_);
         IEnumerable<MedicationRequest> bn_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, bm_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> bp_(MedicationRequest MR) {
-            IEnumerable<Medication> je_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? bp_(MedicationRequest MR) {
+            IEnumerable<Medication> iw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? jf_(Medication M) {
-                object jj_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object jk_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> jl_ = context.Operators.Split((string)jk_, "/");
-                string jm_ = context.Operators.Last<string>(jl_);
-                bool? jn_ = context.Operators.Equal(jj_, jm_);
-                CodeableConcept jo_ = M?.Code;
-                CqlConcept jp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jo_);
-                CqlCode jq_ = this.ergoloid_mesylates__USP_1_MG_Oral_Tablet(context);
-                CqlConcept jr_ = context.Operators.ConvertCodeToConcept(jq_);
-                bool? js_ = context.Operators.Equivalent(jp_, jr_);
-                bool? jt_ = context.Operators.And(jn_, js_);
-                return jt_;
+            bool? ix_(Medication M) {
+                object ja_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object jb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> jc_ = context.Operators.Split((string)jb_, "/");
+                string jd_ = context.Operators.Last<string>(jc_);
+                bool? je_ = context.Operators.Equal(ja_, jd_);
+                CodeableConcept jf_ = M?.Code;
+                CqlConcept jg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jf_);
+                CqlCode jh_ = this.ergoloid_mesylates__USP_1_MG_Oral_Tablet(context);
+                CqlConcept ji_ = context.Operators.ConvertCodeToConcept(jh_);
+                bool? jj_ = context.Operators.Equivalent(jg_, ji_);
+                bool? jk_ = context.Operators.And(je_, jj_);
+                return jk_;
             }
 
-            IEnumerable<Medication> jg_ = context.Operators.Where<Medication>(je_, jf_);
-            MedicationRequest jh_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ji_ = context.Operators.Select<Medication, MedicationRequest>(jg_, jh_);
-            return ji_;
+            IEnumerable<Medication> iy_ = context.Operators.Where<Medication>(iw_, ix_);
+            bool? iz_ = context.Operators.Exists<Medication>(iy_);
+            return iz_;
         }
 
-        IEnumerable<MedicationRequest> bq_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, bp_);
+        IEnumerable<MedicationRequest> bq_ = context.Operators.Where<MedicationRequest>(c_, bp_);
         IEnumerable<MedicationRequest> br_ = context.Operators.Union<MedicationRequest>(bn_, bq_);
         IEnumerable<MedicationRequest> bs_ = this.moreThanOneOrder(context, br_);
         CqlValueSet bt_ = this.Meprobamate_Medications(context);
         IEnumerable<MedicationRequest> bu_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, bt_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> bw_(MedicationRequest MR) {
-            IEnumerable<Medication> ju_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? bw_(MedicationRequest MR) {
+            IEnumerable<Medication> jl_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? jv_(Medication M) {
-                object jz_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ka_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> kb_ = context.Operators.Split((string)ka_, "/");
-                string kc_ = context.Operators.Last<string>(kb_);
-                bool? kd_ = context.Operators.Equal(jz_, kc_);
-                CodeableConcept ke_ = M?.Code;
-                CqlConcept kf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ke_);
-                CqlValueSet kg_ = this.Meprobamate_Medications(context);
-                bool? kh_ = context.Operators.ConceptInValueSet(kf_, kg_);
-                bool? ki_ = context.Operators.And(kd_, kh_);
-                return ki_;
+            bool? jm_(Medication M) {
+                object jp_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object jq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> jr_ = context.Operators.Split((string)jq_, "/");
+                string js_ = context.Operators.Last<string>(jr_);
+                bool? jt_ = context.Operators.Equal(jp_, js_);
+                CodeableConcept ju_ = M?.Code;
+                CqlConcept jv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ju_);
+                CqlValueSet jw_ = this.Meprobamate_Medications(context);
+                bool? jx_ = context.Operators.ConceptInValueSet(jv_, jw_);
+                bool? jy_ = context.Operators.And(jt_, jx_);
+                return jy_;
             }
 
-            IEnumerable<Medication> jw_ = context.Operators.Where<Medication>(ju_, jv_);
-            MedicationRequest jx_(Medication M) => MR;
-            IEnumerable<MedicationRequest> jy_ = context.Operators.Select<Medication, MedicationRequest>(jw_, jx_);
-            return jy_;
+            IEnumerable<Medication> jn_ = context.Operators.Where<Medication>(jl_, jm_);
+            bool? jo_ = context.Operators.Exists<Medication>(jn_);
+            return jo_;
         }
 
-        IEnumerable<MedicationRequest> bx_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, bw_);
+        IEnumerable<MedicationRequest> bx_ = context.Operators.Where<MedicationRequest>(c_, bw_);
         IEnumerable<MedicationRequest> by_ = context.Operators.Union<MedicationRequest>(bu_, bx_);
         IEnumerable<MedicationRequest> bz_ = this.moreThanOneOrder(context, by_);
         IEnumerable<MedicationRequest> ca_ = context.Operators.Union<MedicationRequest>(bs_, bz_);
@@ -842,59 +831,57 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlValueSet cc_ = this.Potentially_Harmful_Estrogens_for_Older_Adults(context);
         IEnumerable<MedicationRequest> cd_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, cc_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> cf_(MedicationRequest MR) {
-            IEnumerable<Medication> kj_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? cf_(MedicationRequest MR) {
+            IEnumerable<Medication> jz_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? kk_(Medication M) {
-                object ko_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object kp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> kq_ = context.Operators.Split((string)kp_, "/");
-                string kr_ = context.Operators.Last<string>(kq_);
-                bool? ks_ = context.Operators.Equal(ko_, kr_);
-                CodeableConcept kt_ = M?.Code;
-                CqlConcept ku_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kt_);
-                CqlValueSet kv_ = this.Potentially_Harmful_Estrogens_for_Older_Adults(context);
-                bool? kw_ = context.Operators.ConceptInValueSet(ku_, kv_);
-                bool? kx_ = context.Operators.And(ks_, kw_);
-                return kx_;
+            bool? ka_(Medication M) {
+                object kd_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ke_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> kf_ = context.Operators.Split((string)ke_, "/");
+                string kg_ = context.Operators.Last<string>(kf_);
+                bool? kh_ = context.Operators.Equal(kd_, kg_);
+                CodeableConcept ki_ = M?.Code;
+                CqlConcept kj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ki_);
+                CqlValueSet kk_ = this.Potentially_Harmful_Estrogens_for_Older_Adults(context);
+                bool? kl_ = context.Operators.ConceptInValueSet(kj_, kk_);
+                bool? km_ = context.Operators.And(kh_, kl_);
+                return km_;
             }
 
-            IEnumerable<Medication> kl_ = context.Operators.Where<Medication>(kj_, kk_);
-            MedicationRequest km_(Medication M) => MR;
-            IEnumerable<MedicationRequest> kn_ = context.Operators.Select<Medication, MedicationRequest>(kl_, km_);
-            return kn_;
+            IEnumerable<Medication> kb_ = context.Operators.Where<Medication>(jz_, ka_);
+            bool? kc_ = context.Operators.Exists<Medication>(kb_);
+            return kc_;
         }
 
-        IEnumerable<MedicationRequest> cg_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, cf_);
+        IEnumerable<MedicationRequest> cg_ = context.Operators.Where<MedicationRequest>(c_, cf_);
         IEnumerable<MedicationRequest> ch_ = context.Operators.Union<MedicationRequest>(cd_, cg_);
         IEnumerable<MedicationRequest> ci_ = this.moreThanOneOrder(context, ch_);
         CqlValueSet cj_ = this.Potentially_Harmful_Sulfonylureas_for_Older_Adults(context);
         IEnumerable<MedicationRequest> ck_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, cj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> cm_(MedicationRequest MR) {
-            IEnumerable<Medication> ky_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? cm_(MedicationRequest MR) {
+            IEnumerable<Medication> kn_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? kz_(Medication M) {
-                object ld_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object le_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> lf_ = context.Operators.Split((string)le_, "/");
-                string lg_ = context.Operators.Last<string>(lf_);
-                bool? lh_ = context.Operators.Equal(ld_, lg_);
-                CodeableConcept li_ = M?.Code;
-                CqlConcept lj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, li_);
-                CqlValueSet lk_ = this.Potentially_Harmful_Sulfonylureas_for_Older_Adults(context);
-                bool? ll_ = context.Operators.ConceptInValueSet(lj_, lk_);
-                bool? lm_ = context.Operators.And(lh_, ll_);
-                return lm_;
+            bool? ko_(Medication M) {
+                object kr_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ks_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> kt_ = context.Operators.Split((string)ks_, "/");
+                string ku_ = context.Operators.Last<string>(kt_);
+                bool? kv_ = context.Operators.Equal(kr_, ku_);
+                CodeableConcept kw_ = M?.Code;
+                CqlConcept kx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kw_);
+                CqlValueSet ky_ = this.Potentially_Harmful_Sulfonylureas_for_Older_Adults(context);
+                bool? kz_ = context.Operators.ConceptInValueSet(kx_, ky_);
+                bool? la_ = context.Operators.And(kv_, kz_);
+                return la_;
             }
 
-            IEnumerable<Medication> la_ = context.Operators.Where<Medication>(ky_, kz_);
-            MedicationRequest lb_(Medication M) => MR;
-            IEnumerable<MedicationRequest> lc_ = context.Operators.Select<Medication, MedicationRequest>(la_, lb_);
-            return lc_;
+            IEnumerable<Medication> kp_ = context.Operators.Where<Medication>(kn_, ko_);
+            bool? kq_ = context.Operators.Exists<Medication>(kp_);
+            return kq_;
         }
 
-        IEnumerable<MedicationRequest> cn_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, cm_);
+        IEnumerable<MedicationRequest> cn_ = context.Operators.Where<MedicationRequest>(c_, cm_);
         IEnumerable<MedicationRequest> co_ = context.Operators.Union<MedicationRequest>(ck_, cn_);
         IEnumerable<MedicationRequest> cp_ = this.moreThanOneOrder(context, co_);
         IEnumerable<MedicationRequest> cq_ = context.Operators.Union<MedicationRequest>(ci_, cp_);
@@ -902,59 +889,57 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlValueSet cs_ = this.Desiccated_Thyroid_Medications(context);
         IEnumerable<MedicationRequest> ct_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, cs_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> cv_(MedicationRequest MR) {
-            IEnumerable<Medication> ln_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? cv_(MedicationRequest MR) {
+            IEnumerable<Medication> lb_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? lo_(Medication M) {
-                object ls_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object lt_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> lu_ = context.Operators.Split((string)lt_, "/");
-                string lv_ = context.Operators.Last<string>(lu_);
-                bool? lw_ = context.Operators.Equal(ls_, lv_);
-                CodeableConcept lx_ = M?.Code;
-                CqlConcept ly_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lx_);
-                CqlValueSet lz_ = this.Desiccated_Thyroid_Medications(context);
-                bool? ma_ = context.Operators.ConceptInValueSet(ly_, lz_);
-                bool? mb_ = context.Operators.And(lw_, ma_);
-                return mb_;
+            bool? lc_(Medication M) {
+                object lf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object lg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> lh_ = context.Operators.Split((string)lg_, "/");
+                string li_ = context.Operators.Last<string>(lh_);
+                bool? lj_ = context.Operators.Equal(lf_, li_);
+                CodeableConcept lk_ = M?.Code;
+                CqlConcept ll_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lk_);
+                CqlValueSet lm_ = this.Desiccated_Thyroid_Medications(context);
+                bool? ln_ = context.Operators.ConceptInValueSet(ll_, lm_);
+                bool? lo_ = context.Operators.And(lj_, ln_);
+                return lo_;
             }
 
-            IEnumerable<Medication> lp_ = context.Operators.Where<Medication>(ln_, lo_);
-            MedicationRequest lq_(Medication M) => MR;
-            IEnumerable<MedicationRequest> lr_ = context.Operators.Select<Medication, MedicationRequest>(lp_, lq_);
-            return lr_;
+            IEnumerable<Medication> ld_ = context.Operators.Where<Medication>(lb_, lc_);
+            bool? le_ = context.Operators.Exists<Medication>(ld_);
+            return le_;
         }
 
-        IEnumerable<MedicationRequest> cw_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, cv_);
+        IEnumerable<MedicationRequest> cw_ = context.Operators.Where<MedicationRequest>(c_, cv_);
         IEnumerable<MedicationRequest> cx_ = context.Operators.Union<MedicationRequest>(ct_, cw_);
         IEnumerable<MedicationRequest> cy_ = this.moreThanOneOrder(context, cx_);
         CqlValueSet cz_ = this.Potentially_Harmful_Nonbenzodiazepine_Hypnotics_for_Older_Adults(context);
         IEnumerable<MedicationRequest> da_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, cz_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> dc_(MedicationRequest MR) {
-            IEnumerable<Medication> mc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? dc_(MedicationRequest MR) {
+            IEnumerable<Medication> lp_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? md_(Medication M) {
-                object mh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object mi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> mj_ = context.Operators.Split((string)mi_, "/");
-                string mk_ = context.Operators.Last<string>(mj_);
-                bool? ml_ = context.Operators.Equal(mh_, mk_);
-                CodeableConcept mm_ = M?.Code;
-                CqlConcept mn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mm_);
-                CqlValueSet mo_ = this.Potentially_Harmful_Nonbenzodiazepine_Hypnotics_for_Older_Adults(context);
-                bool? mp_ = context.Operators.ConceptInValueSet(mn_, mo_);
-                bool? mq_ = context.Operators.And(ml_, mp_);
-                return mq_;
+            bool? lq_(Medication M) {
+                object lt_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object lu_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> lv_ = context.Operators.Split((string)lu_, "/");
+                string lw_ = context.Operators.Last<string>(lv_);
+                bool? lx_ = context.Operators.Equal(lt_, lw_);
+                CodeableConcept ly_ = M?.Code;
+                CqlConcept lz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ly_);
+                CqlValueSet ma_ = this.Potentially_Harmful_Nonbenzodiazepine_Hypnotics_for_Older_Adults(context);
+                bool? mb_ = context.Operators.ConceptInValueSet(lz_, ma_);
+                bool? mc_ = context.Operators.And(lx_, mb_);
+                return mc_;
             }
 
-            IEnumerable<Medication> me_ = context.Operators.Where<Medication>(mc_, md_);
-            MedicationRequest mf_(Medication M) => MR;
-            IEnumerable<MedicationRequest> mg_ = context.Operators.Select<Medication, MedicationRequest>(me_, mf_);
-            return mg_;
+            IEnumerable<Medication> lr_ = context.Operators.Where<Medication>(lp_, lq_);
+            bool? ls_ = context.Operators.Exists<Medication>(lr_);
+            return ls_;
         }
 
-        IEnumerable<MedicationRequest> dd_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, dc_);
+        IEnumerable<MedicationRequest> dd_ = context.Operators.Where<MedicationRequest>(c_, dc_);
         IEnumerable<MedicationRequest> de_ = context.Operators.Union<MedicationRequest>(da_, dd_);
         IEnumerable<MedicationRequest> df_ = this.moreThanOneOrder(context, de_);
         IEnumerable<MedicationRequest> dg_ = context.Operators.Union<MedicationRequest>(cy_, df_);
@@ -962,59 +947,57 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlValueSet di_ = this.Potentially_Harmful_Skeletal_Muscle_Relaxants_for_Older_Adults(context);
         IEnumerable<MedicationRequest> dj_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, di_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> dl_(MedicationRequest MR) {
-            IEnumerable<Medication> mr_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? dl_(MedicationRequest MR) {
+            IEnumerable<Medication> md_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ms_(Medication M) {
-                object mw_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object mx_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> my_ = context.Operators.Split((string)mx_, "/");
-                string mz_ = context.Operators.Last<string>(my_);
-                bool? na_ = context.Operators.Equal(mw_, mz_);
-                CodeableConcept nb_ = M?.Code;
-                CqlConcept nc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, nb_);
-                CqlValueSet nd_ = this.Potentially_Harmful_Skeletal_Muscle_Relaxants_for_Older_Adults(context);
-                bool? ne_ = context.Operators.ConceptInValueSet(nc_, nd_);
-                bool? nf_ = context.Operators.And(na_, ne_);
-                return nf_;
+            bool? me_(Medication M) {
+                object mh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object mi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> mj_ = context.Operators.Split((string)mi_, "/");
+                string mk_ = context.Operators.Last<string>(mj_);
+                bool? ml_ = context.Operators.Equal(mh_, mk_);
+                CodeableConcept mm_ = M?.Code;
+                CqlConcept mn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mm_);
+                CqlValueSet mo_ = this.Potentially_Harmful_Skeletal_Muscle_Relaxants_for_Older_Adults(context);
+                bool? mp_ = context.Operators.ConceptInValueSet(mn_, mo_);
+                bool? mq_ = context.Operators.And(ml_, mp_);
+                return mq_;
             }
 
-            IEnumerable<Medication> mt_ = context.Operators.Where<Medication>(mr_, ms_);
-            MedicationRequest mu_(Medication M) => MR;
-            IEnumerable<MedicationRequest> mv_ = context.Operators.Select<Medication, MedicationRequest>(mt_, mu_);
-            return mv_;
+            IEnumerable<Medication> mf_ = context.Operators.Where<Medication>(md_, me_);
+            bool? mg_ = context.Operators.Exists<Medication>(mf_);
+            return mg_;
         }
 
-        IEnumerable<MedicationRequest> dm_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, dl_);
+        IEnumerable<MedicationRequest> dm_ = context.Operators.Where<MedicationRequest>(c_, dl_);
         IEnumerable<MedicationRequest> dn_ = context.Operators.Union<MedicationRequest>(dj_, dm_);
         IEnumerable<MedicationRequest> do_ = this.moreThanOneOrder(context, dn_);
         CqlValueSet dp_ = this.Potentially_Harmful_Pain_Medications_for_Older_Adults(context);
         IEnumerable<MedicationRequest> dq_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, dp_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ds_(MedicationRequest MR) {
-            IEnumerable<Medication> ng_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ds_(MedicationRequest MR) {
+            IEnumerable<Medication> mr_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? nh_(Medication M) {
-                object nl_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object nm_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> nn_ = context.Operators.Split((string)nm_, "/");
-                string no_ = context.Operators.Last<string>(nn_);
-                bool? np_ = context.Operators.Equal(nl_, no_);
-                CodeableConcept nq_ = M?.Code;
-                CqlConcept nr_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, nq_);
-                CqlValueSet ns_ = this.Potentially_Harmful_Pain_Medications_for_Older_Adults(context);
-                bool? nt_ = context.Operators.ConceptInValueSet(nr_, ns_);
-                bool? nu_ = context.Operators.And(np_, nt_);
-                return nu_;
+            bool? ms_(Medication M) {
+                object mv_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object mw_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> mx_ = context.Operators.Split((string)mw_, "/");
+                string my_ = context.Operators.Last<string>(mx_);
+                bool? mz_ = context.Operators.Equal(mv_, my_);
+                CodeableConcept na_ = M?.Code;
+                CqlConcept nb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, na_);
+                CqlValueSet nc_ = this.Potentially_Harmful_Pain_Medications_for_Older_Adults(context);
+                bool? nd_ = context.Operators.ConceptInValueSet(nb_, nc_);
+                bool? ne_ = context.Operators.And(mz_, nd_);
+                return ne_;
             }
 
-            IEnumerable<Medication> ni_ = context.Operators.Where<Medication>(ng_, nh_);
-            MedicationRequest nj_(Medication M) => MR;
-            IEnumerable<MedicationRequest> nk_ = context.Operators.Select<Medication, MedicationRequest>(ni_, nj_);
-            return nk_;
+            IEnumerable<Medication> mt_ = context.Operators.Where<Medication>(mr_, ms_);
+            bool? mu_ = context.Operators.Exists<Medication>(mt_);
+            return mu_;
         }
 
-        IEnumerable<MedicationRequest> dt_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ds_);
+        IEnumerable<MedicationRequest> dt_ = context.Operators.Where<MedicationRequest>(c_, ds_);
         IEnumerable<MedicationRequest> du_ = context.Operators.Union<MedicationRequest>(dq_, dt_);
         IEnumerable<MedicationRequest> dv_ = this.moreThanOneOrder(context, du_);
         IEnumerable<MedicationRequest> dw_ = context.Operators.Union<MedicationRequest>(do_, dv_);
@@ -1022,59 +1005,57 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlValueSet dy_ = this.Megestrol_Medications(context);
         IEnumerable<MedicationRequest> dz_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, dy_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> eb_(MedicationRequest MR) {
-            IEnumerable<Medication> nv_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? eb_(MedicationRequest MR) {
+            IEnumerable<Medication> nf_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? nw_(Medication M) {
-                object oa_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ob_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> oc_ = context.Operators.Split((string)ob_, "/");
-                string od_ = context.Operators.Last<string>(oc_);
-                bool? oe_ = context.Operators.Equal(oa_, od_);
-                CodeableConcept of_ = M?.Code;
-                CqlConcept og_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, of_);
-                CqlValueSet oh_ = this.Megestrol_Medications(context);
-                bool? oi_ = context.Operators.ConceptInValueSet(og_, oh_);
-                bool? oj_ = context.Operators.And(oe_, oi_);
-                return oj_;
+            bool? ng_(Medication M) {
+                object nj_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object nk_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> nl_ = context.Operators.Split((string)nk_, "/");
+                string nm_ = context.Operators.Last<string>(nl_);
+                bool? nn_ = context.Operators.Equal(nj_, nm_);
+                CodeableConcept no_ = M?.Code;
+                CqlConcept np_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, no_);
+                CqlValueSet nq_ = this.Megestrol_Medications(context);
+                bool? nr_ = context.Operators.ConceptInValueSet(np_, nq_);
+                bool? ns_ = context.Operators.And(nn_, nr_);
+                return ns_;
             }
 
-            IEnumerable<Medication> nx_ = context.Operators.Where<Medication>(nv_, nw_);
-            MedicationRequest ny_(Medication M) => MR;
-            IEnumerable<MedicationRequest> nz_ = context.Operators.Select<Medication, MedicationRequest>(nx_, ny_);
-            return nz_;
+            IEnumerable<Medication> nh_ = context.Operators.Where<Medication>(nf_, ng_);
+            bool? ni_ = context.Operators.Exists<Medication>(nh_);
+            return ni_;
         }
 
-        IEnumerable<MedicationRequest> ec_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, eb_);
+        IEnumerable<MedicationRequest> ec_ = context.Operators.Where<MedicationRequest>(c_, eb_);
         IEnumerable<MedicationRequest> ed_ = context.Operators.Union<MedicationRequest>(dz_, ec_);
         IEnumerable<MedicationRequest> ee_ = this.moreThanOneOrder(context, ed_);
         CqlValueSet ef_ = this.Meperidine_Medications(context);
         IEnumerable<MedicationRequest> eg_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ef_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ei_(MedicationRequest MR) {
-            IEnumerable<Medication> ok_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ei_(MedicationRequest MR) {
+            IEnumerable<Medication> nt_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ol_(Medication M) {
-                object op_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object oq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> or_ = context.Operators.Split((string)oq_, "/");
-                string os_ = context.Operators.Last<string>(or_);
-                bool? ot_ = context.Operators.Equal(op_, os_);
-                CodeableConcept ou_ = M?.Code;
-                CqlConcept ov_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ou_);
-                CqlValueSet ow_ = this.Meperidine_Medications(context);
-                bool? ox_ = context.Operators.ConceptInValueSet(ov_, ow_);
-                bool? oy_ = context.Operators.And(ot_, ox_);
-                return oy_;
+            bool? nu_(Medication M) {
+                object nx_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ny_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> nz_ = context.Operators.Split((string)ny_, "/");
+                string oa_ = context.Operators.Last<string>(nz_);
+                bool? ob_ = context.Operators.Equal(nx_, oa_);
+                CodeableConcept oc_ = M?.Code;
+                CqlConcept od_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, oc_);
+                CqlValueSet oe_ = this.Meperidine_Medications(context);
+                bool? of_ = context.Operators.ConceptInValueSet(od_, oe_);
+                bool? og_ = context.Operators.And(ob_, of_);
+                return og_;
             }
 
-            IEnumerable<Medication> om_ = context.Operators.Where<Medication>(ok_, ol_);
-            MedicationRequest on_(Medication M) => MR;
-            IEnumerable<MedicationRequest> oo_ = context.Operators.Select<Medication, MedicationRequest>(om_, on_);
-            return oo_;
+            IEnumerable<Medication> nv_ = context.Operators.Where<Medication>(nt_, nu_);
+            bool? nw_ = context.Operators.Exists<Medication>(nv_);
+            return nw_;
         }
 
-        IEnumerable<MedicationRequest> ej_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, ei_);
+        IEnumerable<MedicationRequest> ej_ = context.Operators.Where<MedicationRequest>(c_, ei_);
         IEnumerable<MedicationRequest> ek_ = context.Operators.Union<MedicationRequest>(eg_, ej_);
         IEnumerable<MedicationRequest> el_ = this.moreThanOneOrder(context, ek_);
         IEnumerable<MedicationRequest> em_ = context.Operators.Union<MedicationRequest>(ee_, el_);
@@ -1184,36 +1165,35 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? n_(Medication M) {
-                object r_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object s_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> t_ = context.Operators.Split((string)s_, "/");
-                string u_ = context.Operators.Last<string>(t_);
-                bool? v_ = context.Operators.Equal(r_, u_);
-                CodeableConcept w_ = M?.Code;
-                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                CqlValueSet y_ = this.Potentially_Harmful_Antiinfectives_for_Older_Adults(context);
-                bool? z_ = context.Operators.ConceptInValueSet(x_, y_);
-                bool? aa_ = context.Operators.And(v_, z_);
-                return aa_;
+                object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                string t_ = context.Operators.Last<string>(s_);
+                bool? u_ = context.Operators.Equal(q_, t_);
+                CodeableConcept v_ = M?.Code;
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                CqlValueSet x_ = this.Potentially_Harmful_Antiinfectives_for_Older_Adults(context);
+                bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                bool? z_ = context.Operators.And(u_, y_);
+                return z_;
             }
 
             IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
-            MedicationRequest p_(Medication M) => MR;
-            IEnumerable<MedicationRequest> q_ = context.Operators.Select<Medication, MedicationRequest>(o_, p_);
-            return q_;
+            bool? p_ = context.Operators.Exists<Medication>(o_);
+            return p_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = this.moreThanOneOrder(context, f_);
 
         decimal? h_(MedicationRequest AntiInfectives) {
-            decimal? ab_ = this.medicationRequestPeriodInDays(context, AntiInfectives);
-            return ab_;
+            decimal? aa_ = this.medicationRequestPeriodInDays(context, AntiInfectives);
+            return aa_;
         }
 
         IEnumerable<decimal?> i_ = context.Operators.Select<MedicationRequest, decimal?>(g_, h_);
@@ -1506,37 +1486,36 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> v_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? w_(Medication M) {
-                object aa_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ab_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ac_ = context.Operators.Split((string)ab_, "/");
-                string ad_ = context.Operators.Last<string>(ac_);
-                bool? ae_ = context.Operators.Equal(aa_, ad_);
-                CodeableConcept af_ = M?.Code;
-                CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_);
-                CqlValueSet ah_ = this.Digoxin_Medications(context);
-                bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
-                bool? aj_ = context.Operators.And(ae_, ai_);
-                return aj_;
+                object z_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object aa_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ab_ = context.Operators.Split((string)aa_, "/");
+                string ac_ = context.Operators.Last<string>(ab_);
+                bool? ad_ = context.Operators.Equal(z_, ac_);
+                CodeableConcept ae_ = M?.Code;
+                CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_);
+                CqlValueSet ag_ = this.Digoxin_Medications(context);
+                bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+                bool? ai_ = context.Operators.And(ad_, ah_);
+                return ai_;
             }
 
             IEnumerable<Medication> x_ = context.Operators.Where<Medication>(v_, w_);
-            MedicationRequest y_(Medication M) => MR;
-            IEnumerable<MedicationRequest> z_ = context.Operators.Select<Medication, MedicationRequest>(x_, y_);
-            return z_;
+            bool? y_ = context.Operators.Exists<Medication>(x_);
+            return y_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest DigoxinOrdered) {
-            CqlQuantity ak_ = this.averageDailyDose(context, DigoxinOrdered);
-            CqlQuantity al_ = context.Operators.Quantity(0.125m, "mg/d");
-            bool? am_ = context.Operators.Greater(ak_, al_);
-            return am_;
+            CqlQuantity aj_ = this.averageDailyDose(context, DigoxinOrdered);
+            CqlQuantity ak_ = context.Operators.Quantity(0.125m, "mg/d");
+            bool? al_ = context.Operators.Greater(aj_, ak_);
+            return al_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -1545,37 +1524,36 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlValueSet k_ = this.Doxepin_Medications(context);
         IEnumerable<MedicationRequest> l_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, k_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> n_(MedicationRequest MR) {
-            IEnumerable<Medication> an_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? n_(MedicationRequest MR) {
+            IEnumerable<Medication> am_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ao_(Medication M) {
-                object as_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object at_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> au_ = context.Operators.Split((string)at_, "/");
-                string av_ = context.Operators.Last<string>(au_);
-                bool? aw_ = context.Operators.Equal(as_, av_);
-                CodeableConcept ax_ = M?.Code;
-                CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
-                CqlValueSet az_ = this.Doxepin_Medications(context);
-                bool? ba_ = context.Operators.ConceptInValueSet(ay_, az_);
-                bool? bb_ = context.Operators.And(aw_, ba_);
-                return bb_;
+            bool? an_(Medication M) {
+                object aq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ar_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> as_ = context.Operators.Split((string)ar_, "/");
+                string at_ = context.Operators.Last<string>(as_);
+                bool? au_ = context.Operators.Equal(aq_, at_);
+                CodeableConcept av_ = M?.Code;
+                CqlConcept aw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, av_);
+                CqlValueSet ax_ = this.Doxepin_Medications(context);
+                bool? ay_ = context.Operators.ConceptInValueSet(aw_, ax_);
+                bool? az_ = context.Operators.And(au_, ay_);
+                return az_;
             }
 
-            IEnumerable<Medication> ap_ = context.Operators.Where<Medication>(an_, ao_);
-            MedicationRequest aq_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ar_ = context.Operators.Select<Medication, MedicationRequest>(ap_, aq_);
-            return ar_;
+            IEnumerable<Medication> ao_ = context.Operators.Where<Medication>(am_, an_);
+            bool? ap_ = context.Operators.Exists<Medication>(ao_);
+            return ap_;
         }
 
-        IEnumerable<MedicationRequest> o_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, n_);
+        IEnumerable<MedicationRequest> o_ = context.Operators.Where<MedicationRequest>(c_, n_);
         IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(l_, o_);
 
         bool? q_(MedicationRequest DoxepinOrdered) {
-            CqlQuantity bc_ = this.averageDailyDose(context, DoxepinOrdered);
-            CqlQuantity bd_ = context.Operators.Quantity(6m, "mg/d");
-            bool? be_ = context.Operators.Greater(bc_, bd_);
-            return be_;
+            CqlQuantity ba_ = this.averageDailyDose(context, DoxepinOrdered);
+            CqlQuantity bb_ = context.Operators.Quantity(6m, "mg/d");
+            bool? bc_ = context.Operators.Greater(ba_, bb_);
+            return bc_;
         }
 
         IEnumerable<MedicationRequest> r_ = context.Operators.Where<MedicationRequest>(p_, q_);
@@ -1616,30 +1594,29 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationRequest l_(Medication M) => MR;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = this.moreThanOneOrder(context, f_);
         bool? h_ = context.Operators.Exists<MedicationRequest>(g_);
@@ -1693,47 +1670,46 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> o_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? p_(Medication M) {
-                object t_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object u_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> v_ = context.Operators.Split((string)u_, "/");
-                string w_ = context.Operators.Last<string>(v_);
-                bool? x_ = context.Operators.Equal(t_, w_);
-                CodeableConcept y_ = M?.Code;
-                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                CqlValueSet aa_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
-                bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-                bool? ac_ = context.Operators.And(x_, ab_);
-                return ac_;
+                object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
+                string v_ = context.Operators.Last<string>(u_);
+                bool? w_ = context.Operators.Equal(s_, v_);
+                CodeableConcept x_ = M?.Code;
+                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
+                CqlValueSet z_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
+                bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
+                bool? ab_ = context.Operators.And(w_, aa_);
+                return ab_;
             }
 
             IEnumerable<Medication> q_ = context.Operators.Where<Medication>(o_, p_);
-            MedicationRequest r_(Medication M) => MR;
-            IEnumerable<MedicationRequest> s_ = context.Operators.Select<Medication, MedicationRequest>(q_, r_);
-            return s_;
+            bool? r_ = context.Operators.Exists<Medication>(q_);
+            return r_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationOrder(context, f_);
 
         bool? h_(MedicationRequest AntipsychoticMedication) {
-            FhirDateTime ad_ = AntipsychoticMedication?.AuthoredOnElement;
-            CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(ad_);
-            CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
-            bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, (string)default);
-            return ag_;
+            FhirDateTime ac_ = AntipsychoticMedication?.AuthoredOnElement;
+            CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(ac_);
+            CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
+            bool? af_ = context.Operators.In<CqlDateTime>(ad_, ae_, (string)default);
+            return af_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
 
         CqlDateTime j_(MedicationRequest AntipsychoticMedication) {
-            FhirDateTime ah_ = AntipsychoticMedication?.AuthoredOnElement;
-            CqlDateTime ai_ = context.Operators.Convert<CqlDateTime>(ah_);
-            return ai_;
+            FhirDateTime ag_ = AntipsychoticMedication?.AuthoredOnElement;
+            CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
+            return ah_;
         }
 
         IEnumerable<CqlDateTime> k_ = context.Operators.Select<MedicationRequest, CqlDateTime>(i_, j_);
@@ -1756,30 +1732,29 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationRequest l_(Medication M) => MR;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = this.moreThanOneOrder(context, f_);
         bool? h_ = context.Operators.Exists<MedicationRequest>(g_);
@@ -1884,47 +1859,46 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> o_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? p_(Medication M) {
-                object t_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object u_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> v_ = context.Operators.Split((string)u_, "/");
-                string w_ = context.Operators.Last<string>(v_);
-                bool? x_ = context.Operators.Equal(t_, w_);
-                CodeableConcept y_ = M?.Code;
-                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                CqlValueSet aa_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
-                bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-                bool? ac_ = context.Operators.And(x_, ab_);
-                return ac_;
+                object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
+                string v_ = context.Operators.Last<string>(u_);
+                bool? w_ = context.Operators.Equal(s_, v_);
+                CodeableConcept x_ = M?.Code;
+                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
+                CqlValueSet z_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
+                bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
+                bool? ab_ = context.Operators.And(w_, aa_);
+                return ab_;
             }
 
             IEnumerable<Medication> q_ = context.Operators.Where<Medication>(o_, p_);
-            MedicationRequest r_(Medication M) => MR;
-            IEnumerable<MedicationRequest> s_ = context.Operators.Select<Medication, MedicationRequest>(q_, r_);
-            return s_;
+            bool? r_ = context.Operators.Exists<Medication>(q_);
+            return r_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         IEnumerable<MedicationRequest> g_ = Status_1_15_000.Instance.isMedicationOrder(context, f_);
 
         bool? h_(MedicationRequest BenzodiazepineMedication) {
-            FhirDateTime ad_ = BenzodiazepineMedication?.AuthoredOnElement;
-            CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(ad_);
-            CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
-            bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, (string)default);
-            return ag_;
+            FhirDateTime ac_ = BenzodiazepineMedication?.AuthoredOnElement;
+            CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(ac_);
+            CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
+            bool? af_ = context.Operators.In<CqlDateTime>(ad_, ae_, (string)default);
+            return af_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
 
         CqlDateTime j_(MedicationRequest BenzodiazepineMedication) {
-            FhirDateTime ah_ = BenzodiazepineMedication?.AuthoredOnElement;
-            CqlDateTime ai_ = context.Operators.Convert<CqlDateTime>(ah_);
-            return ai_;
+            FhirDateTime ag_ = BenzodiazepineMedication?.AuthoredOnElement;
+            CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
+            return ah_;
         }
 
         IEnumerable<CqlDateTime> k_ = context.Operators.Select<MedicationRequest, CqlDateTime>(i_, j_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
@@ -578,39 +578,38 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
         CqlValueSet a_ = this.Radiation_Treatment_Management(context);
         IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        IEnumerable<Encounter> c_(Encounter RadiationTreatmentManagement) {
+        bool? c_(Encounter RadiationTreatmentManagement) {
             CqlValueSet g_ = this.Cancer(context);
             IEnumerable<Condition> h_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> j_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> k_ = context.Operators.Union<Condition>(h_ as IEnumerable<Condition>, j_ as IEnumerable<Condition>);
 
             bool? l_(Condition CancerDx) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, CancerDx);
-                Period q_ = RadiationTreatmentManagement?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                bool? s_ = context.Operators.Overlaps(p_, r_, "day");
-                return s_;
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, CancerDx);
+                Period p_ = RadiationTreatmentManagement?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.Overlaps(o_, q_, "day");
+                return r_;
             }
 
             IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
-            Encounter n_(Condition CancerDx) => RadiationTreatmentManagement;
-            IEnumerable<Encounter> o_ = context.Operators.Select<Condition, Encounter>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Condition>(m_);
+            return n_;
         }
 
-        IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+        IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
         bool? e_(Encounter RadiationTreatmentManagement) {
-            CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-            Period u_ = RadiationTreatmentManagement?.Period;
-            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-            bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, "day");
-            Code<Encounter.EncounterStatus> x_ = RadiationTreatmentManagement?.StatusElement;
-            Encounter.EncounterStatus? y_ = x_?.Value;
-            Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
-            bool? aa_ = context.Operators.Equal(z_, "finished");
-            bool? ab_ = context.Operators.And(w_, aa_);
-            return ab_;
+            CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
+            Period t_ = RadiationTreatmentManagement?.Period;
+            CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+            bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(s_, u_, "day");
+            Code<Encounter.EncounterStatus> w_ = RadiationTreatmentManagement?.StatusElement;
+            Encounter.EncounterStatus? x_ = w_?.Value;
+            Code<Encounter.EncounterStatus> y_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(x_);
+            bool? z_ = context.Operators.Equal(y_, "finished");
+            bool? aa_ = context.Operators.And(v_, z_);
+            return aa_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
@@ -677,26 +676,25 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Encounter> a_ = this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy(context);
 
-        IEnumerable<Encounter> b_(Encounter FaceToFaceOrTelehealthEncounterWithChemo) {
+        bool? b_(Encounter FaceToFaceOrTelehealthEncounterWithChemo) {
             IEnumerable<Observation> d_ = this.Standard_Pain_Assessment_with_Result(context);
 
             bool? e_(Observation PainAssessed) {
-                Period i_ = FaceToFaceOrTelehealthEncounterWithChemo?.Period;
-                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                DataType k_ = PainAssessed?.Effective;
-                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, "day");
-                return n_;
+                Period h_ = FaceToFaceOrTelehealthEncounterWithChemo?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                DataType j_ = PainAssessed?.Effective;
+                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
+                bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, l_, "day");
+                return m_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
-            Encounter g_(Observation PainAssessed) => FaceToFaceOrTelehealthEncounterWithChemo;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Observation, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Observation>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -711,78 +709,77 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Encounter> a_ = this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter RadiationManagementEncounter) {
+        bool? b_(Encounter RadiationManagementEncounter) {
             IEnumerable<Observation> d_ = this.Standard_Pain_Assessment_with_Result(context);
 
             bool? e_(Observation PainAssessed) {
 
-                bool? i_() {
+                bool? h_() {
 
-                    bool j_() {
-                        List<CodeableConcept> k_ = RadiationManagementEncounter?.Type;
+                    bool i_() {
+                        List<CodeableConcept> j_ = RadiationManagementEncounter?.Type;
 
-                        CqlConcept l_(CodeableConcept @this) {
-                            CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                            return q_;
+                        CqlConcept k_(CodeableConcept @this) {
+                            CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                            return p_;
                         }
 
-                        IEnumerable<CqlConcept> m_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)k_, l_);
+                        IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
 
-                        bool? n_(CqlConcept RadiationManagement) {
-                            CqlCode r_ = this.Radiation_treatment_management__5_treatments(context);
-                            CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
-                            bool? t_ = context.Operators.Equivalent(RadiationManagement, s_);
-                            return t_;
+                        bool? m_(CqlConcept RadiationManagement) {
+                            CqlCode q_ = this.Radiation_treatment_management__5_treatments(context);
+                            CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+                            bool? s_ = context.Operators.Equivalent(RadiationManagement, r_);
+                            return s_;
                         }
 
-                        IEnumerable<CqlConcept> o_ = context.Operators.Where<CqlConcept>(m_, n_);
-                        bool? p_ = context.Operators.Exists<CqlConcept>(o_);
-                        return p_ ?? false;
+                        IEnumerable<CqlConcept> n_ = context.Operators.Where<CqlConcept>(l_, m_);
+                        bool? o_ = context.Operators.Exists<CqlConcept>(n_);
+                        return o_ ?? false;
                     }
 
-                    if (j_())
+                    if (i_())
                     {
-                        DataType u_ = PainAssessed?.Effective;
-                        object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                        CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                        CqlDateTime x_ = context.Operators.End(w_);
-                        Period y_ = RadiationManagementEncounter?.Period;
-                        CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                        CqlDateTime aa_ = context.Operators.Start(z_);
-                        CqlQuantity ab_ = context.Operators.Quantity(6m, "days");
-                        CqlDateTime ac_ = context.Operators.Subtract(aa_, ab_);
-                        CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                        CqlDateTime af_ = context.Operators.Start(ae_);
-                        CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ac_, af_, true, true);
-                        bool? ah_ = context.Operators.In<CqlDateTime>(x_, ag_, "day");
-                        CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                        CqlDateTime ak_ = context.Operators.Start(aj_);
-                        bool? al_ = context.Operators.Not((bool?)(ak_ is null));
-                        bool? am_ = context.Operators.And(ah_, al_);
-                        return am_;
+                        DataType t_ = PainAssessed?.Effective;
+                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                        CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+                        CqlDateTime w_ = context.Operators.End(v_);
+                        Period x_ = RadiationManagementEncounter?.Period;
+                        CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                        CqlDateTime z_ = context.Operators.Start(y_);
+                        CqlQuantity aa_ = context.Operators.Quantity(6m, "days");
+                        CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+                        CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                        CqlDateTime ae_ = context.Operators.Start(ad_);
+                        CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ab_, ae_, true, true);
+                        bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, "day");
+                        CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                        CqlDateTime aj_ = context.Operators.Start(ai_);
+                        bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+                        bool? al_ = context.Operators.And(ag_, ak_);
+                        return al_;
                     }
                     else
                     {
-                        Period an_ = RadiationManagementEncounter?.Period;
-                        CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
-                        DataType ap_ = PainAssessed?.Effective;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
-                        bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, ar_, "day");
-                        return as_;
+                        Period am_ = RadiationManagementEncounter?.Period;
+                        CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
+                        DataType ao_ = PainAssessed?.Effective;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
+                        bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, "day");
+                        return ar_;
                     };
                 }
 
-                return i_();
+                return h_();
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
-            Encounter g_(Observation PainAssessed) => RadiationManagementEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Observation, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Observation>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
@@ -290,34 +290,33 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Contact_or_Office_Visit(context);
         IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        IEnumerable<Encounter> c_(Encounter ValidEncounter) {
+        bool? c_(Encounter ValidEncounter) {
             IEnumerable<Condition> e_ = this.Depression_Diagnoses(context);
 
             bool? f_(Condition Depression) {
-                Period j_ = ValidEncounter?.Period;
-                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Depression);
-                bool? m_ = context.Operators.Overlaps(k_, l_, (string)default);
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                CqlInterval<CqlDateTime> q_ = this.Denominator_Identification_Period(context);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
-                bool? s_ = context.Operators.And(m_, r_);
-                Code<Encounter.EncounterStatus> t_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? u_ = t_?.Value;
-                Code<Encounter.EncounterStatus> v_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(u_);
-                bool? w_ = context.Operators.Equal(v_, "finished");
-                bool? x_ = context.Operators.And(s_, w_);
-                return x_;
+                Period i_ = ValidEncounter?.Period;
+                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Depression);
+                bool? l_ = context.Operators.Overlaps(j_, k_, (string)default);
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                CqlInterval<CqlDateTime> p_ = this.Denominator_Identification_Period(context);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+                bool? r_ = context.Operators.And(l_, q_);
+                Code<Encounter.EncounterStatus> s_ = ValidEncounter?.StatusElement;
+                Encounter.EncounterStatus? t_ = s_?.Value;
+                Code<Encounter.EncounterStatus> u_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(t_);
+                bool? v_ = context.Operators.Equal(u_, "finished");
+                bool? w_ = context.Operators.And(r_, v_);
+                return w_;
             }
 
             IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
-            Encounter h_(Condition Depression) => ValidEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Condition>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+        IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
         return d_;
     }
 
@@ -332,39 +331,38 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Observation> a_ = this.Depression_Assessments_Greater_Than_9(context);
 
-        IEnumerable<Observation> b_(Observation DepressionAssessment) {
+        bool? b_(Observation DepressionAssessment) {
             IEnumerable<Encounter> g_ = this.Depression_Encounter(context);
 
             bool? h_(Encounter DepressionEncounter) {
-                Period l_ = DepressionEncounter?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(7m, "days");
-                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, true);
-                DataType u_ = DepressionAssessment?.Effective;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, w_, "day");
-                return x_;
+                Period k_ = DepressionEncounter?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlQuantity n_ = context.Operators.Quantity(7m, "days");
+                CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime r_ = context.Operators.End(q_);
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(o_, r_, true, true);
+                DataType t_ = DepressionAssessment?.Effective;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+                bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(s_, v_, "day");
+                return w_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter DepressionEncounter) => DepressionAssessment;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
         object d_(Observation @this) {
-            DataType y_ = @this?.Effective;
-            object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-            CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
-            CqlDateTime ab_ = context.Operators.Start(aa_);
-            return ab_;
+            DataType x_ = @this?.Effective;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+            CqlDateTime aa_ = context.Operators.Start(z_);
+            return aa_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.SortBy<Observation>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
@@ -411,54 +411,52 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
         IEnumerable<Observation> b_ = Status_1_15_000.Instance.isObservationBP(context, a_);
-        IEnumerable<Observation> d_ = Status_1_15_000.Instance.isObservationBP(context, a_);
 
-        IEnumerable<Observation> e_(Observation BloodPressure) {
-            CqlValueSet o_ = this.Encounter_Inpatient(context);
-            IEnumerable<Encounter> p_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-            CqlValueSet q_ = this.Emergency_Department_Evaluation_and_Management_Visit(context);
-            IEnumerable<Encounter> r_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, q_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-            IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(p_, r_);
-            IEnumerable<Encounter> t_ = Status_1_15_000.Instance.isEncounterPerformed(context, s_);
+        bool? c_(Observation BloodPressure) {
+            CqlValueSet l_ = this.Encounter_Inpatient(context);
+            IEnumerable<Encounter> m_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            CqlValueSet n_ = this.Emergency_Department_Evaluation_and_Management_Visit(context);
+            IEnumerable<Encounter> o_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+            IEnumerable<Encounter> q_ = Status_1_15_000.Instance.isEncounterPerformed(context, p_);
 
-            bool? u_(Encounter DisqualifyingEncounter) {
-                DataType y_ = BloodPressure?.Effective;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.latest(context, z_);
-                Period ab_ = DisqualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, "day");
-                return ad_;
+            bool? r_(Encounter DisqualifyingEncounter) {
+                DataType v_ = BloodPressure?.Effective;
+                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                CqlDateTime x_ = QICoreCommon_4_0_000.Instance.latest(context, w_);
+                Period y_ = DisqualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
+                return aa_;
             }
 
-            IEnumerable<Encounter> v_ = context.Operators.Where<Encounter>(t_, u_);
-            Observation w_(Encounter DisqualifyingEncounter) => BloodPressure;
-            IEnumerable<Observation> x_ = context.Operators.Select<Encounter, Observation>(v_, w_);
-            return x_;
+            IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
+            bool? t_ = context.Operators.Exists<Encounter>(s_);
+            bool? u_ = context.Operators.Not(t_);
+            return u_;
         }
 
-        IEnumerable<Observation> f_ = context.Operators.SelectMany<Observation, Observation>(d_, e_);
-        IEnumerable<Observation> g_ = context.Operators.Except<Observation>(b_, f_);
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
-        bool? h_(Observation BloodPressure) {
-            DataType ae_ = BloodPressure?.Effective;
-            object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-            CqlDateTime ag_ = QICoreCommon_4_0_000.Instance.latest(context, af_);
-            CqlInterval<CqlDateTime> ah_ = this.Measurement_Period(context);
-            bool? ai_ = context.Operators.In<CqlDateTime>(ag_, ah_, "day");
-            return ai_;
+        bool? e_(Observation BloodPressure) {
+            DataType ab_ = BloodPressure?.Effective;
+            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.latest(context, ac_);
+            CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
+            bool? af_ = context.Operators.In<CqlDateTime>(ad_, ae_, "day");
+            return af_;
         }
 
-        IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
-        IEnumerable<Observation> k_ = Status_1_15_000.Instance.isObservationBP(context, a_);
+        IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
+        IEnumerable<Observation> h_ = Status_1_15_000.Instance.isObservationBP(context, a_);
 
-        bool? l_(Observation BloodPressure) {
-            ResourceReference aj_ = BloodPressure?.Encounter;
-            Encounter ak_ = this.getEncounter(context, aj_);
-            Coding al_ = ak_?.Class;
-            CqlCode am_ = FHIRHelpers_4_4_000.Instance.ToCode(context, al_);
-            string an_ = am_?.code;
-            string[] ao_ = [
+        bool? i_(Observation BloodPressure) {
+            ResourceReference ag_ = BloodPressure?.Encounter;
+            Encounter ah_ = this.getEncounter(context, ag_);
+            Coding ai_ = ah_?.Class;
+            CqlCode aj_ = FHIRHelpers_4_4_000.Instance.ToCode(context, ai_);
+            string ak_ = aj_?.code;
+            string[] al_ = [
                 "EMER",
                 "IMP",
                 "ACUTE",
@@ -466,20 +464,20 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
                 "PRENC",
                 "SS",
             ];
-            bool? ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
-            bool? aq_ = context.Operators.Not(ap_);
-            DataType ar_ = BloodPressure?.Effective;
-            object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-            CqlDateTime at_ = QICoreCommon_4_0_000.Instance.latest(context, as_);
-            CqlInterval<CqlDateTime> au_ = this.Measurement_Period(context);
-            bool? av_ = context.Operators.In<CqlDateTime>(at_, au_, "day");
-            bool? aw_ = context.Operators.And(aq_, av_);
-            return aw_;
+            bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
+            bool? an_ = context.Operators.Not(am_);
+            DataType ao_ = BloodPressure?.Effective;
+            object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+            CqlDateTime aq_ = QICoreCommon_4_0_000.Instance.latest(context, ap_);
+            CqlInterval<CqlDateTime> ar_ = this.Measurement_Period(context);
+            bool? as_ = context.Operators.In<CqlDateTime>(aq_, ar_, "day");
+            bool? at_ = context.Operators.And(an_, as_);
+            return at_;
         }
 
-        IEnumerable<Observation> m_ = context.Operators.Where<Observation>(k_, l_);
-        IEnumerable<Observation> n_ = context.Operators.Union<Observation>(i_, m_);
-        return n_;
+        IEnumerable<Observation> j_ = context.Operators.Where<Observation>(h_, i_);
+        IEnumerable<Observation> k_ = context.Operators.Union<Observation>(f_, j_);
+        return k_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
@@ -369,75 +369,75 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = this.Major_Depressive_Disorder_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter MDDEncounter) {
+        bool? b_(Encounter MDDEncounter) {
             CqlCode d_ = this.Suicide_risk_assessment__procedure_(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? g_(Procedure SuicideRiskAssessmentProcedure) {
-                Code<EventStatus> k_ = SuicideRiskAssessmentProcedure?.StatusElement;
-                EventStatus? l_ = k_?.Value;
-                string m_ = context.Operators.Convert<string>(l_);
-                bool? n_ = context.Operators.Equal(m_, "completed");
-                Period o_ = MDDEncounter?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                Code<EventStatus> j_ = SuicideRiskAssessmentProcedure?.StatusElement;
+                EventStatus? k_ = j_?.Value;
+                string l_ = context.Operators.Convert<string>(k_);
+                bool? m_ = context.Operators.Equal(l_, "completed");
+                Period n_ = MDDEncounter?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
 
-                object q_() {
+                object p_() {
+
+                    bool t_() {
+                        DataType x_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                        bool z_ = y_ is CqlDateTime;
+                        return z_;
+                    }
+
 
                     bool u_() {
-                        DataType y_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                        bool aa_ = z_ is CqlDateTime;
-                        return aa_;
+                        DataType aa_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
+                        return ac_;
                     }
 
 
                     bool v_() {
-                        DataType ab_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-                        bool ad_ = ac_ is CqlInterval<CqlDateTime>;
-                        return ad_;
+                        DataType ad_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                        bool af_ = ae_ is CqlQuantity;
+                        return af_;
                     }
 
 
                     bool w_() {
-                        DataType ae_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                        bool ag_ = af_ is CqlQuantity;
-                        return ag_;
+                        DataType ag_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
+                        return ai_;
                     }
 
-
-                    bool x_() {
-                        DataType ah_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        bool aj_ = ai_ is CqlInterval<CqlQuantity>;
-                        return aj_;
-                    }
-
-                    if (u_())
+                    if (t_())
                     {
-                        DataType ak_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlDateTime) as object;
+                        DataType aj_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlDateTime) as object;
+                    }
+                    else if (u_())
+                    {
+                        DataType al_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (v_())
                     {
-                        DataType am_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlInterval<CqlDateTime>) as object;
+                        DataType an_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlQuantity) as object;
                     }
                     else if (w_())
                     {
-                        DataType ao_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlQuantity) as object;
-                    }
-                    else if (x_())
-                    {
-                        DataType aq_ = SuicideRiskAssessmentProcedure?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        return (ar_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ap_ = SuicideRiskAssessmentProcedure?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        return (aq_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -445,19 +445,18 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, r_, (string)default);
-                bool? t_ = context.Operators.And(n_, s_);
-                return t_;
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
+                bool? s_ = context.Operators.And(m_, r_);
+                return s_;
             }
 
             IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
-            Encounter i_(Procedure SuicideRiskAssessmentProcedure) => MDDEncounter;
-            IEnumerable<Encounter> j_ = context.Operators.Select<Procedure, Encounter>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Procedure>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -472,7 +471,7 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = this.Major_Depressive_Disorder_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter MDDEncounter) {
+        bool? b_(Encounter MDDEncounter) {
             CqlCode d_ = this.Suicide_risk_assessment__procedure_(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
@@ -481,32 +480,31 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
             IEnumerable<Observation> j_ = context.Operators.Union<Observation>(f_ as IEnumerable<Observation>, i_ as IEnumerable<Observation>);
 
             bool? k_(Observation ObservationSuicideRiskAssmt) {
-                Period o_ = MDDEncounter?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                DataType q_ = ObservationSuicideRiskAssmt?.Effective;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, (string)default);
-                Code<ObservationStatus> u_ = ObservationSuicideRiskAssmt?.StatusElement;
-                ObservationStatus? v_ = u_?.Value;
-                string w_ = context.Operators.Convert<string>(v_);
-                string[] x_ = [
+                Period n_ = MDDEncounter?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                DataType p_ = ObservationSuicideRiskAssmt?.Effective;
+                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
+                Code<ObservationStatus> t_ = ObservationSuicideRiskAssmt?.StatusElement;
+                ObservationStatus? u_ = t_?.Value;
+                string v_ = context.Operators.Convert<string>(u_);
+                string[] w_ = [
                     "final",
                     "corrected",
                     "amended",
                 ];
-                bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-                bool? z_ = context.Operators.And(t_, y_);
-                return z_;
+                bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+                bool? y_ = context.Operators.And(s_, x_);
+                return y_;
             }
 
             IEnumerable<Observation> l_ = context.Operators.Where<Observation>(j_, k_);
-            Encounter m_(Observation ObservationSuicideRiskAssmt) => MDDEncounter;
-            IEnumerable<Encounter> n_ = context.Operators.Select<Observation, Encounter>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<Observation>(l_);
+            return m_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS190FHIRVTEProphylaxisICU-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS190FHIRVTEProphylaxisICU-1.0.000.g.cs
@@ -485,67 +485,67 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             IEnumerable<object> d_ = this.Intervention_Comfort_Measures(context);
 
             bool? e_(object ComfortMeasure) {
 
-                object i_() {
+                object h_() {
+
+                    bool y_() {
+                        object ac_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlDateTime;
+                        return ae_;
+                    }
+
 
                     bool z_() {
-                        object ad_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlDateTime;
-                        return af_;
+                        object af_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlDateTime>;
+                        return ah_;
                     }
 
 
                     bool aa_() {
-                        object ag_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlDateTime>;
-                        return ai_;
+                        object ai_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        bool ak_ = aj_ is CqlQuantity;
+                        return ak_;
                     }
 
 
                     bool ab_() {
-                        object aj_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        bool al_ = ak_ is CqlQuantity;
-                        return al_;
+                        object al_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        bool an_ = am_ is CqlInterval<CqlQuantity>;
+                        return an_;
                     }
 
-
-                    bool ac_() {
-                        object am_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        bool ao_ = an_ is CqlInterval<CqlQuantity>;
-                        return ao_;
-                    }
-
-                    if (z_())
+                    if (y_())
                     {
-                        object ap_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlDateTime) as object;
+                        object ao_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlDateTime) as object;
+                    }
+                    else if (z_())
+                    {
+                        object aq_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (aa_())
                     {
-                        object ar_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlInterval<CqlDateTime>) as object;
+                        object as_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        return (at_ as CqlQuantity) as object;
                     }
                     else if (ab_())
                     {
-                        object at_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        return (au_ as CqlQuantity) as object;
-                    }
-                    else if (ac_())
-                    {
-                        object av_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        return (aw_ as CqlInterval<CqlQuantity>) as object;
+                        object au_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        return (av_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -553,29 +553,28 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                     };
                 }
 
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
-                CqlDateTime k_ = context.Operators.Start(j_);
-                object l_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-                CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
-                CqlInterval<CqlDate> n_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
-                CqlDate o_ = n_?.low;
-                CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
-                CqlDate r_ = n_?.high;
-                CqlDateTime s_ = context.Operators.ConvertDateToDateTime(r_);
-                bool? u_ = n_?.lowClosed;
-                bool? w_ = n_?.highClosed;
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(p_, s_, u_, w_);
-                bool? y_ = context.Operators.In<CqlDateTime>(k_ ?? m_, x_, "day");
-                return y_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_());
+                CqlDateTime j_ = context.Operators.Start(i_);
+                object k_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+                CqlDateTime l_ = context.Operators.LateBoundProperty<CqlDateTime>(k_, "value");
+                CqlInterval<CqlDate> m_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
+                CqlDate n_ = m_?.low;
+                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
+                CqlDate q_ = m_?.high;
+                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
+                bool? t_ = m_?.lowClosed;
+                bool? v_ = m_?.highClosed;
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(o_, r_, t_, v_);
+                bool? x_ = context.Operators.In<CqlDateTime>(j_ ?? l_, w_, "day");
+                return x_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object ComfortMeasure) => QualifyingEncounterICU;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1064,82 +1063,80 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         IEnumerable<MedicationAdministration> b_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> d_(MedicationAdministration MR) {
+        bool? d_(MedicationAdministration MR) {
             IEnumerable<Medication> bd_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? be_(Medication M) {
-                object bi_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object bj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> bk_ = context.Operators.Split((string)bj_, "/");
-                string bl_ = context.Operators.Last<string>(bk_);
-                bool? bm_ = context.Operators.Equal(bi_, bl_);
-                CodeableConcept bn_ = M?.Code;
-                CqlConcept bo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bn_);
-                CqlValueSet bp_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                bool? bq_ = context.Operators.ConceptInValueSet(bo_, bp_);
-                bool? br_ = context.Operators.And(bm_, bq_);
-                return br_;
+                object bh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object bi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> bj_ = context.Operators.Split((string)bi_, "/");
+                string bk_ = context.Operators.Last<string>(bj_);
+                bool? bl_ = context.Operators.Equal(bh_, bk_);
+                CodeableConcept bm_ = M?.Code;
+                CqlConcept bn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bm_);
+                CqlValueSet bo_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                bool? bp_ = context.Operators.ConceptInValueSet(bn_, bo_);
+                bool? bq_ = context.Operators.And(bl_, bp_);
+                return bq_;
             }
 
             IEnumerable<Medication> bf_ = context.Operators.Where<Medication>(bd_, be_);
-            MedicationAdministration bg_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> bh_ = context.Operators.Select<Medication, MedicationAdministration>(bf_, bg_);
-            return bh_;
+            bool? bg_ = context.Operators.Exists<Medication>(bf_);
+            return bg_;
         }
 
-        IEnumerable<MedicationAdministration> e_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, d_);
+        IEnumerable<MedicationAdministration> e_ = context.Operators.Where<MedicationAdministration>(c_, d_);
         IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(b_, e_);
 
         bool? g_(MedicationAdministration VTEMedication) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> bs_ = VTEMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? bt_ = bs_?.Value;
-            string bu_ = context.Operators.Convert<string>(bt_);
-            bool? bv_ = context.Operators.Equal(bu_, "completed");
-            MedicationAdministration.DosageComponent bw_ = VTEMedication?.Dosage;
-            CodeableConcept bx_ = bw_?.Route;
-            CqlConcept by_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bx_);
-            CqlValueSet bz_ = this.Subcutaneous_route(context);
-            bool? ca_ = context.Operators.ConceptInValueSet(by_, bz_);
-            bool? cb_ = context.Operators.And(bv_, ca_);
-            return cb_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> br_ = VTEMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? bs_ = br_?.Value;
+            string bt_ = context.Operators.Convert<string>(bs_);
+            bool? bu_ = context.Operators.Equal(bt_, "completed");
+            MedicationAdministration.DosageComponent bv_ = VTEMedication?.Dosage;
+            CodeableConcept bw_ = bv_?.Route;
+            CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
+            CqlValueSet by_ = this.Subcutaneous_route(context);
+            bool? bz_ = context.Operators.ConceptInValueSet(bx_, by_);
+            bool? ca_ = context.Operators.And(bu_, bz_);
+            return ca_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
         CqlValueSet i_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
         IEnumerable<MedicationAdministration> j_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> l_(MedicationAdministration MR) {
-            IEnumerable<Medication> cc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? l_(MedicationAdministration MR) {
+            IEnumerable<Medication> cb_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? cd_(Medication M) {
-                object ch_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ci_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> cj_ = context.Operators.Split((string)ci_, "/");
-                string ck_ = context.Operators.Last<string>(cj_);
-                bool? cl_ = context.Operators.Equal(ch_, ck_);
-                CodeableConcept cm_ = M?.Code;
-                CqlConcept cn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cm_);
-                CqlValueSet co_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                bool? cp_ = context.Operators.ConceptInValueSet(cn_, co_);
-                bool? cq_ = context.Operators.And(cl_, cp_);
-                return cq_;
+            bool? cc_(Medication M) {
+                object cf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ch_ = context.Operators.Split((string)cg_, "/");
+                string ci_ = context.Operators.Last<string>(ch_);
+                bool? cj_ = context.Operators.Equal(cf_, ci_);
+                CodeableConcept ck_ = M?.Code;
+                CqlConcept cl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ck_);
+                CqlValueSet cm_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                bool? cn_ = context.Operators.ConceptInValueSet(cl_, cm_);
+                bool? co_ = context.Operators.And(cj_, cn_);
+                return co_;
             }
 
-            IEnumerable<Medication> ce_ = context.Operators.Where<Medication>(cc_, cd_);
-            MedicationAdministration cf_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> cg_ = context.Operators.Select<Medication, MedicationAdministration>(ce_, cf_);
-            return cg_;
+            IEnumerable<Medication> cd_ = context.Operators.Where<Medication>(cb_, cc_);
+            bool? ce_ = context.Operators.Exists<Medication>(cd_);
+            return ce_;
         }
 
-        IEnumerable<MedicationAdministration> m_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, l_);
+        IEnumerable<MedicationAdministration> m_ = context.Operators.Where<MedicationAdministration>(c_, l_);
         IEnumerable<MedicationAdministration> n_ = context.Operators.Union<MedicationAdministration>(j_, m_);
 
         bool? o_(MedicationAdministration LMWH) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cr_ = LMWH?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? cs_ = cr_?.Value;
-            string ct_ = context.Operators.Convert<string>(cs_);
-            bool? cu_ = context.Operators.Equal(ct_, "completed");
-            return cu_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cp_ = LMWH?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? cq_ = cp_?.Value;
+            string cr_ = context.Operators.Convert<string>(cq_);
+            bool? cs_ = context.Operators.Equal(cr_, "completed");
+            return cs_;
         }
 
         IEnumerable<MedicationAdministration> p_ = context.Operators.Where<MedicationAdministration>(n_, o_);
@@ -1147,76 +1144,74 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         CqlValueSet r_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
         IEnumerable<MedicationAdministration> s_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, r_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> u_(MedicationAdministration MR) {
-            IEnumerable<Medication> cv_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? u_(MedicationAdministration MR) {
+            IEnumerable<Medication> ct_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? cw_(Medication M) {
-                object da_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object db_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> dc_ = context.Operators.Split((string)db_, "/");
-                string dd_ = context.Operators.Last<string>(dc_);
-                bool? de_ = context.Operators.Equal(da_, dd_);
-                CodeableConcept df_ = M?.Code;
-                CqlConcept dg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, df_);
-                CqlValueSet dh_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                bool? di_ = context.Operators.ConceptInValueSet(dg_, dh_);
-                bool? dj_ = context.Operators.And(de_, di_);
-                return dj_;
+            bool? cu_(Medication M) {
+                object cx_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cy_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> cz_ = context.Operators.Split((string)cy_, "/");
+                string da_ = context.Operators.Last<string>(cz_);
+                bool? db_ = context.Operators.Equal(cx_, da_);
+                CodeableConcept dc_ = M?.Code;
+                CqlConcept dd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dc_);
+                CqlValueSet de_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                bool? df_ = context.Operators.ConceptInValueSet(dd_, de_);
+                bool? dg_ = context.Operators.And(db_, df_);
+                return dg_;
             }
 
-            IEnumerable<Medication> cx_ = context.Operators.Where<Medication>(cv_, cw_);
-            MedicationAdministration cy_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> cz_ = context.Operators.Select<Medication, MedicationAdministration>(cx_, cy_);
-            return cz_;
+            IEnumerable<Medication> cv_ = context.Operators.Where<Medication>(ct_, cu_);
+            bool? cw_ = context.Operators.Exists<Medication>(cv_);
+            return cw_;
         }
 
-        IEnumerable<MedicationAdministration> v_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, u_);
+        IEnumerable<MedicationAdministration> v_ = context.Operators.Where<MedicationAdministration>(c_, u_);
         IEnumerable<MedicationAdministration> w_ = context.Operators.Union<MedicationAdministration>(s_, v_);
 
         bool? x_(MedicationAdministration FactorXa) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> dk_ = FactorXa?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? dl_ = dk_?.Value;
-            string dm_ = context.Operators.Convert<string>(dl_);
-            bool? dn_ = context.Operators.Equal(dm_, "completed");
-            return dn_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> dh_ = FactorXa?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? di_ = dh_?.Value;
+            string dj_ = context.Operators.Convert<string>(di_);
+            bool? dk_ = context.Operators.Equal(dj_, "completed");
+            return dk_;
         }
 
         IEnumerable<MedicationAdministration> y_ = context.Operators.Where<MedicationAdministration>(w_, x_);
         CqlValueSet z_ = this.Warfarin(context);
         IEnumerable<MedicationAdministration> aa_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, z_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> ac_(MedicationAdministration MR) {
-            IEnumerable<Medication> do_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ac_(MedicationAdministration MR) {
+            IEnumerable<Medication> dl_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? dp_(Medication M) {
-                object dt_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object du_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> dv_ = context.Operators.Split((string)du_, "/");
-                string dw_ = context.Operators.Last<string>(dv_);
-                bool? dx_ = context.Operators.Equal(dt_, dw_);
-                CodeableConcept dy_ = M?.Code;
-                CqlConcept dz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dy_);
-                CqlValueSet ea_ = this.Warfarin(context);
-                bool? eb_ = context.Operators.ConceptInValueSet(dz_, ea_);
-                bool? ec_ = context.Operators.And(dx_, eb_);
-                return ec_;
+            bool? dm_(Medication M) {
+                object dp_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object dq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> dr_ = context.Operators.Split((string)dq_, "/");
+                string ds_ = context.Operators.Last<string>(dr_);
+                bool? dt_ = context.Operators.Equal(dp_, ds_);
+                CodeableConcept du_ = M?.Code;
+                CqlConcept dv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, du_);
+                CqlValueSet dw_ = this.Warfarin(context);
+                bool? dx_ = context.Operators.ConceptInValueSet(dv_, dw_);
+                bool? dy_ = context.Operators.And(dt_, dx_);
+                return dy_;
             }
 
-            IEnumerable<Medication> dq_ = context.Operators.Where<Medication>(do_, dp_);
-            MedicationAdministration dr_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> ds_ = context.Operators.Select<Medication, MedicationAdministration>(dq_, dr_);
-            return ds_;
+            IEnumerable<Medication> dn_ = context.Operators.Where<Medication>(dl_, dm_);
+            bool? do_ = context.Operators.Exists<Medication>(dn_);
+            return do_;
         }
 
-        IEnumerable<MedicationAdministration> ad_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, ac_);
+        IEnumerable<MedicationAdministration> ad_ = context.Operators.Where<MedicationAdministration>(c_, ac_);
         IEnumerable<MedicationAdministration> ae_ = context.Operators.Union<MedicationAdministration>(aa_, ad_);
 
         bool? af_(MedicationAdministration WarfarinAdm) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ed_ = WarfarinAdm?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ee_ = ed_?.Value;
-            string ef_ = context.Operators.Convert<string>(ee_);
-            bool? eg_ = context.Operators.Equal(ef_, "completed");
-            return eg_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> dz_ = WarfarinAdm?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? ea_ = dz_?.Value;
+            string eb_ = context.Operators.Convert<string>(ea_);
+            bool? ec_ = context.Operators.Equal(eb_, "completed");
+            return ec_;
         }
 
         IEnumerable<MedicationAdministration> ag_ = context.Operators.Where<MedicationAdministration>(ae_, af_);
@@ -1225,38 +1220,37 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         CqlValueSet aj_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
         IEnumerable<MedicationAdministration> ak_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> am_(MedicationAdministration MR) {
-            IEnumerable<Medication> eh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? am_(MedicationAdministration MR) {
+            IEnumerable<Medication> ed_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ei_(Medication M) {
-                object em_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object en_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> eo_ = context.Operators.Split((string)en_, "/");
-                string ep_ = context.Operators.Last<string>(eo_);
-                bool? eq_ = context.Operators.Equal(em_, ep_);
-                CodeableConcept er_ = M?.Code;
-                CqlConcept es_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, er_);
-                CqlValueSet et_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                bool? eu_ = context.Operators.ConceptInValueSet(es_, et_);
-                bool? ev_ = context.Operators.And(eq_, eu_);
-                return ev_;
+            bool? ee_(Medication M) {
+                object eh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ei_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ej_ = context.Operators.Split((string)ei_, "/");
+                string ek_ = context.Operators.Last<string>(ej_);
+                bool? el_ = context.Operators.Equal(eh_, ek_);
+                CodeableConcept em_ = M?.Code;
+                CqlConcept en_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, em_);
+                CqlValueSet eo_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                bool? ep_ = context.Operators.ConceptInValueSet(en_, eo_);
+                bool? eq_ = context.Operators.And(el_, ep_);
+                return eq_;
             }
 
-            IEnumerable<Medication> ej_ = context.Operators.Where<Medication>(eh_, ei_);
-            MedicationAdministration ek_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> el_ = context.Operators.Select<Medication, MedicationAdministration>(ej_, ek_);
-            return el_;
+            IEnumerable<Medication> ef_ = context.Operators.Where<Medication>(ed_, ee_);
+            bool? eg_ = context.Operators.Exists<Medication>(ef_);
+            return eg_;
         }
 
-        IEnumerable<MedicationAdministration> an_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, am_);
+        IEnumerable<MedicationAdministration> an_ = context.Operators.Where<MedicationAdministration>(c_, am_);
         IEnumerable<MedicationAdministration> ao_ = context.Operators.Union<MedicationAdministration>(ak_, an_);
 
         bool? ap_(MedicationAdministration Rivaroxaban) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ew_ = Rivaroxaban?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ex_ = ew_?.Value;
-            string ey_ = context.Operators.Convert<string>(ex_);
-            bool? ez_ = context.Operators.Equal(ey_, "completed");
-            return ez_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> er_ = Rivaroxaban?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? es_ = er_?.Value;
+            string et_ = context.Operators.Convert<string>(es_);
+            bool? eu_ = context.Operators.Equal(et_, "completed");
+            return eu_;
         }
 
         IEnumerable<MedicationAdministration> aq_ = context.Operators.Where<MedicationAdministration>(ao_, ap_);
@@ -1270,11 +1264,11 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         IEnumerable<Procedure> ay_ = context.Operators.Union<Procedure>(av_, ax_);
 
         bool? az_(Procedure DeviceApplied) {
-            Code<EventStatus> fa_ = DeviceApplied?.StatusElement;
-            EventStatus? fb_ = fa_?.Value;
-            string fc_ = context.Operators.Convert<string>(fb_);
-            bool? fd_ = context.Operators.Equal(fc_, "completed");
-            return fd_;
+            Code<EventStatus> ev_ = DeviceApplied?.StatusElement;
+            EventStatus? ew_ = ev_?.Value;
+            string ex_ = context.Operators.Convert<string>(ew_);
+            bool? ey_ = context.Operators.Equal(ex_, "completed");
+            return ey_;
         }
 
         IEnumerable<Procedure> ba_ = context.Operators.Where<Procedure>(ay_, az_);
@@ -1294,70 +1288,70 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             IEnumerable<object> q_ = this.Pharmacological_Or_Mechanical_VTE_Prophylaxis_Received(context);
 
             bool? r_(object VTEProphylaxis) {
-                object v_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "effective");
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
+                object u_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "effective");
+                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
 
-                object y_() {
+                object x_() {
+
+                    bool aq_() {
+                        object au_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlDateTime;
+                        return aw_;
+                    }
+
 
                     bool ar_() {
-                        object av_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlDateTime;
-                        return ax_;
+                        object ax_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlInterval<CqlDateTime>;
+                        return az_;
                     }
 
 
                     bool as_() {
-                        object ay_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlInterval<CqlDateTime>;
-                        return ba_;
+                        object ba_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlQuantity;
+                        return bc_;
                     }
 
 
                     bool at_() {
-                        object bb_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlQuantity;
-                        return bd_;
+                        object bd_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        bool bf_ = be_ is CqlInterval<CqlQuantity>;
+                        return bf_;
                     }
 
-
-                    bool au_() {
-                        object be_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        bool bg_ = bf_ is CqlInterval<CqlQuantity>;
-                        return bg_;
-                    }
-
-                    if (ar_())
+                    if (aq_())
                     {
-                        object bh_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        return (bi_ as CqlDateTime) as object;
+                        object bg_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        return (bh_ as CqlDateTime) as object;
+                    }
+                    else if (ar_())
+                    {
+                        object bi_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                        return (bj_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (as_())
                     {
-                        object bj_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        return (bk_ as CqlInterval<CqlDateTime>) as object;
+                        object bk_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        return (bl_ as CqlQuantity) as object;
                     }
                     else if (at_())
                     {
-                        object bl_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        return (bm_ as CqlQuantity) as object;
-                    }
-                    else if (au_())
-                    {
-                        object bn_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
-                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                        return (bo_ as CqlInterval<CqlQuantity>) as object;
+                        object bm_ = context.Operators.LateBoundProperty<object>(VTEProphylaxis, "performed");
+                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                        return (bn_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1365,105 +1359,104 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                     };
                 }
 
-                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
-                CqlDateTime aa_ = context.Operators.Start(x_ ?? z_);
-                CqlDateTime ab_ = this.startOfFirstICU(context, QualifyingEncounterICU);
-                CqlInterval<CqlDate> ac_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ab_);
-                CqlDate ad_ = ac_?.low;
-                CqlDateTime ae_ = context.Operators.ConvertDateToDateTime(ad_);
-                CqlInterval<CqlDate> ag_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ab_);
-                CqlDate ah_ = ag_?.high;
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(ah_);
-                CqlInterval<CqlDate> ak_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ab_);
-                bool? al_ = ak_?.lowClosed;
-                CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ab_);
-                bool? ao_ = an_?.highClosed;
-                CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ae_, ai_, al_, ao_);
-                bool? aq_ = context.Operators.In<CqlDateTime>(aa_, ap_, "day");
-                return aq_;
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
+                CqlDateTime z_ = context.Operators.Start(w_ ?? y_);
+                CqlDateTime aa_ = this.startOfFirstICU(context, QualifyingEncounterICU);
+                CqlInterval<CqlDate> ab_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aa_);
+                CqlDate ac_ = ab_?.low;
+                CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(ac_);
+                CqlInterval<CqlDate> af_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aa_);
+                CqlDate ag_ = af_?.high;
+                CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
+                CqlInterval<CqlDate> aj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aa_);
+                bool? ak_ = aj_?.lowClosed;
+                CqlInterval<CqlDate> am_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aa_);
+                bool? an_ = am_?.highClosed;
+                CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ad_, ah_, ak_, an_);
+                bool? ap_ = context.Operators.In<CqlDateTime>(z_, ao_, "day");
+                return ap_;
             }
 
             IEnumerable<object> s_ = context.Operators.Where<object>(q_, r_);
-            Encounter t_(object VTEProphylaxis) => QualifyingEncounterICU;
-            IEnumerable<Encounter> u_ = context.Operators.Select<object, Encounter>(s_, t_);
-            return u_;
+            bool? t_ = context.Operators.Exists<object>(s_);
+            return t_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         CqlValueSet e_ = this.General_or_Neuraxial_Anesthesia(context);
         IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
         IEnumerable<object> g_ = this.Pharmacological_Or_Mechanical_VTE_Prophylaxis_Received(context);
         IEnumerable<ValueTuple<Encounter, Procedure, object>> h_ = context.Operators.CrossJoin<Encounter, Procedure, object>(a_, f_, g_);
 
         (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)? i_(ValueTuple<Encounter, Procedure, object> _valueTuple) {
-            (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)? bp_ = (CqlTupleMetadata_CGYAgYdKXUHcFINAPjMZNihh, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
-            return bp_;
+            (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)? bo_ = (CqlTupleMetadata_CGYAgYdKXUHcFINAPjMZNihh, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+            return bo_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)?> j_ = context.Operators.Select<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)?>(h_, i_);
 
         bool? k_((CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)? tuple_drnlhywkgwmzdeyzybtiilbhf) {
-            Code<EventStatus> bq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.StatusElement;
-            EventStatus? br_ = bq_?.Value;
-            string bs_ = context.Operators.Convert<string>(br_);
-            bool? bt_ = context.Operators.Equal(bs_, "completed");
+            Code<EventStatus> bp_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? bq_ = bp_?.Value;
+            string br_ = context.Operators.Convert<string>(bq_);
+            bool? bs_ = context.Operators.Equal(br_, "completed");
 
-            object bu_() {
+            object bt_() {
+
+                bool dg_() {
+                    DataType dk_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
+                    bool dm_ = dl_ is CqlDateTime;
+                    return dm_;
+                }
+
 
                 bool dh_() {
-                    DataType dl_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                    bool dn_ = dm_ is CqlDateTime;
-                    return dn_;
+                    DataType dn_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+                    bool dp_ = do_ is CqlInterval<CqlDateTime>;
+                    return dp_;
                 }
 
 
                 bool di_() {
-                    DataType do_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
-                    bool dq_ = dp_ is CqlInterval<CqlDateTime>;
-                    return dq_;
+                    DataType dq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
+                    bool ds_ = dr_ is CqlQuantity;
+                    return ds_;
                 }
 
 
                 bool dj_() {
-                    DataType dr_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
-                    bool dt_ = ds_ is CqlQuantity;
-                    return dt_;
+                    DataType dt_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                    bool dv_ = du_ is CqlInterval<CqlQuantity>;
+                    return dv_;
                 }
 
-
-                bool dk_() {
-                    DataType du_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                    bool dw_ = dv_ is CqlInterval<CqlQuantity>;
-                    return dw_;
-                }
-
-                if (dh_())
+                if (dg_())
                 {
-                    DataType dx_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
-                    return (dy_ as CqlDateTime) as object;
+                    DataType dw_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                    return (dx_ as CqlDateTime) as object;
+                }
+                else if (dh_())
+                {
+                    DataType dy_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
+                    return (dz_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (di_())
                 {
-                    DataType dz_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
-                    return (ea_ as CqlInterval<CqlDateTime>) as object;
+                    DataType ea_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
+                    return (eb_ as CqlQuantity) as object;
                 }
                 else if (dj_())
                 {
-                    DataType eb_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
-                    return (ec_ as CqlQuantity) as object;
-                }
-                else if (dk_())
-                {
-                    DataType ed_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
-                    return (ee_ as CqlInterval<CqlQuantity>) as object;
+                    DataType ec_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
+                    return (ed_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -1471,73 +1464,73 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_());
-            CqlDateTime bw_ = context.Operators.End(bv_);
-            CqlDateTime bx_ = this.startOfFirstICU(context, tuple_drnlhywkgwmzdeyzybtiilbhf?.QualifyingEncounterICU);
-            CqlQuantity by_ = context.Operators.Quantity(1m, "day");
-            CqlDateTime bz_ = context.Operators.Add(bx_, by_);
-            bool? ca_ = context.Operators.SameAs(bw_, bz_, "day");
-            bool? cb_ = context.Operators.And(bt_, ca_);
-            object cc_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "effective");
-            object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-            CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.toInterval(context, cd_);
+            CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, bt_());
+            CqlDateTime bv_ = context.Operators.End(bu_);
+            CqlDateTime bw_ = this.startOfFirstICU(context, tuple_drnlhywkgwmzdeyzybtiilbhf?.QualifyingEncounterICU);
+            CqlQuantity bx_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime by_ = context.Operators.Add(bw_, bx_);
+            bool? bz_ = context.Operators.SameAs(bv_, by_, "day");
+            bool? ca_ = context.Operators.And(bs_, bz_);
+            object cb_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "effective");
+            object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+            CqlInterval<CqlDateTime> cd_ = QICoreCommon_4_0_000.Instance.toInterval(context, cc_);
 
-            object cf_() {
+            object ce_() {
+
+                bool ee_() {
+                    object ei_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object ej_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ei_);
+                    bool ek_ = ej_ is CqlDateTime;
+                    return ek_;
+                }
+
 
                 bool ef_() {
-                    object ej_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object ek_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ej_);
-                    bool el_ = ek_ is CqlDateTime;
-                    return el_;
+                    object el_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object em_ = FHIRHelpers_4_4_000.Instance.ToValue(context, el_);
+                    bool en_ = em_ is CqlInterval<CqlDateTime>;
+                    return en_;
                 }
 
 
                 bool eg_() {
-                    object em_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object en_ = FHIRHelpers_4_4_000.Instance.ToValue(context, em_);
-                    bool eo_ = en_ is CqlInterval<CqlDateTime>;
-                    return eo_;
+                    object eo_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object ep_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eo_);
+                    bool eq_ = ep_ is CqlQuantity;
+                    return eq_;
                 }
 
 
                 bool eh_() {
-                    object ep_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object eq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ep_);
-                    bool er_ = eq_ is CqlQuantity;
-                    return er_;
+                    object er_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object es_ = FHIRHelpers_4_4_000.Instance.ToValue(context, er_);
+                    bool et_ = es_ is CqlInterval<CqlQuantity>;
+                    return et_;
                 }
 
-
-                bool ei_() {
-                    object es_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
-                    bool eu_ = et_ is CqlInterval<CqlQuantity>;
-                    return eu_;
-                }
-
-                if (ef_())
+                if (ee_())
                 {
-                    object ev_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
-                    return (ew_ as CqlDateTime) as object;
+                    object eu_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
+                    return (ev_ as CqlDateTime) as object;
+                }
+                else if (ef_())
+                {
+                    object ew_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object ex_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ew_);
+                    return (ex_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (eg_())
                 {
-                    object ex_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object ey_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ex_);
-                    return (ey_ as CqlInterval<CqlDateTime>) as object;
+                    object ey_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object ez_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ey_);
+                    return (ez_ as CqlQuantity) as object;
                 }
                 else if (eh_())
                 {
-                    object ez_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object fa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ez_);
-                    return (fa_ as CqlQuantity) as object;
-                }
-                else if (ei_())
-                {
-                    object fb_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                    object fc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fb_);
-                    return (fc_ as CqlInterval<CqlQuantity>) as object;
+                    object fa_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+                    object fb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fa_);
+                    return (fb_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -1545,65 +1538,65 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> cg_ = QICoreCommon_4_0_000.Instance.toInterval(context, cf_());
-            CqlDateTime ch_ = context.Operators.Start(ce_ ?? cg_);
+            CqlInterval<CqlDateTime> cf_ = QICoreCommon_4_0_000.Instance.toInterval(context, ce_());
+            CqlDateTime cg_ = context.Operators.Start(cd_ ?? cf_);
 
-            object ci_() {
+            object ch_() {
+
+                bool fc_() {
+                    DataType fg_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object fh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fg_);
+                    bool fi_ = fh_ is CqlDateTime;
+                    return fi_;
+                }
+
 
                 bool fd_() {
-                    DataType fh_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object fi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fh_);
-                    bool fj_ = fi_ is CqlDateTime;
-                    return fj_;
+                    DataType fj_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object fk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fj_);
+                    bool fl_ = fk_ is CqlInterval<CqlDateTime>;
+                    return fl_;
                 }
 
 
                 bool fe_() {
-                    DataType fk_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object fl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fk_);
-                    bool fm_ = fl_ is CqlInterval<CqlDateTime>;
-                    return fm_;
+                    DataType fm_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object fn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fm_);
+                    bool fo_ = fn_ is CqlQuantity;
+                    return fo_;
                 }
 
 
                 bool ff_() {
-                    DataType fn_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object fo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fn_);
-                    bool fp_ = fo_ is CqlQuantity;
-                    return fp_;
+                    DataType fp_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object fq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fp_);
+                    bool fr_ = fq_ is CqlInterval<CqlQuantity>;
+                    return fr_;
                 }
 
-
-                bool fg_() {
-                    DataType fq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object fr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fq_);
-                    bool fs_ = fr_ is CqlInterval<CqlQuantity>;
-                    return fs_;
-                }
-
-                if (fd_())
+                if (fc_())
                 {
-                    DataType ft_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object fu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ft_);
-                    return (fu_ as CqlDateTime) as object;
+                    DataType fs_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ft_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fs_);
+                    return (ft_ as CqlDateTime) as object;
+                }
+                else if (fd_())
+                {
+                    DataType fu_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object fv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fu_);
+                    return (fv_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (fe_())
                 {
-                    DataType fv_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object fw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fv_);
-                    return (fw_ as CqlInterval<CqlDateTime>) as object;
+                    DataType fw_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object fx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fw_);
+                    return (fx_ as CqlQuantity) as object;
                 }
                 else if (ff_())
                 {
-                    DataType fx_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object fy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fx_);
-                    return (fy_ as CqlQuantity) as object;
-                }
-                else if (fg_())
-                {
-                    DataType fz_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object ga_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fz_);
-                    return (ga_ as CqlInterval<CqlQuantity>) as object;
+                    DataType fy_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object fz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fy_);
+                    return (fz_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -1611,68 +1604,68 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> cj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ci_());
-            CqlDateTime ck_ = context.Operators.End(cj_);
-            CqlInterval<CqlDate> cl_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ck_);
-            CqlDate cm_ = cl_?.low;
-            CqlDateTime cn_ = context.Operators.ConvertDateToDateTime(cm_);
+            CqlInterval<CqlDateTime> ci_ = QICoreCommon_4_0_000.Instance.toInterval(context, ch_());
+            CqlDateTime cj_ = context.Operators.End(ci_);
+            CqlInterval<CqlDate> ck_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cj_);
+            CqlDate cl_ = ck_?.low;
+            CqlDateTime cm_ = context.Operators.ConvertDateToDateTime(cl_);
 
-            object co_() {
+            object cn_() {
+
+                bool ga_() {
+                    DataType ge_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object gf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ge_);
+                    bool gg_ = gf_ is CqlDateTime;
+                    return gg_;
+                }
+
 
                 bool gb_() {
-                    DataType gf_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gf_);
-                    bool gh_ = gg_ is CqlDateTime;
-                    return gh_;
+                    DataType gh_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object gi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gh_);
+                    bool gj_ = gi_ is CqlInterval<CqlDateTime>;
+                    return gj_;
                 }
 
 
                 bool gc_() {
-                    DataType gi_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gi_);
-                    bool gk_ = gj_ is CqlInterval<CqlDateTime>;
-                    return gk_;
+                    DataType gk_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object gl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gk_);
+                    bool gm_ = gl_ is CqlQuantity;
+                    return gm_;
                 }
 
 
                 bool gd_() {
-                    DataType gl_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gl_);
-                    bool gn_ = gm_ is CqlQuantity;
-                    return gn_;
+                    DataType gn_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object go_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gn_);
+                    bool gp_ = go_ is CqlInterval<CqlQuantity>;
+                    return gp_;
                 }
 
-
-                bool ge_() {
-                    DataType go_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, go_);
-                    bool gq_ = gp_ is CqlInterval<CqlQuantity>;
-                    return gq_;
-                }
-
-                if (gb_())
+                if (ga_())
                 {
-                    DataType gr_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gr_);
-                    return (gs_ as CqlDateTime) as object;
+                    DataType gq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object gr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gq_);
+                    return (gr_ as CqlDateTime) as object;
+                }
+                else if (gb_())
+                {
+                    DataType gs_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object gt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gs_);
+                    return (gt_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (gc_())
                 {
-                    DataType gt_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gt_);
-                    return (gu_ as CqlInterval<CqlDateTime>) as object;
+                    DataType gu_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object gv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gu_);
+                    return (gv_ as CqlQuantity) as object;
                 }
                 else if (gd_())
                 {
-                    DataType gv_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gv_);
-                    return (gw_ as CqlQuantity) as object;
-                }
-                else if (ge_())
-                {
-                    DataType gx_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object gy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gx_);
-                    return (gy_ as CqlInterval<CqlQuantity>) as object;
+                    DataType gw_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object gx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gw_);
+                    return (gx_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -1680,68 +1673,68 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> cp_ = QICoreCommon_4_0_000.Instance.toInterval(context, co_());
-            CqlDateTime cq_ = context.Operators.End(cp_);
-            CqlInterval<CqlDate> cr_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cq_);
-            CqlDate cs_ = cr_?.high;
-            CqlDateTime ct_ = context.Operators.ConvertDateToDateTime(cs_);
+            CqlInterval<CqlDateTime> co_ = QICoreCommon_4_0_000.Instance.toInterval(context, cn_());
+            CqlDateTime cp_ = context.Operators.End(co_);
+            CqlInterval<CqlDate> cq_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cp_);
+            CqlDate cr_ = cq_?.high;
+            CqlDateTime cs_ = context.Operators.ConvertDateToDateTime(cr_);
 
-            object cu_() {
+            object ct_() {
+
+                bool gy_() {
+                    DataType hc_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object hd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hc_);
+                    bool he_ = hd_ is CqlDateTime;
+                    return he_;
+                }
+
 
                 bool gz_() {
-                    DataType hd_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object he_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hd_);
-                    bool hf_ = he_ is CqlDateTime;
-                    return hf_;
+                    DataType hf_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object hg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hf_);
+                    bool hh_ = hg_ is CqlInterval<CqlDateTime>;
+                    return hh_;
                 }
 
 
                 bool ha_() {
-                    DataType hg_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object hh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hg_);
-                    bool hi_ = hh_ is CqlInterval<CqlDateTime>;
-                    return hi_;
+                    DataType hi_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object hj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hi_);
+                    bool hk_ = hj_ is CqlQuantity;
+                    return hk_;
                 }
 
 
                 bool hb_() {
-                    DataType hj_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object hk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hj_);
-                    bool hl_ = hk_ is CqlQuantity;
-                    return hl_;
+                    DataType hl_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object hm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hl_);
+                    bool hn_ = hm_ is CqlInterval<CqlQuantity>;
+                    return hn_;
                 }
 
-
-                bool hc_() {
-                    DataType hm_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object hn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hm_);
-                    bool ho_ = hn_ is CqlInterval<CqlQuantity>;
-                    return ho_;
-                }
-
-                if (gz_())
+                if (gy_())
                 {
-                    DataType hp_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object hq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hp_);
-                    return (hq_ as CqlDateTime) as object;
+                    DataType ho_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object hp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ho_);
+                    return (hp_ as CqlDateTime) as object;
+                }
+                else if (gz_())
+                {
+                    DataType hq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object hr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hq_);
+                    return (hr_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (ha_())
                 {
-                    DataType hr_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object hs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hr_);
-                    return (hs_ as CqlInterval<CqlDateTime>) as object;
+                    DataType hs_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ht_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hs_);
+                    return (ht_ as CqlQuantity) as object;
                 }
                 else if (hb_())
                 {
-                    DataType ht_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object hu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ht_);
-                    return (hu_ as CqlQuantity) as object;
-                }
-                else if (hc_())
-                {
-                    DataType hv_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object hw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hv_);
-                    return (hw_ as CqlInterval<CqlQuantity>) as object;
+                    DataType hu_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object hv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hu_);
+                    return (hv_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -1749,67 +1742,67 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> cv_ = QICoreCommon_4_0_000.Instance.toInterval(context, cu_());
-            CqlDateTime cw_ = context.Operators.End(cv_);
-            CqlInterval<CqlDate> cx_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cw_);
-            bool? cy_ = cx_?.lowClosed;
+            CqlInterval<CqlDateTime> cu_ = QICoreCommon_4_0_000.Instance.toInterval(context, ct_());
+            CqlDateTime cv_ = context.Operators.End(cu_);
+            CqlInterval<CqlDate> cw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cv_);
+            bool? cx_ = cw_?.lowClosed;
 
-            object cz_() {
+            object cy_() {
+
+                bool hw_() {
+                    DataType ia_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ib_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ia_);
+                    bool ic_ = ib_ is CqlDateTime;
+                    return ic_;
+                }
+
 
                 bool hx_() {
-                    DataType ib_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object ic_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ib_);
-                    bool id_ = ic_ is CqlDateTime;
-                    return id_;
+                    DataType id_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ie_ = FHIRHelpers_4_4_000.Instance.ToValue(context, id_);
+                    bool if_ = ie_ is CqlInterval<CqlDateTime>;
+                    return if_;
                 }
 
 
                 bool hy_() {
-                    DataType ie_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object if_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ie_);
-                    bool ig_ = if_ is CqlInterval<CqlDateTime>;
-                    return ig_;
+                    DataType ig_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ih_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ig_);
+                    bool ii_ = ih_ is CqlQuantity;
+                    return ii_;
                 }
 
 
                 bool hz_() {
-                    DataType ih_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object ii_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ih_);
-                    bool ij_ = ii_ is CqlQuantity;
-                    return ij_;
+                    DataType ij_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ik_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ij_);
+                    bool il_ = ik_ is CqlInterval<CqlQuantity>;
+                    return il_;
                 }
 
-
-                bool ia_() {
-                    DataType ik_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object il_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ik_);
-                    bool im_ = il_ is CqlInterval<CqlQuantity>;
-                    return im_;
-                }
-
-                if (hx_())
+                if (hw_())
                 {
-                    DataType in_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object io_ = FHIRHelpers_4_4_000.Instance.ToValue(context, in_);
-                    return (io_ as CqlDateTime) as object;
+                    DataType im_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object in_ = FHIRHelpers_4_4_000.Instance.ToValue(context, im_);
+                    return (in_ as CqlDateTime) as object;
+                }
+                else if (hx_())
+                {
+                    DataType io_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ip_ = FHIRHelpers_4_4_000.Instance.ToValue(context, io_);
+                    return (ip_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (hy_())
                 {
-                    DataType ip_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object iq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ip_);
-                    return (iq_ as CqlInterval<CqlDateTime>) as object;
+                    DataType iq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object ir_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iq_);
+                    return (ir_ as CqlQuantity) as object;
                 }
                 else if (hz_())
                 {
-                    DataType ir_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object is_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ir_);
-                    return (is_ as CqlQuantity) as object;
-                }
-                else if (ia_())
-                {
-                    DataType it_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                    object iu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, it_);
-                    return (iu_ as CqlInterval<CqlQuantity>) as object;
+                    DataType is_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+                    object it_ = FHIRHelpers_4_4_000.Instance.ToValue(context, is_);
+                    return (it_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -1817,14 +1810,14 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> da_ = QICoreCommon_4_0_000.Instance.toInterval(context, cz_());
-            CqlDateTime db_ = context.Operators.End(da_);
-            CqlInterval<CqlDate> dc_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, db_);
-            bool? dd_ = dc_?.highClosed;
-            CqlInterval<CqlDateTime> de_ = context.Operators.Interval(cn_, ct_, cy_, dd_);
-            bool? df_ = context.Operators.In<CqlDateTime>(ch_, de_, "day");
-            bool? dg_ = context.Operators.And(cb_, df_);
-            return dg_;
+            CqlInterval<CqlDateTime> cz_ = QICoreCommon_4_0_000.Instance.toInterval(context, cy_());
+            CqlDateTime da_ = context.Operators.End(cz_);
+            CqlInterval<CqlDate> db_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, da_);
+            bool? dc_ = db_?.highClosed;
+            CqlInterval<CqlDateTime> dd_ = context.Operators.Interval(cm_, cs_, cx_, dc_);
+            bool? de_ = context.Operators.In<CqlDateTime>(cg_, dd_, "day");
+            bool? df_ = context.Operators.And(ca_, de_);
+            return df_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)?> l_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)?>(j_, k_);
@@ -1846,177 +1839,174 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             CqlValueSet v_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
             IEnumerable<MedicationAdministration> w_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, v_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
             IEnumerable<MedicationAdministration> x_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-            IEnumerable<MedicationAdministration> y_(MedicationAdministration MR) {
-                IEnumerable<Medication> af_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? y_(MedicationAdministration MR) {
+                IEnumerable<Medication> ae_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? ag_(Medication M) {
-                    object ak_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object al_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> am_ = context.Operators.Split((string)al_, "/");
-                    string an_ = context.Operators.Last<string>(am_);
-                    bool? ao_ = context.Operators.Equal(ak_, an_);
-                    CodeableConcept ap_ = M?.Code;
-                    CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
-                    CqlValueSet ar_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                    bool? as_ = context.Operators.ConceptInValueSet(aq_, ar_);
-                    bool? at_ = context.Operators.And(ao_, as_);
-                    return at_;
+                bool? af_(Medication M) {
+                    object ai_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object aj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> ak_ = context.Operators.Split((string)aj_, "/");
+                    string al_ = context.Operators.Last<string>(ak_);
+                    bool? am_ = context.Operators.Equal(ai_, al_);
+                    CodeableConcept an_ = M?.Code;
+                    CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, an_);
+                    CqlValueSet ap_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                    bool? aq_ = context.Operators.ConceptInValueSet(ao_, ap_);
+                    bool? ar_ = context.Operators.And(am_, aq_);
+                    return ar_;
                 }
 
-                IEnumerable<Medication> ah_ = context.Operators.Where<Medication>(af_, ag_);
-                MedicationAdministration ai_(Medication M) => MR;
-                IEnumerable<MedicationAdministration> aj_ = context.Operators.Select<Medication, MedicationAdministration>(ah_, ai_);
-                return aj_;
+                IEnumerable<Medication> ag_ = context.Operators.Where<Medication>(ae_, af_);
+                bool? ah_ = context.Operators.Exists<Medication>(ag_);
+                return ah_;
             }
 
-            IEnumerable<MedicationAdministration> z_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(x_, y_);
+            IEnumerable<MedicationAdministration> z_ = context.Operators.Where<MedicationAdministration>(x_, y_);
             IEnumerable<MedicationAdministration> aa_ = context.Operators.Union<MedicationAdministration>(w_, z_);
 
             bool? ab_(MedicationAdministration FactorXaMedication) {
-                Code<MedicationAdministration.MedicationAdministrationStatusCodes> au_ = FactorXaMedication?.StatusElement;
-                MedicationAdministration.MedicationAdministrationStatusCodes? av_ = au_?.Value;
-                string aw_ = context.Operators.Convert<string>(av_);
-                bool? ax_ = context.Operators.Equal(aw_, "completed");
-                DataType ay_ = FactorXaMedication?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                CqlInterval<CqlDateTime> ba_ = QICoreCommon_4_0_000.Instance.toInterval(context, az_);
-                CqlDateTime bb_ = context.Operators.Start(ba_);
-                CqlDateTime bc_ = this.startOfFirstICU(context, QualifyingEncounterICU);
-                CqlInterval<CqlDate> bd_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bc_);
-                CqlDate be_ = bd_?.low;
-                CqlDateTime bf_ = context.Operators.ConvertDateToDateTime(be_);
-                CqlInterval<CqlDate> bh_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bc_);
-                CqlDate bi_ = bh_?.high;
-                CqlDateTime bj_ = context.Operators.ConvertDateToDateTime(bi_);
-                CqlInterval<CqlDate> bl_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bc_);
-                bool? bm_ = bl_?.lowClosed;
-                CqlInterval<CqlDate> bo_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bc_);
-                bool? bp_ = bo_?.highClosed;
-                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bf_, bj_, bm_, bp_);
-                bool? br_ = context.Operators.In<CqlDateTime>(bb_, bq_, "day");
-                bool? bs_ = context.Operators.And(ax_, br_);
-                return bs_;
+                Code<MedicationAdministration.MedicationAdministrationStatusCodes> as_ = FactorXaMedication?.StatusElement;
+                MedicationAdministration.MedicationAdministrationStatusCodes? at_ = as_?.Value;
+                string au_ = context.Operators.Convert<string>(at_);
+                bool? av_ = context.Operators.Equal(au_, "completed");
+                DataType aw_ = FactorXaMedication?.Effective;
+                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+                CqlDateTime ba_ = this.startOfFirstICU(context, QualifyingEncounterICU);
+                CqlInterval<CqlDate> bb_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
+                CqlDate bc_ = bb_?.low;
+                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
+                CqlInterval<CqlDate> bf_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
+                CqlDate bg_ = bf_?.high;
+                CqlDateTime bh_ = context.Operators.ConvertDateToDateTime(bg_);
+                CqlInterval<CqlDate> bj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
+                bool? bk_ = bj_?.lowClosed;
+                CqlInterval<CqlDate> bm_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
+                bool? bn_ = bm_?.highClosed;
+                CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bd_, bh_, bk_, bn_);
+                bool? bp_ = context.Operators.In<CqlDateTime>(az_, bo_, "day");
+                bool? bq_ = context.Operators.And(av_, bp_);
+                return bq_;
             }
 
             IEnumerable<MedicationAdministration> ac_ = context.Operators.Where<MedicationAdministration>(aa_, ab_);
-            Encounter ad_(MedicationAdministration FactorXaMedication) => QualifyingEncounterICU;
-            IEnumerable<Encounter> ae_ = context.Operators.Select<MedicationAdministration, Encounter>(ac_, ad_);
-            return ae_;
+            bool? ad_ = context.Operators.Exists<MedicationAdministration>(ac_);
+            return ad_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         CqlValueSet e_ = this.General_or_Neuraxial_Anesthesia(context);
         IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
         CqlValueSet g_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
         IEnumerable<MedicationAdministration> h_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> i_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> j_(MedicationAdministration MR) {
-            IEnumerable<Medication> bt_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? j_(MedicationAdministration MR) {
+            IEnumerable<Medication> br_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? bu_(Medication M) {
-                object by_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object bz_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ca_ = context.Operators.Split((string)bz_, "/");
-                string cb_ = context.Operators.Last<string>(ca_);
-                bool? cc_ = context.Operators.Equal(by_, cb_);
-                CodeableConcept cd_ = M?.Code;
-                CqlConcept ce_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cd_);
-                CqlValueSet cf_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                bool? cg_ = context.Operators.ConceptInValueSet(ce_, cf_);
-                bool? ch_ = context.Operators.And(cc_, cg_);
-                return ch_;
+            bool? bs_(Medication M) {
+                object bv_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object bw_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> bx_ = context.Operators.Split((string)bw_, "/");
+                string by_ = context.Operators.Last<string>(bx_);
+                bool? bz_ = context.Operators.Equal(bv_, by_);
+                CodeableConcept ca_ = M?.Code;
+                CqlConcept cb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ca_);
+                CqlValueSet cc_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                bool? cd_ = context.Operators.ConceptInValueSet(cb_, cc_);
+                bool? ce_ = context.Operators.And(bz_, cd_);
+                return ce_;
             }
 
-            IEnumerable<Medication> bv_ = context.Operators.Where<Medication>(bt_, bu_);
-            MedicationAdministration bw_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> bx_ = context.Operators.Select<Medication, MedicationAdministration>(bv_, bw_);
-            return bx_;
+            IEnumerable<Medication> bt_ = context.Operators.Where<Medication>(br_, bs_);
+            bool? bu_ = context.Operators.Exists<Medication>(bt_);
+            return bu_;
         }
 
-        IEnumerable<MedicationAdministration> k_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(i_, j_);
+        IEnumerable<MedicationAdministration> k_ = context.Operators.Where<MedicationAdministration>(i_, j_);
         IEnumerable<MedicationAdministration> l_ = context.Operators.Union<MedicationAdministration>(h_, k_);
         IEnumerable<ValueTuple<Encounter, Procedure, MedicationAdministration>> m_ = context.Operators.CrossJoin<Encounter, Procedure, MedicationAdministration>(a_, f_, l_);
 
         (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? n_(ValueTuple<Encounter, Procedure, MedicationAdministration> _valueTuple) {
-            (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? ci_ = (CqlTupleMetadata_IGcdIOTLGJfibgSLNOGSFRVB, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
-            return ci_;
+            (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? cf_ = (CqlTupleMetadata_IGcdIOTLGJfibgSLNOGSFRVB, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+            return cf_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?> o_ = context.Operators.Select<ValueTuple<Encounter, Procedure, MedicationAdministration>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?>(m_, n_);
 
         bool? p_((CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)? tuple_elrfucfgncrbdgahdtkitiyzu) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cj_ = tuple_elrfucfgncrbdgahdtkitiyzu?.FactorXaMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ck_ = cj_?.Value;
-            string cl_ = context.Operators.Convert<string>(ck_);
-            bool? cm_ = context.Operators.Equal(cl_, "completed");
-            Code<EventStatus> cn_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.StatusElement;
-            EventStatus? co_ = cn_?.Value;
-            string cp_ = context.Operators.Convert<string>(co_);
-            bool? cq_ = context.Operators.Equal(cp_, "completed");
-            bool? cr_ = context.Operators.And(cm_, cq_);
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> cg_ = tuple_elrfucfgncrbdgahdtkitiyzu?.FactorXaMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? ch_ = cg_?.Value;
+            string ci_ = context.Operators.Convert<string>(ch_);
+            bool? cj_ = context.Operators.Equal(ci_, "completed");
+            Code<EventStatus> ck_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? cl_ = ck_?.Value;
+            string cm_ = context.Operators.Convert<string>(cl_);
+            bool? cn_ = context.Operators.Equal(cm_, "completed");
+            bool? co_ = context.Operators.And(cj_, cn_);
 
-            object cs_() {
+            object cp_() {
 
-                bool ed_() {
+                bool ea_() {
+                    DataType ee_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
+                    bool eg_ = ef_ is CqlDateTime;
+                    return eg_;
+                }
+
+
+                bool eb_() {
                     DataType eh_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object ei_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eh_);
-                    bool ej_ = ei_ is CqlDateTime;
+                    bool ej_ = ei_ is CqlInterval<CqlDateTime>;
                     return ej_;
                 }
 
 
-                bool ee_() {
+                bool ec_() {
                     DataType ek_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object el_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ek_);
-                    bool em_ = el_ is CqlInterval<CqlDateTime>;
+                    bool em_ = el_ is CqlQuantity;
                     return em_;
                 }
 
 
-                bool ef_() {
+                bool ed_() {
                     DataType en_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
-                    bool ep_ = eo_ is CqlQuantity;
+                    bool ep_ = eo_ is CqlInterval<CqlQuantity>;
                     return ep_;
                 }
 
-
-                bool eg_() {
+                if (ea_())
+                {
                     DataType eq_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
-                    bool es_ = er_ is CqlInterval<CqlQuantity>;
-                    return es_;
+                    return (er_ as CqlDateTime) as object;
                 }
-
-                if (ed_())
+                else if (eb_())
                 {
-                    DataType et_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object eu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, et_);
-                    return (eu_ as CqlDateTime) as object;
+                    DataType es_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
+                    return (et_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (ee_())
+                else if (ec_())
                 {
-                    DataType ev_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
-                    return (ew_ as CqlInterval<CqlDateTime>) as object;
+                    DataType eu_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
+                    return (ev_ as CqlQuantity) as object;
                 }
-                else if (ef_())
+                else if (ed_())
                 {
-                    DataType ex_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object ey_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ex_);
-                    return (ey_ as CqlQuantity) as object;
-                }
-                else if (eg_())
-                {
-                    DataType ez_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object fa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ez_);
-                    return (fa_ as CqlInterval<CqlQuantity>) as object;
+                    DataType ew_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object ex_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ew_);
+                    return (ex_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2024,74 +2014,74 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> ct_ = QICoreCommon_4_0_000.Instance.toInterval(context, cs_());
-            CqlDateTime cu_ = context.Operators.End(ct_);
-            CqlDateTime cv_ = this.startOfFirstICU(context, tuple_elrfucfgncrbdgahdtkitiyzu?.QualifyingEncounterICU);
-            CqlQuantity cw_ = context.Operators.Quantity(1m, "day");
-            CqlDateTime cx_ = context.Operators.Add(cv_, cw_);
-            bool? cy_ = context.Operators.SameAs(cu_, cx_, "day");
-            bool? cz_ = context.Operators.And(cr_, cy_);
-            DataType da_ = tuple_elrfucfgncrbdgahdtkitiyzu?.FactorXaMedication?.Effective;
-            object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-            CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_);
-            CqlDateTime dd_ = context.Operators.Start(dc_);
+            CqlInterval<CqlDateTime> cq_ = QICoreCommon_4_0_000.Instance.toInterval(context, cp_());
+            CqlDateTime cr_ = context.Operators.End(cq_);
+            CqlDateTime cs_ = this.startOfFirstICU(context, tuple_elrfucfgncrbdgahdtkitiyzu?.QualifyingEncounterICU);
+            CqlQuantity ct_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime cu_ = context.Operators.Add(cs_, ct_);
+            bool? cv_ = context.Operators.SameAs(cr_, cu_, "day");
+            bool? cw_ = context.Operators.And(co_, cv_);
+            DataType cx_ = tuple_elrfucfgncrbdgahdtkitiyzu?.FactorXaMedication?.Effective;
+            object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
+            CqlInterval<CqlDateTime> cz_ = QICoreCommon_4_0_000.Instance.toInterval(context, cy_);
+            CqlDateTime da_ = context.Operators.Start(cz_);
 
-            object de_() {
+            object db_() {
 
-                bool fb_() {
+                bool ey_() {
+                    DataType fc_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object fd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fc_);
+                    bool fe_ = fd_ is CqlDateTime;
+                    return fe_;
+                }
+
+
+                bool ez_() {
                     DataType ff_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object fg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ff_);
-                    bool fh_ = fg_ is CqlDateTime;
+                    bool fh_ = fg_ is CqlInterval<CqlDateTime>;
                     return fh_;
                 }
 
 
-                bool fc_() {
+                bool fa_() {
                     DataType fi_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object fj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fi_);
-                    bool fk_ = fj_ is CqlInterval<CqlDateTime>;
+                    bool fk_ = fj_ is CqlQuantity;
                     return fk_;
                 }
 
 
-                bool fd_() {
+                bool fb_() {
                     DataType fl_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object fm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fl_);
-                    bool fn_ = fm_ is CqlQuantity;
+                    bool fn_ = fm_ is CqlInterval<CqlQuantity>;
                     return fn_;
                 }
 
-
-                bool fe_() {
+                if (ey_())
+                {
                     DataType fo_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object fp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fo_);
-                    bool fq_ = fp_ is CqlInterval<CqlQuantity>;
-                    return fq_;
+                    return (fp_ as CqlDateTime) as object;
                 }
-
-                if (fb_())
+                else if (ez_())
                 {
-                    DataType fr_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object fs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fr_);
-                    return (fs_ as CqlDateTime) as object;
+                    DataType fq_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object fr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fq_);
+                    return (fr_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (fc_())
+                else if (fa_())
                 {
-                    DataType ft_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object fu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ft_);
-                    return (fu_ as CqlInterval<CqlDateTime>) as object;
+                    DataType fs_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object ft_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fs_);
+                    return (ft_ as CqlQuantity) as object;
                 }
-                else if (fd_())
+                else if (fb_())
                 {
-                    DataType fv_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object fw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fv_);
-                    return (fw_ as CqlQuantity) as object;
-                }
-                else if (fe_())
-                {
-                    DataType fx_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object fy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fx_);
-                    return (fy_ as CqlInterval<CqlQuantity>) as object;
+                    DataType fu_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object fv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fu_);
+                    return (fv_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2099,68 +2089,68 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> df_ = QICoreCommon_4_0_000.Instance.toInterval(context, de_());
-            CqlDateTime dg_ = context.Operators.End(df_);
-            CqlInterval<CqlDate> dh_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dg_);
-            CqlDate di_ = dh_?.low;
-            CqlDateTime dj_ = context.Operators.ConvertDateToDateTime(di_);
+            CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_());
+            CqlDateTime dd_ = context.Operators.End(dc_);
+            CqlInterval<CqlDate> de_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dd_);
+            CqlDate df_ = de_?.low;
+            CqlDateTime dg_ = context.Operators.ConvertDateToDateTime(df_);
 
-            object dk_() {
+            object dh_() {
 
-                bool fz_() {
+                bool fw_() {
+                    DataType ga_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object gb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ga_);
+                    bool gc_ = gb_ is CqlDateTime;
+                    return gc_;
+                }
+
+
+                bool fx_() {
                     DataType gd_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object ge_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gd_);
-                    bool gf_ = ge_ is CqlDateTime;
+                    bool gf_ = ge_ is CqlInterval<CqlDateTime>;
                     return gf_;
                 }
 
 
-                bool ga_() {
+                bool fy_() {
                     DataType gg_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object gh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gg_);
-                    bool gi_ = gh_ is CqlInterval<CqlDateTime>;
+                    bool gi_ = gh_ is CqlQuantity;
                     return gi_;
                 }
 
 
-                bool gb_() {
+                bool fz_() {
                     DataType gj_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object gk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gj_);
-                    bool gl_ = gk_ is CqlQuantity;
+                    bool gl_ = gk_ is CqlInterval<CqlQuantity>;
                     return gl_;
                 }
 
-
-                bool gc_() {
+                if (fw_())
+                {
                     DataType gm_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object gn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gm_);
-                    bool go_ = gn_ is CqlInterval<CqlQuantity>;
-                    return go_;
+                    return (gn_ as CqlDateTime) as object;
                 }
-
-                if (fz_())
+                else if (fx_())
                 {
-                    DataType gp_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object gq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gp_);
-                    return (gq_ as CqlDateTime) as object;
+                    DataType go_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object gp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, go_);
+                    return (gp_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (ga_())
+                else if (fy_())
                 {
-                    DataType gr_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object gs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gr_);
-                    return (gs_ as CqlInterval<CqlDateTime>) as object;
+                    DataType gq_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object gr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gq_);
+                    return (gr_ as CqlQuantity) as object;
                 }
-                else if (gb_())
+                else if (fz_())
                 {
-                    DataType gt_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object gu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gt_);
-                    return (gu_ as CqlQuantity) as object;
-                }
-                else if (gc_())
-                {
-                    DataType gv_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object gw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gv_);
-                    return (gw_ as CqlInterval<CqlQuantity>) as object;
+                    DataType gs_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object gt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gs_);
+                    return (gt_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2168,68 +2158,68 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> dl_ = QICoreCommon_4_0_000.Instance.toInterval(context, dk_());
-            CqlDateTime dm_ = context.Operators.End(dl_);
-            CqlInterval<CqlDate> dn_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dm_);
-            CqlDate do_ = dn_?.high;
-            CqlDateTime dp_ = context.Operators.ConvertDateToDateTime(do_);
+            CqlInterval<CqlDateTime> di_ = QICoreCommon_4_0_000.Instance.toInterval(context, dh_());
+            CqlDateTime dj_ = context.Operators.End(di_);
+            CqlInterval<CqlDate> dk_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dj_);
+            CqlDate dl_ = dk_?.high;
+            CqlDateTime dm_ = context.Operators.ConvertDateToDateTime(dl_);
 
-            object dq_() {
+            object dn_() {
 
-                bool gx_() {
+                bool gu_() {
+                    DataType gy_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object gz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gy_);
+                    bool ha_ = gz_ is CqlDateTime;
+                    return ha_;
+                }
+
+
+                bool gv_() {
                     DataType hb_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object hc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hb_);
-                    bool hd_ = hc_ is CqlDateTime;
+                    bool hd_ = hc_ is CqlInterval<CqlDateTime>;
                     return hd_;
                 }
 
 
-                bool gy_() {
+                bool gw_() {
                     DataType he_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object hf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, he_);
-                    bool hg_ = hf_ is CqlInterval<CqlDateTime>;
+                    bool hg_ = hf_ is CqlQuantity;
                     return hg_;
                 }
 
 
-                bool gz_() {
+                bool gx_() {
                     DataType hh_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object hi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hh_);
-                    bool hj_ = hi_ is CqlQuantity;
+                    bool hj_ = hi_ is CqlInterval<CqlQuantity>;
                     return hj_;
                 }
 
-
-                bool ha_() {
+                if (gu_())
+                {
                     DataType hk_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object hl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hk_);
-                    bool hm_ = hl_ is CqlInterval<CqlQuantity>;
-                    return hm_;
+                    return (hl_ as CqlDateTime) as object;
                 }
-
-                if (gx_())
+                else if (gv_())
                 {
-                    DataType hn_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object ho_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hn_);
-                    return (ho_ as CqlDateTime) as object;
+                    DataType hm_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object hn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hm_);
+                    return (hn_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (gy_())
+                else if (gw_())
                 {
-                    DataType hp_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object hq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hp_);
-                    return (hq_ as CqlInterval<CqlDateTime>) as object;
+                    DataType ho_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object hp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ho_);
+                    return (hp_ as CqlQuantity) as object;
                 }
-                else if (gz_())
+                else if (gx_())
                 {
-                    DataType hr_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object hs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hr_);
-                    return (hs_ as CqlQuantity) as object;
-                }
-                else if (ha_())
-                {
-                    DataType ht_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object hu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ht_);
-                    return (hu_ as CqlInterval<CqlQuantity>) as object;
+                    DataType hq_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object hr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hq_);
+                    return (hr_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2237,67 +2227,67 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> dr_ = QICoreCommon_4_0_000.Instance.toInterval(context, dq_());
-            CqlDateTime ds_ = context.Operators.End(dr_);
-            CqlInterval<CqlDate> dt_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ds_);
-            bool? du_ = dt_?.lowClosed;
+            CqlInterval<CqlDateTime> do_ = QICoreCommon_4_0_000.Instance.toInterval(context, dn_());
+            CqlDateTime dp_ = context.Operators.End(do_);
+            CqlInterval<CqlDate> dq_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dp_);
+            bool? dr_ = dq_?.lowClosed;
 
-            object dv_() {
+            object ds_() {
 
-                bool hv_() {
+                bool hs_() {
+                    DataType hw_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object hx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hw_);
+                    bool hy_ = hx_ is CqlDateTime;
+                    return hy_;
+                }
+
+
+                bool ht_() {
                     DataType hz_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object ia_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hz_);
-                    bool ib_ = ia_ is CqlDateTime;
+                    bool ib_ = ia_ is CqlInterval<CqlDateTime>;
                     return ib_;
                 }
 
 
-                bool hw_() {
+                bool hu_() {
                     DataType ic_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object id_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ic_);
-                    bool ie_ = id_ is CqlInterval<CqlDateTime>;
+                    bool ie_ = id_ is CqlQuantity;
                     return ie_;
                 }
 
 
-                bool hx_() {
+                bool hv_() {
                     DataType if_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object ig_ = FHIRHelpers_4_4_000.Instance.ToValue(context, if_);
-                    bool ih_ = ig_ is CqlQuantity;
+                    bool ih_ = ig_ is CqlInterval<CqlQuantity>;
                     return ih_;
                 }
 
-
-                bool hy_() {
+                if (hs_())
+                {
                     DataType ii_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
                     object ij_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ii_);
-                    bool ik_ = ij_ is CqlInterval<CqlQuantity>;
-                    return ik_;
+                    return (ij_ as CqlDateTime) as object;
                 }
-
-                if (hv_())
+                else if (ht_())
                 {
-                    DataType il_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object im_ = FHIRHelpers_4_4_000.Instance.ToValue(context, il_);
-                    return (im_ as CqlDateTime) as object;
+                    DataType ik_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object il_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ik_);
+                    return (il_ as CqlInterval<CqlDateTime>) as object;
                 }
-                else if (hw_())
+                else if (hu_())
                 {
-                    DataType in_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object io_ = FHIRHelpers_4_4_000.Instance.ToValue(context, in_);
-                    return (io_ as CqlInterval<CqlDateTime>) as object;
+                    DataType im_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object in_ = FHIRHelpers_4_4_000.Instance.ToValue(context, im_);
+                    return (in_ as CqlQuantity) as object;
                 }
-                else if (hx_())
+                else if (hv_())
                 {
-                    DataType ip_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object iq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ip_);
-                    return (iq_ as CqlQuantity) as object;
-                }
-                else if (hy_())
-                {
-                    DataType ir_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                    object is_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ir_);
-                    return (is_ as CqlInterval<CqlQuantity>) as object;
+                    DataType io_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+                    object ip_ = FHIRHelpers_4_4_000.Instance.ToValue(context, io_);
+                    return (ip_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -2305,14 +2295,14 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 };
             }
 
-            CqlInterval<CqlDateTime> dw_ = QICoreCommon_4_0_000.Instance.toInterval(context, dv_());
-            CqlDateTime dx_ = context.Operators.End(dw_);
-            CqlInterval<CqlDate> dy_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dx_);
-            bool? dz_ = dy_?.highClosed;
-            CqlInterval<CqlDateTime> ea_ = context.Operators.Interval(dj_, dp_, du_, dz_);
-            bool? eb_ = context.Operators.In<CqlDateTime>(dd_, ea_, "day");
-            bool? ec_ = context.Operators.And(cz_, eb_);
-            return ec_;
+            CqlInterval<CqlDateTime> dt_ = QICoreCommon_4_0_000.Instance.toInterval(context, ds_());
+            CqlDateTime du_ = context.Operators.End(dt_);
+            CqlInterval<CqlDate> dv_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, du_);
+            bool? dw_ = dv_?.highClosed;
+            CqlInterval<CqlDateTime> dx_ = context.Operators.Interval(dg_, dm_, dr_, dw_);
+            bool? dy_ = context.Operators.In<CqlDateTime>(da_, dx_, "day");
+            bool? dz_ = context.Operators.And(cw_, dy_);
+            return dz_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?> q_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?>(o_, p_);
@@ -2334,132 +2324,130 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             CqlValueSet l_ = this.Atrial_Fibrillation_or_Flutter(context);
             IEnumerable<Condition> m_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? n_(Condition AtrialFibrillation) {
-                CodeableConcept r_ = AtrialFibrillation?.VerificationStatus;
-                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                bool? t_ = context.Operators.Not((bool?)(s_ is null));
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                CqlCode w_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
-                bool? y_ = context.Operators.Equivalent(v_, x_);
-                bool? z_ = context.Operators.Not(y_);
-                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                CqlCode ac_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
-                bool? ae_ = context.Operators.Equivalent(ab_, ad_);
-                bool? af_ = context.Operators.Not(ae_);
-                bool? ag_ = context.Operators.And(z_, af_);
-                DataType ah_ = AtrialFibrillation?.Onset;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                CqlDateTime ak_ = context.Operators.Start(aj_);
-                Period al_ = QualifyingEncounterICU?.Period;
-                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                CqlDateTime an_ = context.Operators.End(am_);
-                bool? ao_ = context.Operators.SameOrBefore(ak_, an_, (string)default);
-                bool? ap_ = context.Operators.And(ag_, ao_);
-                bool? aq_ = context.Operators.Implies(t_, ap_);
-                return aq_;
+                CodeableConcept q_ = AtrialFibrillation?.VerificationStatus;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                bool? s_ = context.Operators.Not((bool?)(r_ is null));
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlCode v_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
+                bool? x_ = context.Operators.Equivalent(u_, w_);
+                bool? y_ = context.Operators.Not(x_);
+                CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlCode ab_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
+                bool? ad_ = context.Operators.Equivalent(aa_, ac_);
+                bool? ae_ = context.Operators.Not(ad_);
+                bool? af_ = context.Operators.And(y_, ae_);
+                DataType ag_ = AtrialFibrillation?.Onset;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
+                CqlDateTime aj_ = context.Operators.Start(ai_);
+                Period ak_ = QualifyingEncounterICU?.Period;
+                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
+                CqlDateTime am_ = context.Operators.End(al_);
+                bool? an_ = context.Operators.SameOrBefore(aj_, am_, (string)default);
+                bool? ao_ = context.Operators.And(af_, an_);
+                bool? ap_ = context.Operators.Implies(s_, ao_);
+                return ap_;
             }
 
             IEnumerable<Condition> o_ = context.Operators.Where<Condition>(m_, n_);
-            Encounter p_(Condition AtrialFibrillation) => QualifyingEncounterICU;
-            IEnumerable<Encounter> q_ = context.Operators.Select<Condition, Encounter>(o_, p_);
-            return q_;
+            bool? p_ = context.Operators.Exists<Condition>(o_);
+            return p_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? e_(Encounter QualifyingEncounterICU) {
-            CqlValueSet ar_ = this.Atrial_Fibrillation_or_Flutter(context);
-            bool? as_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounterICU, ar_);
-            return as_;
+            CqlValueSet aq_ = this.Atrial_Fibrillation_or_Flutter(context);
+            bool? ar_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounterICU, aq_);
+            return ar_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
         IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 
-        IEnumerable<Encounter> i_(Encounter QualifyingEncounterICU) {
-            CqlValueSet at_ = this.Venous_Thromboembolism(context);
-            IEnumerable<Condition> au_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, at_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? i_(Encounter QualifyingEncounterICU) {
+            CqlValueSet as_ = this.Venous_Thromboembolism(context);
+            IEnumerable<Condition> at_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, as_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            bool? av_(Condition VTEDiagnosis) {
-                CodeableConcept az_ = VTEDiagnosis?.ClinicalStatus;
-                CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                CqlCode bb_ = QICoreCommon_4_0_000.Instance.inactive(context);
-                CqlConcept bc_ = context.Operators.ConvertCodeToConcept(bb_);
-                bool? bd_ = context.Operators.Equivalent(ba_, bc_);
-                CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                CqlCode bg_ = QICoreCommon_4_0_000.Instance.remission(context);
-                CqlConcept bh_ = context.Operators.ConvertCodeToConcept(bg_);
-                bool? bi_ = context.Operators.Equivalent(bf_, bh_);
-                bool? bj_ = context.Operators.Or(bd_, bi_);
-                CqlConcept bl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                CqlCode bm_ = QICoreCommon_4_0_000.Instance.resolved(context);
-                CqlConcept bn_ = context.Operators.ConvertCodeToConcept(bm_);
-                bool? bo_ = context.Operators.Equivalent(bl_, bn_);
-                bool? bp_ = context.Operators.Or(bj_, bo_);
-                CodeableConcept bq_ = VTEDiagnosis?.VerificationStatus;
-                CqlConcept br_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
-                bool? bs_ = context.Operators.Not((bool?)(br_ is null));
-                bool? bt_ = context.Operators.And(bp_, bs_);
-                CqlConcept bv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
-                CqlCode bw_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept bx_ = context.Operators.ConvertCodeToConcept(bw_);
-                bool? by_ = context.Operators.Equivalent(bv_, bx_);
-                bool? bz_ = context.Operators.Not(by_);
-                CqlConcept cb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
-                CqlCode cc_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept cd_ = context.Operators.ConvertCodeToConcept(cc_);
-                bool? ce_ = context.Operators.Equivalent(cb_, cd_);
-                bool? cf_ = context.Operators.Not(ce_);
-                bool? cg_ = context.Operators.And(bz_, cf_);
-                DataType ch_ = VTEDiagnosis?.Onset;
-                object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                CqlInterval<CqlDateTime> cj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ci_);
+            bool? au_(Condition VTEDiagnosis) {
+                CodeableConcept ax_ = VTEDiagnosis?.ClinicalStatus;
+                CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                CqlCode az_ = QICoreCommon_4_0_000.Instance.inactive(context);
+                CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
+                bool? bb_ = context.Operators.Equivalent(ay_, ba_);
+                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                CqlCode be_ = QICoreCommon_4_0_000.Instance.remission(context);
+                CqlConcept bf_ = context.Operators.ConvertCodeToConcept(be_);
+                bool? bg_ = context.Operators.Equivalent(bd_, bf_);
+                bool? bh_ = context.Operators.Or(bb_, bg_);
+                CqlConcept bj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                CqlCode bk_ = QICoreCommon_4_0_000.Instance.resolved(context);
+                CqlConcept bl_ = context.Operators.ConvertCodeToConcept(bk_);
+                bool? bm_ = context.Operators.Equivalent(bj_, bl_);
+                bool? bn_ = context.Operators.Or(bh_, bm_);
+                CodeableConcept bo_ = VTEDiagnosis?.VerificationStatus;
+                CqlConcept bp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
+                bool? bq_ = context.Operators.Not((bool?)(bp_ is null));
+                bool? br_ = context.Operators.And(bn_, bq_);
+                CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
+                CqlCode bu_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept bv_ = context.Operators.ConvertCodeToConcept(bu_);
+                bool? bw_ = context.Operators.Equivalent(bt_, bv_);
+                bool? bx_ = context.Operators.Not(bw_);
+                CqlConcept bz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
+                CqlCode ca_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept cb_ = context.Operators.ConvertCodeToConcept(ca_);
+                bool? cc_ = context.Operators.Equivalent(bz_, cb_);
+                bool? cd_ = context.Operators.Not(cc_);
+                bool? ce_ = context.Operators.And(bx_, cd_);
+                DataType cf_ = VTEDiagnosis?.Onset;
+                object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                CqlInterval<CqlDateTime> ch_ = QICoreCommon_4_0_000.Instance.toInterval(context, cg_);
 
-                CqlInterval<CqlDateTime> ck_() {
+                CqlInterval<CqlDateTime> ci_() {
 
-                    bool co_() {
-                        Period cp_ = QualifyingEncounterICU?.Period;
-                        CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
-                        CqlDateTime cr_ = context.Operators.Start(cq_);
-                        return cr_ is null;
+                    bool cm_() {
+                        Period cn_ = QualifyingEncounterICU?.Period;
+                        CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cn_);
+                        CqlDateTime cp_ = context.Operators.Start(co_);
+                        return cp_ is null;
                     }
 
-                    if (co_())
+                    if (cm_())
                     {
                         return default;
                     }
                     else
                     {
-                        Period cs_ = QualifyingEncounterICU?.Period;
-                        CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cs_);
-                        CqlDateTime cu_ = context.Operators.Start(ct_);
-                        CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cs_);
-                        CqlDateTime cx_ = context.Operators.Start(cw_);
-                        CqlInterval<CqlDateTime> cy_ = context.Operators.Interval(cu_, cx_, true, true);
-                        return cy_;
+                        Period cq_ = QualifyingEncounterICU?.Period;
+                        CqlInterval<CqlDateTime> cr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
+                        CqlDateTime cs_ = context.Operators.Start(cr_);
+                        CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
+                        CqlDateTime cv_ = context.Operators.Start(cu_);
+                        CqlInterval<CqlDateTime> cw_ = context.Operators.Interval(cs_, cv_, true, true);
+                        return cw_;
                     };
                 }
 
-                bool? cl_ = context.Operators.Before(cj_, ck_(), (string)default);
-                bool? cm_ = context.Operators.And(cg_, cl_);
-                bool? cn_ = context.Operators.Implies(bt_, cm_);
-                return cn_;
+                bool? cj_ = context.Operators.Before(ch_, ci_(), (string)default);
+                bool? ck_ = context.Operators.And(ce_, cj_);
+                bool? cl_ = context.Operators.Implies(br_, ck_);
+                return cl_;
             }
 
-            IEnumerable<Condition> aw_ = context.Operators.Where<Condition>(au_, av_);
-            Encounter ax_(Condition VTEDiagnosis) => QualifyingEncounterICU;
-            IEnumerable<Encounter> ay_ = context.Operators.Select<Condition, Encounter>(aw_, ax_);
-            return ay_;
+            IEnumerable<Condition> av_ = context.Operators.Where<Condition>(at_, au_);
+            bool? aw_ = context.Operators.Exists<Condition>(av_);
+            return aw_;
         }
 
-        IEnumerable<Encounter> j_ = context.Operators.SelectMany<Encounter, Encounter>(a_, i_);
+        IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(a_, i_);
         IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
         return k_;
     }
@@ -2475,7 +2463,7 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             CqlValueSet d_ = this.Hip_Replacement_Surgery(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
             CqlValueSet f_ = this.Knee_Replacement_Surgery(context);
@@ -2483,67 +2471,67 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 
             bool? i_(Procedure HipKneeProcedure) {
-                Code<EventStatus> m_ = HipKneeProcedure?.StatusElement;
-                EventStatus? n_ = m_?.Value;
-                string o_ = context.Operators.Convert<string>(n_);
-                bool? p_ = context.Operators.Equal(o_, "completed");
+                Code<EventStatus> l_ = HipKneeProcedure?.StatusElement;
+                EventStatus? m_ = l_?.Value;
+                string n_ = context.Operators.Convert<string>(m_);
+                bool? o_ = context.Operators.Equal(n_, "completed");
 
-                object q_() {
+                object p_() {
+
+                    bool x_() {
+                        DataType ab_ = HipKneeProcedure?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlDateTime;
+                        return ad_;
+                    }
+
 
                     bool y_() {
-                        DataType ac_ = HipKneeProcedure?.Performed;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlDateTime;
-                        return ae_;
+                        DataType ae_ = HipKneeProcedure?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlDateTime>;
+                        return ag_;
                     }
 
 
                     bool z_() {
-                        DataType af_ = HipKneeProcedure?.Performed;
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlInterval<CqlDateTime>;
-                        return ah_;
+                        DataType ah_ = HipKneeProcedure?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        bool aj_ = ai_ is CqlQuantity;
+                        return aj_;
                     }
 
 
                     bool aa_() {
-                        DataType ai_ = HipKneeProcedure?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        bool ak_ = aj_ is CqlQuantity;
-                        return ak_;
+                        DataType ak_ = HipKneeProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        bool am_ = al_ is CqlInterval<CqlQuantity>;
+                        return am_;
                     }
 
-
-                    bool ab_() {
-                        DataType al_ = HipKneeProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        bool an_ = am_ is CqlInterval<CqlQuantity>;
-                        return an_;
-                    }
-
-                    if (y_())
+                    if (x_())
                     {
-                        DataType ao_ = HipKneeProcedure?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlDateTime) as object;
+                        DataType an_ = HipKneeProcedure?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlDateTime) as object;
+                    }
+                    else if (y_())
+                    {
+                        DataType ap_ = HipKneeProcedure?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        return (aq_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (z_())
                     {
-                        DataType aq_ = HipKneeProcedure?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        return (ar_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ar_ = HipKneeProcedure?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        return (as_ as CqlQuantity) as object;
                     }
                     else if (aa_())
                     {
-                        DataType as_ = HipKneeProcedure?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        return (at_ as CqlQuantity) as object;
-                    }
-                    else if (ab_())
-                    {
-                        DataType au_ = HipKneeProcedure?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        return (av_ as CqlInterval<CqlQuantity>) as object;
+                        DataType at_ = HipKneeProcedure?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        return (au_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2551,23 +2539,22 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                CqlDateTime s_ = context.Operators.Start(r_);
-                Period t_ = QualifyingEncounterICU?.Period;
-                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                CqlDateTime v_ = context.Operators.End(u_);
-                bool? w_ = context.Operators.SameOrBefore(s_, v_, (string)default);
-                bool? x_ = context.Operators.And(p_, w_);
-                return x_;
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                CqlDateTime r_ = context.Operators.Start(q_);
+                Period s_ = QualifyingEncounterICU?.Period;
+                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
+                CqlDateTime u_ = context.Operators.End(t_);
+                bool? v_ = context.Operators.SameOrBefore(r_, u_, (string)default);
+                bool? w_ = context.Operators.And(o_, v_);
+                return w_;
             }
 
             IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
-            Encounter k_(Procedure HipKneeProcedure) => QualifyingEncounterICU;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Procedure, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Procedure>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -2704,120 +2691,117 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         IEnumerable<MedicationAdministration> r_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, q_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> s_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> t_(MedicationAdministration MR) {
+        bool? t_(MedicationAdministration MR) {
             IEnumerable<Medication> cp_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? cq_(Medication M) {
-                object cu_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object cv_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> cw_ = context.Operators.Split((string)cv_, "/");
-                string cx_ = context.Operators.Last<string>(cw_);
-                bool? cy_ = context.Operators.Equal(cu_, cx_);
-                CodeableConcept cz_ = M?.Code;
-                CqlConcept da_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cz_);
-                CqlValueSet db_ = this.Unfractionated_Heparin(context);
-                bool? dc_ = context.Operators.ConceptInValueSet(da_, db_);
-                bool? dd_ = context.Operators.And(cy_, dc_);
-                return dd_;
+                object ct_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cu_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> cv_ = context.Operators.Split((string)cu_, "/");
+                string cw_ = context.Operators.Last<string>(cv_);
+                bool? cx_ = context.Operators.Equal(ct_, cw_);
+                CodeableConcept cy_ = M?.Code;
+                CqlConcept cz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cy_);
+                CqlValueSet da_ = this.Unfractionated_Heparin(context);
+                bool? db_ = context.Operators.ConceptInValueSet(cz_, da_);
+                bool? dc_ = context.Operators.And(cx_, db_);
+                return dc_;
             }
 
             IEnumerable<Medication> cr_ = context.Operators.Where<Medication>(cp_, cq_);
-            MedicationAdministration cs_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> ct_ = context.Operators.Select<Medication, MedicationAdministration>(cr_, cs_);
-            return ct_;
+            bool? cs_ = context.Operators.Exists<Medication>(cr_);
+            return cs_;
         }
 
-        IEnumerable<MedicationAdministration> u_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(s_, t_);
+        IEnumerable<MedicationAdministration> u_ = context.Operators.Where<MedicationAdministration>(s_, t_);
         IEnumerable<MedicationAdministration> v_ = context.Operators.Union<MedicationAdministration>(r_, u_);
 
         bool? w_(MedicationAdministration UnfractionatedHeparin) {
-            MedicationAdministration.DosageComponent de_ = UnfractionatedHeparin?.Dosage;
-            CodeableConcept df_ = de_?.Route;
-            CqlConcept dg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, df_);
-            CqlValueSet dh_ = this.Intravenous_route(context);
-            bool? di_ = context.Operators.ConceptInValueSet(dg_, dh_);
-            return di_;
+            MedicationAdministration.DosageComponent dd_ = UnfractionatedHeparin?.Dosage;
+            CodeableConcept de_ = dd_?.Route;
+            CqlConcept df_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, de_);
+            CqlValueSet dg_ = this.Intravenous_route(context);
+            bool? dh_ = context.Operators.ConceptInValueSet(df_, dg_);
+            return dh_;
         }
 
         IEnumerable<MedicationAdministration> x_ = context.Operators.Where<MedicationAdministration>(v_, w_);
         CqlValueSet y_ = this.Direct_Thrombin_Inhibitor(context);
         IEnumerable<MedicationAdministration> z_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> ab_(MedicationAdministration MR) {
-            IEnumerable<Medication> dj_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ab_(MedicationAdministration MR) {
+            IEnumerable<Medication> di_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? dk_(Medication M) {
-                object do_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object dp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> dq_ = context.Operators.Split((string)dp_, "/");
-                string dr_ = context.Operators.Last<string>(dq_);
-                bool? ds_ = context.Operators.Equal(do_, dr_);
-                CodeableConcept dt_ = M?.Code;
-                CqlConcept du_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dt_);
-                CqlValueSet dv_ = this.Direct_Thrombin_Inhibitor(context);
-                bool? dw_ = context.Operators.ConceptInValueSet(du_, dv_);
-                bool? dx_ = context.Operators.And(ds_, dw_);
-                return dx_;
+            bool? dj_(Medication M) {
+                object dm_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object dn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> do_ = context.Operators.Split((string)dn_, "/");
+                string dp_ = context.Operators.Last<string>(do_);
+                bool? dq_ = context.Operators.Equal(dm_, dp_);
+                CodeableConcept dr_ = M?.Code;
+                CqlConcept ds_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dr_);
+                CqlValueSet dt_ = this.Direct_Thrombin_Inhibitor(context);
+                bool? du_ = context.Operators.ConceptInValueSet(ds_, dt_);
+                bool? dv_ = context.Operators.And(dq_, du_);
+                return dv_;
             }
 
-            IEnumerable<Medication> dl_ = context.Operators.Where<Medication>(dj_, dk_);
-            MedicationAdministration dm_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> dn_ = context.Operators.Select<Medication, MedicationAdministration>(dl_, dm_);
-            return dn_;
+            IEnumerable<Medication> dk_ = context.Operators.Where<Medication>(di_, dj_);
+            bool? dl_ = context.Operators.Exists<Medication>(dk_);
+            return dl_;
         }
 
-        IEnumerable<MedicationAdministration> ac_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(s_, ab_);
+        IEnumerable<MedicationAdministration> ac_ = context.Operators.Where<MedicationAdministration>(s_, ab_);
         IEnumerable<MedicationAdministration> ad_ = context.Operators.Union<MedicationAdministration>(z_, ac_);
         IEnumerable<MedicationAdministration> ae_ = context.Operators.Union<MedicationAdministration>(x_, ad_);
         CqlValueSet af_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
         IEnumerable<MedicationAdministration> ag_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, af_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> ai_(MedicationAdministration MR) {
-            IEnumerable<Medication> dy_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ai_(MedicationAdministration MR) {
+            IEnumerable<Medication> dw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? dz_(Medication M) {
-                object ed_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ee_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ef_ = context.Operators.Split((string)ee_, "/");
-                string eg_ = context.Operators.Last<string>(ef_);
-                bool? eh_ = context.Operators.Equal(ed_, eg_);
-                CodeableConcept ei_ = M?.Code;
-                CqlConcept ej_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ei_);
-                CqlValueSet ek_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
-                bool? el_ = context.Operators.ConceptInValueSet(ej_, ek_);
-                bool? em_ = context.Operators.And(eh_, el_);
-                return em_;
+            bool? dx_(Medication M) {
+                object ea_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object eb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ec_ = context.Operators.Split((string)eb_, "/");
+                string ed_ = context.Operators.Last<string>(ec_);
+                bool? ee_ = context.Operators.Equal(ea_, ed_);
+                CodeableConcept ef_ = M?.Code;
+                CqlConcept eg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ef_);
+                CqlValueSet eh_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
+                bool? ei_ = context.Operators.ConceptInValueSet(eg_, eh_);
+                bool? ej_ = context.Operators.And(ee_, ei_);
+                return ej_;
             }
 
-            IEnumerable<Medication> ea_ = context.Operators.Where<Medication>(dy_, dz_);
-            MedicationAdministration eb_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> ec_ = context.Operators.Select<Medication, MedicationAdministration>(ea_, eb_);
-            return ec_;
+            IEnumerable<Medication> dy_ = context.Operators.Where<Medication>(dw_, dx_);
+            bool? dz_ = context.Operators.Exists<Medication>(dy_);
+            return dz_;
         }
 
-        IEnumerable<MedicationAdministration> aj_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(s_, ai_);
+        IEnumerable<MedicationAdministration> aj_ = context.Operators.Where<MedicationAdministration>(s_, ai_);
         IEnumerable<MedicationAdministration> ak_ = context.Operators.Union<MedicationAdministration>(ag_, aj_);
         IEnumerable<MedicationAdministration> al_ = context.Operators.Union<MedicationAdministration>(ae_, ak_);
 
         bool? am_(MedicationAdministration AnticoagulantMedication) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> en_ = AnticoagulantMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? eo_ = en_?.Value;
-            string ep_ = context.Operators.Convert<string>(eo_);
-            bool? eq_ = context.Operators.Equal(ep_, "completed");
-            return eq_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ek_ = AnticoagulantMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? el_ = ek_?.Value;
+            string em_ = context.Operators.Convert<string>(el_);
+            bool? en_ = context.Operators.Equal(em_, "completed");
+            return en_;
         }
 
         IEnumerable<MedicationAdministration> an_ = context.Operators.Where<MedicationAdministration>(al_, am_);
 
         (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? ao_(MedicationAdministration AnticoagulantMedication) {
-            Id er_ = AnticoagulantMedication?.IdElement;
-            string es_ = er_?.Value;
-            DataType et_ = AnticoagulantMedication?.Effective;
-            object eu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, et_);
-            CqlInterval<CqlDateTime> ev_ = QICoreCommon_4_0_000.Instance.toInterval(context, eu_);
-            CqlDateTime ew_ = context.Operators.Start(ev_);
-            (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? ex_ = (CqlTupleMetadata_DMAfXNhTfZDWOGdfEceXbfaSJ, es_, ew_);
-            return ex_;
+            Id eo_ = AnticoagulantMedication?.IdElement;
+            string ep_ = eo_?.Value;
+            DataType eq_ = AnticoagulantMedication?.Effective;
+            object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+            CqlInterval<CqlDateTime> es_ = QICoreCommon_4_0_000.Instance.toInterval(context, er_);
+            CqlDateTime et_ = context.Operators.Start(es_);
+            (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? eu_ = (CqlTupleMetadata_DMAfXNhTfZDWOGdfEceXbfaSJ, ep_, et_);
+            return eu_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?> ap_ = context.Operators.Select<MedicationAdministration, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>(an_, ao_);
@@ -2837,30 +2821,29 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             IEnumerable<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?> d_ = this.Low_Risk_Indicator_For_VTE(context);
 
             bool? e_((CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE) {
-                CqlDateTime i_ = LowRiskForVTE?.LowRiskDatetime;
-                CqlInterval<CqlDate> j_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
-                CqlDate k_ = j_?.low;
-                CqlDateTime l_ = context.Operators.ConvertDateToDateTime(k_);
-                CqlDate n_ = j_?.high;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                bool? q_ = j_?.lowClosed;
-                bool? s_ = j_?.highClosed;
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(l_, o_, q_, s_);
-                bool? u_ = context.Operators.In<CqlDateTime>(i_, t_, "day");
-                return u_;
+                CqlDateTime h_ = LowRiskForVTE?.LowRiskDatetime;
+                CqlInterval<CqlDate> i_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
+                CqlDate j_ = i_?.low;
+                CqlDateTime k_ = context.Operators.ConvertDateToDateTime(j_);
+                CqlDate m_ = i_?.high;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                bool? p_ = i_?.lowClosed;
+                bool? r_ = i_?.highClosed;
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(k_, n_, p_, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(h_, s_, "day");
+                return t_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE) => QualifyingEncounterICU;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -3407,184 +3390,179 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         IEnumerable<MedicationRequest> bs_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> bt_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> bu_(MedicationRequest MR) {
+        bool? bu_(MedicationRequest MR) {
             IEnumerable<Medication> eu_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? ev_(Medication M) {
-                object ez_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object fa_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fb_ = context.Operators.Split((string)fa_, "/");
-                string fc_ = context.Operators.Last<string>(fb_);
-                bool? fd_ = context.Operators.Equal(ez_, fc_);
-                CodeableConcept fe_ = M?.Code;
-                CqlConcept ff_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fe_);
-                CqlValueSet fg_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                bool? fh_ = context.Operators.ConceptInValueSet(ff_, fg_);
-                bool? fi_ = context.Operators.And(fd_, fh_);
-                return fi_;
+                object ey_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ez_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fa_ = context.Operators.Split((string)ez_, "/");
+                string fb_ = context.Operators.Last<string>(fa_);
+                bool? fc_ = context.Operators.Equal(ey_, fb_);
+                CodeableConcept fd_ = M?.Code;
+                CqlConcept fe_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fd_);
+                CqlValueSet ff_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                bool? fg_ = context.Operators.ConceptInValueSet(fe_, ff_);
+                bool? fh_ = context.Operators.And(fc_, fg_);
+                return fh_;
             }
 
             IEnumerable<Medication> ew_ = context.Operators.Where<Medication>(eu_, ev_);
-            MedicationRequest ex_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ey_ = context.Operators.Select<Medication, MedicationRequest>(ew_, ex_);
-            return ey_;
+            bool? ex_ = context.Operators.Exists<Medication>(ew_);
+            return ex_;
         }
 
-        IEnumerable<MedicationRequest> bv_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, bu_);
+        IEnumerable<MedicationRequest> bv_ = context.Operators.Where<MedicationRequest>(bt_, bu_);
         IEnumerable<MedicationRequest> bw_ = context.Operators.Union<MedicationRequest>(bs_, bv_);
         IEnumerable<MedicationRequest> by_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ca_(MedicationRequest MR) {
-            IEnumerable<Medication> fj_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ca_(MedicationRequest MR) {
+            IEnumerable<Medication> fi_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? fk_(Medication M) {
-                object fo_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object fp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> fq_ = context.Operators.Split((string)fp_, "/");
-                string fr_ = context.Operators.Last<string>(fq_);
-                bool? fs_ = context.Operators.Equal(fo_, fr_);
-                CodeableConcept ft_ = M?.Code;
-                CqlConcept fu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ft_);
-                CqlValueSet fv_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                bool? fw_ = context.Operators.ConceptInValueSet(fu_, fv_);
-                bool? fx_ = context.Operators.And(fs_, fw_);
-                return fx_;
+            bool? fj_(Medication M) {
+                object fm_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object fn_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> fo_ = context.Operators.Split((string)fn_, "/");
+                string fp_ = context.Operators.Last<string>(fo_);
+                bool? fq_ = context.Operators.Equal(fm_, fp_);
+                CodeableConcept fr_ = M?.Code;
+                CqlConcept fs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fr_);
+                CqlValueSet ft_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                bool? fu_ = context.Operators.ConceptInValueSet(fs_, ft_);
+                bool? fv_ = context.Operators.And(fq_, fu_);
+                return fv_;
             }
 
-            IEnumerable<Medication> fl_ = context.Operators.Where<Medication>(fj_, fk_);
-            MedicationRequest fm_(Medication M) => MR;
-            IEnumerable<MedicationRequest> fn_ = context.Operators.Select<Medication, MedicationRequest>(fl_, fm_);
-            return fn_;
+            IEnumerable<Medication> fk_ = context.Operators.Where<Medication>(fi_, fj_);
+            bool? fl_ = context.Operators.Exists<Medication>(fk_);
+            return fl_;
         }
 
-        IEnumerable<MedicationRequest> cb_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, ca_);
+        IEnumerable<MedicationRequest> cb_ = context.Operators.Where<MedicationRequest>(bt_, ca_);
         IEnumerable<MedicationRequest> cc_ = context.Operators.Union<MedicationRequest>(by_, cb_);
         IEnumerable<MedicationRequest> cd_ = context.Operators.Union<MedicationRequest>(bw_, cc_);
         IEnumerable<MedicationRequest> cf_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> ch_(MedicationRequest MR) {
-            IEnumerable<Medication> fy_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? ch_(MedicationRequest MR) {
+            IEnumerable<Medication> fw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? fz_(Medication M) {
-                object gd_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ge_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> gf_ = context.Operators.Split((string)ge_, "/");
-                string gg_ = context.Operators.Last<string>(gf_);
-                bool? gh_ = context.Operators.Equal(gd_, gg_);
-                CodeableConcept gi_ = M?.Code;
-                CqlConcept gj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gi_);
-                CqlValueSet gk_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                bool? gl_ = context.Operators.ConceptInValueSet(gj_, gk_);
-                bool? gm_ = context.Operators.And(gh_, gl_);
-                return gm_;
+            bool? fx_(Medication M) {
+                object ga_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object gb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gc_ = context.Operators.Split((string)gb_, "/");
+                string gd_ = context.Operators.Last<string>(gc_);
+                bool? ge_ = context.Operators.Equal(ga_, gd_);
+                CodeableConcept gf_ = M?.Code;
+                CqlConcept gg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gf_);
+                CqlValueSet gh_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                bool? gi_ = context.Operators.ConceptInValueSet(gg_, gh_);
+                bool? gj_ = context.Operators.And(ge_, gi_);
+                return gj_;
             }
 
-            IEnumerable<Medication> ga_ = context.Operators.Where<Medication>(fy_, fz_);
-            MedicationRequest gb_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gc_ = context.Operators.Select<Medication, MedicationRequest>(ga_, gb_);
-            return gc_;
+            IEnumerable<Medication> fy_ = context.Operators.Where<Medication>(fw_, fx_);
+            bool? fz_ = context.Operators.Exists<Medication>(fy_);
+            return fz_;
         }
 
-        IEnumerable<MedicationRequest> ci_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, ch_);
+        IEnumerable<MedicationRequest> ci_ = context.Operators.Where<MedicationRequest>(bt_, ch_);
         IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cf_, ci_);
         IEnumerable<MedicationRequest> ck_ = context.Operators.Union<MedicationRequest>(cd_, cj_);
         IEnumerable<MedicationRequest> cm_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, r_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> co_(MedicationRequest MR) {
-            IEnumerable<Medication> gn_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? co_(MedicationRequest MR) {
+            IEnumerable<Medication> gk_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? go_(Medication M) {
-                object gs_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object gt_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> gu_ = context.Operators.Split((string)gt_, "/");
-                string gv_ = context.Operators.Last<string>(gu_);
-                bool? gw_ = context.Operators.Equal(gs_, gv_);
-                CodeableConcept gx_ = M?.Code;
-                CqlConcept gy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gx_);
-                CqlValueSet gz_ = this.Warfarin(context);
-                bool? ha_ = context.Operators.ConceptInValueSet(gy_, gz_);
-                bool? hb_ = context.Operators.And(gw_, ha_);
-                return hb_;
+            bool? gl_(Medication M) {
+                object go_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object gp_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> gq_ = context.Operators.Split((string)gp_, "/");
+                string gr_ = context.Operators.Last<string>(gq_);
+                bool? gs_ = context.Operators.Equal(go_, gr_);
+                CodeableConcept gt_ = M?.Code;
+                CqlConcept gu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gt_);
+                CqlValueSet gv_ = this.Warfarin(context);
+                bool? gw_ = context.Operators.ConceptInValueSet(gu_, gv_);
+                bool? gx_ = context.Operators.And(gs_, gw_);
+                return gx_;
             }
 
-            IEnumerable<Medication> gp_ = context.Operators.Where<Medication>(gn_, go_);
-            MedicationRequest gq_(Medication M) => MR;
-            IEnumerable<MedicationRequest> gr_ = context.Operators.Select<Medication, MedicationRequest>(gp_, gq_);
-            return gr_;
+            IEnumerable<Medication> gm_ = context.Operators.Where<Medication>(gk_, gl_);
+            bool? gn_ = context.Operators.Exists<Medication>(gm_);
+            return gn_;
         }
 
-        IEnumerable<MedicationRequest> cp_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, co_);
+        IEnumerable<MedicationRequest> cp_ = context.Operators.Where<MedicationRequest>(bt_, co_);
         IEnumerable<MedicationRequest> cq_ = context.Operators.Union<MedicationRequest>(cm_, cp_);
         IEnumerable<MedicationRequest> cr_ = context.Operators.Union<MedicationRequest>(ck_, cq_);
         IEnumerable<MedicationRequest> ct_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, x_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> cv_(MedicationRequest MR) {
-            IEnumerable<Medication> hc_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? cv_(MedicationRequest MR) {
+            IEnumerable<Medication> gy_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? hd_(Medication M) {
-                object hh_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object hi_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> hj_ = context.Operators.Split((string)hi_, "/");
-                string hk_ = context.Operators.Last<string>(hj_);
-                bool? hl_ = context.Operators.Equal(hh_, hk_);
-                CodeableConcept hm_ = M?.Code;
-                CqlConcept hn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hm_);
-                CqlValueSet ho_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                bool? hp_ = context.Operators.ConceptInValueSet(hn_, ho_);
-                bool? hq_ = context.Operators.And(hl_, hp_);
-                return hq_;
+            bool? gz_(Medication M) {
+                object hc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object hd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> he_ = context.Operators.Split((string)hd_, "/");
+                string hf_ = context.Operators.Last<string>(he_);
+                bool? hg_ = context.Operators.Equal(hc_, hf_);
+                CodeableConcept hh_ = M?.Code;
+                CqlConcept hi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hh_);
+                CqlValueSet hj_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                bool? hk_ = context.Operators.ConceptInValueSet(hi_, hj_);
+                bool? hl_ = context.Operators.And(hg_, hk_);
+                return hl_;
             }
 
-            IEnumerable<Medication> he_ = context.Operators.Where<Medication>(hc_, hd_);
-            MedicationRequest hf_(Medication M) => MR;
-            IEnumerable<MedicationRequest> hg_ = context.Operators.Select<Medication, MedicationRequest>(he_, hf_);
-            return hg_;
+            IEnumerable<Medication> ha_ = context.Operators.Where<Medication>(gy_, gz_);
+            bool? hb_ = context.Operators.Exists<Medication>(ha_);
+            return hb_;
         }
 
-        IEnumerable<MedicationRequest> cw_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(bt_, cv_);
+        IEnumerable<MedicationRequest> cw_ = context.Operators.Where<MedicationRequest>(bt_, cv_);
         IEnumerable<MedicationRequest> cx_ = context.Operators.Union<MedicationRequest>(ct_, cw_);
         IEnumerable<MedicationRequest> cy_ = context.Operators.Union<MedicationRequest>(cr_, cx_);
         IEnumerable<Task> cz_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
         IEnumerable<ValueTuple<MedicationRequest, Task>> da_ = context.Operators.CrossJoin<MedicationRequest, Task>(cy_, cz_);
 
         (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? db_(ValueTuple<MedicationRequest, Task> _valueTuple) {
-            (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? hr_ = (CqlTupleMetadata_IIUQMBcJhJBPgdDOLHaTTRUE, _valueTuple.Item1, _valueTuple.Item2);
-            return hr_;
+            (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? hm_ = (CqlTupleMetadata_IIUQMBcJhJBPgdDOLHaTTRUE, _valueTuple.Item1, _valueTuple.Item2);
+            return hm_;
         }
 
         IEnumerable<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?> dc_ = context.Operators.Select<ValueTuple<MedicationRequest, Task>, (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?>(da_, db_);
 
         bool? dd_((CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? tuple_iiuqmbcjhjbpgddolhattrue) {
-            ResourceReference hs_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Focus;
-            bool? ht_ = QICoreCommon_4_0_000.Instance.references(context, hs_, tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject);
-            CodeableConcept hu_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
-            CqlConcept hv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hu_);
-            CqlCode hw_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-            CqlConcept hx_ = context.Operators.ConvertCodeToConcept(hw_);
-            bool? hy_ = context.Operators.Equivalent(hv_, hx_);
-            bool? hz_ = context.Operators.And(ht_, hy_);
-            Code<MedicationRequest.MedicationrequestStatus> ia_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ib_ = ia_?.Value;
-            string ic_ = context.Operators.Convert<string>(ib_);
-            bool? id_ = context.Operators.Equal(ic_, "active");
-            bool? ie_ = context.Operators.And(hz_, id_);
-            return ie_;
+            ResourceReference hn_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Focus;
+            bool? ho_ = QICoreCommon_4_0_000.Instance.references(context, hn_, tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject);
+            CodeableConcept hp_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
+            CqlConcept hq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hp_);
+            CqlCode hr_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+            CqlConcept hs_ = context.Operators.ConvertCodeToConcept(hr_);
+            bool? ht_ = context.Operators.Equivalent(hq_, hs_);
+            bool? hu_ = context.Operators.And(ho_, ht_);
+            Code<MedicationRequest.MedicationrequestStatus> hv_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? hw_ = hv_?.Value;
+            string hx_ = context.Operators.Convert<string>(hw_);
+            bool? hy_ = context.Operators.Equal(hx_, "active");
+            bool? hz_ = context.Operators.And(hu_, hy_);
+            return hz_;
         }
 
         IEnumerable<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?> de_ = context.Operators.Where<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?>(dc_, dd_);
 
         (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? df_((CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? tuple_iiuqmbcjhjbpgddolhattrue) {
-            Id if_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.IdElement;
-            string ig_ = if_?.Value;
-            CodeableConcept ih_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.StatusReason;
-            CqlConcept ii_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ih_);
-            CqlConcept[] ij_ = [
-                ii_,
+            Id ia_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.IdElement;
+            string ib_ = ia_?.Value;
+            CodeableConcept ic_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.StatusReason;
+            CqlConcept id_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ic_);
+            CqlConcept[] ie_ = [
+                id_,
             ];
-            FhirDateTime ik_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.AuthoredOnElement;
-            CqlDateTime il_ = context.Operators.Convert<CqlDateTime>(ik_);
-            (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? im_ = (CqlTupleMetadata_CNeQfiIHcQEUBjZNVZiOLfdeP, ig_, (IEnumerable<CqlConcept>)ij_, il_);
-            return im_;
+            FhirDateTime if_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.AuthoredOnElement;
+            CqlDateTime ig_ = context.Operators.Convert<CqlDateTime>(if_);
+            (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? ih_ = (CqlTupleMetadata_CNeQfiIHcQEUBjZNVZiOLfdeP, ib_, (IEnumerable<CqlConcept>)ie_, ig_);
+            return ih_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?> dg_ = context.Operators.Select<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(de_, df_);
@@ -3604,34 +3582,33 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             IEnumerable<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?> d_ = this.No_VTE_Prophylaxis_Medication_Administered_Or_Ordered(context);
 
             bool? e_((CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication) {
-                IEnumerable<CqlConcept> i_ = NoVTEMedication?.medicationStatusReason;
-                CqlValueSet j_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                bool? k_ = context.Operators.ConceptsInValueSet(i_, j_);
-                CqlDateTime l_ = NoVTEMedication?.authoredOn;
-                CqlInterval<CqlDate> m_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
-                CqlDate n_ = m_?.low;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                CqlDate q_ = m_?.high;
-                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
-                bool? t_ = m_?.lowClosed;
-                bool? v_ = m_?.highClosed;
-                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(o_, r_, t_, v_);
-                bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, "day");
-                bool? y_ = context.Operators.And(k_, x_);
-                return y_;
+                IEnumerable<CqlConcept> h_ = NoVTEMedication?.medicationStatusReason;
+                CqlValueSet i_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                bool? j_ = context.Operators.ConceptsInValueSet(h_, i_);
+                CqlDateTime k_ = NoVTEMedication?.authoredOn;
+                CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
+                CqlDate m_ = l_?.low;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                CqlDate p_ = l_?.high;
+                CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+                bool? s_ = l_?.lowClosed;
+                bool? u_ = l_?.highClosed;
+                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(n_, q_, s_, u_);
+                bool? w_ = context.Operators.In<CqlDateTime>(k_, v_, "day");
+                bool? x_ = context.Operators.And(j_, w_);
+                return x_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication) => QualifyingEncounterICU;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -3834,34 +3811,33 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             IEnumerable<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?> d_ = this.No_Mechanical_VTE_Prophylaxis_Performed_Or_Ordered(context);
 
             bool? e_((CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice) {
-                CqlConcept i_ = NoVTEDevice?.requestStatusReason;
-                CqlValueSet j_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                bool? k_ = context.Operators.ConceptInValueSet(i_, j_);
-                CqlDateTime l_ = NoVTEDevice?.authoredOn;
-                CqlInterval<CqlDate> m_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
-                CqlDate n_ = m_?.low;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                CqlDate q_ = m_?.high;
-                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
-                bool? t_ = m_?.lowClosed;
-                bool? v_ = m_?.highClosed;
-                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(o_, r_, t_, v_);
-                bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, "day");
-                bool? y_ = context.Operators.And(k_, x_);
-                return y_;
+                CqlConcept h_ = NoVTEDevice?.requestStatusReason;
+                CqlValueSet i_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                bool? j_ = context.Operators.ConceptInValueSet(h_, i_);
+                CqlDateTime k_ = NoVTEDevice?.authoredOn;
+                CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
+                CqlDate m_ = l_?.low;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                CqlDate p_ = l_?.high;
+                CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+                bool? s_ = l_?.lowClosed;
+                bool? u_ = l_?.highClosed;
+                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(n_, q_, s_, u_);
+                bool? w_ = context.Operators.In<CqlDateTime>(k_, v_, "day");
+                bool? x_ = context.Operators.And(j_, w_);
+                return x_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice) => QualifyingEncounterICU;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -4708,30 +4684,29 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_ICU_Location(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounterICU) {
+        bool? b_(Encounter QualifyingEncounterICU) {
             IEnumerable<object> d_ = this.No_Mechanical_or_Pharmacological_VTE_Prophylaxis_Due_To_Patient_Refusal(context);
 
             bool? e_(object PatientRefusal) {
-                CqlDateTime i_ = context.Operators.LateBoundProperty<CqlDateTime>(PatientRefusal, "authoredOn");
-                CqlInterval<CqlDate> j_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
-                CqlDate k_ = j_?.low;
-                CqlDateTime l_ = context.Operators.ConvertDateToDateTime(k_);
-                CqlDate n_ = j_?.high;
-                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
-                bool? q_ = j_?.lowClosed;
-                bool? s_ = j_?.highClosed;
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(l_, o_, q_, s_);
-                bool? u_ = context.Operators.In<CqlDateTime>(i_, t_, "day");
-                return u_;
+                CqlDateTime h_ = context.Operators.LateBoundProperty<CqlDateTime>(PatientRefusal, "authoredOn");
+                CqlInterval<CqlDate> i_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
+                CqlDate j_ = i_?.low;
+                CqlDateTime k_ = context.Operators.ConvertDateToDateTime(j_);
+                CqlDate m_ = i_?.high;
+                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+                bool? p_ = i_?.lowClosed;
+                bool? r_ = i_?.highClosed;
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(k_, n_, p_, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(h_, s_, "day");
+                return t_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object PatientRefusal) => QualifyingEncounterICU;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
@@ -287,49 +287,48 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Diagnosis_of_Hypertension(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? f_(Condition Hypertension) {
 
-                CqlInterval<CqlDateTime> j_() {
+                CqlInterval<CqlDateTime> i_() {
 
-                    bool p_() {
-                        CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Hypertension as Condition);
-                        CqlDateTime r_ = context.Operators.Start(q_);
-                        return r_ is null;
+                    bool o_() {
+                        CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Hypertension as Condition);
+                        CqlDateTime q_ = context.Operators.Start(p_);
+                        return q_ is null;
                     }
 
-                    if (p_())
+                    if (o_())
                     {
                         return default;
                     }
                     else
                     {
-                        CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Hypertension as Condition);
-                        CqlDateTime t_ = context.Operators.Start(s_);
-                        CqlDateTime v_ = context.Operators.Start(s_);
-                        CqlInterval<CqlDateTime> w_ = context.Operators.Interval(t_, v_, true, true);
-                        return w_;
+                        CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Hypertension as Condition);
+                        CqlDateTime s_ = context.Operators.Start(r_);
+                        CqlDateTime u_ = context.Operators.Start(r_);
+                        CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
+                        return v_;
                     };
                 }
 
-                Period k_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? m_ = context.Operators.SameOrBefore(j_(), l_, "day");
-                bool? n_ = this.isVerified(context, Hypertension as Condition);
-                bool? o_ = context.Operators.And(m_, n_);
-                return o_;
+                Period j_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? l_ = context.Operators.SameOrBefore(i_(), k_, "day");
+                bool? m_ = this.isVerified(context, Hypertension as Condition);
+                bool? n_ = context.Operators.And(l_, m_);
+                return n_;
             }
 
             IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
-            Encounter h_(Condition Hypertension) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Condition>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -708,65 +707,62 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80(context);
 
-        IEnumerable<Encounter> b_(Encounter ElevatedEncounter) {
+        bool? b_(Encounter ElevatedEncounter) {
             IEnumerable<ServiceRequest> j_ = this.Follow_up_with_Rescreen_Within_6_Months(context);
 
             bool? k_(ServiceRequest Twoto6MonthRescreen) {
-                FhirDateTime o_ = Twoto6MonthRescreen?.AuthoredOnElement;
-                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
-                Period q_ = ElevatedEncounter?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
-                return s_;
+                FhirDateTime n_ = Twoto6MonthRescreen?.AuthoredOnElement;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = ElevatedEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
+                return r_;
             }
 
             IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
-            Encounter m_(ServiceRequest Twoto6MonthRescreen) => ElevatedEncounter;
-            IEnumerable<Encounter> n_ = context.Operators.Select<ServiceRequest, Encounter>(l_, m_);
-            return n_;
+            bool? m_ = context.Operators.Exists<ServiceRequest>(l_);
+            return m_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
-        IEnumerable<Encounter> d_(Encounter ElevatedEncounter) {
-            IEnumerable<ServiceRequest> t_ = this.NonPharmacological_Interventions(context);
+        bool? d_(Encounter ElevatedEncounter) {
+            IEnumerable<ServiceRequest> s_ = this.NonPharmacological_Interventions(context);
 
-            bool? u_(ServiceRequest NonPharmInterventions) {
-                FhirDateTime y_ = NonPharmInterventions?.AuthoredOnElement;
-                CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
-                Period aa_ = ElevatedEncounter?.Period;
-                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                bool? ac_ = context.Operators.In<CqlDateTime>(z_, ab_, "day");
-                return ac_;
+            bool? t_(ServiceRequest NonPharmInterventions) {
+                FhirDateTime w_ = NonPharmInterventions?.AuthoredOnElement;
+                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+                Period y_ = ElevatedEncounter?.Period;
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
+                return aa_;
             }
 
-            IEnumerable<ServiceRequest> v_ = context.Operators.Where<ServiceRequest>(t_, u_);
-            Encounter w_(ServiceRequest NonPharmInterventions) => ElevatedEncounter;
-            IEnumerable<Encounter> x_ = context.Operators.Select<ServiceRequest, Encounter>(v_, w_);
-            return x_;
+            IEnumerable<ServiceRequest> u_ = context.Operators.Where<ServiceRequest>(s_, t_);
+            bool? v_ = context.Operators.Exists<ServiceRequest>(u_);
+            return v_;
         }
 
-        IEnumerable<Encounter> e_ = context.Operators.SelectMany<Encounter, Encounter>(c_, d_);
+        IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 
-        IEnumerable<Encounter> g_(Encounter ElevatedEncounter) {
-            IEnumerable<ServiceRequest> ad_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading(context);
+        bool? g_(Encounter ElevatedEncounter) {
+            IEnumerable<ServiceRequest> ab_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading(context);
 
-            bool? ae_(ServiceRequest Referral) {
-                FhirDateTime ai_ = Referral?.AuthoredOnElement;
-                CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
-                Period ak_ = ElevatedEncounter?.Period;
-                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
-                bool? am_ = context.Operators.In<CqlDateTime>(aj_, al_, "day");
-                return am_;
+            bool? ac_(ServiceRequest Referral) {
+                FhirDateTime af_ = Referral?.AuthoredOnElement;
+                CqlDateTime ag_ = context.Operators.Convert<CqlDateTime>(af_);
+                Period ah_ = ElevatedEncounter?.Period;
+                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
+                bool? aj_ = context.Operators.In<CqlDateTime>(ag_, ai_, "day");
+                return aj_;
             }
 
-            IEnumerable<ServiceRequest> af_ = context.Operators.Where<ServiceRequest>(ad_, ae_);
-            Encounter ag_(ServiceRequest Referral) => ElevatedEncounter;
-            IEnumerable<Encounter> ah_ = context.Operators.Select<ServiceRequest, Encounter>(af_, ag_);
-            return ah_;
+            IEnumerable<ServiceRequest> ad_ = context.Operators.Where<ServiceRequest>(ab_, ac_);
+            bool? ae_ = context.Operators.Exists<ServiceRequest>(ad_);
+            return ae_;
         }
 
-        IEnumerable<Encounter> h_ = context.Operators.SelectMany<Encounter, Encounter>(a_, g_);
+        IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(a_, g_);
         IEnumerable<Encounter> i_ = context.Operators.Union<Encounter>(e_, h_);
         return i_;
     }
@@ -1277,41 +1273,40 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Follow_Up_Within_4_Weeks(context);
         IEnumerable<ServiceRequest> b_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
-        IEnumerable<ServiceRequest> c_(ServiceRequest FourWeekRescreen) {
+        bool? c_(ServiceRequest FourWeekRescreen) {
             IEnumerable<ServiceRequest> g_ = this.NonPharmacological_Interventions(context);
 
             bool? h_(ServiceRequest NonPharmInterventionsHTN) {
-                FhirDateTime l_ = FourWeekRescreen?.AuthoredOnElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
-                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
-                FhirDateTime p_ = NonPharmInterventionsHTN?.AuthoredOnElement;
-                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                bool? s_ = context.Operators.In<CqlDateTime>(q_, n_, "day");
-                bool? t_ = context.Operators.And(o_, s_);
-                Code<RequestIntent> u_ = FourWeekRescreen?.IntentElement;
-                RequestIntent? v_ = u_?.Value;
-                Code<RequestIntent> w_ = context.Operators.Convert<Code<RequestIntent>>(v_);
-                string x_ = context.Operators.Convert<string>(w_);
-                string[] y_ = [
+                FhirDateTime k_ = FourWeekRescreen?.AuthoredOnElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
+                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, "day");
+                FhirDateTime o_ = NonPharmInterventionsHTN?.AuthoredOnElement;
+                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+                bool? r_ = context.Operators.In<CqlDateTime>(p_, m_, "day");
+                bool? s_ = context.Operators.And(n_, r_);
+                Code<RequestIntent> t_ = FourWeekRescreen?.IntentElement;
+                RequestIntent? u_ = t_?.Value;
+                Code<RequestIntent> v_ = context.Operators.Convert<Code<RequestIntent>>(u_);
+                string w_ = context.Operators.Convert<string>(v_);
+                string[] x_ = [
                     "order",
                     "original-order",
                     "reflex-order",
                     "filler-order",
                     "instance-order",
                 ];
-                bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
-                bool? aa_ = context.Operators.And(t_, z_);
-                return aa_;
+                bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
+                bool? z_ = context.Operators.And(s_, y_);
+                return z_;
             }
 
             IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(g_, h_);
-            ServiceRequest j_(ServiceRequest NonPharmInterventionsHTN) => FourWeekRescreen;
-            IEnumerable<ServiceRequest> k_ = context.Operators.Select<ServiceRequest, ServiceRequest>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<ServiceRequest>(i_);
+            return j_;
         }
 
-        IEnumerable<ServiceRequest> d_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(b_, c_);
+        IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
         IEnumerable<ServiceRequest> e_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading(context);
         IEnumerable<ServiceRequest> f_ = context.Operators.Union<ServiceRequest>(d_, e_);
         return f_;
@@ -1328,25 +1323,24 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80(context);
 
-        IEnumerable<Encounter> b_(Encounter FirstHTNEncounter) {
+        bool? b_(Encounter FirstHTNEncounter) {
             IEnumerable<ServiceRequest> d_ = this.First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional(context);
 
             bool? e_(ServiceRequest FirstHTNIntervention) {
-                FhirDateTime i_ = FirstHTNIntervention?.AuthoredOnElement;
-                CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
-                Period k_ = FirstHTNEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, "day");
-                return m_;
+                FhirDateTime h_ = FirstHTNIntervention?.AuthoredOnElement;
+                CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
+                Period j_ = FirstHTNEncounter?.Period;
+                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? l_ = context.Operators.In<CqlDateTime>(i_, k_, "day");
+                return l_;
             }
 
             IEnumerable<ServiceRequest> f_ = context.Operators.Where<ServiceRequest>(d_, e_);
-            Encounter g_(ServiceRequest FirstHTNIntervention) => FirstHTNEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<ServiceRequest, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<ServiceRequest>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1635,47 +1629,45 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<ServiceRequest> a_ = this.Follow_up_with_Rescreen_Within_6_Months(context);
 
-        IEnumerable<ServiceRequest> b_(ServiceRequest Rescreen2to6) {
+        bool? b_(ServiceRequest Rescreen2to6) {
             IEnumerable<ServiceRequest> f_ = this.Laboratory_Test_or_ECG_for_Hypertension(context);
 
             bool? g_(ServiceRequest LabECGIntervention) {
-                FhirDateTime k_ = Rescreen2to6?.AuthoredOnElement;
-                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
-                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, "day");
-                FhirDateTime o_ = LabECGIntervention?.AuthoredOnElement;
-                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, m_, "day");
-                bool? s_ = context.Operators.And(n_, r_);
-                return s_;
+                FhirDateTime j_ = Rescreen2to6?.AuthoredOnElement;
+                CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
+                CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+                bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+                FhirDateTime n_ = LabECGIntervention?.AuthoredOnElement;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, l_, "day");
+                bool? r_ = context.Operators.And(m_, q_);
+                return r_;
             }
 
             IEnumerable<ServiceRequest> h_ = context.Operators.Where<ServiceRequest>(f_, g_);
-            ServiceRequest i_(ServiceRequest LabECGIntervention) => Rescreen2to6;
-            IEnumerable<ServiceRequest> j_ = context.Operators.Select<ServiceRequest, ServiceRequest>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<ServiceRequest>(h_);
+            return i_;
         }
 
-        IEnumerable<ServiceRequest> c_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(a_, b_);
+        IEnumerable<ServiceRequest> c_ = context.Operators.Where<ServiceRequest>(a_, b_);
 
-        IEnumerable<ServiceRequest> d_(ServiceRequest Rescreen2to6) {
-            IEnumerable<ServiceRequest> t_ = this.NonPharmacological_Interventions(context);
+        bool? d_(ServiceRequest Rescreen2to6) {
+            IEnumerable<ServiceRequest> s_ = this.NonPharmacological_Interventions(context);
 
-            bool? u_(ServiceRequest NonPharmSecondIntervention) {
-                FhirDateTime y_ = NonPharmSecondIntervention?.AuthoredOnElement;
-                CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
-                CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
-                bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
-                return ab_;
+            bool? t_(ServiceRequest NonPharmSecondIntervention) {
+                FhirDateTime w_ = NonPharmSecondIntervention?.AuthoredOnElement;
+                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+                CqlInterval<CqlDateTime> y_ = this.Measurement_Period(context);
+                bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, "day");
+                return z_;
             }
 
-            IEnumerable<ServiceRequest> v_ = context.Operators.Where<ServiceRequest>(t_, u_);
-            ServiceRequest w_(ServiceRequest NonPharmSecondIntervention) => Rescreen2to6;
-            IEnumerable<ServiceRequest> x_ = context.Operators.Select<ServiceRequest, ServiceRequest>(v_, w_);
-            return x_;
+            IEnumerable<ServiceRequest> u_ = context.Operators.Where<ServiceRequest>(s_, t_);
+            bool? v_ = context.Operators.Exists<ServiceRequest>(u_);
+            return v_;
         }
 
-        IEnumerable<ServiceRequest> e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
+        IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
         return e_;
     }
 
@@ -1690,45 +1682,43 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89(context);
 
-        IEnumerable<Encounter> b_(Encounter SecondHTNEncounterReading) {
+        bool? b_(Encounter SecondHTNEncounterReading) {
             IEnumerable<ServiceRequest> h_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions(context);
 
             bool? i_(ServiceRequest EncounterInterventions) {
-                FhirDateTime m_ = EncounterInterventions?.AuthoredOnElement;
-                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
-                Period o_ = SecondHTNEncounterReading?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
-                return q_;
+                FhirDateTime l_ = EncounterInterventions?.AuthoredOnElement;
+                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+                Period n_ = SecondHTNEncounterReading?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, "day");
+                return p_;
             }
 
             IEnumerable<ServiceRequest> j_ = context.Operators.Where<ServiceRequest>(h_, i_);
-            Encounter k_(ServiceRequest EncounterInterventions) => SecondHTNEncounterReading;
-            IEnumerable<Encounter> l_ = context.Operators.Select<ServiceRequest, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<ServiceRequest>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
-        IEnumerable<Encounter> e_(Encounter SecondHTNEncounterReading) {
-            IEnumerable<ServiceRequest> r_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading(context);
+        bool? e_(Encounter SecondHTNEncounterReading) {
+            IEnumerable<ServiceRequest> q_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading(context);
 
-            bool? s_(ServiceRequest ReferralForHTN) {
-                FhirDateTime w_ = ReferralForHTN?.AuthoredOnElement;
-                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
-                Period y_ = SecondHTNEncounterReading?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
-                return aa_;
+            bool? r_(ServiceRequest ReferralForHTN) {
+                FhirDateTime u_ = ReferralForHTN?.AuthoredOnElement;
+                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                Period w_ = SecondHTNEncounterReading?.Period;
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
+                bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, "day");
+                return y_;
             }
 
-            IEnumerable<ServiceRequest> t_ = context.Operators.Where<ServiceRequest>(r_, s_);
-            Encounter u_(ServiceRequest ReferralForHTN) => SecondHTNEncounterReading;
-            IEnumerable<Encounter> v_ = context.Operators.Select<ServiceRequest, Encounter>(t_, u_);
-            return v_;
+            IEnumerable<ServiceRequest> s_ = context.Operators.Where<ServiceRequest>(q_, r_);
+            bool? t_ = context.Operators.Exists<ServiceRequest>(s_);
+            return t_;
         }
 
-        IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+        IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
         IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
         return g_;
     }
@@ -1973,122 +1963,118 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Follow_Up_Within_4_Weeks(context);
         IEnumerable<ServiceRequest> b_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
-        IEnumerable<ServiceRequest> c_(ServiceRequest WeeksRescreen) {
+        bool? c_(ServiceRequest WeeksRescreen) {
             IEnumerable<ServiceRequest> i_ = this.Laboratory_Test_or_ECG_for_Hypertension(context);
 
             bool? j_(ServiceRequest ECGLabTest) {
-                FhirDateTime n_ = WeeksRescreen?.AuthoredOnElement;
-                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
-                FhirDateTime r_ = ECGLabTest?.AuthoredOnElement;
-                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(r_);
-                bool? u_ = context.Operators.In<CqlDateTime>(s_, p_, "day");
-                bool? v_ = context.Operators.And(q_, u_);
-                Code<RequestIntent> w_ = WeeksRescreen?.IntentElement;
-                RequestIntent? x_ = w_?.Value;
-                Code<RequestIntent> y_ = context.Operators.Convert<Code<RequestIntent>>(x_);
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
+                FhirDateTime m_ = WeeksRescreen?.AuthoredOnElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+                bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+                FhirDateTime q_ = ECGLabTest?.AuthoredOnElement;
+                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
+                bool? t_ = context.Operators.In<CqlDateTime>(r_, o_, "day");
+                bool? u_ = context.Operators.And(p_, t_);
+                Code<RequestIntent> v_ = WeeksRescreen?.IntentElement;
+                RequestIntent? w_ = v_?.Value;
+                Code<RequestIntent> x_ = context.Operators.Convert<Code<RequestIntent>>(w_);
+                string y_ = context.Operators.Convert<string>(x_);
+                string[] z_ = [
                     "order",
                     "original-order",
                     "reflex-order",
                     "filler-order",
                     "instance-order",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                bool? ac_ = context.Operators.And(v_, ab_);
-                Code<RequestIntent> ad_ = ECGLabTest?.IntentElement;
-                RequestIntent? ae_ = ad_?.Value;
-                Code<RequestIntent> af_ = context.Operators.Convert<Code<RequestIntent>>(ae_);
-                string ag_ = context.Operators.Convert<string>(af_);
-                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)aa_);
-                bool? aj_ = context.Operators.And(ac_, ai_);
-                return aj_;
+                bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+                bool? ab_ = context.Operators.And(u_, aa_);
+                Code<RequestIntent> ac_ = ECGLabTest?.IntentElement;
+                RequestIntent? ad_ = ac_?.Value;
+                Code<RequestIntent> ae_ = context.Operators.Convert<Code<RequestIntent>>(ad_);
+                string af_ = context.Operators.Convert<string>(ae_);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)z_);
+                bool? ai_ = context.Operators.And(ab_, ah_);
+                return ai_;
             }
 
             IEnumerable<ServiceRequest> k_ = context.Operators.Where<ServiceRequest>(i_, j_);
-            ServiceRequest l_(ServiceRequest ECGLabTest) => WeeksRescreen;
-            IEnumerable<ServiceRequest> m_ = context.Operators.Select<ServiceRequest, ServiceRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<ServiceRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<ServiceRequest> d_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(b_, c_);
+        IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
 
-        IEnumerable<ServiceRequest> e_(ServiceRequest WeeksRescreen) {
-            IEnumerable<ServiceRequest> ak_ = this.NonPharmacological_Interventions(context);
+        bool? e_(ServiceRequest WeeksRescreen) {
+            IEnumerable<ServiceRequest> aj_ = this.NonPharmacological_Interventions(context);
 
-            bool? al_(ServiceRequest HTNInterventions) {
-                FhirDateTime ap_ = HTNInterventions?.AuthoredOnElement;
-                CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(ap_);
-                CqlInterval<CqlDateTime> ar_ = this.Measurement_Period(context);
-                bool? as_ = context.Operators.In<CqlDateTime>(aq_, ar_, "day");
-                return as_;
+            bool? ak_(ServiceRequest HTNInterventions) {
+                FhirDateTime an_ = HTNInterventions?.AuthoredOnElement;
+                CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(an_);
+                CqlInterval<CqlDateTime> ap_ = this.Measurement_Period(context);
+                bool? aq_ = context.Operators.In<CqlDateTime>(ao_, ap_, "day");
+                return aq_;
             }
 
-            IEnumerable<ServiceRequest> am_ = context.Operators.Where<ServiceRequest>(ak_, al_);
-            ServiceRequest an_(ServiceRequest HTNInterventions) => WeeksRescreen;
-            IEnumerable<ServiceRequest> ao_ = context.Operators.Select<ServiceRequest, ServiceRequest>(am_, an_);
-            return ao_;
+            IEnumerable<ServiceRequest> al_ = context.Operators.Where<ServiceRequest>(aj_, ak_);
+            bool? am_ = context.Operators.Exists<ServiceRequest>(al_);
+            return am_;
         }
 
-        IEnumerable<ServiceRequest> f_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(d_, e_);
+        IEnumerable<ServiceRequest> f_ = context.Operators.Where<ServiceRequest>(d_, e_);
 
-        IEnumerable<ServiceRequest> g_(ServiceRequest WeeksRescreen) {
-            CqlValueSet at_ = this.Pharmacologic_Therapy_for_Hypertension(context);
-            IEnumerable<MedicationRequest> au_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, at_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> av_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? g_(ServiceRequest WeeksRescreen) {
+            CqlValueSet ar_ = this.Pharmacologic_Therapy_for_Hypertension(context);
+            IEnumerable<MedicationRequest> as_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ar_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> at_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> aw_(MedicationRequest MR) {
-                IEnumerable<Medication> bd_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? au_(MedicationRequest MR) {
+                IEnumerable<Medication> ba_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? be_(Medication M) {
-                    object bi_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object bj_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> bk_ = context.Operators.Split((string)bj_, "/");
-                    string bl_ = context.Operators.Last<string>(bk_);
-                    bool? bm_ = context.Operators.Equal(bi_, bl_);
-                    CodeableConcept bn_ = M?.Code;
-                    CqlConcept bo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bn_);
-                    CqlValueSet bp_ = this.Pharmacologic_Therapy_for_Hypertension(context);
-                    bool? bq_ = context.Operators.ConceptInValueSet(bo_, bp_);
-                    bool? br_ = context.Operators.And(bm_, bq_);
-                    return br_;
+                bool? bb_(Medication M) {
+                    object be_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object bf_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> bg_ = context.Operators.Split((string)bf_, "/");
+                    string bh_ = context.Operators.Last<string>(bg_);
+                    bool? bi_ = context.Operators.Equal(be_, bh_);
+                    CodeableConcept bj_ = M?.Code;
+                    CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
+                    CqlValueSet bl_ = this.Pharmacologic_Therapy_for_Hypertension(context);
+                    bool? bm_ = context.Operators.ConceptInValueSet(bk_, bl_);
+                    bool? bn_ = context.Operators.And(bi_, bm_);
+                    return bn_;
                 }
 
-                IEnumerable<Medication> bf_ = context.Operators.Where<Medication>(bd_, be_);
-                MedicationRequest bg_(Medication M) => MR;
-                IEnumerable<MedicationRequest> bh_ = context.Operators.Select<Medication, MedicationRequest>(bf_, bg_);
-                return bh_;
+                IEnumerable<Medication> bc_ = context.Operators.Where<Medication>(ba_, bb_);
+                bool? bd_ = context.Operators.Exists<Medication>(bc_);
+                return bd_;
             }
 
-            IEnumerable<MedicationRequest> ax_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(av_, aw_);
-            IEnumerable<MedicationRequest> ay_ = context.Operators.Union<MedicationRequest>(au_, ax_);
+            IEnumerable<MedicationRequest> av_ = context.Operators.Where<MedicationRequest>(at_, au_);
+            IEnumerable<MedicationRequest> aw_ = context.Operators.Union<MedicationRequest>(as_, av_);
 
-            bool? az_(MedicationRequest Medications) {
-                FhirDateTime bs_ = Medications?.AuthoredOnElement;
-                CqlDateTime bt_ = context.Operators.Convert<CqlDateTime>(bs_);
-                CqlInterval<CqlDateTime> bu_ = this.Measurement_Period(context);
-                bool? bv_ = context.Operators.In<CqlDateTime>(bt_, bu_, "day");
-                Code<MedicationRequest.MedicationrequestStatus> bw_ = Medications?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? bx_ = bw_?.Value;
-                string by_ = context.Operators.Convert<string>(bx_);
-                string[] bz_ = [
+            bool? ax_(MedicationRequest Medications) {
+                FhirDateTime bo_ = Medications?.AuthoredOnElement;
+                CqlDateTime bp_ = context.Operators.Convert<CqlDateTime>(bo_);
+                CqlInterval<CqlDateTime> bq_ = this.Measurement_Period(context);
+                bool? br_ = context.Operators.In<CqlDateTime>(bp_, bq_, "day");
+                Code<MedicationRequest.MedicationrequestStatus> bs_ = Medications?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? bt_ = bs_?.Value;
+                string bu_ = context.Operators.Convert<string>(bt_);
+                string[] bv_ = [
                     "active",
                     "completed",
                 ];
-                bool? ca_ = context.Operators.In<string>(by_, (IEnumerable<string>)bz_);
-                bool? cb_ = context.Operators.And(bv_, ca_);
-                return cb_;
+                bool? bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
+                bool? bx_ = context.Operators.And(br_, bw_);
+                return bx_;
             }
 
-            IEnumerable<MedicationRequest> ba_ = context.Operators.Where<MedicationRequest>(ay_, az_);
-            ServiceRequest bb_(MedicationRequest Medications) => WeeksRescreen;
-            IEnumerable<ServiceRequest> bc_ = context.Operators.Select<MedicationRequest, ServiceRequest>(ba_, bb_);
-            return bc_;
+            IEnumerable<MedicationRequest> ay_ = context.Operators.Where<MedicationRequest>(aw_, ax_);
+            bool? az_ = context.Operators.Exists<MedicationRequest>(ay_);
+            return az_;
         }
 
-        IEnumerable<ServiceRequest> h_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(f_, g_);
+        IEnumerable<ServiceRequest> h_ = context.Operators.Where<ServiceRequest>(f_, g_);
         return h_;
     }
 
@@ -2103,45 +2089,43 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90(context);
 
-        IEnumerable<Encounter> b_(Encounter SecondHTNEncounterReading140Over90) {
+        bool? b_(Encounter SecondHTNEncounterReading140Over90) {
             IEnumerable<ServiceRequest> h_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions(context);
 
             bool? i_(ServiceRequest SecondHTN140Over90Interventions) {
-                FhirDateTime m_ = SecondHTN140Over90Interventions?.AuthoredOnElement;
-                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
-                Period o_ = SecondHTNEncounterReading140Over90?.Period;
-                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
-                return q_;
+                FhirDateTime l_ = SecondHTN140Over90Interventions?.AuthoredOnElement;
+                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+                Period n_ = SecondHTNEncounterReading140Over90?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, "day");
+                return p_;
             }
 
             IEnumerable<ServiceRequest> j_ = context.Operators.Where<ServiceRequest>(h_, i_);
-            Encounter k_(ServiceRequest SecondHTN140Over90Interventions) => SecondHTNEncounterReading140Over90;
-            IEnumerable<Encounter> l_ = context.Operators.Select<ServiceRequest, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<ServiceRequest>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
-        IEnumerable<Encounter> e_(Encounter SecondHTNEncounterReading140Over90) {
-            IEnumerable<ServiceRequest> r_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading(context);
+        bool? e_(Encounter SecondHTNEncounterReading140Over90) {
+            IEnumerable<ServiceRequest> q_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading(context);
 
-            bool? s_(ServiceRequest ReferralToProfessional) {
-                FhirDateTime w_ = ReferralToProfessional?.AuthoredOnElement;
-                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
-                Period y_ = SecondHTNEncounterReading140Over90?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
-                return aa_;
+            bool? r_(ServiceRequest ReferralToProfessional) {
+                FhirDateTime u_ = ReferralToProfessional?.AuthoredOnElement;
+                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                Period w_ = SecondHTNEncounterReading140Over90?.Period;
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
+                bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, "day");
+                return y_;
             }
 
-            IEnumerable<ServiceRequest> t_ = context.Operators.Where<ServiceRequest>(r_, s_);
-            Encounter u_(ServiceRequest ReferralToProfessional) => SecondHTNEncounterReading140Over90;
-            IEnumerable<Encounter> v_ = context.Operators.Select<ServiceRequest, Encounter>(t_, u_);
-            return v_;
+            IEnumerable<ServiceRequest> s_ = context.Operators.Where<ServiceRequest>(q_, r_);
+            bool? t_ = context.Operators.Exists<ServiceRequest>(s_);
+            return t_;
         }
 
-        IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+        IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
         IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
         return g_;
     }
@@ -2178,7 +2162,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlCode d_ = this.Blood_pressure_panel_with_all_children_optional(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
@@ -2192,68 +2176,67 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<Observation> n_ = context.Operators.Union<Observation>(j_, m_);
 
             bool? o_(Observation NoBPScreen) {
-                Instant s_ = NoBPScreen?.IssuedElement;
-                DateTimeOffset? t_ = s_?.Value;
-                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
-                Period v_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                bool? x_ = context.Operators.In<CqlDateTime>(u_, w_, "day");
+                Instant r_ = NoBPScreen?.IssuedElement;
+                DateTimeOffset? s_ = r_?.Value;
+                CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
+                Period u_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+                bool? w_ = context.Operators.In<CqlDateTime>(t_, v_, "day");
 
-                bool? y_(Extension @this) {
-                    FhirUri aq_ = @this?.UrlElement;
-                    string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
-                    bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                bool? x_(Extension @this) {
+                    FhirUri ap_ = @this?.UrlElement;
+                    string aq_ = FHIRHelpers_4_4_000.Instance.ToString(context, ap_);
+                    bool? ar_ = context.Operators.Equal(aq_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                    return ar_;
+                }
+
+                IEnumerable<Extension> y_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBPScreen is DomainResource
+                    ? (NoBPScreen as DomainResource).Extension
+                    : default), x_);
+
+                object z_(Extension @this) {
+                    DataType as_ = @this?.Value;
                     return as_;
                 }
 
-                IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBPScreen is DomainResource
-                    ? (NoBPScreen as DomainResource).Extension
-                    : default), y_);
+                IEnumerable<object> aa_ = context.Operators.Select<Extension, object>(y_, z_);
+                object ab_ = context.Operators.SingletonFrom<object>(aa_);
+                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_ as CodeableConcept);
+                CqlValueSet ad_ = this.Patient_Declined(context);
+                bool? ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
 
-                object aa_(Extension @this) {
-                    DataType at_ = @this?.Value;
-                    return at_;
+                bool? af_(Extension @this) {
+                    FhirUri at_ = @this?.UrlElement;
+                    string au_ = FHIRHelpers_4_4_000.Instance.ToString(context, at_);
+                    bool? av_ = context.Operators.Equal(au_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                    return av_;
                 }
 
-                IEnumerable<object> ab_ = context.Operators.Select<Extension, object>(z_, aa_);
-                object ac_ = context.Operators.SingletonFrom<object>(ab_);
-                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_ as CodeableConcept);
-                CqlValueSet ae_ = this.Patient_Declined(context);
-                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBPScreen is DomainResource
+                    ? (NoBPScreen as DomainResource).Extension
+                    : default), af_);
 
-                bool? ag_(Extension @this) {
-                    FhirUri au_ = @this?.UrlElement;
-                    string av_ = FHIRHelpers_4_4_000.Instance.ToString(context, au_);
-                    bool? aw_ = context.Operators.Equal(av_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                object ah_(Extension @this) {
+                    DataType aw_ = @this?.Value;
                     return aw_;
                 }
 
-                IEnumerable<Extension> ah_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBPScreen is DomainResource
-                    ? (NoBPScreen as DomainResource).Extension
-                    : default), ag_);
-
-                object ai_(Extension @this) {
-                    DataType ax_ = @this?.Value;
-                    return ax_;
-                }
-
-                IEnumerable<object> aj_ = context.Operators.Select<Extension, object>(ah_, ai_);
-                object ak_ = context.Operators.SingletonFrom<object>(aj_);
-                CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_ as CodeableConcept);
-                CqlValueSet am_ = this.Medical_Reason(context);
-                bool? an_ = context.Operators.ConceptInValueSet(al_, am_);
-                bool? ao_ = context.Operators.Or(af_, an_);
-                bool? ap_ = context.Operators.And(x_, ao_);
-                return ap_;
+                IEnumerable<object> ai_ = context.Operators.Select<Extension, object>(ag_, ah_);
+                object aj_ = context.Operators.SingletonFrom<object>(ai_);
+                CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_ as CodeableConcept);
+                CqlValueSet al_ = this.Medical_Reason(context);
+                bool? am_ = context.Operators.ConceptInValueSet(ak_, al_);
+                bool? an_ = context.Operators.Or(ae_, am_);
+                bool? ao_ = context.Operators.And(w_, an_);
+                return ao_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(n_, o_);
-            Encounter q_(Observation NoBPScreen) => QualifyingEncounter;
-            IEnumerable<Encounter> r_ = context.Operators.Select<Observation, Encounter>(p_, q_);
-            return r_;
+            bool? q_ = context.Operators.Exists<Observation>(p_);
+            return q_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -2553,7 +2536,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80(context);
 
-        IEnumerable<Encounter> b_(Encounter ElevatedBPEncounter) {
+        bool? b_(Encounter ElevatedBPEncounter) {
             CqlValueSet x_ = this.Referral_to_Primary_Care_or_Alternate_Provider(context);
             IEnumerable<ServiceRequest> y_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, x_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
             IEnumerable<ServiceRequest> aa_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, x_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
@@ -2565,203 +2548,197 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<ServiceRequest> ah_ = context.Operators.Union<ServiceRequest>(ab_, ag_);
 
             bool? ai_(ServiceRequest ElevatedBPDeclinedInterventions) {
-                FhirDateTime am_ = ElevatedBPDeclinedInterventions?.AuthoredOnElement;
-                CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(am_);
-                Period ao_ = ElevatedBPEncounter?.Period;
-                CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, "day");
-                Code<RequestStatus> ar_ = ElevatedBPDeclinedInterventions?.StatusElement;
-                RequestStatus? as_ = ar_?.Value;
-                Code<RequestStatus> at_ = context.Operators.Convert<Code<RequestStatus>>(as_);
-                string au_ = context.Operators.Convert<string>(at_);
-                string[] av_ = [
+                FhirDateTime al_ = ElevatedBPDeclinedInterventions?.AuthoredOnElement;
+                CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
+                Period an_ = ElevatedBPEncounter?.Period;
+                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                bool? ap_ = context.Operators.In<CqlDateTime>(am_, ao_, "day");
+                Code<RequestStatus> aq_ = ElevatedBPDeclinedInterventions?.StatusElement;
+                RequestStatus? ar_ = aq_?.Value;
+                Code<RequestStatus> as_ = context.Operators.Convert<Code<RequestStatus>>(ar_);
+                string at_ = context.Operators.Convert<string>(as_);
+                string[] au_ = [
                     "active",
                     "completed",
                     "on-hold",
                 ];
-                bool? aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
-                bool? ax_ = context.Operators.And(aq_, aw_);
+                bool? av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+                bool? aw_ = context.Operators.And(ap_, av_);
 
-                bool? ay_(Extension @this) {
-                    FhirUri bh_ = @this?.UrlElement;
-                    string bi_ = FHIRHelpers_4_4_000.Instance.ToString(context, bh_);
-                    bool? bj_ = context.Operators.Equal(bi_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                bool? ax_(Extension @this) {
+                    FhirUri bg_ = @this?.UrlElement;
+                    string bh_ = FHIRHelpers_4_4_000.Instance.ToString(context, bg_);
+                    bool? bi_ = context.Operators.Equal(bh_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                    return bi_;
+                }
+
+                IEnumerable<Extension> ay_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(ElevatedBPDeclinedInterventions is DomainResource
+                    ? (ElevatedBPDeclinedInterventions as DomainResource).Extension
+                    : default), ax_);
+
+                object az_(Extension @this) {
+                    DataType bj_ = @this?.Value;
                     return bj_;
                 }
 
-                IEnumerable<Extension> az_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(ElevatedBPDeclinedInterventions is DomainResource
-                    ? (ElevatedBPDeclinedInterventions as DomainResource).Extension
-                    : default), ay_);
-
-                object ba_(Extension @this) {
-                    DataType bk_ = @this?.Value;
-                    return bk_;
-                }
-
-                IEnumerable<object> bb_ = context.Operators.Select<Extension, object>(az_, ba_);
-                object bc_ = context.Operators.SingletonFrom<object>(bb_);
-                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_ as CodeableConcept);
-                CqlValueSet be_ = this.Patient_Declined(context);
-                bool? bf_ = context.Operators.ConceptInValueSet(bd_, be_);
-                bool? bg_ = context.Operators.And(ax_, bf_);
-                return bg_;
+                IEnumerable<object> ba_ = context.Operators.Select<Extension, object>(ay_, az_);
+                object bb_ = context.Operators.SingletonFrom<object>(ba_);
+                CqlConcept bc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bb_ as CodeableConcept);
+                CqlValueSet bd_ = this.Patient_Declined(context);
+                bool? be_ = context.Operators.ConceptInValueSet(bc_, bd_);
+                bool? bf_ = context.Operators.And(aw_, be_);
+                return bf_;
             }
 
             IEnumerable<ServiceRequest> aj_ = context.Operators.Where<ServiceRequest>(ah_, ai_);
-            Encounter ak_(ServiceRequest ElevatedBPDeclinedInterventions) => ElevatedBPEncounter;
-            IEnumerable<Encounter> al_ = context.Operators.Select<ServiceRequest, Encounter>(aj_, ak_);
-            return al_;
+            bool? ak_ = context.Operators.Exists<ServiceRequest>(aj_);
+            return ak_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
-        IEnumerable<Encounter> e_(Encounter ElevatedBPEncounter) {
-            IEnumerable<ServiceRequest> bl_ = this.NonPharmacological_Intervention_Not_Ordered(context);
+        bool? e_(Encounter ElevatedBPEncounter) {
+            IEnumerable<ServiceRequest> bk_ = this.NonPharmacological_Intervention_Not_Ordered(context);
 
-            bool? bm_(ServiceRequest NotOrdered) {
-                FhirDateTime bq_ = NotOrdered?.AuthoredOnElement;
-                CqlDateTime br_ = context.Operators.Convert<CqlDateTime>(bq_);
-                Period bs_ = ElevatedBPEncounter?.Period;
-                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
-                bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, "day");
-                return bu_;
+            bool? bl_(ServiceRequest NotOrdered) {
+                FhirDateTime bo_ = NotOrdered?.AuthoredOnElement;
+                CqlDateTime bp_ = context.Operators.Convert<CqlDateTime>(bo_);
+                Period bq_ = ElevatedBPEncounter?.Period;
+                CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bq_);
+                bool? bs_ = context.Operators.In<CqlDateTime>(bp_, br_, "day");
+                return bs_;
             }
 
-            IEnumerable<ServiceRequest> bn_ = context.Operators.Where<ServiceRequest>(bl_, bm_);
-            Encounter bo_(ServiceRequest NotOrdered) => ElevatedBPEncounter;
-            IEnumerable<Encounter> bp_ = context.Operators.Select<ServiceRequest, Encounter>(bn_, bo_);
-            return bp_;
+            IEnumerable<ServiceRequest> bm_ = context.Operators.Where<ServiceRequest>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<ServiceRequest>(bm_);
+            return bn_;
         }
 
-        IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+        IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
         IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
         IEnumerable<Encounter> h_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80(context);
 
-        IEnumerable<Encounter> i_(Encounter FirstHTNEncounter) {
-            CqlValueSet bv_ = this.Follow_Up_Within_4_Weeks(context);
-            IEnumerable<ServiceRequest> bw_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, bv_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
-            IEnumerable<ServiceRequest> by_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, bv_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
-            IEnumerable<ServiceRequest> bz_ = context.Operators.Union<ServiceRequest>(bw_, by_);
-            CqlValueSet ca_ = this.Referral_to_Primary_Care_or_Alternate_Provider(context);
-            IEnumerable<ServiceRequest> cb_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, ca_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
-            IEnumerable<ServiceRequest> cd_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, ca_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
-            IEnumerable<ServiceRequest> ce_ = context.Operators.Union<ServiceRequest>(cb_, cd_);
-            IEnumerable<ServiceRequest> cf_ = context.Operators.Union<ServiceRequest>(bz_, ce_);
+        bool? i_(Encounter FirstHTNEncounter) {
+            CqlValueSet bt_ = this.Follow_Up_Within_4_Weeks(context);
+            IEnumerable<ServiceRequest> bu_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, bt_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
+            IEnumerable<ServiceRequest> bw_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, bt_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
+            IEnumerable<ServiceRequest> bx_ = context.Operators.Union<ServiceRequest>(bu_, bw_);
+            CqlValueSet by_ = this.Referral_to_Primary_Care_or_Alternate_Provider(context);
+            IEnumerable<ServiceRequest> bz_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, by_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
+            IEnumerable<ServiceRequest> cb_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, by_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
+            IEnumerable<ServiceRequest> cc_ = context.Operators.Union<ServiceRequest>(bz_, cb_);
+            IEnumerable<ServiceRequest> cd_ = context.Operators.Union<ServiceRequest>(bx_, cc_);
 
-            bool? cg_(ServiceRequest FirstHTNDeclinedInterventions) {
-                FhirDateTime ck_ = FirstHTNDeclinedInterventions?.AuthoredOnElement;
-                CqlDateTime cl_ = context.Operators.Convert<CqlDateTime>(ck_);
-                Period cm_ = FirstHTNEncounter?.Period;
-                CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
-                bool? co_ = context.Operators.In<CqlDateTime>(cl_, cn_, "day");
-                Code<RequestStatus> cp_ = FirstHTNDeclinedInterventions?.StatusElement;
-                RequestStatus? cq_ = cp_?.Value;
-                Code<RequestStatus> cr_ = context.Operators.Convert<Code<RequestStatus>>(cq_);
-                string cs_ = context.Operators.Convert<string>(cr_);
-                string[] ct_ = [
+            bool? ce_(ServiceRequest FirstHTNDeclinedInterventions) {
+                FhirDateTime ch_ = FirstHTNDeclinedInterventions?.AuthoredOnElement;
+                CqlDateTime ci_ = context.Operators.Convert<CqlDateTime>(ch_);
+                Period cj_ = FirstHTNEncounter?.Period;
+                CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cj_);
+                bool? cl_ = context.Operators.In<CqlDateTime>(ci_, ck_, "day");
+                Code<RequestStatus> cm_ = FirstHTNDeclinedInterventions?.StatusElement;
+                RequestStatus? cn_ = cm_?.Value;
+                Code<RequestStatus> co_ = context.Operators.Convert<Code<RequestStatus>>(cn_);
+                string cp_ = context.Operators.Convert<string>(co_);
+                string[] cq_ = [
                     "active",
                     "completed",
                     "on-hold",
                 ];
-                bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
-                bool? cv_ = context.Operators.And(co_, cu_);
+                bool? cr_ = context.Operators.In<string>(cp_, (IEnumerable<string>)cq_);
+                bool? cs_ = context.Operators.And(cl_, cr_);
 
-                bool? cw_(Extension @this) {
-                    FhirUri df_ = @this?.UrlElement;
-                    string dg_ = FHIRHelpers_4_4_000.Instance.ToString(context, df_);
-                    bool? dh_ = context.Operators.Equal(dg_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                    return dh_;
+                bool? ct_(Extension @this) {
+                    FhirUri dc_ = @this?.UrlElement;
+                    string dd_ = FHIRHelpers_4_4_000.Instance.ToString(context, dc_);
+                    bool? de_ = context.Operators.Equal(dd_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                    return de_;
                 }
 
-                IEnumerable<Extension> cx_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(FirstHTNDeclinedInterventions is DomainResource
+                IEnumerable<Extension> cu_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(FirstHTNDeclinedInterventions is DomainResource
                     ? (FirstHTNDeclinedInterventions as DomainResource).Extension
-                    : default), cw_);
+                    : default), ct_);
 
-                object cy_(Extension @this) {
-                    DataType di_ = @this?.Value;
-                    return di_;
+                object cv_(Extension @this) {
+                    DataType df_ = @this?.Value;
+                    return df_;
                 }
 
-                IEnumerable<object> cz_ = context.Operators.Select<Extension, object>(cx_, cy_);
-                object da_ = context.Operators.SingletonFrom<object>(cz_);
-                CqlConcept db_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, da_ as CodeableConcept);
-                CqlValueSet dc_ = this.Patient_Declined(context);
-                bool? dd_ = context.Operators.ConceptInValueSet(db_, dc_);
-                bool? de_ = context.Operators.And(cv_, dd_);
-                return de_;
+                IEnumerable<object> cw_ = context.Operators.Select<Extension, object>(cu_, cv_);
+                object cx_ = context.Operators.SingletonFrom<object>(cw_);
+                CqlConcept cy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cx_ as CodeableConcept);
+                CqlValueSet cz_ = this.Patient_Declined(context);
+                bool? da_ = context.Operators.ConceptInValueSet(cy_, cz_);
+                bool? db_ = context.Operators.And(cs_, da_);
+                return db_;
             }
 
-            IEnumerable<ServiceRequest> ch_ = context.Operators.Where<ServiceRequest>(cf_, cg_);
-            Encounter ci_(ServiceRequest FirstHTNDeclinedInterventions) => FirstHTNEncounter;
-            IEnumerable<Encounter> cj_ = context.Operators.Select<ServiceRequest, Encounter>(ch_, ci_);
-            return cj_;
+            IEnumerable<ServiceRequest> cf_ = context.Operators.Where<ServiceRequest>(cd_, ce_);
+            bool? cg_ = context.Operators.Exists<ServiceRequest>(cf_);
+            return cg_;
         }
 
-        IEnumerable<Encounter> j_ = context.Operators.SelectMany<Encounter, Encounter>(h_, i_);
+        IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 
-        IEnumerable<Encounter> l_(Encounter FirstHTNEncounter) {
-            IEnumerable<ServiceRequest> dj_ = this.NonPharmacological_Intervention_Not_Ordered(context);
+        bool? l_(Encounter FirstHTNEncounter) {
+            IEnumerable<ServiceRequest> dg_ = this.NonPharmacological_Intervention_Not_Ordered(context);
 
-            bool? dk_(ServiceRequest NoNonPharm) {
-                FhirDateTime do_ = NoNonPharm?.AuthoredOnElement;
-                CqlDateTime dp_ = context.Operators.Convert<CqlDateTime>(do_);
-                Period dq_ = FirstHTNEncounter?.Period;
-                CqlInterval<CqlDateTime> dr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dq_);
-                bool? ds_ = context.Operators.In<CqlDateTime>(dp_, dr_, "day");
-                return ds_;
+            bool? dh_(ServiceRequest NoNonPharm) {
+                FhirDateTime dk_ = NoNonPharm?.AuthoredOnElement;
+                CqlDateTime dl_ = context.Operators.Convert<CqlDateTime>(dk_);
+                Period dm_ = FirstHTNEncounter?.Period;
+                CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dm_);
+                bool? do_ = context.Operators.In<CqlDateTime>(dl_, dn_, "day");
+                return do_;
             }
 
-            IEnumerable<ServiceRequest> dl_ = context.Operators.Where<ServiceRequest>(dj_, dk_);
-            Encounter dm_(ServiceRequest NoNonPharm) => FirstHTNEncounter;
-            IEnumerable<Encounter> dn_ = context.Operators.Select<ServiceRequest, Encounter>(dl_, dm_);
-            return dn_;
+            IEnumerable<ServiceRequest> di_ = context.Operators.Where<ServiceRequest>(dg_, dh_);
+            bool? dj_ = context.Operators.Exists<ServiceRequest>(di_);
+            return dj_;
         }
 
-        IEnumerable<Encounter> m_ = context.Operators.SelectMany<Encounter, Encounter>(h_, l_);
+        IEnumerable<Encounter> m_ = context.Operators.Where<Encounter>(h_, l_);
         IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(j_, m_);
         IEnumerable<Encounter> o_ = context.Operators.Union<Encounter>(g_, n_);
         IEnumerable<Encounter> p_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89(context);
 
-        IEnumerable<Encounter> q_(Encounter SecondHTNEncounter) {
-            IEnumerable<ServiceRequest> dt_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined(context);
+        bool? q_(Encounter SecondHTNEncounter) {
+            IEnumerable<ServiceRequest> dp_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined(context);
 
-            bool? du_(ServiceRequest SecondHTNDeclinedInterventions) {
-                FhirDateTime dy_ = SecondHTNDeclinedInterventions?.AuthoredOnElement;
-                CqlDateTime dz_ = context.Operators.Convert<CqlDateTime>(dy_);
-                Period ea_ = SecondHTNEncounter?.Period;
-                CqlInterval<CqlDateTime> eb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ea_);
-                bool? ec_ = context.Operators.In<CqlDateTime>(dz_, eb_, "day");
-                return ec_;
+            bool? dq_(ServiceRequest SecondHTNDeclinedInterventions) {
+                FhirDateTime dt_ = SecondHTNDeclinedInterventions?.AuthoredOnElement;
+                CqlDateTime du_ = context.Operators.Convert<CqlDateTime>(dt_);
+                Period dv_ = SecondHTNEncounter?.Period;
+                CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
+                bool? dx_ = context.Operators.In<CqlDateTime>(du_, dw_, "day");
+                return dx_;
             }
 
-            IEnumerable<ServiceRequest> dv_ = context.Operators.Where<ServiceRequest>(dt_, du_);
-            Encounter dw_(ServiceRequest SecondHTNDeclinedInterventions) => SecondHTNEncounter;
-            IEnumerable<Encounter> dx_ = context.Operators.Select<ServiceRequest, Encounter>(dv_, dw_);
-            return dx_;
+            IEnumerable<ServiceRequest> dr_ = context.Operators.Where<ServiceRequest>(dp_, dq_);
+            bool? ds_ = context.Operators.Exists<ServiceRequest>(dr_);
+            return ds_;
         }
 
-        IEnumerable<Encounter> r_ = context.Operators.SelectMany<Encounter, Encounter>(p_, q_);
+        IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
         IEnumerable<Encounter> s_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90(context);
 
-        IEnumerable<Encounter> t_(Encounter SecondHTN140Over90Encounter) {
-            IEnumerable<object> ed_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined(context);
+        bool? t_(Encounter SecondHTN140Over90Encounter) {
+            IEnumerable<object> dy_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined(context);
 
-            bool? ee_(object SecondHTN140Over90DeclinedInterventions) {
-                object ei_ = context.Operators.LateBoundProperty<object>(SecondHTN140Over90DeclinedInterventions, "authoredOn");
-                CqlDateTime ej_ = context.Operators.LateBoundProperty<CqlDateTime>(ei_, "value");
-                Period ek_ = SecondHTN140Over90Encounter?.Period;
-                CqlInterval<CqlDateTime> el_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ek_);
-                bool? em_ = context.Operators.In<CqlDateTime>(ej_, el_, "day");
-                return em_;
+            bool? dz_(object SecondHTN140Over90DeclinedInterventions) {
+                object ec_ = context.Operators.LateBoundProperty<object>(SecondHTN140Over90DeclinedInterventions, "authoredOn");
+                CqlDateTime ed_ = context.Operators.LateBoundProperty<CqlDateTime>(ec_, "value");
+                Period ee_ = SecondHTN140Over90Encounter?.Period;
+                CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ee_);
+                bool? eg_ = context.Operators.In<CqlDateTime>(ed_, ef_, "day");
+                return eg_;
             }
 
-            IEnumerable<object> ef_ = context.Operators.Where<object>(ed_, ee_);
-            Encounter eg_(object SecondHTN140Over90DeclinedInterventions) => SecondHTN140Over90Encounter;
-            IEnumerable<Encounter> eh_ = context.Operators.Select<object, Encounter>(ef_, eg_);
-            return eh_;
+            IEnumerable<object> ea_ = context.Operators.Where<object>(dy_, dz_);
+            bool? eb_ = context.Operators.Exists<object>(ea_);
+            return eb_;
         }
 
-        IEnumerable<Encounter> u_ = context.Operators.SelectMany<Encounter, Encounter>(s_, t_);
+        IEnumerable<Encounter> u_ = context.Operators.Where<Encounter>(s_, t_);
         IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(r_, u_);
         IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(o_, v_);
         return w_;

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
@@ -239,26 +239,25 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         CqlValueSet a_ = this.Bipolar_Disorder(context);
         IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-        IEnumerable<Condition> c_(Condition BipolarDiagnosis) {
+        bool? c_(Condition BipolarDiagnosis) {
             IEnumerable<Encounter> e_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? f_(Encounter QualifyingEncounter) {
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BipolarDiagnosis as Condition);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                Period l_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                bool? o_ = context.Operators.Before(k_, n_, "day");
-                return o_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BipolarDiagnosis as Condition);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                Period k_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                bool? n_ = context.Operators.Before(j_, m_, "day");
+                return n_;
             }
 
             IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
-            Condition h_(Encounter QualifyingEncounter) => BipolarDiagnosis;
-            IEnumerable<Condition> i_ = context.Operators.Select<Encounter, Condition>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Encounter>(g_);
+            return h_;
         }
 
-        IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
         return d_;
     }
 
@@ -311,58 +310,57 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
-        IEnumerable<Observation> d_(Observation AdolescentDepressionScreening) {
+        bool? d_(Observation AdolescentDepressionScreening) {
             IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? j_(Encounter QualifyingEncounter) {
-                DataType n_ = AdolescentDepressionScreening?.Effective;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                CqlDateTime q_ = context.Operators.End(p_);
-                Period r_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
-                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
-                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
-                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime ad_ = context.Operators.Start(ac_);
-                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
-                bool? af_ = context.Operators.And(aa_, ae_);
-                DataType ag_ = AdolescentDepressionScreening?.Value;
-                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
-                bool? aj_ = context.Operators.And(af_, ai_);
-                Code<ObservationStatus> ak_ = AdolescentDepressionScreening?.StatusElement;
-                ObservationStatus? al_ = ak_?.Value;
-                string am_ = context.Operators.Convert<string>(al_);
-                string[] an_ = [
+                DataType m_ = AdolescentDepressionScreening?.Effective;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                Period q_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime u_ = context.Operators.Subtract(s_, t_);
+                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                CqlInterval<CqlDateTime> y_ = context.Operators.Interval(u_, x_, true, true);
+                bool? z_ = context.Operators.In<CqlDateTime>(p_, y_, "day");
+                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime ac_ = context.Operators.Start(ab_);
+                bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+                bool? ae_ = context.Operators.And(z_, ad_);
+                DataType af_ = AdolescentDepressionScreening?.Value;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+                bool? ai_ = context.Operators.And(ae_, ah_);
+                Code<ObservationStatus> aj_ = AdolescentDepressionScreening?.StatusElement;
+                ObservationStatus? ak_ = aj_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                string[] am_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
-                bool? ap_ = context.Operators.And(aj_, ao_);
-                return ap_;
+                bool? an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
+                bool? ao_ = context.Operators.And(ai_, an_);
+                return ao_;
             }
 
             IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
-            Observation l_(Encounter QualifyingEncounter) => AdolescentDepressionScreening;
-            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Encounter>(k_);
+            return l_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         object f_(Observation @this) {
-            DataType aq_ = @this?.Effective;
-            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-            CqlDateTime at_ = context.Operators.Start(as_);
-            return at_;
+            DataType ap_ = @this?.Effective;
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.Start(ar_);
+            return as_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
@@ -412,117 +410,115 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? t_(Medication M) {
-                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
-                string aa_ = context.Operators.Last<string>(z_);
-                bool? ab_ = context.Operators.Equal(x_, aa_);
-                CodeableConcept ac_ = M?.Code;
-                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
-                CqlValueSet ae_ = this.Adolescent_Depression_Medications(context);
-                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
-                bool? ag_ = context.Operators.And(ab_, af_);
-                return ag_;
+                object w_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object x_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> y_ = context.Operators.Split((string)x_, "/");
+                string z_ = context.Operators.Last<string>(y_);
+                bool? aa_ = context.Operators.Equal(w_, z_);
+                CodeableConcept ab_ = M?.Code;
+                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
+                CqlValueSet ad_ = this.Adolescent_Depression_Medications(context);
+                bool? ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+                bool? af_ = context.Operators.And(aa_, ae_);
+                return af_;
             }
 
             IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
-            MedicationRequest v_(Medication M) => MR;
-            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
-            return w_;
+            bool? v_ = context.Operators.Exists<Medication>(u_);
+            return v_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
-        IEnumerable<MedicationRequest> g_(MedicationRequest AdolescentMed) {
-            IEnumerable<Encounter> ah_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        bool? g_(MedicationRequest AdolescentMed) {
+            IEnumerable<Encounter> ag_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
-            bool? ai_(Encounter QualifyingEncounter) {
-                Observation am_ = this.Most_Recent_Adolescent_Depression_Screening(context);
-                DataType an_ = am_?.Effective;
-                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
-                CqlDateTime aq_ = context.Operators.Start(ap_);
-                Period ar_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.Start(as_);
-                CqlQuantity au_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime av_ = context.Operators.Subtract(at_, au_);
-                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                CqlDateTime ay_ = context.Operators.Start(ax_);
-                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(av_, ay_, true, true);
-                bool? ba_ = context.Operators.In<CqlDateTime>(aq_, az_, "day");
-                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                CqlDateTime bd_ = context.Operators.Start(bc_);
-                bool? be_ = context.Operators.Not((bool?)(bd_ is null));
-                bool? bf_ = context.Operators.And(ba_, be_);
-                CqlInterval<CqlDate> bg_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdolescentMed);
-                CqlDate bh_ = (bg_ as CqlInterval<CqlDate>)?.low;
-                CqlDateTime bi_ = context.Operators.ConvertDateToDateTime(bh_);
-                CqlDate bk_ = (bg_ as CqlInterval<CqlDate>)?.high;
-                CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
-                bool? bn_ = (bg_ as CqlInterval<CqlDate>)?.lowClosed;
-                bool? bp_ = (bg_ as CqlInterval<CqlDate>)?.highClosed;
-                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bi_, bl_, bn_, bp_);
-                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
-                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                bool? bu_ = context.Operators.OverlapsAfter(br_, bt_, "day");
-                bool? bv_ = context.Operators.And(bf_, bu_);
-                DataType bx_ = am_?.Value;
-                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                CqlCode bz_ = this.Depression_screening_positive__finding_(context);
-                CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
-                bool? cb_ = context.Operators.Equivalent(by_ as CqlConcept, ca_);
-                bool? cc_ = context.Operators.And(bv_, cb_);
-                Code<MedicationRequest.MedicationrequestStatus> cd_ = AdolescentMed?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ce_ = cd_?.Value;
-                string cf_ = context.Operators.Convert<string>(ce_);
-                string[] cg_ = [
+            bool? ah_(Encounter QualifyingEncounter) {
+                Observation ak_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+                DataType al_ = ak_?.Effective;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
+                CqlDateTime ao_ = context.Operators.Start(an_);
+                Period ap_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                CqlDateTime ar_ = context.Operators.Start(aq_);
+                CqlQuantity as_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime at_ = context.Operators.Subtract(ar_, as_);
+                CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                CqlDateTime aw_ = context.Operators.Start(av_);
+                CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(at_, aw_, true, true);
+                bool? ay_ = context.Operators.In<CqlDateTime>(ao_, ax_, "day");
+                CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                CqlDateTime bb_ = context.Operators.Start(ba_);
+                bool? bc_ = context.Operators.Not((bool?)(bb_ is null));
+                bool? bd_ = context.Operators.And(ay_, bc_);
+                CqlInterval<CqlDate> be_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdolescentMed);
+                CqlDate bf_ = (be_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
+                CqlDate bi_ = (be_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime bj_ = context.Operators.ConvertDateToDateTime(bi_);
+                bool? bl_ = (be_ as CqlInterval<CqlDate>)?.lowClosed;
+                bool? bn_ = (be_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bg_, bj_, bl_, bn_);
+                CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_);
+                CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                bool? bs_ = context.Operators.OverlapsAfter(bp_, br_, "day");
+                bool? bt_ = context.Operators.And(bd_, bs_);
+                DataType bv_ = ak_?.Value;
+                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                CqlCode bx_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept by_ = context.Operators.ConvertCodeToConcept(bx_);
+                bool? bz_ = context.Operators.Equivalent(bw_ as CqlConcept, by_);
+                bool? ca_ = context.Operators.And(bt_, bz_);
+                Code<MedicationRequest.MedicationrequestStatus> cb_ = AdolescentMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? cc_ = cb_?.Value;
+                string cd_ = context.Operators.Convert<string>(cc_);
+                string[] ce_ = [
                     "active",
                     "completed",
                 ];
-                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
-                bool? ci_ = context.Operators.And(cc_, ch_);
-                Code<MedicationRequest.MedicationRequestIntent> cj_ = AdolescentMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ck_ = cj_?.Value;
-                string cl_ = context.Operators.Convert<string>(ck_);
-                string[] cm_ = [
+                bool? cf_ = context.Operators.In<string>(cd_, (IEnumerable<string>)ce_);
+                bool? cg_ = context.Operators.And(ca_, cf_);
+                Code<MedicationRequest.MedicationRequestIntent> ch_ = AdolescentMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ci_ = ch_?.Value;
+                string cj_ = context.Operators.Convert<string>(ci_);
+                string[] ck_ = [
                     "order",
                     "original-order",
                     "reflex-order",
                     "filler-order",
                     "instance-order",
                 ];
-                bool? cn_ = context.Operators.In<string>(cl_, (IEnumerable<string>)cm_);
-                bool? co_ = context.Operators.And(ci_, cn_);
-                return co_;
+                bool? cl_ = context.Operators.In<string>(cj_, (IEnumerable<string>)ck_);
+                bool? cm_ = context.Operators.And(cg_, cl_);
+                return cm_;
             }
 
-            IEnumerable<Encounter> aj_ = context.Operators.Where<Encounter>(ah_, ai_);
-            MedicationRequest ak_(Encounter QualifyingEncounter) => AdolescentMed;
-            IEnumerable<MedicationRequest> al_ = context.Operators.Select<Encounter, MedicationRequest>(aj_, ak_);
-            return al_;
+            IEnumerable<Encounter> ai_ = context.Operators.Where<Encounter>(ag_, ah_);
+            bool? aj_ = context.Operators.Exists<Encounter>(ai_);
+            return aj_;
         }
 
-        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
         CqlValueSet i_ = this.Referral_for_Adolescent_Depression(context);
         IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
         bool? k_(ServiceRequest AdolescentReferral) {
-            Code<RequestStatus> cp_ = AdolescentReferral?.StatusElement;
-            RequestStatus? cq_ = cp_?.Value;
-            Code<RequestStatus> cr_ = context.Operators.Convert<Code<RequestStatus>>(cq_);
-            string cs_ = context.Operators.Convert<string>(cr_);
-            string[] ct_ = [
+            Code<RequestStatus> cn_ = AdolescentReferral?.StatusElement;
+            RequestStatus? co_ = cn_?.Value;
+            Code<RequestStatus> cp_ = context.Operators.Convert<Code<RequestStatus>>(co_);
+            string cq_ = context.Operators.Convert<string>(cp_);
+            string[] cr_ = [
                 "active",
                 "completed",
             ];
-            bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
-            return cu_;
+            bool? cs_ = context.Operators.In<string>(cq_, (IEnumerable<string>)cr_);
+            return cs_;
         }
 
         IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
@@ -531,11 +527,11 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
         bool? p_(Procedure AdolescentFollowUp) {
-            Code<EventStatus> cv_ = AdolescentFollowUp?.StatusElement;
-            EventStatus? cw_ = cv_?.Value;
-            string cx_ = context.Operators.Convert<string>(cw_);
-            bool? cy_ = context.Operators.Equal(cx_, "completed");
-            return cy_;
+            Code<EventStatus> ct_ = AdolescentFollowUp?.StatusElement;
+            EventStatus? cu_ = ct_?.Value;
+            string cv_ = context.Operators.Convert<string>(cu_);
+            bool? cw_ = context.Operators.Equal(cv_, "completed");
+            return cw_;
         }
 
         IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
@@ -794,58 +790,57 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
-        IEnumerable<Observation> d_(Observation AdultDepressionScreening) {
+        bool? d_(Observation AdultDepressionScreening) {
             IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? j_(Encounter QualifyingEncounter) {
-                DataType n_ = AdultDepressionScreening?.Effective;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                CqlDateTime q_ = context.Operators.End(p_);
-                Period r_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
-                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
-                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
-                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime ad_ = context.Operators.Start(ac_);
-                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
-                bool? af_ = context.Operators.And(aa_, ae_);
-                DataType ag_ = AdultDepressionScreening?.Value;
-                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
-                bool? aj_ = context.Operators.And(af_, ai_);
-                Code<ObservationStatus> ak_ = AdultDepressionScreening?.StatusElement;
-                ObservationStatus? al_ = ak_?.Value;
-                string am_ = context.Operators.Convert<string>(al_);
-                string[] an_ = [
+                DataType m_ = AdultDepressionScreening?.Effective;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                Period q_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime u_ = context.Operators.Subtract(s_, t_);
+                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                CqlInterval<CqlDateTime> y_ = context.Operators.Interval(u_, x_, true, true);
+                bool? z_ = context.Operators.In<CqlDateTime>(p_, y_, "day");
+                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime ac_ = context.Operators.Start(ab_);
+                bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+                bool? ae_ = context.Operators.And(z_, ad_);
+                DataType af_ = AdultDepressionScreening?.Value;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+                bool? ai_ = context.Operators.And(ae_, ah_);
+                Code<ObservationStatus> aj_ = AdultDepressionScreening?.StatusElement;
+                ObservationStatus? ak_ = aj_?.Value;
+                string al_ = context.Operators.Convert<string>(ak_);
+                string[] am_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
-                bool? ap_ = context.Operators.And(aj_, ao_);
-                return ap_;
+                bool? an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
+                bool? ao_ = context.Operators.And(ai_, an_);
+                return ao_;
             }
 
             IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
-            Observation l_(Encounter QualifyingEncounter) => AdultDepressionScreening;
-            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Encounter>(k_);
+            return l_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         object f_(Observation @this) {
-            DataType aq_ = @this?.Effective;
-            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-            CqlDateTime at_ = context.Operators.Start(as_);
-            return at_;
+            DataType ap_ = @this?.Effective;
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.Start(ar_);
+            return as_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
@@ -895,117 +890,115 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? t_(Medication M) {
-                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
-                string aa_ = context.Operators.Last<string>(z_);
-                bool? ab_ = context.Operators.Equal(x_, aa_);
-                CodeableConcept ac_ = M?.Code;
-                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
-                CqlValueSet ae_ = this.Adult_Depression_Medications(context);
-                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
-                bool? ag_ = context.Operators.And(ab_, af_);
-                return ag_;
+                object w_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object x_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> y_ = context.Operators.Split((string)x_, "/");
+                string z_ = context.Operators.Last<string>(y_);
+                bool? aa_ = context.Operators.Equal(w_, z_);
+                CodeableConcept ab_ = M?.Code;
+                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
+                CqlValueSet ad_ = this.Adult_Depression_Medications(context);
+                bool? ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+                bool? af_ = context.Operators.And(aa_, ae_);
+                return af_;
             }
 
             IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
-            MedicationRequest v_(Medication M) => MR;
-            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
-            return w_;
+            bool? v_ = context.Operators.Exists<Medication>(u_);
+            return v_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
-        IEnumerable<MedicationRequest> g_(MedicationRequest AdultMed) {
-            IEnumerable<Encounter> ah_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        bool? g_(MedicationRequest AdultMed) {
+            IEnumerable<Encounter> ag_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
-            bool? ai_(Encounter QualifyingEncounter) {
-                Observation am_ = this.Most_Recent_Adult_Depression_Screening(context);
-                DataType an_ = am_?.Effective;
-                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
-                CqlDateTime aq_ = context.Operators.Start(ap_);
-                Period ar_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.Start(as_);
-                CqlQuantity au_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime av_ = context.Operators.Subtract(at_, au_);
-                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                CqlDateTime ay_ = context.Operators.Start(ax_);
-                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(av_, ay_, true, true);
-                bool? ba_ = context.Operators.In<CqlDateTime>(aq_, az_, "day");
-                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                CqlDateTime bd_ = context.Operators.Start(bc_);
-                bool? be_ = context.Operators.Not((bool?)(bd_ is null));
-                bool? bf_ = context.Operators.And(ba_, be_);
-                CqlInterval<CqlDate> bg_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdultMed);
-                CqlDate bh_ = (bg_ as CqlInterval<CqlDate>)?.low;
-                CqlDateTime bi_ = context.Operators.ConvertDateToDateTime(bh_);
-                CqlDate bk_ = (bg_ as CqlInterval<CqlDate>)?.high;
-                CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
-                bool? bn_ = (bg_ as CqlInterval<CqlDate>)?.lowClosed;
-                bool? bp_ = (bg_ as CqlInterval<CqlDate>)?.highClosed;
-                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bi_, bl_, bn_, bp_);
-                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
-                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                bool? bu_ = context.Operators.OverlapsAfter(br_, bt_, "day");
-                bool? bv_ = context.Operators.And(bf_, bu_);
-                DataType bx_ = am_?.Value;
-                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                CqlCode bz_ = this.Depression_screening_positive__finding_(context);
-                CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
-                bool? cb_ = context.Operators.Equivalent(by_ as CqlConcept, ca_);
-                bool? cc_ = context.Operators.And(bv_, cb_);
-                Code<MedicationRequest.MedicationrequestStatus> cd_ = AdultMed?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ce_ = cd_?.Value;
-                string cf_ = context.Operators.Convert<string>(ce_);
-                string[] cg_ = [
+            bool? ah_(Encounter QualifyingEncounter) {
+                Observation ak_ = this.Most_Recent_Adult_Depression_Screening(context);
+                DataType al_ = ak_?.Effective;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
+                CqlDateTime ao_ = context.Operators.Start(an_);
+                Period ap_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                CqlDateTime ar_ = context.Operators.Start(aq_);
+                CqlQuantity as_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime at_ = context.Operators.Subtract(ar_, as_);
+                CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                CqlDateTime aw_ = context.Operators.Start(av_);
+                CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(at_, aw_, true, true);
+                bool? ay_ = context.Operators.In<CqlDateTime>(ao_, ax_, "day");
+                CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                CqlDateTime bb_ = context.Operators.Start(ba_);
+                bool? bc_ = context.Operators.Not((bool?)(bb_ is null));
+                bool? bd_ = context.Operators.And(ay_, bc_);
+                CqlInterval<CqlDate> be_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdultMed);
+                CqlDate bf_ = (be_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
+                CqlDate bi_ = (be_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime bj_ = context.Operators.ConvertDateToDateTime(bi_);
+                bool? bl_ = (be_ as CqlInterval<CqlDate>)?.lowClosed;
+                bool? bn_ = (be_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bg_, bj_, bl_, bn_);
+                CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_);
+                CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+                bool? bs_ = context.Operators.OverlapsAfter(bp_, br_, "day");
+                bool? bt_ = context.Operators.And(bd_, bs_);
+                DataType bv_ = ak_?.Value;
+                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                CqlCode bx_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept by_ = context.Operators.ConvertCodeToConcept(bx_);
+                bool? bz_ = context.Operators.Equivalent(bw_ as CqlConcept, by_);
+                bool? ca_ = context.Operators.And(bt_, bz_);
+                Code<MedicationRequest.MedicationrequestStatus> cb_ = AdultMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? cc_ = cb_?.Value;
+                string cd_ = context.Operators.Convert<string>(cc_);
+                string[] ce_ = [
                     "active",
                     "completed",
                 ];
-                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
-                bool? ci_ = context.Operators.And(cc_, ch_);
-                Code<MedicationRequest.MedicationRequestIntent> cj_ = AdultMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ck_ = cj_?.Value;
-                string cl_ = context.Operators.Convert<string>(ck_);
-                string[] cm_ = [
+                bool? cf_ = context.Operators.In<string>(cd_, (IEnumerable<string>)ce_);
+                bool? cg_ = context.Operators.And(ca_, cf_);
+                Code<MedicationRequest.MedicationRequestIntent> ch_ = AdultMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ci_ = ch_?.Value;
+                string cj_ = context.Operators.Convert<string>(ci_);
+                string[] ck_ = [
                     "order",
                     "original-order",
                     "reflex-order",
                     "filler-order",
                     "instance-order",
                 ];
-                bool? cn_ = context.Operators.In<string>(cl_, (IEnumerable<string>)cm_);
-                bool? co_ = context.Operators.And(ci_, cn_);
-                return co_;
+                bool? cl_ = context.Operators.In<string>(cj_, (IEnumerable<string>)ck_);
+                bool? cm_ = context.Operators.And(cg_, cl_);
+                return cm_;
             }
 
-            IEnumerable<Encounter> aj_ = context.Operators.Where<Encounter>(ah_, ai_);
-            MedicationRequest ak_(Encounter QualifyingEncounter) => AdultMed;
-            IEnumerable<MedicationRequest> al_ = context.Operators.Select<Encounter, MedicationRequest>(aj_, ak_);
-            return al_;
+            IEnumerable<Encounter> ai_ = context.Operators.Where<Encounter>(ag_, ah_);
+            bool? aj_ = context.Operators.Exists<Encounter>(ai_);
+            return aj_;
         }
 
-        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
         CqlValueSet i_ = this.Referral_for_Adult_Depression(context);
         IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
         bool? k_(ServiceRequest AdultReferral) {
-            Code<RequestStatus> cp_ = AdultReferral?.StatusElement;
-            RequestStatus? cq_ = cp_?.Value;
-            Code<RequestStatus> cr_ = context.Operators.Convert<Code<RequestStatus>>(cq_);
-            string cs_ = context.Operators.Convert<string>(cr_);
-            string[] ct_ = [
+            Code<RequestStatus> cn_ = AdultReferral?.StatusElement;
+            RequestStatus? co_ = cn_?.Value;
+            Code<RequestStatus> cp_ = context.Operators.Convert<Code<RequestStatus>>(co_);
+            string cq_ = context.Operators.Convert<string>(cp_);
+            string[] cr_ = [
                 "active",
                 "completed",
             ];
-            bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
-            return cu_;
+            bool? cs_ = context.Operators.In<string>(cq_, (IEnumerable<string>)cr_);
+            return cs_;
         }
 
         IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
@@ -1014,11 +1007,11 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
         bool? p_(Procedure AdultFollowUp) {
-            Code<EventStatus> cv_ = AdultFollowUp?.StatusElement;
-            EventStatus? cw_ = cv_?.Value;
-            string cx_ = context.Operators.Convert<string>(cw_);
-            bool? cy_ = context.Operators.Equal(cx_, "completed");
-            return cy_;
+            Code<EventStatus> ct_ = AdultFollowUp?.StatusElement;
+            EventStatus? cu_ = ct_?.Value;
+            string cv_ = context.Operators.Convert<string>(cu_);
+            bool? cw_ = context.Operators.Equal(cv_, "completed");
+            return cw_;
         }
 
         IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
@@ -1310,75 +1303,74 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
 
-        IEnumerable<Observation> d_(Observation NoAdolescentScreen) {
+        bool? d_(Observation NoAdolescentScreen) {
             IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? i_(Encounter QualifyingEncounter) {
-                Instant m_ = NoAdolescentScreen?.IssuedElement;
-                DateTimeOffset? n_ = m_?.Value;
-                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
-                Period p_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
-                return r_;
+                Instant l_ = NoAdolescentScreen?.IssuedElement;
+                DateTimeOffset? m_ = l_?.Value;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                Period o_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+                return q_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            Observation k_(Encounter QualifyingEncounter) => NoAdolescentScreen;
-            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         bool? f_(Observation NoAdolescentScreen) {
 
-            bool? s_(Extension @this) {
-                FhirUri ak_ = @this?.UrlElement;
-                string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
-                bool? am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            bool? r_(Extension @this) {
+                FhirUri aj_ = @this?.UrlElement;
+                string ak_ = FHIRHelpers_4_4_000.Instance.ToString(context, aj_);
+                bool? al_ = context.Operators.Equal(ak_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return al_;
+            }
+
+            IEnumerable<Extension> s_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                ? (NoAdolescentScreen as DomainResource).Extension
+                : default), r_);
+
+            object t_(Extension @this) {
+                DataType am_ = @this?.Value;
                 return am_;
             }
 
-            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
-                ? (NoAdolescentScreen as DomainResource).Extension
-                : default), s_);
+            IEnumerable<object> u_ = context.Operators.Select<Extension, object>(s_, t_);
+            object v_ = context.Operators.SingletonFrom<object>(u_);
+            CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_ as CodeableConcept);
+            CqlCode x_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
+            bool? z_ = context.Operators.Equivalent(w_, y_);
 
-            object u_(Extension @this) {
-                DataType an_ = @this?.Value;
-                return an_;
+            bool? aa_(Extension @this) {
+                FhirUri an_ = @this?.UrlElement;
+                string ao_ = FHIRHelpers_4_4_000.Instance.ToString(context, an_);
+                bool? ap_ = context.Operators.Equal(ao_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return ap_;
             }
 
-            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
-            object w_ = context.Operators.SingletonFrom<object>(v_);
-            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
-            CqlCode y_ = this.Depression_screening_declined__situation_(context);
-            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
-            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            IEnumerable<Extension> ab_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                ? (NoAdolescentScreen as DomainResource).Extension
+                : default), aa_);
 
-            bool? ab_(Extension @this) {
-                FhirUri ao_ = @this?.UrlElement;
-                string ap_ = FHIRHelpers_4_4_000.Instance.ToString(context, ao_);
-                bool? aq_ = context.Operators.Equal(ap_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            object ac_(Extension @this) {
+                DataType aq_ = @this?.Value;
                 return aq_;
             }
 
-            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
-                ? (NoAdolescentScreen as DomainResource).Extension
-                : default), ab_);
-
-            object ad_(Extension @this) {
-                DataType ar_ = @this?.Value;
-                return ar_;
-            }
-
-            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
-            object af_ = context.Operators.SingletonFrom<object>(ae_);
-            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
-            CqlValueSet ah_ = this.Medical_Reason(context);
-            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
-            bool? aj_ = context.Operators.Or(aa_, ai_);
-            return aj_;
+            IEnumerable<object> ad_ = context.Operators.Select<Extension, object>(ab_, ac_);
+            object ae_ = context.Operators.SingletonFrom<object>(ad_);
+            CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_ as CodeableConcept);
+            CqlValueSet ag_ = this.Medical_Reason(context);
+            bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+            bool? ai_ = context.Operators.Or(z_, ah_);
+            return ai_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
@@ -1398,51 +1390,50 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
-        IEnumerable<Observation> d_(Observation AdolescentScreening) {
+        bool? d_(Observation AdolescentScreening) {
             IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? h_(Encounter QualifyingEncounter) {
-                DataType l_ = AdolescentScreening?.Effective;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                CqlDateTime o_ = context.Operators.End(n_);
-                Period p_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
-                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
-                bool? ad_ = context.Operators.And(y_, ac_);
-                DataType ae_ = AdolescentScreening?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
-                bool? ah_ = context.Operators.And(ad_, ag_);
-                Code<ObservationStatus> ai_ = AdolescentScreening?.StatusElement;
-                ObservationStatus? aj_ = ai_?.Value;
-                string ak_ = context.Operators.Convert<string>(aj_);
-                string[] al_ = [
+                DataType k_ = AdolescentScreening?.Effective;
+                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.End(m_);
+                Period o_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlQuantity r_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+                bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, "day");
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+                bool? ac_ = context.Operators.And(x_, ab_);
+                DataType ad_ = AdolescentScreening?.Value;
+                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                bool? af_ = context.Operators.Not((bool?)(ae_ is null));
+                bool? ag_ = context.Operators.And(ac_, af_);
+                Code<ObservationStatus> ah_ = AdolescentScreening?.StatusElement;
+                ObservationStatus? ai_ = ah_?.Value;
+                string aj_ = context.Operators.Convert<string>(ai_);
+                string[] ak_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
-                bool? an_ = context.Operators.And(ah_, am_);
-                return an_;
+                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+                bool? am_ = context.Operators.And(ag_, al_);
+                return am_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter QualifyingEncounter) => AdolescentScreening;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
         bool? f_ = context.Operators.Exists<Observation>(e_);
         return f_;
     }
@@ -1460,75 +1451,74 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
 
-        IEnumerable<Observation> d_(Observation NoAdultScreen) {
+        bool? d_(Observation NoAdultScreen) {
             IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? i_(Encounter QualifyingEncounter) {
-                Instant m_ = NoAdultScreen?.IssuedElement;
-                DateTimeOffset? n_ = m_?.Value;
-                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
-                Period p_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
-                return r_;
+                Instant l_ = NoAdultScreen?.IssuedElement;
+                DateTimeOffset? m_ = l_?.Value;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                Period o_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+                return q_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            Observation k_(Encounter QualifyingEncounter) => NoAdultScreen;
-            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         bool? f_(Observation NoAdultScreen) {
 
-            bool? s_(Extension @this) {
-                FhirUri ak_ = @this?.UrlElement;
-                string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
-                bool? am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            bool? r_(Extension @this) {
+                FhirUri aj_ = @this?.UrlElement;
+                string ak_ = FHIRHelpers_4_4_000.Instance.ToString(context, aj_);
+                bool? al_ = context.Operators.Equal(ak_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return al_;
+            }
+
+            IEnumerable<Extension> s_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                ? (NoAdultScreen as DomainResource).Extension
+                : default), r_);
+
+            object t_(Extension @this) {
+                DataType am_ = @this?.Value;
                 return am_;
             }
 
-            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
-                ? (NoAdultScreen as DomainResource).Extension
-                : default), s_);
+            IEnumerable<object> u_ = context.Operators.Select<Extension, object>(s_, t_);
+            object v_ = context.Operators.SingletonFrom<object>(u_);
+            CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_ as CodeableConcept);
+            CqlCode x_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
+            bool? z_ = context.Operators.Equivalent(w_, y_);
 
-            object u_(Extension @this) {
-                DataType an_ = @this?.Value;
-                return an_;
+            bool? aa_(Extension @this) {
+                FhirUri an_ = @this?.UrlElement;
+                string ao_ = FHIRHelpers_4_4_000.Instance.ToString(context, an_);
+                bool? ap_ = context.Operators.Equal(ao_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return ap_;
             }
 
-            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
-            object w_ = context.Operators.SingletonFrom<object>(v_);
-            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
-            CqlCode y_ = this.Depression_screening_declined__situation_(context);
-            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
-            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            IEnumerable<Extension> ab_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                ? (NoAdultScreen as DomainResource).Extension
+                : default), aa_);
 
-            bool? ab_(Extension @this) {
-                FhirUri ao_ = @this?.UrlElement;
-                string ap_ = FHIRHelpers_4_4_000.Instance.ToString(context, ao_);
-                bool? aq_ = context.Operators.Equal(ap_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            object ac_(Extension @this) {
+                DataType aq_ = @this?.Value;
                 return aq_;
             }
 
-            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
-                ? (NoAdultScreen as DomainResource).Extension
-                : default), ab_);
-
-            object ad_(Extension @this) {
-                DataType ar_ = @this?.Value;
-                return ar_;
-            }
-
-            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
-            object af_ = context.Operators.SingletonFrom<object>(ae_);
-            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
-            CqlValueSet ah_ = this.Medical_Reason(context);
-            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
-            bool? aj_ = context.Operators.Or(aa_, ai_);
-            return aj_;
+            IEnumerable<object> ad_ = context.Operators.Select<Extension, object>(ab_, ac_);
+            object ae_ = context.Operators.SingletonFrom<object>(ad_);
+            CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_ as CodeableConcept);
+            CqlValueSet ag_ = this.Medical_Reason(context);
+            bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+            bool? ai_ = context.Operators.Or(z_, ah_);
+            return ai_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
@@ -1548,51 +1538,50 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
-        IEnumerable<Observation> d_(Observation AdultScreening) {
+        bool? d_(Observation AdultScreening) {
             IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
             bool? h_(Encounter QualifyingEncounter) {
-                DataType l_ = AdultScreening?.Effective;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                CqlDateTime o_ = context.Operators.End(n_);
-                Period p_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
-                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
-                bool? ad_ = context.Operators.And(y_, ac_);
-                DataType ae_ = AdultScreening?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
-                bool? ah_ = context.Operators.And(ad_, ag_);
-                Code<ObservationStatus> ai_ = AdultScreening?.StatusElement;
-                ObservationStatus? aj_ = ai_?.Value;
-                string ak_ = context.Operators.Convert<string>(aj_);
-                string[] al_ = [
+                DataType k_ = AdultScreening?.Effective;
+                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.End(m_);
+                Period o_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlQuantity r_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+                bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, "day");
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+                bool? ac_ = context.Operators.And(x_, ab_);
+                DataType ad_ = AdultScreening?.Value;
+                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                bool? af_ = context.Operators.Not((bool?)(ae_ is null));
+                bool? ag_ = context.Operators.And(ac_, af_);
+                Code<ObservationStatus> ah_ = AdultScreening?.StatusElement;
+                ObservationStatus? ai_ = ah_?.Value;
+                string aj_ = context.Operators.Convert<string>(ai_);
+                string[] ak_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
-                bool? an_ = context.Operators.And(ah_, am_);
-                return an_;
+                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+                bool? am_ = context.Operators.And(ag_, al_);
+                return am_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Observation j_(Encounter QualifyingEncounter) => AdultScreening;
-            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
         bool? f_ = context.Operators.Exists<Observation>(e_);
         return f_;
     }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
@@ -1013,45 +1013,44 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
         IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
         IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
 
-        IEnumerable<MedicationRequest> r_(MedicationRequest NoStatinTherapyOrdered) {
+        bool? r_(MedicationRequest NoStatinTherapyOrdered) {
             IEnumerable<Encounter> u_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
 
             bool? v_(Encounter QualifyingEncounter) {
-                FhirDateTime z_ = NoStatinTherapyOrdered?.AuthoredOnElement;
-                CqlDateTime aa_ = context.Operators.Convert<CqlDateTime>(z_);
-                Period ab_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, "day");
-                Code<MedicationRequest.MedicationrequestStatus> ae_ = NoStatinTherapyOrdered?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? af_ = ae_?.Value;
-                string ag_ = context.Operators.Convert<string>(af_);
-                string[] ah_ = [
+                FhirDateTime y_ = NoStatinTherapyOrdered?.AuthoredOnElement;
+                CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
+                Period aa_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
+                bool? ac_ = context.Operators.In<CqlDateTime>(z_, ab_, "day");
+                Code<MedicationRequest.MedicationrequestStatus> ad_ = NoStatinTherapyOrdered?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                string[] ag_ = [
                     "active",
                     "completed",
                 ];
-                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                bool? aj_ = context.Operators.And(ad_, ai_);
-                List<CodeableConcept> ak_ = NoStatinTherapyOrdered?.ReasonCode;
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
+                bool? ai_ = context.Operators.And(ac_, ah_);
+                List<CodeableConcept> aj_ = NoStatinTherapyOrdered?.ReasonCode;
 
-                CqlConcept al_(CodeableConcept @this) {
-                    CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return aq_;
+                CqlConcept ak_(CodeableConcept @this) {
+                    CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ap_;
                 }
 
-                IEnumerable<CqlConcept> am_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ak_, al_);
-                CqlValueSet an_ = this.Medical_Reason(context);
-                bool? ao_ = context.Operators.ConceptsInValueSet(am_, an_);
-                bool? ap_ = context.Operators.And(aj_, ao_);
-                return ap_;
+                IEnumerable<CqlConcept> al_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)aj_, ak_);
+                CqlValueSet am_ = this.Medical_Reason(context);
+                bool? an_ = context.Operators.ConceptsInValueSet(al_, am_);
+                bool? ao_ = context.Operators.And(ai_, an_);
+                return ao_;
             }
 
             IEnumerable<Encounter> w_ = context.Operators.Where<Encounter>(u_, v_);
-            MedicationRequest x_(Encounter QualifyingEncounter) => NoStatinTherapyOrdered;
-            IEnumerable<MedicationRequest> y_ = context.Operators.Select<Encounter, MedicationRequest>(w_, x_);
-            return y_;
+            bool? x_ = context.Operators.Exists<Encounter>(w_);
+            return x_;
         }
 
-        IEnumerable<MedicationRequest> s_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(q_, r_);
+        IEnumerable<MedicationRequest> s_ = context.Operators.Where<MedicationRequest>(q_, r_);
         bool? t_ = context.Operators.Exists<MedicationRequest>(s_);
         return t_;
     }
@@ -1096,117 +1095,114 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> w_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? x_(Medication M) {
-                object ab_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ac_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ad_ = context.Operators.Split((string)ac_, "/");
-                string ae_ = context.Operators.Last<string>(ad_);
-                bool? af_ = context.Operators.Equal(ab_, ae_);
-                CodeableConcept ag_ = M?.Code;
-                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_);
-                CqlValueSet ai_ = this.Low_Intensity_Statin_Therapy(context);
-                bool? aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
-                bool? ak_ = context.Operators.And(af_, aj_);
-                return ak_;
+                object aa_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ab_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ac_ = context.Operators.Split((string)ab_, "/");
+                string ad_ = context.Operators.Last<string>(ac_);
+                bool? ae_ = context.Operators.Equal(aa_, ad_);
+                CodeableConcept af_ = M?.Code;
+                CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_);
+                CqlValueSet ah_ = this.Low_Intensity_Statin_Therapy(context);
+                bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+                bool? aj_ = context.Operators.And(ae_, ai_);
+                return aj_;
             }
 
             IEnumerable<Medication> y_ = context.Operators.Where<Medication>(w_, x_);
-            MedicationRequest z_(Medication M) => MR;
-            IEnumerable<MedicationRequest> aa_ = context.Operators.Select<Medication, MedicationRequest>(y_, z_);
-            return aa_;
+            bool? z_ = context.Operators.Exists<Medication>(y_);
+            return z_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         CqlValueSet g_ = this.Moderate_Intensity_Statin_Therapy(context);
         IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> j_(MedicationRequest MR) {
-            IEnumerable<Medication> al_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? j_(MedicationRequest MR) {
+            IEnumerable<Medication> ak_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? am_(Medication M) {
-                object aq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ar_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> as_ = context.Operators.Split((string)ar_, "/");
-                string at_ = context.Operators.Last<string>(as_);
-                bool? au_ = context.Operators.Equal(aq_, at_);
-                CodeableConcept av_ = M?.Code;
-                CqlConcept aw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, av_);
-                CqlValueSet ax_ = this.Moderate_Intensity_Statin_Therapy(context);
-                bool? ay_ = context.Operators.ConceptInValueSet(aw_, ax_);
-                bool? az_ = context.Operators.And(au_, ay_);
-                return az_;
+            bool? al_(Medication M) {
+                object ao_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ap_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> aq_ = context.Operators.Split((string)ap_, "/");
+                string ar_ = context.Operators.Last<string>(aq_);
+                bool? as_ = context.Operators.Equal(ao_, ar_);
+                CodeableConcept at_ = M?.Code;
+                CqlConcept au_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, at_);
+                CqlValueSet av_ = this.Moderate_Intensity_Statin_Therapy(context);
+                bool? aw_ = context.Operators.ConceptInValueSet(au_, av_);
+                bool? ax_ = context.Operators.And(as_, aw_);
+                return ax_;
             }
 
-            IEnumerable<Medication> an_ = context.Operators.Where<Medication>(al_, am_);
-            MedicationRequest ao_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ap_ = context.Operators.Select<Medication, MedicationRequest>(an_, ao_);
-            return ap_;
+            IEnumerable<Medication> am_ = context.Operators.Where<Medication>(ak_, al_);
+            bool? an_ = context.Operators.Exists<Medication>(am_);
+            return an_;
         }
 
-        IEnumerable<MedicationRequest> k_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, j_);
+        IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(c_, j_);
         IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(h_, k_);
         IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(f_, l_);
         CqlValueSet n_ = this.High_Intensity_Statin_Therapy(context);
         IEnumerable<MedicationRequest> o_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> q_(MedicationRequest MR) {
-            IEnumerable<Medication> ba_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? q_(MedicationRequest MR) {
+            IEnumerable<Medication> ay_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? bb_(Medication M) {
-                object bf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object bg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> bh_ = context.Operators.Split((string)bg_, "/");
-                string bi_ = context.Operators.Last<string>(bh_);
-                bool? bj_ = context.Operators.Equal(bf_, bi_);
-                CodeableConcept bk_ = M?.Code;
-                CqlConcept bl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bk_);
-                CqlValueSet bm_ = this.High_Intensity_Statin_Therapy(context);
-                bool? bn_ = context.Operators.ConceptInValueSet(bl_, bm_);
-                bool? bo_ = context.Operators.And(bj_, bn_);
-                return bo_;
+            bool? az_(Medication M) {
+                object bc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object bd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> be_ = context.Operators.Split((string)bd_, "/");
+                string bf_ = context.Operators.Last<string>(be_);
+                bool? bg_ = context.Operators.Equal(bc_, bf_);
+                CodeableConcept bh_ = M?.Code;
+                CqlConcept bi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bh_);
+                CqlValueSet bj_ = this.High_Intensity_Statin_Therapy(context);
+                bool? bk_ = context.Operators.ConceptInValueSet(bi_, bj_);
+                bool? bl_ = context.Operators.And(bg_, bk_);
+                return bl_;
             }
 
-            IEnumerable<Medication> bc_ = context.Operators.Where<Medication>(ba_, bb_);
-            MedicationRequest bd_(Medication M) => MR;
-            IEnumerable<MedicationRequest> be_ = context.Operators.Select<Medication, MedicationRequest>(bc_, bd_);
-            return be_;
+            IEnumerable<Medication> ba_ = context.Operators.Where<Medication>(ay_, az_);
+            bool? bb_ = context.Operators.Exists<Medication>(ba_);
+            return bb_;
         }
 
-        IEnumerable<MedicationRequest> r_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, q_);
+        IEnumerable<MedicationRequest> r_ = context.Operators.Where<MedicationRequest>(c_, q_);
         IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(o_, r_);
         IEnumerable<MedicationRequest> t_ = context.Operators.Union<MedicationRequest>(m_, s_);
 
         bool? u_(MedicationRequest StatinRequest) {
-            FhirDateTime bp_ = StatinRequest?.AuthoredOnElement;
-            CqlDateTime bq_ = context.Operators.Convert<CqlDateTime>(bp_);
-            CqlInterval<CqlDateTime> br_ = this.Measurement_Period(context);
-            bool? bs_ = context.Operators.In<CqlDateTime>(bq_, br_, "day");
-            Code<MedicationRequest.MedicationrequestStatus> bt_ = StatinRequest?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? bu_ = bt_?.Value;
-            string bv_ = context.Operators.Convert<string>(bu_);
-            string[] bw_ = [
+            FhirDateTime bm_ = StatinRequest?.AuthoredOnElement;
+            CqlDateTime bn_ = context.Operators.Convert<CqlDateTime>(bm_);
+            CqlInterval<CqlDateTime> bo_ = this.Measurement_Period(context);
+            bool? bp_ = context.Operators.In<CqlDateTime>(bn_, bo_, "day");
+            Code<MedicationRequest.MedicationrequestStatus> bq_ = StatinRequest?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? br_ = bq_?.Value;
+            string bs_ = context.Operators.Convert<string>(br_);
+            string[] bt_ = [
                 "active",
                 "completed",
             ];
-            bool? bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
-            bool? by_ = context.Operators.And(bs_, bx_);
-            Code<MedicationRequest.MedicationRequestIntent> bz_ = StatinRequest?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ca_ = bz_?.Value;
-            string cb_ = context.Operators.Convert<string>(ca_);
-            string[] cc_ = [
+            bool? bu_ = context.Operators.In<string>(bs_, (IEnumerable<string>)bt_);
+            bool? bv_ = context.Operators.And(bp_, bu_);
+            Code<MedicationRequest.MedicationRequestIntent> bw_ = StatinRequest?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bx_ = bw_?.Value;
+            string by_ = context.Operators.Convert<string>(bx_);
+            string[] bz_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filter-order",
                 "instance-order",
             ];
-            bool? cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
-            bool? ce_ = context.Operators.And(by_, cd_);
-            return ce_;
+            bool? ca_ = context.Operators.In<string>(by_, (IEnumerable<string>)bz_);
+            bool? cb_ = context.Operators.And(bv_, ca_);
+            return cb_;
         }
 
         IEnumerable<MedicationRequest> v_ = context.Operators.Where<MedicationRequest>(t_, u_);
@@ -1226,111 +1222,108 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> w_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? x_(Medication M) {
-                object ab_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ac_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ad_ = context.Operators.Split((string)ac_, "/");
-                string ae_ = context.Operators.Last<string>(ad_);
-                bool? af_ = context.Operators.Equal(ab_, ae_);
-                CodeableConcept ag_ = M?.Code;
-                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_);
-                CqlValueSet ai_ = this.Low_Intensity_Statin_Therapy(context);
-                bool? aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
-                bool? ak_ = context.Operators.And(af_, aj_);
-                return ak_;
+                object aa_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ab_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ac_ = context.Operators.Split((string)ab_, "/");
+                string ad_ = context.Operators.Last<string>(ac_);
+                bool? ae_ = context.Operators.Equal(aa_, ad_);
+                CodeableConcept af_ = M?.Code;
+                CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_);
+                CqlValueSet ah_ = this.Low_Intensity_Statin_Therapy(context);
+                bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+                bool? aj_ = context.Operators.And(ae_, ai_);
+                return aj_;
             }
 
             IEnumerable<Medication> y_ = context.Operators.Where<Medication>(w_, x_);
-            MedicationRequest z_(Medication M) => MR;
-            IEnumerable<MedicationRequest> aa_ = context.Operators.Select<Medication, MedicationRequest>(y_, z_);
-            return aa_;
+            bool? z_ = context.Operators.Exists<Medication>(y_);
+            return z_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
         CqlValueSet g_ = this.Moderate_Intensity_Statin_Therapy(context);
         IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> j_(MedicationRequest MR) {
-            IEnumerable<Medication> al_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? j_(MedicationRequest MR) {
+            IEnumerable<Medication> ak_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? am_(Medication M) {
-                object aq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object ar_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> as_ = context.Operators.Split((string)ar_, "/");
-                string at_ = context.Operators.Last<string>(as_);
-                bool? au_ = context.Operators.Equal(aq_, at_);
-                CodeableConcept av_ = M?.Code;
-                CqlConcept aw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, av_);
-                CqlValueSet ax_ = this.Moderate_Intensity_Statin_Therapy(context);
-                bool? ay_ = context.Operators.ConceptInValueSet(aw_, ax_);
-                bool? az_ = context.Operators.And(au_, ay_);
-                return az_;
+            bool? al_(Medication M) {
+                object ao_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ap_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> aq_ = context.Operators.Split((string)ap_, "/");
+                string ar_ = context.Operators.Last<string>(aq_);
+                bool? as_ = context.Operators.Equal(ao_, ar_);
+                CodeableConcept at_ = M?.Code;
+                CqlConcept au_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, at_);
+                CqlValueSet av_ = this.Moderate_Intensity_Statin_Therapy(context);
+                bool? aw_ = context.Operators.ConceptInValueSet(au_, av_);
+                bool? ax_ = context.Operators.And(as_, aw_);
+                return ax_;
             }
 
-            IEnumerable<Medication> an_ = context.Operators.Where<Medication>(al_, am_);
-            MedicationRequest ao_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ap_ = context.Operators.Select<Medication, MedicationRequest>(an_, ao_);
-            return ap_;
+            IEnumerable<Medication> am_ = context.Operators.Where<Medication>(ak_, al_);
+            bool? an_ = context.Operators.Exists<Medication>(am_);
+            return an_;
         }
 
-        IEnumerable<MedicationRequest> k_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, j_);
+        IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(c_, j_);
         IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(h_, k_);
         IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(f_, l_);
         CqlValueSet n_ = this.High_Intensity_Statin_Therapy(context);
         IEnumerable<MedicationRequest> o_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> q_(MedicationRequest MR) {
-            IEnumerable<Medication> ba_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        bool? q_(MedicationRequest MR) {
+            IEnumerable<Medication> ay_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? bb_(Medication M) {
-                object bf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object bg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> bh_ = context.Operators.Split((string)bg_, "/");
-                string bi_ = context.Operators.Last<string>(bh_);
-                bool? bj_ = context.Operators.Equal(bf_, bi_);
-                CodeableConcept bk_ = M?.Code;
-                CqlConcept bl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bk_);
-                CqlValueSet bm_ = this.High_Intensity_Statin_Therapy(context);
-                bool? bn_ = context.Operators.ConceptInValueSet(bl_, bm_);
-                bool? bo_ = context.Operators.And(bj_, bn_);
-                return bo_;
+            bool? az_(Medication M) {
+                object bc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object bd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> be_ = context.Operators.Split((string)bd_, "/");
+                string bf_ = context.Operators.Last<string>(be_);
+                bool? bg_ = context.Operators.Equal(bc_, bf_);
+                CodeableConcept bh_ = M?.Code;
+                CqlConcept bi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bh_);
+                CqlValueSet bj_ = this.High_Intensity_Statin_Therapy(context);
+                bool? bk_ = context.Operators.ConceptInValueSet(bi_, bj_);
+                bool? bl_ = context.Operators.And(bg_, bk_);
+                return bl_;
             }
 
-            IEnumerable<Medication> bc_ = context.Operators.Where<Medication>(ba_, bb_);
-            MedicationRequest bd_(Medication M) => MR;
-            IEnumerable<MedicationRequest> be_ = context.Operators.Select<Medication, MedicationRequest>(bc_, bd_);
-            return be_;
+            IEnumerable<Medication> ba_ = context.Operators.Where<Medication>(ay_, az_);
+            bool? bb_ = context.Operators.Exists<Medication>(ba_);
+            return bb_;
         }
 
-        IEnumerable<MedicationRequest> r_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, q_);
+        IEnumerable<MedicationRequest> r_ = context.Operators.Where<MedicationRequest>(c_, q_);
         IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(o_, r_);
         IEnumerable<MedicationRequest> t_ = context.Operators.Union<MedicationRequest>(m_, s_);
 
         bool? u_(MedicationRequest ActiveStatin) {
-            CqlInterval<CqlDate> bp_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveStatin);
-            CqlDate bq_ = bp_?.low;
+            CqlInterval<CqlDate> bm_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveStatin);
+            CqlDate bn_ = bm_?.low;
+            CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(bn_);
+            CqlDate bq_ = bm_?.high;
             CqlDateTime br_ = context.Operators.ConvertDateToDateTime(bq_);
-            CqlDate bt_ = bp_?.high;
-            CqlDateTime bu_ = context.Operators.ConvertDateToDateTime(bt_);
-            bool? bw_ = bp_?.lowClosed;
-            bool? by_ = bp_?.highClosed;
-            CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(br_, bu_, bw_, by_);
-            CqlInterval<CqlDateTime> ca_ = this.Measurement_Period(context);
-            bool? cb_ = context.Operators.Overlaps(bz_, ca_, "day");
-            Code<MedicationRequest.MedicationrequestStatus> cc_ = ActiveStatin?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? cd_ = cc_?.Value;
-            string ce_ = context.Operators.Convert<string>(cd_);
-            string[] cf_ = [
+            bool? bt_ = bm_?.lowClosed;
+            bool? bv_ = bm_?.highClosed;
+            CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(bo_, br_, bt_, bv_);
+            CqlInterval<CqlDateTime> bx_ = this.Measurement_Period(context);
+            bool? by_ = context.Operators.Overlaps(bw_, bx_, "day");
+            Code<MedicationRequest.MedicationrequestStatus> bz_ = ActiveStatin?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ca_ = bz_?.Value;
+            string cb_ = context.Operators.Convert<string>(ca_);
+            string[] cc_ = [
                 "active",
                 "completed",
             ];
-            bool? cg_ = context.Operators.In<string>(ce_, (IEnumerable<string>)cf_);
-            bool? ch_ = context.Operators.And(cb_, cg_);
-            return ch_;
+            bool? cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
+            bool? ce_ = context.Operators.And(by_, cd_);
+            return ce_;
         }
 
         IEnumerable<MedicationRequest> v_ = context.Operators.Where<MedicationRequest>(t_, u_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
@@ -145,58 +145,57 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Schedule_II__III_and_IV_Opioid_Medications(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Schedule_II__III_and_IV_Opioid_Medications(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationRequest l_(Medication M) => MR;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest OpioidMedications) {
-            bool? x_ = QICoreCommon_4_0_000.Instance.isCommunity(context, OpioidMedications as MedicationRequest);
-            bool? y_ = QICoreCommon_4_0_000.Instance.isDischarge(context, OpioidMedications as MedicationRequest);
-            bool? z_ = context.Operators.Or(x_, y_);
-            Code<MedicationRequest.MedicationrequestStatus> aa_ = OpioidMedications?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
-            string ac_ = context.Operators.Convert<string>(ab_);
-            string[] ad_ = [
+            bool? w_ = QICoreCommon_4_0_000.Instance.isCommunity(context, OpioidMedications as MedicationRequest);
+            bool? x_ = QICoreCommon_4_0_000.Instance.isDischarge(context, OpioidMedications as MedicationRequest);
+            bool? y_ = context.Operators.Or(w_, x_);
+            Code<MedicationRequest.MedicationrequestStatus> z_ = OpioidMedications?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-            bool? af_ = context.Operators.And(z_, ae_);
-            Code<MedicationRequest.MedicationRequestIntent> ag_ = OpioidMedications?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
-            string ai_ = context.Operators.Convert<string>(ah_);
-            string[] aj_ = [
+            bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            bool? ae_ = context.Operators.And(y_, ad_);
+            Code<MedicationRequest.MedicationRequestIntent> af_ = OpioidMedications?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+            string ah_ = context.Operators.Convert<string>(ag_);
+            string[] ai_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-            bool? al_ = context.Operators.And(af_, ak_);
-            return al_;
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+            bool? ak_ = context.Operators.And(ae_, aj_);
+            return ak_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -216,58 +215,57 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Schedule_IV_Benzodiazepines(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Schedule_IV_Benzodiazepines(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationRequest l_(Medication M) => MR;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest BenzoMedications) {
-            bool? x_ = QICoreCommon_4_0_000.Instance.isCommunity(context, BenzoMedications as MedicationRequest);
-            bool? y_ = QICoreCommon_4_0_000.Instance.isDischarge(context, BenzoMedications as MedicationRequest);
-            bool? z_ = context.Operators.Or(x_, y_);
-            Code<MedicationRequest.MedicationrequestStatus> aa_ = BenzoMedications?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
-            string ac_ = context.Operators.Convert<string>(ab_);
-            string[] ad_ = [
+            bool? w_ = QICoreCommon_4_0_000.Instance.isCommunity(context, BenzoMedications as MedicationRequest);
+            bool? x_ = QICoreCommon_4_0_000.Instance.isDischarge(context, BenzoMedications as MedicationRequest);
+            bool? y_ = context.Operators.Or(w_, x_);
+            Code<MedicationRequest.MedicationrequestStatus> z_ = BenzoMedications?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-            bool? af_ = context.Operators.And(z_, ae_);
-            Code<MedicationRequest.MedicationRequestIntent> ag_ = BenzoMedications?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
-            string ai_ = context.Operators.Convert<string>(ah_);
-            string[] aj_ = [
+            bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            bool? ae_ = context.Operators.And(y_, ad_);
+            Code<MedicationRequest.MedicationRequestIntent> af_ = BenzoMedications?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+            string ah_ = context.Operators.Convert<string>(ag_);
+            string[] ai_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-            bool? al_ = context.Operators.And(af_, ak_);
-            return al_;
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+            bool? ak_ = context.Operators.And(ae_, aj_);
+            return ak_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -286,27 +284,26 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<Encounter> a_ = this.Inpatient_Encounter_With_Age_Greater_Than_Or_Equal_To_18(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             IEnumerable<MedicationRequest> d_ = this.Opioid_At_Discharge(context);
             IEnumerable<MedicationRequest> e_ = this.Benzodiazepine_At_Discharge(context);
             IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(d_, e_);
 
             bool? g_(MedicationRequest OpioidOrBenzodiazepineAtDischarge) {
-                FhirDateTime k_ = OpioidOrBenzodiazepineAtDischarge?.AuthoredOnElement;
-                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
-                Period m_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                bool? o_ = context.Operators.In<CqlDateTime>(l_, n_, "day");
-                return o_;
+                FhirDateTime j_ = OpioidOrBenzodiazepineAtDischarge?.AuthoredOnElement;
+                CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
+                Period l_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                bool? n_ = context.Operators.In<CqlDateTime>(k_, m_, "day");
+                return n_;
             }
 
             IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
-            Encounter i_(MedicationRequest OpioidOrBenzodiazepineAtDischarge) => InpatientEncounter;
-            IEnumerable<Encounter> j_ = context.Operators.Select<MedicationRequest, Encounter>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<MedicationRequest>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -499,58 +496,57 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Medications_for_Opioid_Use_Disorder__MOUD_(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Medications_for_Opioid_Use_Disorder__MOUD_(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationRequest l_(Medication M) => MR;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest DischargeMedication) {
-            bool? x_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeMedication as MedicationRequest);
-            bool? y_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeMedication as MedicationRequest);
-            bool? z_ = context.Operators.Or(x_, y_);
-            Code<MedicationRequest.MedicationrequestStatus> aa_ = DischargeMedication?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
-            string ac_ = context.Operators.Convert<string>(ab_);
-            string[] ad_ = [
+            bool? w_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeMedication as MedicationRequest);
+            bool? x_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeMedication as MedicationRequest);
+            bool? y_ = context.Operators.Or(w_, x_);
+            Code<MedicationRequest.MedicationrequestStatus> z_ = DischargeMedication?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-            bool? af_ = context.Operators.And(z_, ae_);
-            Code<MedicationRequest.MedicationRequestIntent> ag_ = DischargeMedication?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
-            string ai_ = context.Operators.Convert<string>(ah_);
-            string[] aj_ = [
+            bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            bool? ae_ = context.Operators.And(y_, ad_);
+            Code<MedicationRequest.MedicationRequestIntent> af_ = DischargeMedication?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+            string ah_ = context.Operators.Convert<string>(ag_);
+            string[] ai_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-            bool? al_ = context.Operators.And(af_, ak_);
-            return al_;
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+            bool? ak_ = context.Operators.And(ae_, aj_);
+            return ak_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -568,70 +564,70 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<MedicationRequest> a_ = this.Medications_For_Opioid_Use_Disorder(context);
 
-        IEnumerable<MedicationRequest> b_(MedicationRequest MedicationTreatment) {
+        bool? b_(MedicationRequest MedicationTreatment) {
             CqlValueSet h_ = this.Opioid_Medication_Assisted_Treatment__MAT_(context);
             IEnumerable<Procedure> i_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? j_(Procedure MAT) {
-                FhirDateTime n_ = MedicationTreatment?.AuthoredOnElement;
-                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                FhirDateTime m_ = MedicationTreatment?.AuthoredOnElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 
-                object p_() {
+                object o_() {
+
+                    bool ac_() {
+                        DataType ag_ = MAT?.Performed;
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        bool ai_ = ah_ is CqlDateTime;
+                        return ai_;
+                    }
+
 
                     bool ad_() {
-                        DataType ah_ = MAT?.Performed;
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        bool aj_ = ai_ is CqlDateTime;
-                        return aj_;
+                        DataType aj_ = MAT?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlInterval<CqlDateTime>;
+                        return al_;
                     }
 
 
                     bool ae_() {
-                        DataType ak_ = MAT?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        bool am_ = al_ is CqlInterval<CqlDateTime>;
-                        return am_;
+                        DataType am_ = MAT?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        bool ao_ = an_ is CqlQuantity;
+                        return ao_;
                     }
 
 
                     bool af_() {
-                        DataType an_ = MAT?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        bool ap_ = ao_ is CqlQuantity;
-                        return ap_;
+                        DataType ap_ = MAT?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        bool ar_ = aq_ is CqlInterval<CqlQuantity>;
+                        return ar_;
                     }
 
-
-                    bool ag_() {
-                        DataType aq_ = MAT?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        bool as_ = ar_ is CqlInterval<CqlQuantity>;
-                        return as_;
-                    }
-
-                    if (ad_())
+                    if (ac_())
                     {
-                        DataType at_ = MAT?.Performed;
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        return (au_ as CqlDateTime) as object;
+                        DataType as_ = MAT?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        return (at_ as CqlDateTime) as object;
+                    }
+                    else if (ad_())
+                    {
+                        DataType au_ = MAT?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        return (av_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ae_())
                     {
-                        DataType av_ = MAT?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        return (aw_ as CqlInterval<CqlDateTime>) as object;
+                        DataType aw_ = MAT?.Performed;
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        return (ax_ as CqlQuantity) as object;
                     }
                     else if (af_())
                     {
-                        DataType ax_ = MAT?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        return (ay_ as CqlQuantity) as object;
-                    }
-                    else if (ag_())
-                    {
-                        DataType az_ = MAT?.Performed;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        return (ba_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ay_ = MAT?.Performed;
+                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+                        return (az_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -639,56 +635,54 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
                     };
                 }
 
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
-                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
-                CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(n_);
-                CqlInterval<CqlDateTime> u_ = this.Measurement_Period(context);
-                bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
-                bool? w_ = context.Operators.And(r_, v_);
-                Code<EventStatus> x_ = MAT?.StatusElement;
-                EventStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(m_);
+                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
+                bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
+                bool? v_ = context.Operators.And(q_, u_);
+                Code<EventStatus> w_ = MAT?.StatusElement;
+                EventStatus? x_ = w_?.Value;
+                string y_ = context.Operators.Convert<string>(x_);
+                string[] z_ = [
                     "completed",
                     "in-progress",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                bool? ac_ = context.Operators.And(w_, ab_);
-                return ac_;
+                bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+                bool? ab_ = context.Operators.And(v_, aa_);
+                return ab_;
             }
 
             IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
-            MedicationRequest l_(Procedure MAT) => MedicationTreatment;
-            IEnumerable<MedicationRequest> m_ = context.Operators.Select<Procedure, MedicationRequest>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Procedure>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationRequest> c_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(a_, b_);
+        IEnumerable<MedicationRequest> c_ = context.Operators.Where<MedicationRequest>(a_, b_);
 
-        IEnumerable<MedicationRequest> e_(MedicationRequest MedicationTreatment) {
-            CqlValueSet bb_ = this.Opioid_Use_Disorder(context);
-            IEnumerable<Condition> bc_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, bb_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? e_(MedicationRequest MedicationTreatment) {
+            CqlValueSet ba_ = this.Opioid_Use_Disorder(context);
+            IEnumerable<Condition> bb_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ba_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            bool? bd_(Condition OUD) {
-                FhirDateTime bh_ = MedicationTreatment?.AuthoredOnElement;
-                CqlDateTime bi_ = context.Operators.Convert<CqlDateTime>(bh_);
-                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OUD as Condition);
-                bool? bk_ = context.Operators.In<CqlDateTime>(bi_, bj_, "day");
-                CqlInterval<CqlDateTime> bm_ = this.Measurement_Period(context);
-                bool? bn_ = context.Operators.Overlaps(bj_, bm_, "day");
-                bool? bo_ = context.Operators.And(bk_, bn_);
-                bool? bp_ = this.isVerified(context, OUD as Condition);
-                bool? bq_ = context.Operators.And(bo_, bp_);
-                return bq_;
+            bool? bc_(Condition OUD) {
+                FhirDateTime bf_ = MedicationTreatment?.AuthoredOnElement;
+                CqlDateTime bg_ = context.Operators.Convert<CqlDateTime>(bf_);
+                CqlInterval<CqlDateTime> bh_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OUD as Condition);
+                bool? bi_ = context.Operators.In<CqlDateTime>(bg_, bh_, "day");
+                CqlInterval<CqlDateTime> bk_ = this.Measurement_Period(context);
+                bool? bl_ = context.Operators.Overlaps(bh_, bk_, "day");
+                bool? bm_ = context.Operators.And(bi_, bl_);
+                bool? bn_ = this.isVerified(context, OUD as Condition);
+                bool? bo_ = context.Operators.And(bm_, bn_);
+                return bo_;
             }
 
-            IEnumerable<Condition> be_ = context.Operators.Where<Condition>(bc_, bd_);
-            MedicationRequest bf_(Condition OUD) => MedicationTreatment;
-            IEnumerable<MedicationRequest> bg_ = context.Operators.Select<Condition, MedicationRequest>(be_, bf_);
-            return bg_;
+            IEnumerable<Condition> bd_ = context.Operators.Where<Condition>(bb_, bc_);
+            bool? be_ = context.Operators.Exists<Condition>(bd_);
+            return be_;
         }
 
-        IEnumerable<MedicationRequest> f_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(a_, e_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(a_, e_);
         IEnumerable<MedicationRequest> g_ = context.Operators.Union<MedicationRequest>(c_, f_);
         return g_;
     }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
@@ -440,50 +440,49 @@ public partial class CMS50FHIRReceiptofSpecialistReport_1_0_000 : ILibrary, ISin
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Task> c_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-task"));
 
-        IEnumerable<Task> d_(Task ConsultantReportObtained) {
+        bool? d_(Task ConsultantReportObtained) {
             ServiceRequest g_ = this.First_Referral_during_First_10_Months_of_Measurement_Period(context);
             ServiceRequest[] h_ = [
                 g_,
             ];
 
             bool? i_(ServiceRequest FirstReferral) {
-                ResourceReference m_ = ConsultantReportObtained?.Focus;
-                bool? n_ = QICoreCommon_4_0_000.Instance.references(context, m_, FirstReferral);
-                List<ResourceReference> o_ = ConsultantReportObtained?.BasedOn;
-                bool? p_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)o_, FirstReferral);
-                bool? q_ = context.Operators.Or(n_, p_);
-                Period r_ = ConsultantReportObtained?.ExecutionPeriod;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime t_ = context.Operators.End(s_);
-                FhirDateTime u_ = FirstReferral?.AuthoredOnElement;
-                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
-                bool? w_ = context.Operators.After(t_, v_, (string)default);
-                bool? x_ = context.Operators.And(q_, w_);
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime aa_ = context.Operators.End(z_);
-                CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
-                bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, "day");
-                bool? ad_ = context.Operators.And(x_, ac_);
-                Code<Task.TaskStatus> ae_ = ConsultantReportObtained?.StatusElement;
-                Task.TaskStatus? af_ = ae_?.Value;
-                string ag_ = context.Operators.Convert<string>(af_);
-                bool? ah_ = context.Operators.Equal(ag_, "completed");
-                bool? ai_ = context.Operators.And(ad_, ah_);
-                CodeableConcept aj_ = ConsultantReportObtained?.ReasonCode;
-                CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
-                CqlValueSet al_ = this.Consultant_Report(context);
-                bool? am_ = context.Operators.ConceptInValueSet(ak_, al_);
-                bool? an_ = context.Operators.And(ai_, am_);
-                return an_;
+                ResourceReference l_ = ConsultantReportObtained?.Focus;
+                bool? m_ = QICoreCommon_4_0_000.Instance.references(context, l_, FirstReferral);
+                List<ResourceReference> n_ = ConsultantReportObtained?.BasedOn;
+                bool? o_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)n_, FirstReferral);
+                bool? p_ = context.Operators.Or(m_, o_);
+                Period q_ = ConsultantReportObtained?.ExecutionPeriod;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime s_ = context.Operators.End(r_);
+                FhirDateTime t_ = FirstReferral?.AuthoredOnElement;
+                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
+                bool? v_ = context.Operators.After(s_, u_, (string)default);
+                bool? w_ = context.Operators.And(p_, v_);
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime z_ = context.Operators.End(y_);
+                CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
+                bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
+                bool? ac_ = context.Operators.And(w_, ab_);
+                Code<Task.TaskStatus> ad_ = ConsultantReportObtained?.StatusElement;
+                Task.TaskStatus? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                bool? ag_ = context.Operators.Equal(af_, "completed");
+                bool? ah_ = context.Operators.And(ac_, ag_);
+                CodeableConcept ai_ = ConsultantReportObtained?.ReasonCode;
+                CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ai_);
+                CqlValueSet ak_ = this.Consultant_Report(context);
+                bool? al_ = context.Operators.ConceptInValueSet(aj_, ak_);
+                bool? am_ = context.Operators.And(ah_, al_);
+                return am_;
             }
 
             IEnumerable<ServiceRequest> j_ = context.Operators.Where<ServiceRequest>((IEnumerable<ServiceRequest>)h_, i_);
-            Task k_(ServiceRequest FirstReferral) => ConsultantReportObtained;
-            IEnumerable<Task> l_ = context.Operators.Select<ServiceRequest, Task>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<ServiceRequest>(j_);
+            return k_;
         }
 
-        IEnumerable<Task> e_ = context.Operators.SelectMany<Task, Task>(c_, d_);
+        IEnumerable<Task> e_ = context.Operators.Where<Task>(c_, d_);
         bool? f_ = context.Operators.Exists<Task>(e_);
         return f_;
     }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
@@ -564,20 +564,784 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
 
-        IEnumerable<Procedure> b_(Procedure THAProcedure) {
+        bool? b_(Procedure THAProcedure) {
             CqlValueSet e_ = this.Lower_Body_Fractures_Excluding_Ankle_and_Foot(context);
             IEnumerable<Condition> f_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> h_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> i_ = context.Operators.Union<Condition>(f_ as IEnumerable<Condition>, h_ as IEnumerable<Condition>);
 
             bool? j_(Condition LowerBodyFracture) {
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LowerBodyFracture);
-                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LowerBodyFracture);
+                CqlDateTime n_ = context.Operators.Start(m_);
 
-                object p_() {
+                object o_() {
+
+                    bool af_() {
+                        DataType aj_ = THAProcedure?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlDateTime;
+                        return al_;
+                    }
+
 
                     bool ag_() {
+                        DataType am_ = THAProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        bool ao_ = an_ is CqlInterval<CqlDateTime>;
+                        return ao_;
+                    }
+
+
+                    bool ah_() {
+                        DataType ap_ = THAProcedure?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        bool ar_ = aq_ is CqlQuantity;
+                        return ar_;
+                    }
+
+
+                    bool ai_() {
+                        DataType as_ = THAProcedure?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        bool au_ = at_ is CqlInterval<CqlQuantity>;
+                        return au_;
+                    }
+
+                    if (af_())
+                    {
+                        DataType av_ = THAProcedure?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        return (aw_ as CqlDateTime) as object;
+                    }
+                    else if (ag_())
+                    {
+                        DataType ax_ = THAProcedure?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        return (ay_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (ah_())
+                    {
+                        DataType az_ = THAProcedure?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        return (ba_ as CqlQuantity) as object;
+                    }
+                    else if (ai_())
+                    {
+                        DataType bb_ = THAProcedure?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        return (bc_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlQuantity r_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+
+                object t_() {
+
+                    bool bd_() {
+                        DataType bh_ = THAProcedure?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        bool bj_ = bi_ is CqlDateTime;
+                        return bj_;
+                    }
+
+
+                    bool be_() {
+                        DataType bk_ = THAProcedure?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        bool bm_ = bl_ is CqlInterval<CqlDateTime>;
+                        return bm_;
+                    }
+
+
+                    bool bf_() {
+                        DataType bn_ = THAProcedure?.Performed;
+                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                        bool bp_ = bo_ is CqlQuantity;
+                        return bp_;
+                    }
+
+
+                    bool bg_() {
+                        DataType bq_ = THAProcedure?.Performed;
+                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                        bool bs_ = br_ is CqlInterval<CqlQuantity>;
+                        return bs_;
+                    }
+
+                    if (bd_())
+                    {
+                        DataType bt_ = THAProcedure?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        return (bu_ as CqlDateTime) as object;
+                    }
+                    else if (be_())
+                    {
+                        DataType bv_ = THAProcedure?.Performed;
+                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                        return (bw_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (bf_())
+                    {
+                        DataType bx_ = THAProcedure?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        return (by_ as CqlQuantity) as object;
+                    }
+                    else if (bg_())
+                    {
+                        DataType bz_ = THAProcedure?.Performed;
+                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                        return (ca_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+                bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, (string)default);
+
+                object y_() {
+
+                    bool cb_() {
+                        DataType cf_ = THAProcedure?.Performed;
+                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                        bool ch_ = cg_ is CqlDateTime;
+                        return ch_;
+                    }
+
+
+                    bool cc_() {
+                        DataType ci_ = THAProcedure?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        bool ck_ = cj_ is CqlInterval<CqlDateTime>;
+                        return ck_;
+                    }
+
+
+                    bool cd_() {
+                        DataType cl_ = THAProcedure?.Performed;
+                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                        bool cn_ = cm_ is CqlQuantity;
+                        return cn_;
+                    }
+
+
+                    bool ce_() {
+                        DataType co_ = THAProcedure?.Performed;
+                        object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+                        bool cq_ = cp_ is CqlInterval<CqlQuantity>;
+                        return cq_;
+                    }
+
+                    if (cb_())
+                    {
+                        DataType cr_ = THAProcedure?.Performed;
+                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+                        return (cs_ as CqlDateTime) as object;
+                    }
+                    else if (cc_())
+                    {
+                        DataType ct_ = THAProcedure?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        return (cu_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (cd_())
+                    {
+                        DataType cv_ = THAProcedure?.Performed;
+                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                        return (cw_ as CqlQuantity) as object;
+                    }
+                    else if (ce_())
+                    {
+                        DataType cx_ = THAProcedure?.Performed;
+                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
+                        return (cy_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+                bool? ac_ = context.Operators.And(x_, ab_);
+                bool? ad_ = this.isVerified(context, LowerBodyFracture);
+                bool? ae_ = context.Operators.And(ac_, ad_);
+                return ae_;
+            }
+
+            IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
+            bool? l_ = context.Operators.Exists<Condition>(k_);
+            return l_;
+        }
+
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
+        bool? d_ = context.Operators.Exists<Procedure>(c_);
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Partial Hip Arthroplasty Procedure")]
+    public bool? Has_Partial_Hip_Arthroplasty_Procedure(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure, Has_Partial_Hip_Arthroplasty_Procedure_Compute);
+
+    private const long _cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure = 5573278062808731434L;
+
+    private bool? Has_Partial_Hip_Arthroplasty_Procedure_Compute(CqlContext context)
+    {
+        CqlValueSet a_ = this.Partial_Arthroplasty_of_Hip(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> c_ = Status_1_15_000.Instance.isProcedurePerformed(context, b_);
+
+        bool? d_(Procedure PartialTHAProcedure) {
+            IEnumerable<Procedure> g_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+            bool? h_(Procedure THAProcedure) {
+
+                object k_() {
+
+                    bool p_() {
+                        DataType t_ = THAProcedure?.Performed;
+                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                        bool v_ = u_ is CqlDateTime;
+                        return v_;
+                    }
+
+
+                    bool q_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlInterval<CqlDateTime>;
+                        return y_;
+                    }
+
+
+                    bool r_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlQuantity;
+                        return ab_;
+                    }
+
+
+                    bool s_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlQuantity>;
+                        return ae_;
+                    }
+
+                    if (p_())
+                    {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        return (ag_ as CqlDateTime) as object;
+                    }
+                    else if (q_())
+                    {
+                        DataType ah_ = THAProcedure?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (r_())
+                    {
+                        DataType aj_ = THAProcedure?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlQuantity) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType al_ = THAProcedure?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
+
+                object m_() {
+
+                    bool an_() {
+                        DataType ar_ = PartialTHAProcedure?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        bool at_ = as_ is CqlDateTime;
+                        return at_;
+                    }
+
+
+                    bool ao_() {
+                        DataType au_ = PartialTHAProcedure?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
+                        return aw_;
+                    }
+
+
+                    bool ap_() {
+                        DataType ax_ = PartialTHAProcedure?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlQuantity;
+                        return az_;
+                    }
+
+
+                    bool aq_() {
+                        DataType ba_ = PartialTHAProcedure?.Performed;
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlInterval<CqlQuantity>;
+                        return bc_;
+                    }
+
+                    if (an_())
+                    {
+                        DataType bd_ = PartialTHAProcedure?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        return (be_ as CqlDateTime) as object;
+                    }
+                    else if (ao_())
+                    {
+                        DataType bf_ = PartialTHAProcedure?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        return (bg_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (ap_())
+                    {
+                        DataType bh_ = PartialTHAProcedure?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        return (bi_ as CqlQuantity) as object;
+                    }
+                    else if (aq_())
+                    {
+                        DataType bj_ = PartialTHAProcedure?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        return (bk_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, "day");
+                return o_;
+            }
+
+            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
+            bool? j_ = context.Operators.Exists<Procedure>(i_);
+            return j_;
+        }
+
+        IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+        bool? f_ = context.Operators.Exists<Procedure>(e_);
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Has Revision Hip Arthroplasty Procedure or Implanted Device or Prosthesis Removal Procedure")]
+    public bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure, Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute);
+
+    private const long _cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure = 5889930654885795887L;
+
+    private bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute(CqlContext context)
+    {
+        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+        bool? b_(Procedure THAProcedure) {
+            CqlValueSet e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine(context);
+            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
+
+            bool? h_(Procedure RevisionTHAProcedure) {
+
+                object k_() {
+
+                    bool p_() {
+                        DataType t_ = THAProcedure?.Performed;
+                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                        bool v_ = u_ is CqlDateTime;
+                        return v_;
+                    }
+
+
+                    bool q_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlInterval<CqlDateTime>;
+                        return y_;
+                    }
+
+
+                    bool r_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlQuantity;
+                        return ab_;
+                    }
+
+
+                    bool s_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlQuantity>;
+                        return ae_;
+                    }
+
+                    if (p_())
+                    {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        return (ag_ as CqlDateTime) as object;
+                    }
+                    else if (q_())
+                    {
+                        DataType ah_ = THAProcedure?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (r_())
+                    {
+                        DataType aj_ = THAProcedure?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlQuantity) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType al_ = THAProcedure?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
+
+                object m_() {
+
+                    bool an_() {
+                        DataType ar_ = RevisionTHAProcedure?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        bool at_ = as_ is CqlDateTime;
+                        return at_;
+                    }
+
+
+                    bool ao_() {
+                        DataType au_ = RevisionTHAProcedure?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
+                        return aw_;
+                    }
+
+
+                    bool ap_() {
+                        DataType ax_ = RevisionTHAProcedure?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlQuantity;
+                        return az_;
+                    }
+
+
+                    bool aq_() {
+                        DataType ba_ = RevisionTHAProcedure?.Performed;
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlInterval<CqlQuantity>;
+                        return bc_;
+                    }
+
+                    if (an_())
+                    {
+                        DataType bd_ = RevisionTHAProcedure?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        return (be_ as CqlDateTime) as object;
+                    }
+                    else if (ao_())
+                    {
+                        DataType bf_ = RevisionTHAProcedure?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        return (bg_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (ap_())
+                    {
+                        DataType bh_ = RevisionTHAProcedure?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        return (bi_ as CqlQuantity) as object;
+                    }
+                    else if (aq_())
+                    {
+                        DataType bj_ = RevisionTHAProcedure?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        return (bk_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, "day");
+                return o_;
+            }
+
+            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
+            bool? j_ = context.Operators.Exists<Procedure>(i_);
+            return j_;
+        }
+
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
+        bool? d_ = context.Operators.Exists<Procedure>(c_);
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Malignant Neoplasm of Lower and Unspecified Limbs")]
+    public bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs, Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute);
+
+    private const long _cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs = -2389632056529416502L;
+
+    private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute(CqlContext context)
+    {
+        CqlValueSet a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
+
+        bool? f_(Condition MalignantNeoplasm) {
+            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+            bool? j_(Procedure THAProcedure) {
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MalignantNeoplasm);
+
+                object n_() {
+
+                    bool s_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
+
+                    bool t_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
+                    }
+
+
+                    bool u_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
+                    }
+
+
+                    bool v_() {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
+                    }
+
+                    if (s_())
+                    {
+                        DataType ai_ = THAProcedure?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
                         DataType ak_ = THAProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (u_())
+                    {
+                        DataType am_ = THAProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
+                    }
+                    else if (v_())
+                    {
+                        DataType ao_ = THAProcedure?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
+                bool? p_ = context.Operators.Overlaps(m_, o_, "day");
+                bool? q_ = this.isVerified(context, MalignantNeoplasm);
+                bool? r_ = context.Operators.And(p_, q_);
+                return r_;
+            }
+
+            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
+            bool? l_ = context.Operators.Exists<Procedure>(k_);
+            return l_;
+        }
+
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Mechanical Complication")]
+    public bool? Has_Mechanical_Complication(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Mechanical_Complication, Has_Mechanical_Complication_Compute);
+
+    private const long _cacheIndex_Has_Mechanical_Complication = 7139202238750288841L;
+
+    private bool? Has_Mechanical_Complication_Compute(CqlContext context)
+    {
+        CqlValueSet a_ = this.Mechanical_Complications_Excluding_Upper_Body(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
+
+        bool? f_(Condition MechanicalComplications) {
+            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+            bool? j_(Procedure THAProcedure) {
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MechanicalComplications);
+
+                object n_() {
+
+                    bool s_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
+
+                    bool t_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
+                    }
+
+
+                    bool u_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
+                    }
+
+
+                    bool v_() {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
+                    }
+
+                    if (s_())
+                    {
+                        DataType ai_ = THAProcedure?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = THAProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (u_())
+                    {
+                        DataType am_ = THAProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
+                    }
+                    else if (v_())
+                    {
+                        DataType ao_ = THAProcedure?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
+                bool? p_ = context.Operators.Overlaps(m_, o_, "day");
+                bool? q_ = this.isVerified(context, MechanicalComplications);
+                bool? r_ = context.Operators.And(p_, q_);
+                return r_;
+            }
+
+            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
+            bool? l_ = context.Operators.Exists<Procedure>(k_);
+            return l_;
+        }
+
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has More Than One Elective Primary Total Hip Arthroplasty Performed")]
+    public bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed, Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute);
+
+    private const long _cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed = -923175309866963357L;
+
+    private bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute(CqlContext context)
+    {
+        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+        bool? b_(Procedure THAProcedure) {
+            CqlValueSet e_ = this.Primary_THA_Procedure(context);
+            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
+
+            bool? h_(Procedure ElectiveTHAProcedure) {
+                Id k_ = THAProcedure?.IdElement;
+                string l_ = k_?.Value;
+                Id m_ = ElectiveTHAProcedure?.IdElement;
+                string n_ = m_?.Value;
+                bool? o_ = context.Operators.Equivalent(l_, n_);
+                bool? p_ = context.Operators.Not(o_);
+
+                object q_() {
+
+                    bool ag_() {
+                        DataType ak_ = ElectiveTHAProcedure?.Performed;
                         object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
                         bool am_ = al_ is CqlDateTime;
                         return am_;
@@ -585,7 +1349,7 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
 
                     bool ah_() {
-                        DataType an_ = THAProcedure?.Performed;
+                        DataType an_ = ElectiveTHAProcedure?.Performed;
                         object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
                         bool ap_ = ao_ is CqlInterval<CqlDateTime>;
                         return ap_;
@@ -593,7 +1357,7 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
 
                     bool ai_() {
-                        DataType aq_ = THAProcedure?.Performed;
+                        DataType aq_ = ElectiveTHAProcedure?.Performed;
                         object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                         bool as_ = ar_ is CqlQuantity;
                         return as_;
@@ -601,7 +1365,7 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
 
                     bool aj_() {
-                        DataType at_ = THAProcedure?.Performed;
+                        DataType at_ = ElectiveTHAProcedure?.Performed;
                         object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
                         bool av_ = au_ is CqlInterval<CqlQuantity>;
                         return av_;
@@ -609,25 +1373,25 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
                     if (ag_())
                     {
-                        DataType aw_ = THAProcedure?.Performed;
+                        DataType aw_ = ElectiveTHAProcedure?.Performed;
                         object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
                         return (ax_ as CqlDateTime) as object;
                     }
                     else if (ah_())
                     {
-                        DataType ay_ = THAProcedure?.Performed;
+                        DataType ay_ = ElectiveTHAProcedure?.Performed;
                         object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
                         return (az_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ai_())
                     {
-                        DataType ba_ = THAProcedure?.Performed;
+                        DataType ba_ = ElectiveTHAProcedure?.Performed;
                         object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
                         return (bb_ as CqlQuantity) as object;
                     }
                     else if (aj_())
                     {
-                        DataType bc_ = THAProcedure?.Performed;
+                        DataType bc_ = ElectiveTHAProcedure?.Performed;
                         object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
                         return (bd_ as CqlInterval<CqlQuantity>) as object;
                     }
@@ -637,12 +1401,10 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
+                CqlDateTime s_ = context.Operators.Start(r_);
 
-                object u_() {
+                object t_() {
 
                     bool be_() {
                         DataType bi_ = THAProcedure?.Performed;
@@ -705,12 +1467,12 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
-                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, (string)default);
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlQuantity w_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime x_ = context.Operators.Subtract(v_, w_);
 
-                object z_() {
+                object y_() {
 
                     bool cc_() {
                         DataType cg_ = THAProcedure?.Performed;
@@ -773,789 +1535,21 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
-                bool? ad_ = context.Operators.And(y_, ac_);
-                bool? ae_ = this.isVerified(context, LowerBodyFracture);
-                bool? af_ = context.Operators.And(ad_, ae_);
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlDateTime ac_ = context.Operators.Add(aa_, w_);
+                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
+                bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, "day");
+                bool? af_ = context.Operators.And(p_, ae_);
                 return af_;
             }
 
-            IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
-            Procedure l_(Condition LowerBodyFracture) => THAProcedure;
-            IEnumerable<Procedure> m_ = context.Operators.Select<Condition, Procedure>(k_, l_);
-            return m_;
-        }
-
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
-        bool? d_ = context.Operators.Exists<Procedure>(c_);
-        return d_;
-    }
-
-
-    [CqlExpressionDefinition("Has Partial Hip Arthroplasty Procedure")]
-    public bool? Has_Partial_Hip_Arthroplasty_Procedure(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure, Has_Partial_Hip_Arthroplasty_Procedure_Compute);
-
-    private const long _cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure = 5573278062808731434L;
-
-    private bool? Has_Partial_Hip_Arthroplasty_Procedure_Compute(CqlContext context)
-    {
-        CqlValueSet a_ = this.Partial_Arthroplasty_of_Hip(context);
-        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-        IEnumerable<Procedure> c_ = Status_1_15_000.Instance.isProcedurePerformed(context, b_);
-
-        IEnumerable<Procedure> d_(Procedure PartialTHAProcedure) {
-            IEnumerable<Procedure> g_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-            bool? h_(Procedure THAProcedure) {
-
-                object l_() {
-
-                    bool q_() {
-                        DataType u_ = THAProcedure?.Performed;
-                        object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                        bool w_ = v_ is CqlDateTime;
-                        return w_;
-                    }
-
-
-                    bool r_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlInterval<CqlDateTime>;
-                        return z_;
-                    }
-
-
-                    bool s_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlQuantity;
-                        return ac_;
-                    }
-
-
-                    bool t_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlInterval<CqlQuantity>;
-                        return af_;
-                    }
-
-                    if (q_())
-                    {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        return (ah_ as CqlDateTime) as object;
-                    }
-                    else if (r_())
-                    {
-                        DataType ai_ = THAProcedure?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (s_())
-                    {
-                        DataType ak_ = THAProcedure?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlQuantity) as object;
-                    }
-                    else if (t_())
-                    {
-                        DataType am_ = THAProcedure?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
-
-                object n_() {
-
-                    bool ao_() {
-                        DataType as_ = PartialTHAProcedure?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        bool au_ = at_ is CqlDateTime;
-                        return au_;
-                    }
-
-
-                    bool ap_() {
-                        DataType av_ = PartialTHAProcedure?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlInterval<CqlDateTime>;
-                        return ax_;
-                    }
-
-
-                    bool aq_() {
-                        DataType ay_ = PartialTHAProcedure?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlQuantity;
-                        return ba_;
-                    }
-
-
-                    bool ar_() {
-                        DataType bb_ = PartialTHAProcedure?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlInterval<CqlQuantity>;
-                        return bd_;
-                    }
-
-                    if (ao_())
-                    {
-                        DataType be_ = PartialTHAProcedure?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        return (bf_ as CqlDateTime) as object;
-                    }
-                    else if (ap_())
-                    {
-                        DataType bg_ = PartialTHAProcedure?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        return (bh_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aq_())
-                    {
-                        DataType bi_ = PartialTHAProcedure?.Performed;
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        return (bj_ as CqlQuantity) as object;
-                    }
-                    else if (ar_())
-                    {
-                        DataType bk_ = PartialTHAProcedure?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        return (bl_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
-                return p_;
-            }
-
             IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
-            Procedure j_(Procedure THAProcedure) => PartialTHAProcedure;
-            IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Procedure>(i_);
+            return j_;
         }
 
-        IEnumerable<Procedure> e_ = context.Operators.SelectMany<Procedure, Procedure>(c_, d_);
-        bool? f_ = context.Operators.Exists<Procedure>(e_);
-        return f_;
-    }
-
-
-    [CqlExpressionDefinition("Has Revision Hip Arthroplasty Procedure or Implanted Device or Prosthesis Removal Procedure")]
-    public bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure, Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute);
-
-    private const long _cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure = 5889930654885795887L;
-
-    private bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute(CqlContext context)
-    {
-        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-        IEnumerable<Procedure> b_(Procedure THAProcedure) {
-            CqlValueSet e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine(context);
-            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
-
-            bool? h_(Procedure RevisionTHAProcedure) {
-
-                object l_() {
-
-                    bool q_() {
-                        DataType u_ = THAProcedure?.Performed;
-                        object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                        bool w_ = v_ is CqlDateTime;
-                        return w_;
-                    }
-
-
-                    bool r_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlInterval<CqlDateTime>;
-                        return z_;
-                    }
-
-
-                    bool s_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlQuantity;
-                        return ac_;
-                    }
-
-
-                    bool t_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlInterval<CqlQuantity>;
-                        return af_;
-                    }
-
-                    if (q_())
-                    {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        return (ah_ as CqlDateTime) as object;
-                    }
-                    else if (r_())
-                    {
-                        DataType ai_ = THAProcedure?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (s_())
-                    {
-                        DataType ak_ = THAProcedure?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlQuantity) as object;
-                    }
-                    else if (t_())
-                    {
-                        DataType am_ = THAProcedure?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
-
-                object n_() {
-
-                    bool ao_() {
-                        DataType as_ = RevisionTHAProcedure?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        bool au_ = at_ is CqlDateTime;
-                        return au_;
-                    }
-
-
-                    bool ap_() {
-                        DataType av_ = RevisionTHAProcedure?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlInterval<CqlDateTime>;
-                        return ax_;
-                    }
-
-
-                    bool aq_() {
-                        DataType ay_ = RevisionTHAProcedure?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlQuantity;
-                        return ba_;
-                    }
-
-
-                    bool ar_() {
-                        DataType bb_ = RevisionTHAProcedure?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlInterval<CqlQuantity>;
-                        return bd_;
-                    }
-
-                    if (ao_())
-                    {
-                        DataType be_ = RevisionTHAProcedure?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        return (bf_ as CqlDateTime) as object;
-                    }
-                    else if (ap_())
-                    {
-                        DataType bg_ = RevisionTHAProcedure?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        return (bh_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aq_())
-                    {
-                        DataType bi_ = RevisionTHAProcedure?.Performed;
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        return (bj_ as CqlQuantity) as object;
-                    }
-                    else if (ar_())
-                    {
-                        DataType bk_ = RevisionTHAProcedure?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        return (bl_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
-                return p_;
-            }
-
-            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
-            Procedure j_(Procedure RevisionTHAProcedure) => THAProcedure;
-            IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
-            return k_;
-        }
-
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
-        bool? d_ = context.Operators.Exists<Procedure>(c_);
-        return d_;
-    }
-
-
-    [CqlExpressionDefinition("Has Malignant Neoplasm of Lower and Unspecified Limbs")]
-    public bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs, Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute);
-
-    private const long _cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs = -2389632056529416502L;
-
-    private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute(CqlContext context)
-    {
-        CqlValueSet a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs(context);
-        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
-
-        IEnumerable<Condition> f_(Condition MalignantNeoplasm) {
-            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-            bool? j_(Procedure THAProcedure) {
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MalignantNeoplasm);
-
-                object o_() {
-
-                    bool t_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
-                    }
-
-
-                    bool u_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
-                    }
-
-
-                    bool v_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
-                    }
-
-
-                    bool w_() {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
-                    {
-                        DataType aj_ = THAProcedure?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
-                    }
-                    else if (u_())
-                    {
-                        DataType al_ = THAProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (v_())
-                    {
-                        DataType an_ = THAProcedure?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = THAProcedure?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
-                bool? q_ = context.Operators.Overlaps(n_, p_, "day");
-                bool? r_ = this.isVerified(context, MalignantNeoplasm);
-                bool? s_ = context.Operators.And(q_, r_);
-                return s_;
-            }
-
-            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
-            Condition l_(Procedure THAProcedure) => MalignantNeoplasm;
-            IEnumerable<Condition> m_ = context.Operators.Select<Procedure, Condition>(k_, l_);
-            return m_;
-        }
-
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
-        bool? h_ = context.Operators.Exists<Condition>(g_);
-        return h_;
-    }
-
-
-    [CqlExpressionDefinition("Has Mechanical Complication")]
-    public bool? Has_Mechanical_Complication(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Mechanical_Complication, Has_Mechanical_Complication_Compute);
-
-    private const long _cacheIndex_Has_Mechanical_Complication = 7139202238750288841L;
-
-    private bool? Has_Mechanical_Complication_Compute(CqlContext context)
-    {
-        CqlValueSet a_ = this.Mechanical_Complications_Excluding_Upper_Body(context);
-        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
-
-        IEnumerable<Condition> f_(Condition MechanicalComplications) {
-            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-            bool? j_(Procedure THAProcedure) {
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MechanicalComplications);
-
-                object o_() {
-
-                    bool t_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
-                    }
-
-
-                    bool u_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
-                    }
-
-
-                    bool v_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
-                    }
-
-
-                    bool w_() {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
-                    {
-                        DataType aj_ = THAProcedure?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
-                    }
-                    else if (u_())
-                    {
-                        DataType al_ = THAProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (v_())
-                    {
-                        DataType an_ = THAProcedure?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = THAProcedure?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
-                bool? q_ = context.Operators.Overlaps(n_, p_, "day");
-                bool? r_ = this.isVerified(context, MechanicalComplications);
-                bool? s_ = context.Operators.And(q_, r_);
-                return s_;
-            }
-
-            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
-            Condition l_(Procedure THAProcedure) => MechanicalComplications;
-            IEnumerable<Condition> m_ = context.Operators.Select<Procedure, Condition>(k_, l_);
-            return m_;
-        }
-
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
-        bool? h_ = context.Operators.Exists<Condition>(g_);
-        return h_;
-    }
-
-
-    [CqlExpressionDefinition("Has More Than One Elective Primary Total Hip Arthroplasty Performed")]
-    public bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed, Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute);
-
-    private const long _cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed = -923175309866963357L;
-
-    private bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute(CqlContext context)
-    {
-        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-        IEnumerable<Procedure> b_(Procedure THAProcedure) {
-            CqlValueSet e_ = this.Primary_THA_Procedure(context);
-            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
-
-            bool? h_(Procedure ElectiveTHAProcedure) {
-                Id l_ = THAProcedure?.IdElement;
-                string m_ = l_?.Value;
-                Id n_ = ElectiveTHAProcedure?.IdElement;
-                string o_ = n_?.Value;
-                bool? p_ = context.Operators.Equivalent(m_, o_);
-                bool? q_ = context.Operators.Not(p_);
-
-                object r_() {
-
-                    bool ah_() {
-                        DataType al_ = ElectiveTHAProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        bool an_ = am_ is CqlDateTime;
-                        return an_;
-                    }
-
-
-                    bool ai_() {
-                        DataType ao_ = ElectiveTHAProcedure?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        bool aq_ = ap_ is CqlInterval<CqlDateTime>;
-                        return aq_;
-                    }
-
-
-                    bool aj_() {
-                        DataType ar_ = ElectiveTHAProcedure?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlQuantity;
-                        return at_;
-                    }
-
-
-                    bool ak_() {
-                        DataType au_ = ElectiveTHAProcedure?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlInterval<CqlQuantity>;
-                        return aw_;
-                    }
-
-                    if (ah_())
-                    {
-                        DataType ax_ = ElectiveTHAProcedure?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        return (ay_ as CqlDateTime) as object;
-                    }
-                    else if (ai_())
-                    {
-                        DataType az_ = ElectiveTHAProcedure?.Performed;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        return (ba_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aj_())
-                    {
-                        DataType bb_ = ElectiveTHAProcedure?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        return (bc_ as CqlQuantity) as object;
-                    }
-                    else if (ak_())
-                    {
-                        DataType bd_ = ElectiveTHAProcedure?.Performed;
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        return (be_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
-                CqlDateTime t_ = context.Operators.Start(s_);
-
-                object u_() {
-
-                    bool bf_() {
-                        DataType bj_ = THAProcedure?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        bool bl_ = bk_ is CqlDateTime;
-                        return bl_;
-                    }
-
-
-                    bool bg_() {
-                        DataType bm_ = THAProcedure?.Performed;
-                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                        bool bo_ = bn_ is CqlInterval<CqlDateTime>;
-                        return bo_;
-                    }
-
-
-                    bool bh_() {
-                        DataType bp_ = THAProcedure?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        bool br_ = bq_ is CqlQuantity;
-                        return br_;
-                    }
-
-
-                    bool bi_() {
-                        DataType bs_ = THAProcedure?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        bool bu_ = bt_ is CqlInterval<CqlQuantity>;
-                        return bu_;
-                    }
-
-                    if (bf_())
-                    {
-                        DataType bv_ = THAProcedure?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        return (bw_ as CqlDateTime) as object;
-                    }
-                    else if (bg_())
-                    {
-                        DataType bx_ = THAProcedure?.Performed;
-                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                        return (by_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (bh_())
-                    {
-                        DataType bz_ = THAProcedure?.Performed;
-                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                        return (ca_ as CqlQuantity) as object;
-                    }
-                    else if (bi_())
-                    {
-                        DataType cb_ = THAProcedure?.Performed;
-                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                        return (cc_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(1m, "year");
-                CqlDateTime y_ = context.Operators.Subtract(w_, x_);
-
-                object z_() {
-
-                    bool cd_() {
-                        DataType ch_ = THAProcedure?.Performed;
-                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                        bool cj_ = ci_ is CqlDateTime;
-                        return cj_;
-                    }
-
-
-                    bool ce_() {
-                        DataType ck_ = THAProcedure?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        bool cm_ = cl_ is CqlInterval<CqlDateTime>;
-                        return cm_;
-                    }
-
-
-                    bool cf_() {
-                        DataType cn_ = THAProcedure?.Performed;
-                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                        bool cp_ = co_ is CqlQuantity;
-                        return cp_;
-                    }
-
-
-                    bool cg_() {
-                        DataType cq_ = THAProcedure?.Performed;
-                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                        bool cs_ = cr_ is CqlInterval<CqlQuantity>;
-                        return cs_;
-                    }
-
-                    if (cd_())
-                    {
-                        DataType ct_ = THAProcedure?.Performed;
-                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                        return (cu_ as CqlDateTime) as object;
-                    }
-                    else if (ce_())
-                    {
-                        DataType cv_ = THAProcedure?.Performed;
-                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                        return (cw_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (cf_())
-                    {
-                        DataType cx_ = THAProcedure?.Performed;
-                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
-                        return (cy_ as CqlQuantity) as object;
-                    }
-                    else if (cg_())
-                    {
-                        DataType cz_ = THAProcedure?.Performed;
-                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
-                        return (da_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlDateTime ad_ = context.Operators.Add(ab_, x_);
-                CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(y_, ad_, true, true);
-                bool? af_ = context.Operators.In<CqlDateTime>(t_, ae_, "day");
-                bool? ag_ = context.Operators.And(q_, af_);
-                return ag_;
-            }
-
-            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
-            Procedure j_(Procedure ElectiveTHAProcedure) => THAProcedure;
-            IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
-            return k_;
-        }
-
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
         bool? d_ = context.Operators.Exists<Procedure>(c_);
         return d_;
     }
@@ -1984,66 +1978,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_HOOS_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentHOOS) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentHOOS, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentHOOS, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentHOOS, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentHOOS, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentHOOS, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentHOOS, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentHOOS, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentHOOS, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentHOOS) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_HOOS_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_HOOS_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentHOOS) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentHOOS);
+            bool? bl_(CqlDate FollowUpHipAssessmentHOOS) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentHOOS);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentHOOS) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2168,66 +2160,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_HOOSJr_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessment) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessment, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessment, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessment, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessment, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessment, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessment, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessment, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessment, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessment) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_HOOSJr_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_HOOSJr_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessment) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessment);
+            bool? bl_(CqlDate FollowUpHipAssessment) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessment);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessment) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2390,66 +2380,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_PROMIS10_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentPROMIS10) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentPROMIS10) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_PROMIS10_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_PROMIS10_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentPROMIS10) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentPROMIS10);
+            bool? bl_(CqlDate FollowUpHipAssessmentPROMIS10) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentPROMIS10);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentPROMIS10) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2612,66 +2600,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_VR12_Oblique_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentOblique) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentOblique, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentOblique, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentOblique, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentOblique, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentOblique, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentOblique, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentOblique, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentOblique, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentOblique) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_VR12_Oblique_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_VR12_Oblique_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentOblique) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOblique);
+            bool? bl_(CqlDate FollowUpHipAssessmentOblique) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOblique);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentOblique) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2834,66 +2820,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentOrthogonal) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentOrthogonal) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentOrthogonal) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOrthogonal);
+            bool? bl_(CqlDate FollowUpHipAssessmentOrthogonal) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOrthogonal);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentOrthogonal) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
@@ -136,238 +136,237 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> l_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? m_(Medication M) {
-                object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
-                string t_ = context.Operators.Last<string>(s_);
-                bool? u_ = context.Operators.Equal(q_, t_);
-                CodeableConcept v_ = M?.Code;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlValueSet x_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
-                bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
-                bool? z_ = context.Operators.And(u_, y_);
-                return z_;
+                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
+                string s_ = context.Operators.Last<string>(r_);
+                bool? t_ = context.Operators.Equal(p_, s_);
+                CodeableConcept u_ = M?.Code;
+                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
+                CqlValueSet w_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
+                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
+                bool? y_ = context.Operators.And(t_, x_);
+                return y_;
             }
 
             IEnumerable<Medication> n_ = context.Operators.Where<Medication>(l_, m_);
-            MedicationRequest o_(Medication M) => MR;
-            IEnumerable<MedicationRequest> p_ = context.Operators.Select<Medication, MedicationRequest>(n_, o_);
-            return p_;
+            bool? o_ = context.Operators.Exists<Medication>(n_);
+            return o_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest ADTActive) {
-            Code<MedicationRequest.MedicationrequestStatus> aa_ = ADTActive?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
-            string ac_ = context.Operators.Convert<string>(ab_);
-            string[] ad_ = [
+            Code<MedicationRequest.MedicationrequestStatus> z_ = ADTActive?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-            Code<MedicationRequest.MedicationRequestIntent> af_ = ADTActive?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-            string ah_ = context.Operators.Convert<string>(ag_);
-            string[] ai_ = [
+            bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            Code<MedicationRequest.MedicationRequestIntent> ae_ = ADTActive?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? af_ = ae_?.Value;
+            string ag_ = context.Operators.Convert<string>(af_);
+            string[] ah_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-            bool? ak_ = context.Operators.And(ae_, aj_);
-            return ak_;
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
+            bool? aj_ = context.Operators.And(ad_, ai_);
+            return aj_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 
         CqlDateTime i_(MedicationRequest ADTActive) {
-            List<Dosage> al_ = ADTActive?.DosageInstruction;
+            List<Dosage> ak_ = ADTActive?.DosageInstruction;
 
-            bool? am_(Dosage @this) {
-                Timing cn_ = @this?.Timing;
-                bool? co_ = context.Operators.Not((bool?)(cn_ is null));
+            bool? al_(Dosage @this) {
+                Timing cm_ = @this?.Timing;
+                bool? cn_ = context.Operators.Not((bool?)(cm_ is null));
+                return cn_;
+            }
+
+            IEnumerable<Dosage> am_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)ak_, al_);
+
+            Timing an_(Dosage @this) {
+                Timing co_ = @this?.Timing;
                 return co_;
             }
 
-            IEnumerable<Dosage> an_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)al_, am_);
+            IEnumerable<Timing> ao_ = context.Operators.Select<Dosage, Timing>(am_, an_);
 
-            Timing ao_(Dosage @this) {
-                Timing cp_ = @this?.Timing;
-                return cp_;
-            }
+            CqlDateTime ap_(Timing dosageTiming) {
+                List<FhirDateTime> cp_ = dosageTiming?.EventElement;
 
-            IEnumerable<Timing> ap_ = context.Operators.Select<Dosage, Timing>(an_, ao_);
+                string cq_(FhirDateTime @this) {
+                    string cw_ = @this?.Value;
+                    return cw_;
+                }
 
-            CqlDateTime aq_(Timing dosageTiming) {
-                List<FhirDateTime> cq_ = dosageTiming?.EventElement;
+                IEnumerable<string> cr_ = context.Operators.Select<FhirDateTime, string>((IEnumerable<FhirDateTime>)cp_, cq_);
 
-                string cr_(FhirDateTime @this) {
-                    string cx_ = @this?.Value;
+                CqlDateTime cs_(string @string) {
+                    CqlDateTime cx_ = context.Operators.ConvertStringToDateTime(@string);
                     return cx_;
                 }
 
-                IEnumerable<string> cs_ = context.Operators.Select<FhirDateTime, string>((IEnumerable<FhirDateTime>)cq_, cr_);
-
-                CqlDateTime ct_(string @string) {
-                    CqlDateTime cy_ = context.Operators.ConvertStringToDateTime(@string);
-                    return cy_;
-                }
-
-                IEnumerable<CqlDateTime> cu_ = context.Operators.Select<string, CqlDateTime>(cs_, ct_);
-                IEnumerable<CqlDateTime> cv_ = context.Operators.ListSort<CqlDateTime>(cu_, System.ComponentModel.ListSortDirection.Ascending);
-                CqlDateTime cw_ = context.Operators.First<CqlDateTime>(cv_);
-                return cw_;
+                IEnumerable<CqlDateTime> ct_ = context.Operators.Select<string, CqlDateTime>(cr_, cs_);
+                IEnumerable<CqlDateTime> cu_ = context.Operators.ListSort<CqlDateTime>(ct_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlDateTime cv_ = context.Operators.First<CqlDateTime>(cu_);
+                return cv_;
             }
 
-            IEnumerable<CqlDateTime> ar_ = context.Operators.Select<Timing, CqlDateTime>(ap_, aq_);
-            IEnumerable<CqlDateTime> as_ = context.Operators.Distinct<CqlDateTime>(ar_);
-            IEnumerable<CqlDateTime> at_ = context.Operators.ListSort<CqlDateTime>(as_, System.ComponentModel.ListSortDirection.Ascending);
-            CqlDateTime au_ = context.Operators.First<CqlDateTime>(at_);
+            IEnumerable<CqlDateTime> aq_ = context.Operators.Select<Timing, CqlDateTime>(ao_, ap_);
+            IEnumerable<CqlDateTime> ar_ = context.Operators.Distinct<CqlDateTime>(aq_);
+            IEnumerable<CqlDateTime> as_ = context.Operators.ListSort<CqlDateTime>(ar_, System.ComponentModel.ListSortDirection.Ascending);
+            CqlDateTime at_ = context.Operators.First<CqlDateTime>(as_);
 
-            bool? aw_(Dosage @this) {
-                Timing cz_ = @this?.Timing;
-                bool? da_ = context.Operators.Not((bool?)(cz_ is null));
+            bool? av_(Dosage @this) {
+                Timing cy_ = @this?.Timing;
+                bool? cz_ = context.Operators.Not((bool?)(cy_ is null));
+                return cz_;
+            }
+
+            IEnumerable<Dosage> aw_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)ak_, av_);
+
+            Timing ax_(Dosage @this) {
+                Timing da_ = @this?.Timing;
                 return da_;
             }
 
-            IEnumerable<Dosage> ax_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)al_, aw_);
+            IEnumerable<Timing> ay_ = context.Operators.Select<Dosage, Timing>(aw_, ax_);
 
-            Timing ay_(Dosage @this) {
-                Timing db_ = @this?.Timing;
-                return db_;
+            bool? az_(Timing @this) {
+                Timing.RepeatComponent db_ = @this?.Repeat;
+                bool? dc_ = context.Operators.Not((bool?)(db_ is null));
+                return dc_;
             }
 
-            IEnumerable<Timing> az_ = context.Operators.Select<Dosage, Timing>(ax_, ay_);
+            IEnumerable<Timing> ba_ = context.Operators.Where<Timing>(ay_, az_);
 
-            bool? ba_(Timing @this) {
-                Timing.RepeatComponent dc_ = @this?.Repeat;
-                bool? dd_ = context.Operators.Not((bool?)(dc_ is null));
+            Timing.RepeatComponent bb_(Timing @this) {
+                Timing.RepeatComponent dd_ = @this?.Repeat;
                 return dd_;
             }
 
-            IEnumerable<Timing> bb_ = context.Operators.Where<Timing>(az_, ba_);
+            IEnumerable<Timing.RepeatComponent> bc_ = context.Operators.Select<Timing, Timing.RepeatComponent>(ba_, bb_);
 
-            Timing.RepeatComponent bc_(Timing @this) {
-                Timing.RepeatComponent de_ = @this?.Repeat;
-                return de_;
+            bool? bd_(Timing.RepeatComponent @this) {
+                DataType de_ = @this?.Bounds;
+                object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                bool? dg_ = context.Operators.Not((bool?)(df_ is null));
+                return dg_;
             }
 
-            IEnumerable<Timing.RepeatComponent> bd_ = context.Operators.Select<Timing, Timing.RepeatComponent>(bb_, bc_);
+            IEnumerable<Timing.RepeatComponent> be_ = context.Operators.Where<Timing.RepeatComponent>(bc_, bd_);
 
-            bool? be_(Timing.RepeatComponent @this) {
-                DataType df_ = @this?.Bounds;
-                object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                bool? dh_ = context.Operators.Not((bool?)(dg_ is null));
-                return dh_;
+            object bf_(Timing.RepeatComponent @this) {
+                DataType dh_ = @this?.Bounds;
+                object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+                return di_;
             }
 
-            IEnumerable<Timing.RepeatComponent> bf_ = context.Operators.Where<Timing.RepeatComponent>(bd_, be_);
+            IEnumerable<object> bg_ = context.Operators.Select<Timing.RepeatComponent, object>(be_, bf_);
 
-            object bg_(Timing.RepeatComponent @this) {
-                DataType di_ = @this?.Bounds;
-                object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+            CqlInterval<CqlDateTime> bh_(object DoseTime) {
+                CqlInterval<CqlDateTime> dj_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
                 return dj_;
             }
 
-            IEnumerable<object> bh_ = context.Operators.Select<Timing.RepeatComponent, object>(bf_, bg_);
+            IEnumerable<CqlInterval<CqlDateTime>> bi_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bg_, bh_);
+            IEnumerable<CqlInterval<CqlDateTime>> bj_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bi_);
+            IEnumerable<CqlInterval<CqlDateTime>> bk_ = context.Operators.Collapse(bj_, (string)default);
 
-            CqlInterval<CqlDateTime> bi_(object DoseTime) {
-                CqlInterval<CqlDateTime> dk_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+            object bl_(CqlInterval<CqlDateTime> @this) {
+                CqlDateTime dk_ = context.Operators.Start(@this);
                 return dk_;
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> bj_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bh_, bi_);
-            IEnumerable<CqlInterval<CqlDateTime>> bk_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bj_);
-            IEnumerable<CqlInterval<CqlDateTime>> bl_ = context.Operators.Collapse(bk_, (string)default);
+            IEnumerable<CqlInterval<CqlDateTime>> bm_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(bk_, bl_, System.ComponentModel.ListSortDirection.Ascending);
+            CqlInterval<CqlDateTime> bn_ = context.Operators.First<CqlInterval<CqlDateTime>>(bm_);
+            CqlDateTime bo_ = context.Operators.Start(bn_);
 
-            object bm_(CqlInterval<CqlDateTime> @this) {
-                CqlDateTime dl_ = context.Operators.Start(@this);
-                return dl_;
+            bool? bq_(Dosage @this) {
+                Timing dl_ = @this?.Timing;
+                bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
+                return dm_;
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> bn_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(bl_, bm_, System.ComponentModel.ListSortDirection.Ascending);
-            CqlInterval<CqlDateTime> bo_ = context.Operators.First<CqlInterval<CqlDateTime>>(bn_);
-            CqlDateTime bp_ = context.Operators.Start(bo_);
+            IEnumerable<Dosage> br_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)ak_, bq_);
 
-            bool? br_(Dosage @this) {
-                Timing dm_ = @this?.Timing;
-                bool? dn_ = context.Operators.Not((bool?)(dm_ is null));
+            Timing bs_(Dosage @this) {
+                Timing dn_ = @this?.Timing;
                 return dn_;
             }
 
-            IEnumerable<Dosage> bs_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)al_, br_);
+            IEnumerable<Timing> bt_ = context.Operators.Select<Dosage, Timing>(br_, bs_);
 
-            Timing bt_(Dosage @this) {
-                Timing do_ = @this?.Timing;
-                return do_;
+            bool? bu_(Timing @this) {
+                Timing.RepeatComponent do_ = @this?.Repeat;
+                bool? dp_ = context.Operators.Not((bool?)(do_ is null));
+                return dp_;
             }
 
-            IEnumerable<Timing> bu_ = context.Operators.Select<Dosage, Timing>(bs_, bt_);
+            IEnumerable<Timing> bv_ = context.Operators.Where<Timing>(bt_, bu_);
 
-            bool? bv_(Timing @this) {
-                Timing.RepeatComponent dp_ = @this?.Repeat;
-                bool? dq_ = context.Operators.Not((bool?)(dp_ is null));
+            Timing.RepeatComponent bw_(Timing @this) {
+                Timing.RepeatComponent dq_ = @this?.Repeat;
                 return dq_;
             }
 
-            IEnumerable<Timing> bw_ = context.Operators.Where<Timing>(bu_, bv_);
+            IEnumerable<Timing.RepeatComponent> bx_ = context.Operators.Select<Timing, Timing.RepeatComponent>(bv_, bw_);
 
-            Timing.RepeatComponent bx_(Timing @this) {
-                Timing.RepeatComponent dr_ = @this?.Repeat;
-                return dr_;
+            bool? by_(Timing.RepeatComponent @this) {
+                DataType dr_ = @this?.Bounds;
+                object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                bool? dt_ = context.Operators.Not((bool?)(ds_ is null));
+                return dt_;
             }
 
-            IEnumerable<Timing.RepeatComponent> by_ = context.Operators.Select<Timing, Timing.RepeatComponent>(bw_, bx_);
+            IEnumerable<Timing.RepeatComponent> bz_ = context.Operators.Where<Timing.RepeatComponent>(bx_, by_);
 
-            bool? bz_(Timing.RepeatComponent @this) {
-                DataType ds_ = @this?.Bounds;
-                object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
-                bool? du_ = context.Operators.Not((bool?)(dt_ is null));
-                return du_;
+            object ca_(Timing.RepeatComponent @this) {
+                DataType du_ = @this?.Bounds;
+                object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
+                return dv_;
             }
 
-            IEnumerable<Timing.RepeatComponent> ca_ = context.Operators.Where<Timing.RepeatComponent>(by_, bz_);
+            IEnumerable<object> cb_ = context.Operators.Select<Timing.RepeatComponent, object>(bz_, ca_);
 
-            object cb_(Timing.RepeatComponent @this) {
-                DataType dv_ = @this?.Bounds;
-                object dw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dv_);
+            CqlInterval<CqlDateTime> cc_(object DoseTime) {
+                CqlInterval<CqlDateTime> dw_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
                 return dw_;
             }
 
-            IEnumerable<object> cc_ = context.Operators.Select<Timing.RepeatComponent, object>(ca_, cb_);
+            IEnumerable<CqlInterval<CqlDateTime>> cd_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(cb_, cc_);
+            IEnumerable<CqlInterval<CqlDateTime>> ce_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(cd_);
+            IEnumerable<CqlInterval<CqlDateTime>> cf_ = context.Operators.Collapse(ce_, (string)default);
 
-            CqlInterval<CqlDateTime> cd_(object DoseTime) {
-                CqlInterval<CqlDateTime> dx_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+            object cg_(CqlInterval<CqlDateTime> @this) {
+                CqlDateTime dx_ = context.Operators.Start(@this);
                 return dx_;
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> ce_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(cc_, cd_);
-            IEnumerable<CqlInterval<CqlDateTime>> cf_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(ce_);
-            IEnumerable<CqlInterval<CqlDateTime>> cg_ = context.Operators.Collapse(cf_, (string)default);
-
-            object ch_(CqlInterval<CqlDateTime> @this) {
-                CqlDateTime dy_ = context.Operators.Start(@this);
-                return dy_;
-            }
-
-            IEnumerable<CqlInterval<CqlDateTime>> ci_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(cg_, ch_, System.ComponentModel.ListSortDirection.Ascending);
-            CqlInterval<CqlDateTime> cj_ = context.Operators.First<CqlInterval<CqlDateTime>>(ci_);
-            CqlDateTime ck_ = context.Operators.End(cj_);
-            CqlDateTime[] cl_ = [
-                au_,
-                bp_,
-                ck_,
+            IEnumerable<CqlInterval<CqlDateTime>> ch_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(cf_, cg_, System.ComponentModel.ListSortDirection.Ascending);
+            CqlInterval<CqlDateTime> ci_ = context.Operators.First<CqlInterval<CqlDateTime>>(ch_);
+            CqlDateTime cj_ = context.Operators.End(ci_);
+            CqlDateTime[] ck_ = [
+                at_,
+                bo_,
+                cj_,
             ];
-            CqlDateTime cm_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)cl_);
-            return cm_;
+            CqlDateTime cl_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)ck_);
+            return cl_;
         }
 
         IEnumerable<CqlDateTime> j_ = context.Operators.Select<MedicationRequest, CqlDateTime>(h_, i_);
@@ -388,199 +387,198 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> l_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? m_(Medication M) {
-                object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
-                string t_ = context.Operators.Last<string>(s_);
-                bool? u_ = context.Operators.Equal(q_, t_);
-                CodeableConcept v_ = M?.Code;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlValueSet x_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
-                bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
-                bool? z_ = context.Operators.And(u_, y_);
-                return z_;
+                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
+                string s_ = context.Operators.Last<string>(r_);
+                bool? t_ = context.Operators.Equal(p_, s_);
+                CodeableConcept u_ = M?.Code;
+                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
+                CqlValueSet w_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
+                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
+                bool? y_ = context.Operators.And(t_, x_);
+                return y_;
             }
 
             IEnumerable<Medication> n_ = context.Operators.Where<Medication>(l_, m_);
-            MedicationRequest o_(Medication M) => MR;
-            IEnumerable<MedicationRequest> p_ = context.Operators.Select<Medication, MedicationRequest>(n_, o_);
-            return p_;
+            bool? o_ = context.Operators.Exists<Medication>(n_);
+            return o_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
         bool? g_(MedicationRequest ADTOrder) {
-            Code<MedicationRequest.MedicationrequestStatus> aa_ = ADTOrder?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
-            string ac_ = context.Operators.Convert<string>(ab_);
-            string[] ad_ = [
+            Code<MedicationRequest.MedicationrequestStatus> z_ = ADTOrder?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-            Code<MedicationRequest.MedicationRequestIntent> af_ = ADTOrder?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-            string ah_ = context.Operators.Convert<string>(ag_);
-            string[] ai_ = [
+            bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            Code<MedicationRequest.MedicationRequestIntent> ae_ = ADTOrder?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? af_ = ae_?.Value;
+            string ag_ = context.Operators.Convert<string>(af_);
+            string[] ah_ = [
                 "order",
                 "original-order",
                 "reflex-order",
                 "filler-order",
                 "instance-order",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-            bool? ak_ = context.Operators.And(ae_, aj_);
-            return ak_;
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
+            bool? aj_ = context.Operators.And(ad_, ai_);
+            return aj_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 
         CqlDateTime i_(MedicationRequest ADTOrder) {
-            FhirDateTime al_ = ADTOrder?.AuthoredOnElement;
-            CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
-            List<Dosage> an_ = ADTOrder?.DosageInstruction;
+            FhirDateTime ak_ = ADTOrder?.AuthoredOnElement;
+            CqlDateTime al_ = context.Operators.Convert<CqlDateTime>(ak_);
+            List<Dosage> am_ = ADTOrder?.DosageInstruction;
 
-            bool? ao_(Dosage @this) {
-                Timing cf_ = @this?.Timing;
-                bool? cg_ = context.Operators.Not((bool?)(cf_ is null));
+            bool? an_(Dosage @this) {
+                Timing ce_ = @this?.Timing;
+                bool? cf_ = context.Operators.Not((bool?)(ce_ is null));
+                return cf_;
+            }
+
+            IEnumerable<Dosage> ao_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)am_, an_);
+
+            Timing ap_(Dosage @this) {
+                Timing cg_ = @this?.Timing;
                 return cg_;
             }
 
-            IEnumerable<Dosage> ap_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)an_, ao_);
+            IEnumerable<Timing> aq_ = context.Operators.Select<Dosage, Timing>(ao_, ap_);
 
-            Timing aq_(Dosage @this) {
-                Timing ch_ = @this?.Timing;
-                return ch_;
+            bool? ar_(Timing @this) {
+                Timing.RepeatComponent ch_ = @this?.Repeat;
+                bool? ci_ = context.Operators.Not((bool?)(ch_ is null));
+                return ci_;
             }
 
-            IEnumerable<Timing> ar_ = context.Operators.Select<Dosage, Timing>(ap_, aq_);
+            IEnumerable<Timing> as_ = context.Operators.Where<Timing>(aq_, ar_);
 
-            bool? as_(Timing @this) {
-                Timing.RepeatComponent ci_ = @this?.Repeat;
-                bool? cj_ = context.Operators.Not((bool?)(ci_ is null));
+            Timing.RepeatComponent at_(Timing @this) {
+                Timing.RepeatComponent cj_ = @this?.Repeat;
                 return cj_;
             }
 
-            IEnumerable<Timing> at_ = context.Operators.Where<Timing>(ar_, as_);
+            IEnumerable<Timing.RepeatComponent> au_ = context.Operators.Select<Timing, Timing.RepeatComponent>(as_, at_);
 
-            Timing.RepeatComponent au_(Timing @this) {
-                Timing.RepeatComponent ck_ = @this?.Repeat;
-                return ck_;
+            bool? av_(Timing.RepeatComponent @this) {
+                DataType ck_ = @this?.Bounds;
+                object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+                bool? cm_ = context.Operators.Not((bool?)(cl_ is null));
+                return cm_;
             }
 
-            IEnumerable<Timing.RepeatComponent> av_ = context.Operators.Select<Timing, Timing.RepeatComponent>(at_, au_);
+            IEnumerable<Timing.RepeatComponent> aw_ = context.Operators.Where<Timing.RepeatComponent>(au_, av_);
 
-            bool? aw_(Timing.RepeatComponent @this) {
-                DataType cl_ = @this?.Bounds;
-                object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                bool? cn_ = context.Operators.Not((bool?)(cm_ is null));
-                return cn_;
+            object ax_(Timing.RepeatComponent @this) {
+                DataType cn_ = @this?.Bounds;
+                object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+                return co_;
             }
 
-            IEnumerable<Timing.RepeatComponent> ax_ = context.Operators.Where<Timing.RepeatComponent>(av_, aw_);
+            IEnumerable<object> ay_ = context.Operators.Select<Timing.RepeatComponent, object>(aw_, ax_);
 
-            object ay_(Timing.RepeatComponent @this) {
-                DataType co_ = @this?.Bounds;
-                object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+            CqlInterval<CqlDateTime> az_(object DoseTime) {
+                CqlInterval<CqlDateTime> cp_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
                 return cp_;
             }
 
-            IEnumerable<object> az_ = context.Operators.Select<Timing.RepeatComponent, object>(ax_, ay_);
+            IEnumerable<CqlInterval<CqlDateTime>> ba_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(ay_, az_);
+            IEnumerable<CqlInterval<CqlDateTime>> bb_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(ba_);
+            IEnumerable<CqlInterval<CqlDateTime>> bc_ = context.Operators.Collapse(bb_, (string)default);
 
-            CqlInterval<CqlDateTime> ba_(object DoseTime) {
-                CqlInterval<CqlDateTime> cq_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+            object bd_(CqlInterval<CqlDateTime> @this) {
+                CqlDateTime cq_ = context.Operators.Start(@this);
                 return cq_;
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> bb_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(az_, ba_);
-            IEnumerable<CqlInterval<CqlDateTime>> bc_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bb_);
-            IEnumerable<CqlInterval<CqlDateTime>> bd_ = context.Operators.Collapse(bc_, (string)default);
+            IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(bc_, bd_, System.ComponentModel.ListSortDirection.Ascending);
+            CqlInterval<CqlDateTime> bf_ = context.Operators.First<CqlInterval<CqlDateTime>>(be_);
+            CqlDateTime bg_ = context.Operators.Start(bf_);
 
-            object be_(CqlInterval<CqlDateTime> @this) {
-                CqlDateTime cr_ = context.Operators.Start(@this);
-                return cr_;
+            bool? bi_(Dosage @this) {
+                Timing cr_ = @this?.Timing;
+                bool? cs_ = context.Operators.Not((bool?)(cr_ is null));
+                return cs_;
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> bf_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(bd_, be_, System.ComponentModel.ListSortDirection.Ascending);
-            CqlInterval<CqlDateTime> bg_ = context.Operators.First<CqlInterval<CqlDateTime>>(bf_);
-            CqlDateTime bh_ = context.Operators.Start(bg_);
+            IEnumerable<Dosage> bj_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)am_, bi_);
 
-            bool? bj_(Dosage @this) {
-                Timing cs_ = @this?.Timing;
-                bool? ct_ = context.Operators.Not((bool?)(cs_ is null));
+            Timing bk_(Dosage @this) {
+                Timing ct_ = @this?.Timing;
                 return ct_;
             }
 
-            IEnumerable<Dosage> bk_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)an_, bj_);
+            IEnumerable<Timing> bl_ = context.Operators.Select<Dosage, Timing>(bj_, bk_);
 
-            Timing bl_(Dosage @this) {
-                Timing cu_ = @this?.Timing;
-                return cu_;
+            bool? bm_(Timing @this) {
+                Timing.RepeatComponent cu_ = @this?.Repeat;
+                bool? cv_ = context.Operators.Not((bool?)(cu_ is null));
+                return cv_;
             }
 
-            IEnumerable<Timing> bm_ = context.Operators.Select<Dosage, Timing>(bk_, bl_);
+            IEnumerable<Timing> bn_ = context.Operators.Where<Timing>(bl_, bm_);
 
-            bool? bn_(Timing @this) {
-                Timing.RepeatComponent cv_ = @this?.Repeat;
-                bool? cw_ = context.Operators.Not((bool?)(cv_ is null));
+            Timing.RepeatComponent bo_(Timing @this) {
+                Timing.RepeatComponent cw_ = @this?.Repeat;
                 return cw_;
             }
 
-            IEnumerable<Timing> bo_ = context.Operators.Where<Timing>(bm_, bn_);
+            IEnumerable<Timing.RepeatComponent> bp_ = context.Operators.Select<Timing, Timing.RepeatComponent>(bn_, bo_);
 
-            Timing.RepeatComponent bp_(Timing @this) {
-                Timing.RepeatComponent cx_ = @this?.Repeat;
-                return cx_;
+            bool? bq_(Timing.RepeatComponent @this) {
+                DataType cx_ = @this?.Bounds;
+                object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
+                bool? cz_ = context.Operators.Not((bool?)(cy_ is null));
+                return cz_;
             }
 
-            IEnumerable<Timing.RepeatComponent> bq_ = context.Operators.Select<Timing, Timing.RepeatComponent>(bo_, bp_);
+            IEnumerable<Timing.RepeatComponent> br_ = context.Operators.Where<Timing.RepeatComponent>(bp_, bq_);
 
-            bool? br_(Timing.RepeatComponent @this) {
-                DataType cy_ = @this?.Bounds;
-                object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
-                bool? da_ = context.Operators.Not((bool?)(cz_ is null));
-                return da_;
+            object bs_(Timing.RepeatComponent @this) {
+                DataType da_ = @this?.Bounds;
+                object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
+                return db_;
             }
 
-            IEnumerable<Timing.RepeatComponent> bs_ = context.Operators.Where<Timing.RepeatComponent>(bq_, br_);
+            IEnumerable<object> bt_ = context.Operators.Select<Timing.RepeatComponent, object>(br_, bs_);
 
-            object bt_(Timing.RepeatComponent @this) {
-                DataType db_ = @this?.Bounds;
-                object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+            CqlInterval<CqlDateTime> bu_(object DoseTime) {
+                CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
                 return dc_;
             }
 
-            IEnumerable<object> bu_ = context.Operators.Select<Timing.RepeatComponent, object>(bs_, bt_);
+            IEnumerable<CqlInterval<CqlDateTime>> bv_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bt_, bu_);
+            IEnumerable<CqlInterval<CqlDateTime>> bw_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bv_);
+            IEnumerable<CqlInterval<CqlDateTime>> bx_ = context.Operators.Collapse(bw_, (string)default);
 
-            CqlInterval<CqlDateTime> bv_(object DoseTime) {
-                CqlInterval<CqlDateTime> dd_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+            object by_(CqlInterval<CqlDateTime> @this) {
+                CqlDateTime dd_ = context.Operators.Start(@this);
                 return dd_;
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> bw_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bu_, bv_);
-            IEnumerable<CqlInterval<CqlDateTime>> bx_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bw_);
-            IEnumerable<CqlInterval<CqlDateTime>> by_ = context.Operators.Collapse(bx_, (string)default);
-
-            object bz_(CqlInterval<CqlDateTime> @this) {
-                CqlDateTime de_ = context.Operators.Start(@this);
-                return de_;
-            }
-
-            IEnumerable<CqlInterval<CqlDateTime>> ca_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(by_, bz_, System.ComponentModel.ListSortDirection.Ascending);
-            CqlInterval<CqlDateTime> cb_ = context.Operators.First<CqlInterval<CqlDateTime>>(ca_);
-            CqlDateTime cc_ = context.Operators.End(cb_);
-            CqlDateTime[] cd_ = [
-                am_,
-                bh_,
-                cc_,
+            IEnumerable<CqlInterval<CqlDateTime>> bz_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(bx_, by_, System.ComponentModel.ListSortDirection.Ascending);
+            CqlInterval<CqlDateTime> ca_ = context.Operators.First<CqlInterval<CqlDateTime>>(bz_);
+            CqlDateTime cb_ = context.Operators.End(ca_);
+            CqlDateTime[] cc_ = [
+                al_,
+                bg_,
+                cb_,
             ];
-            CqlDateTime ce_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)cd_);
-            return ce_;
+            CqlDateTime cd_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)cc_);
+            return cd_;
         }
 
         IEnumerable<CqlDateTime> j_ = context.Operators.Select<MedicationRequest, CqlDateTime>(h_, i_);
@@ -659,32 +657,31 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<CqlDateTime> b_ = this.Androgen_Deprivation_Therapy_for_Urology_Care_Medication_Order_Start_Dates(context);
         IEnumerable<CqlDateTime> c_ = context.Operators.Union<CqlDateTime>(a_, b_);
 
-        IEnumerable<CqlDateTime> d_(CqlDateTime ADTDateTime) {
+        bool? d_(CqlDateTime ADTDateTime) {
             IEnumerable<Condition> h_ = this.Prostate_Cancer_Diagnosis(context);
 
             bool? i_(Condition ProstateCancer) {
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ProstateCancer);
-                bool? n_ = context.Operators.In<CqlDateTime>(ADTDateTime, m_, "day");
-                CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
-                CqlDateTime p_ = context.Operators.Start(o_);
-                CqlQuantity q_ = context.Operators.Quantity(3m, "months");
-                CqlDateTime r_ = context.Operators.Subtract(p_, q_);
-                CqlDateTime t_ = context.Operators.Start(o_);
-                CqlQuantity u_ = context.Operators.Quantity(9m, "months");
-                CqlDateTime v_ = context.Operators.Add(t_, u_);
-                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(r_, v_, true, true);
-                bool? x_ = context.Operators.In<CqlDateTime>(ADTDateTime, w_, "day");
-                bool? y_ = context.Operators.And(n_, x_);
-                return y_;
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ProstateCancer);
+                bool? m_ = context.Operators.In<CqlDateTime>(ADTDateTime, l_, "day");
+                CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
+                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlQuantity p_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime q_ = context.Operators.Subtract(o_, p_);
+                CqlDateTime s_ = context.Operators.Start(n_);
+                CqlQuantity t_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime u_ = context.Operators.Add(s_, t_);
+                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(q_, u_, true, true);
+                bool? w_ = context.Operators.In<CqlDateTime>(ADTDateTime, v_, "day");
+                bool? x_ = context.Operators.And(m_, w_);
+                return x_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
-            CqlDateTime k_(Condition ProstateCancer) => ADTDateTime;
-            IEnumerable<CqlDateTime> l_ = context.Operators.Select<Condition, CqlDateTime>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<CqlDateTime> e_ = context.Operators.SelectMany<CqlDateTime, CqlDateTime>(c_, d_);
+        IEnumerable<CqlDateTime> e_ = context.Operators.Where<CqlDateTime>(c_, d_);
         IEnumerable<CqlDateTime> f_ = context.Operators.ListSort<CqlDateTime>(e_, System.ComponentModel.ListSortDirection.Ascending);
         CqlDateTime g_ = context.Operators.First<CqlDateTime>(f_);
         return g_;
@@ -703,52 +700,51 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<ServiceRequest> c_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
-        IEnumerable<ServiceRequest> d_(ServiceRequest OrderTwelveMonthADT) {
+        bool? d_(ServiceRequest OrderTwelveMonthADT) {
             CqlDateTime f_ = this.First_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
             CqlDateTime[] g_ = [
                 f_,
             ];
 
             bool? h_(CqlDateTime FirstADTMP) {
-                FhirDateTime l_ = OrderTwelveMonthADT?.AuthoredOnElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                bool? n_ = context.Operators.SameOrAfter(m_, FirstADTMP, "day");
-                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(l_);
-                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(3m, "months");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-                CqlDateTime v_ = context.Operators.Start(q_);
-                CqlQuantity w_ = context.Operators.Quantity(9m, "months");
-                CqlDateTime x_ = context.Operators.Add(v_, w_);
-                CqlInterval<CqlDateTime> y_ = context.Operators.Interval(t_, x_, true, true);
-                bool? z_ = context.Operators.In<CqlDateTime>(p_, y_, "day");
-                bool? aa_ = context.Operators.And(n_, z_);
-                Code<RequestStatus> ab_ = OrderTwelveMonthADT?.StatusElement;
-                RequestStatus? ac_ = ab_?.Value;
-                Code<RequestStatus> ad_ = context.Operators.Convert<Code<RequestStatus>>(ac_);
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                FhirDateTime k_ = OrderTwelveMonthADT?.AuthoredOnElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                bool? m_ = context.Operators.SameOrAfter(l_, FirstADTMP, "day");
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(k_);
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlQuantity r_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlDateTime u_ = context.Operators.Start(p_);
+                CqlQuantity v_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime w_ = context.Operators.Add(u_, v_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(s_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                bool? z_ = context.Operators.And(m_, y_);
+                Code<RequestStatus> aa_ = OrderTwelveMonthADT?.StatusElement;
+                RequestStatus? ab_ = aa_?.Value;
+                Code<RequestStatus> ac_ = context.Operators.Convert<Code<RequestStatus>>(ab_);
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                bool? ah_ = context.Operators.And(aa_, ag_);
-                Code<RequestIntent> ai_ = OrderTwelveMonthADT?.IntentElement;
-                RequestIntent? aj_ = ai_?.Value;
-                Code<RequestIntent> ak_ = context.Operators.Convert<Code<RequestIntent>>(aj_);
-                bool? al_ = context.Operators.Equal(ak_, "order");
-                bool? am_ = context.Operators.And(ah_, al_);
-                return am_;
+                bool? af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                bool? ag_ = context.Operators.And(z_, af_);
+                Code<RequestIntent> ah_ = OrderTwelveMonthADT?.IntentElement;
+                RequestIntent? ai_ = ah_?.Value;
+                Code<RequestIntent> aj_ = context.Operators.Convert<Code<RequestIntent>>(ai_);
+                bool? ak_ = context.Operators.Equal(aj_, "order");
+                bool? al_ = context.Operators.And(ag_, ak_);
+                return al_;
             }
 
             IEnumerable<CqlDateTime> i_ = context.Operators.Where<CqlDateTime>((IEnumerable<CqlDateTime>)g_, h_);
-            ServiceRequest j_(CqlDateTime FirstADTMP) => OrderTwelveMonthADT;
-            IEnumerable<ServiceRequest> k_ = context.Operators.Select<CqlDateTime, ServiceRequest>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<CqlDateTime>(i_);
+            return j_;
         }
 
-        IEnumerable<ServiceRequest> e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
+        IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
         return e_;
     }
 
@@ -793,118 +789,116 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.DEXA_Bone_Density_for_Urology_Care(context);
         IEnumerable<ServiceRequest> b_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
-        IEnumerable<ServiceRequest> c_(ServiceRequest DEXAOrdered) {
+        bool? c_(ServiceRequest DEXAOrdered) {
             IEnumerable<ServiceRequest> o_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
 
             bool? p_(ServiceRequest OrderTwelveMonthsADT) {
-                FhirDateTime t_ = DEXAOrdered?.AuthoredOnElement;
-                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
-                FhirDateTime v_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(v_);
-                CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(v_);
-                CqlQuantity z_ = context.Operators.Quantity(3m, "months");
-                CqlDateTime aa_ = context.Operators.Add(y_, z_);
-                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(w_, aa_, true, true);
-                bool? ac_ = context.Operators.In<CqlDateTime>(u_, ab_, "day");
-                CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(v_);
-                bool? af_ = context.Operators.Not((bool?)(ae_ is null));
-                bool? ag_ = context.Operators.And(ac_, af_);
-                CqlDateTime ai_ = context.Operators.Convert<CqlDateTime>(t_);
-                CqlDateTime ak_ = context.Operators.Convert<CqlDateTime>(v_);
-                CqlQuantity al_ = context.Operators.Quantity(2m, "years");
-                CqlDateTime am_ = context.Operators.Subtract(ak_, al_);
-                CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(v_);
-                CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(am_, ao_, true, false);
-                bool? aq_ = context.Operators.In<CqlDateTime>(ai_, ap_, "day");
-                CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(v_);
-                bool? at_ = context.Operators.Not((bool?)(as_ is null));
-                bool? au_ = context.Operators.And(aq_, at_);
-                bool? av_ = context.Operators.Or(ag_, au_);
-                return av_;
+                FhirDateTime s_ = DEXAOrdered?.AuthoredOnElement;
+                CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
+                FhirDateTime u_ = OrderTwelveMonthsADT?.AuthoredOnElement;
+                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(u_);
+                CqlQuantity y_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime z_ = context.Operators.Add(x_, y_);
+                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(v_, z_, true, true);
+                bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, "day");
+                CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(u_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(ab_, ae_);
+                CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(s_);
+                CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(u_);
+                CqlQuantity ak_ = context.Operators.Quantity(2m, "years");
+                CqlDateTime al_ = context.Operators.Subtract(aj_, ak_);
+                CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(u_);
+                CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(al_, an_, true, false);
+                bool? ap_ = context.Operators.In<CqlDateTime>(ah_, ao_, "day");
+                CqlDateTime ar_ = context.Operators.Convert<CqlDateTime>(u_);
+                bool? as_ = context.Operators.Not((bool?)(ar_ is null));
+                bool? at_ = context.Operators.And(ap_, as_);
+                bool? au_ = context.Operators.Or(af_, at_);
+                return au_;
             }
 
             IEnumerable<ServiceRequest> q_ = context.Operators.Where<ServiceRequest>(o_, p_);
-            ServiceRequest r_(ServiceRequest OrderTwelveMonthsADT) => DEXAOrdered;
-            IEnumerable<ServiceRequest> s_ = context.Operators.Select<ServiceRequest, ServiceRequest>(q_, r_);
-            return s_;
+            bool? r_ = context.Operators.Exists<ServiceRequest>(q_);
+            return r_;
         }
 
-        IEnumerable<ServiceRequest> d_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(b_, c_);
+        IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
 
         bool? e_(ServiceRequest DEXAOrdered) {
-            Code<RequestStatus> aw_ = DEXAOrdered?.StatusElement;
-            RequestStatus? ax_ = aw_?.Value;
-            Code<RequestStatus> ay_ = context.Operators.Convert<Code<RequestStatus>>(ax_);
-            string az_ = context.Operators.Convert<string>(ay_);
-            string[] ba_ = [
+            Code<RequestStatus> av_ = DEXAOrdered?.StatusElement;
+            RequestStatus? aw_ = av_?.Value;
+            Code<RequestStatus> ax_ = context.Operators.Convert<Code<RequestStatus>>(aw_);
+            string ay_ = context.Operators.Convert<string>(ax_);
+            string[] az_ = [
                 "active",
                 "completed",
             ];
-            bool? bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
-            Code<RequestIntent> bc_ = DEXAOrdered?.IntentElement;
-            RequestIntent? bd_ = bc_?.Value;
-            Code<RequestIntent> be_ = context.Operators.Convert<Code<RequestIntent>>(bd_);
-            bool? bf_ = context.Operators.Equal(be_, "order");
-            bool? bg_ = context.Operators.And(bb_, bf_);
-            return bg_;
+            bool? ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+            Code<RequestIntent> bb_ = DEXAOrdered?.IntentElement;
+            RequestIntent? bc_ = bb_?.Value;
+            Code<RequestIntent> bd_ = context.Operators.Convert<Code<RequestIntent>>(bc_);
+            bool? be_ = context.Operators.Equal(bd_, "order");
+            bool? bf_ = context.Operators.And(ba_, be_);
+            return bf_;
         }
 
         IEnumerable<ServiceRequest> f_ = context.Operators.Where<ServiceRequest>(d_, e_);
         IEnumerable<Observation> h_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
-        IEnumerable<Observation> i_(Observation DEXAPerformed) {
-            IEnumerable<ServiceRequest> bh_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
+        bool? i_(Observation DEXAPerformed) {
+            IEnumerable<ServiceRequest> bg_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
 
-            bool? bi_(ServiceRequest OrderTwelveMonthsADT) {
-                DataType bm_ = DEXAPerformed?.Effective;
-                object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                CqlInterval<CqlDateTime> bo_ = QICoreCommon_4_0_000.Instance.toInterval(context, bn_);
-                CqlDateTime bp_ = context.Operators.Start(bo_);
-                FhirDateTime bq_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                CqlDateTime br_ = context.Operators.Convert<CqlDateTime>(bq_);
-                CqlDateTime bt_ = context.Operators.Convert<CqlDateTime>(bq_);
-                CqlQuantity bu_ = context.Operators.Quantity(3m, "months");
-                CqlDateTime bv_ = context.Operators.Add(bt_, bu_);
-                CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(br_, bv_, true, true);
-                bool? bx_ = context.Operators.In<CqlDateTime>(bp_, bw_, "day");
-                CqlDateTime bz_ = context.Operators.Convert<CqlDateTime>(bq_);
-                bool? ca_ = context.Operators.Not((bool?)(bz_ is null));
-                bool? cb_ = context.Operators.And(bx_, ca_);
-                object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.toInterval(context, cd_);
-                CqlDateTime cf_ = context.Operators.End(ce_);
-                CqlDateTime ch_ = context.Operators.Convert<CqlDateTime>(bq_);
-                CqlQuantity ci_ = context.Operators.Quantity(2m, "years");
-                CqlDateTime cj_ = context.Operators.Subtract(ch_, ci_);
-                CqlDateTime cl_ = context.Operators.Convert<CqlDateTime>(bq_);
-                CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(cj_, cl_, true, false);
-                bool? cn_ = context.Operators.In<CqlDateTime>(cf_, cm_, "day");
-                CqlDateTime cp_ = context.Operators.Convert<CqlDateTime>(bq_);
-                bool? cq_ = context.Operators.Not((bool?)(cp_ is null));
-                bool? cr_ = context.Operators.And(cn_, cq_);
-                bool? cs_ = context.Operators.Or(cb_, cr_);
-                return cs_;
+            bool? bh_(ServiceRequest OrderTwelveMonthsADT) {
+                DataType bk_ = DEXAPerformed?.Effective;
+                object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_);
+                CqlDateTime bn_ = context.Operators.Start(bm_);
+                FhirDateTime bo_ = OrderTwelveMonthsADT?.AuthoredOnElement;
+                CqlDateTime bp_ = context.Operators.Convert<CqlDateTime>(bo_);
+                CqlDateTime br_ = context.Operators.Convert<CqlDateTime>(bo_);
+                CqlQuantity bs_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime bt_ = context.Operators.Add(br_, bs_);
+                CqlInterval<CqlDateTime> bu_ = context.Operators.Interval(bp_, bt_, true, true);
+                bool? bv_ = context.Operators.In<CqlDateTime>(bn_, bu_, "day");
+                CqlDateTime bx_ = context.Operators.Convert<CqlDateTime>(bo_);
+                bool? by_ = context.Operators.Not((bool?)(bx_ is null));
+                bool? bz_ = context.Operators.And(bv_, by_);
+                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
+                CqlDateTime cd_ = context.Operators.End(cc_);
+                CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(bo_);
+                CqlQuantity cg_ = context.Operators.Quantity(2m, "years");
+                CqlDateTime ch_ = context.Operators.Subtract(cf_, cg_);
+                CqlDateTime cj_ = context.Operators.Convert<CqlDateTime>(bo_);
+                CqlInterval<CqlDateTime> ck_ = context.Operators.Interval(ch_, cj_, true, false);
+                bool? cl_ = context.Operators.In<CqlDateTime>(cd_, ck_, "day");
+                CqlDateTime cn_ = context.Operators.Convert<CqlDateTime>(bo_);
+                bool? co_ = context.Operators.Not((bool?)(cn_ is null));
+                bool? cp_ = context.Operators.And(cl_, co_);
+                bool? cq_ = context.Operators.Or(bz_, cp_);
+                return cq_;
             }
 
-            IEnumerable<ServiceRequest> bj_ = context.Operators.Where<ServiceRequest>(bh_, bi_);
-            Observation bk_(ServiceRequest OrderTwelveMonthsADT) => DEXAPerformed;
-            IEnumerable<Observation> bl_ = context.Operators.Select<ServiceRequest, Observation>(bj_, bk_);
-            return bl_;
+            IEnumerable<ServiceRequest> bi_ = context.Operators.Where<ServiceRequest>(bg_, bh_);
+            bool? bj_ = context.Operators.Exists<ServiceRequest>(bi_);
+            return bj_;
         }
 
-        IEnumerable<Observation> j_ = context.Operators.SelectMany<Observation, Observation>(h_, i_);
+        IEnumerable<Observation> j_ = context.Operators.Where<Observation>(h_, i_);
 
         bool? k_(Observation DEXAPerformed) {
-            Code<ObservationStatus> ct_ = DEXAPerformed?.StatusElement;
-            ObservationStatus? cu_ = ct_?.Value;
-            string cv_ = context.Operators.Convert<string>(cu_);
-            string[] cw_ = [
+            Code<ObservationStatus> cr_ = DEXAPerformed?.StatusElement;
+            ObservationStatus? cs_ = cr_?.Value;
+            string ct_ = context.Operators.Convert<string>(cs_);
+            string[] cu_ = [
                 "final",
                 "amended",
                 "corrected",
             ];
-            bool? cx_ = context.Operators.In<string>(cv_, (IEnumerable<string>)cw_);
-            return cx_;
+            bool? cv_ = context.Operators.In<string>(ct_, (IEnumerable<string>)cu_);
+            return cv_;
         }
 
         IEnumerable<Observation> l_ = context.Operators.Where<Observation>(j_, k_);
@@ -940,55 +934,54 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<ServiceRequest> d_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested"));
         IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 
-        IEnumerable<ServiceRequest> f_(ServiceRequest DEXANotOrdered) {
+        bool? f_(ServiceRequest DEXANotOrdered) {
             IEnumerable<ServiceRequest> h_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
 
             bool? i_(ServiceRequest OrderTwelveMonthsADT) {
-                FhirDateTime m_ = DEXANotOrdered?.AuthoredOnElement;
-                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
-                FhirDateTime o_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
-                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(o_);
-                CqlQuantity s_ = context.Operators.Quantity(3m, "months");
-                CqlDateTime t_ = context.Operators.Add(r_, s_);
-                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
-                bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
-                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(o_);
-                bool? y_ = context.Operators.Not((bool?)(x_ is null));
-                bool? z_ = context.Operators.And(v_, y_);
+                FhirDateTime l_ = DEXANotOrdered?.AuthoredOnElement;
+                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+                FhirDateTime n_ = OrderTwelveMonthsADT?.AuthoredOnElement;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(n_);
+                CqlQuantity r_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime s_ = context.Operators.Add(q_, r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(o_, s_, true, true);
+                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, "day");
+                CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(n_);
+                bool? x_ = context.Operators.Not((bool?)(w_ is null));
+                bool? y_ = context.Operators.And(u_, x_);
 
-                bool? aa_(Extension @this) {
-                    FhirUri aj_ = @this?.UrlElement;
-                    string ak_ = FHIRHelpers_4_4_000.Instance.ToString(context, aj_);
-                    bool? al_ = context.Operators.Equal(ak_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                bool? z_(Extension @this) {
+                    FhirUri ai_ = @this?.UrlElement;
+                    string aj_ = FHIRHelpers_4_4_000.Instance.ToString(context, ai_);
+                    bool? ak_ = context.Operators.Equal(aj_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                    return ak_;
+                }
+
+                IEnumerable<Extension> aa_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(DEXANotOrdered is DomainResource
+                    ? (DEXANotOrdered as DomainResource).Extension
+                    : default), z_);
+
+                object ab_(Extension @this) {
+                    DataType al_ = @this?.Value;
                     return al_;
                 }
 
-                IEnumerable<Extension> ab_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(DEXANotOrdered is DomainResource
-                    ? (DEXANotOrdered as DomainResource).Extension
-                    : default), aa_);
-
-                object ac_(Extension @this) {
-                    DataType am_ = @this?.Value;
-                    return am_;
-                }
-
-                IEnumerable<object> ad_ = context.Operators.Select<Extension, object>(ab_, ac_);
-                object ae_ = context.Operators.SingletonFrom<object>(ad_);
-                CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_ as CodeableConcept);
-                CqlValueSet ag_ = this.Patient_Declined(context);
-                bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
-                bool? ai_ = context.Operators.And(z_, ah_);
-                return ai_;
+                IEnumerable<object> ac_ = context.Operators.Select<Extension, object>(aa_, ab_);
+                object ad_ = context.Operators.SingletonFrom<object>(ac_);
+                CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_ as CodeableConcept);
+                CqlValueSet af_ = this.Patient_Declined(context);
+                bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
+                bool? ah_ = context.Operators.And(y_, ag_);
+                return ah_;
             }
 
             IEnumerable<ServiceRequest> j_ = context.Operators.Where<ServiceRequest>(h_, i_);
-            ServiceRequest k_(ServiceRequest OrderTwelveMonthsADT) => DEXANotOrdered;
-            IEnumerable<ServiceRequest> l_ = context.Operators.Select<ServiceRequest, ServiceRequest>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<ServiceRequest>(j_);
+            return k_;
         }
 
-        IEnumerable<ServiceRequest> g_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(e_, f_);
+        IEnumerable<ServiceRequest> g_ = context.Operators.Where<ServiceRequest>(e_, f_);
         return g_;
     }
 
@@ -1006,56 +999,55 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
         IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 
-        IEnumerable<Observation> f_(Observation DEXANotPerformed) {
+        bool? f_(Observation DEXANotPerformed) {
             IEnumerable<ServiceRequest> h_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
 
             bool? i_(ServiceRequest OrderTwelveMonthsADT) {
-                Instant m_ = DEXANotPerformed?.IssuedElement;
-                DateTimeOffset? n_ = m_?.Value;
-                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
-                FhirDateTime p_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(p_);
-                CqlQuantity t_ = context.Operators.Quantity(3m, "months");
-                CqlDateTime u_ = context.Operators.Add(s_, t_);
-                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(q_, u_, true, true);
-                bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, "day");
-                CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(p_);
-                bool? z_ = context.Operators.Not((bool?)(y_ is null));
-                bool? aa_ = context.Operators.And(w_, z_);
+                Instant l_ = DEXANotPerformed?.IssuedElement;
+                DateTimeOffset? m_ = l_?.Value;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                FhirDateTime o_ = OrderTwelveMonthsADT?.AuthoredOnElement;
+                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+                CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(o_);
+                CqlQuantity s_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime t_ = context.Operators.Add(r_, s_);
+                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
+                bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(o_);
+                bool? y_ = context.Operators.Not((bool?)(x_ is null));
+                bool? z_ = context.Operators.And(v_, y_);
 
-                bool? ab_(Extension @this) {
-                    FhirUri ak_ = @this?.UrlElement;
-                    string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
-                    bool? am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                bool? aa_(Extension @this) {
+                    FhirUri aj_ = @this?.UrlElement;
+                    string ak_ = FHIRHelpers_4_4_000.Instance.ToString(context, aj_);
+                    bool? al_ = context.Operators.Equal(ak_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                    return al_;
+                }
+
+                IEnumerable<Extension> ab_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(DEXANotPerformed is DomainResource
+                    ? (DEXANotPerformed as DomainResource).Extension
+                    : default), aa_);
+
+                object ac_(Extension @this) {
+                    DataType am_ = @this?.Value;
                     return am_;
                 }
 
-                IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(DEXANotPerformed is DomainResource
-                    ? (DEXANotPerformed as DomainResource).Extension
-                    : default), ab_);
-
-                object ad_(Extension @this) {
-                    DataType an_ = @this?.Value;
-                    return an_;
-                }
-
-                IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
-                object af_ = context.Operators.SingletonFrom<object>(ae_);
-                CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
-                CqlValueSet ah_ = this.Patient_Declined(context);
-                bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
-                bool? aj_ = context.Operators.And(aa_, ai_);
-                return aj_;
+                IEnumerable<object> ad_ = context.Operators.Select<Extension, object>(ab_, ac_);
+                object ae_ = context.Operators.SingletonFrom<object>(ad_);
+                CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_ as CodeableConcept);
+                CqlValueSet ag_ = this.Patient_Declined(context);
+                bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+                bool? ai_ = context.Operators.And(z_, ah_);
+                return ai_;
             }
 
             IEnumerable<ServiceRequest> j_ = context.Operators.Where<ServiceRequest>(h_, i_);
-            Observation k_(ServiceRequest OrderTwelveMonthsADT) => DEXANotPerformed;
-            IEnumerable<Observation> l_ = context.Operators.Select<ServiceRequest, Observation>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<ServiceRequest>(j_);
+            return k_;
         }
 
-        IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
         return g_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
@@ -289,67 +289,67 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Procedure> c_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> d_(Procedure BladderCancerStaging) {
+        bool? d_(Procedure BladderCancerStaging) {
             IEnumerable<Condition> k_ = this.Bladder_Cancer_Diagnosis(context);
 
             bool? l_(Condition BladderCancer) {
 
-                object p_() {
+                object o_() {
+
+                    bool u_() {
+                        DataType y_ = BladderCancerStaging?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlDateTime;
+                        return aa_;
+                    }
+
 
                     bool v_() {
-                        DataType z_ = BladderCancerStaging?.Performed;
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlDateTime;
-                        return ab_;
+                        DataType ab_ = BladderCancerStaging?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlInterval<CqlDateTime>;
+                        return ad_;
                     }
 
 
                     bool w_() {
-                        DataType ac_ = BladderCancerStaging?.Performed;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlInterval<CqlDateTime>;
-                        return ae_;
+                        DataType ae_ = BladderCancerStaging?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlQuantity;
+                        return ag_;
                     }
 
 
                     bool x_() {
-                        DataType af_ = BladderCancerStaging?.Performed;
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlQuantity;
-                        return ah_;
+                        DataType ah_ = BladderCancerStaging?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        bool aj_ = ai_ is CqlInterval<CqlQuantity>;
+                        return aj_;
                     }
 
-
-                    bool y_() {
-                        DataType ai_ = BladderCancerStaging?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        bool ak_ = aj_ is CqlInterval<CqlQuantity>;
-                        return ak_;
-                    }
-
-                    if (v_())
+                    if (u_())
                     {
-                        DataType al_ = BladderCancerStaging?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlDateTime) as object;
+                        DataType ak_ = BladderCancerStaging?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlDateTime) as object;
+                    }
+                    else if (v_())
+                    {
+                        DataType am_ = BladderCancerStaging?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (w_())
                     {
-                        DataType an_ = BladderCancerStaging?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ao_ = BladderCancerStaging?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlQuantity) as object;
                     }
                     else if (x_())
                     {
-                        DataType ap_ = BladderCancerStaging?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlQuantity) as object;
-                    }
-                    else if (y_())
-                    {
-                        DataType ar_ = BladderCancerStaging?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlInterval<CqlQuantity>) as object;
+                        DataType aq_ = BladderCancerStaging?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -357,90 +357,89 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BladderCancer);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                bool? u_ = context.Operators.SameOrBefore(r_, t_, "day");
-                return u_;
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BladderCancer);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                bool? t_ = context.Operators.SameOrBefore(q_, s_, "day");
+                return t_;
             }
 
             IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
-            Procedure n_(Condition BladderCancer) => BladderCancerStaging;
-            IEnumerable<Procedure> o_ = context.Operators.Select<Condition, Procedure>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Condition>(m_);
+            return n_;
         }
 
-        IEnumerable<Procedure> e_ = context.Operators.SelectMany<Procedure, Procedure>(c_, d_);
+        IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 
         bool? f_(Procedure BladderCancerStaging) {
-            Code<EventStatus> at_ = BladderCancerStaging?.StatusElement;
-            EventStatus? au_ = at_?.Value;
-            string av_ = context.Operators.Convert<string>(au_);
-            bool? aw_ = context.Operators.Equal(av_, "completed");
-            return aw_;
+            Code<EventStatus> as_ = BladderCancerStaging?.StatusElement;
+            EventStatus? at_ = as_?.Value;
+            string au_ = context.Operators.Convert<string>(at_);
+            bool? av_ = context.Operators.Equal(au_, "completed");
+            return av_;
         }
 
         IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 
         object h_(Procedure @this) {
 
-            object ax_() {
+            object aw_() {
+
+                bool az_() {
+                    DataType bd_ = @this?.Performed;
+                    object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                    bool bf_ = be_ is CqlDateTime;
+                    return bf_;
+                }
+
 
                 bool ba_() {
-                    DataType be_ = @this?.Performed;
-                    object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                    bool bg_ = bf_ is CqlDateTime;
-                    return bg_;
+                    DataType bg_ = @this?.Performed;
+                    object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                    bool bi_ = bh_ is CqlInterval<CqlDateTime>;
+                    return bi_;
                 }
 
 
                 bool bb_() {
-                    DataType bh_ = @this?.Performed;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    bool bj_ = bi_ is CqlInterval<CqlDateTime>;
-                    return bj_;
+                    DataType bj_ = @this?.Performed;
+                    object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                    bool bl_ = bk_ is CqlQuantity;
+                    return bl_;
                 }
 
 
                 bool bc_() {
-                    DataType bk_ = @this?.Performed;
-                    object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                    bool bm_ = bl_ is CqlQuantity;
-                    return bm_;
+                    DataType bm_ = @this?.Performed;
+                    object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                    bool bo_ = bn_ is CqlInterval<CqlQuantity>;
+                    return bo_;
                 }
 
-
-                bool bd_() {
-                    DataType bn_ = @this?.Performed;
-                    object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                    bool bp_ = bo_ is CqlInterval<CqlQuantity>;
-                    return bp_;
-                }
-
-                if (ba_())
+                if (az_())
                 {
-                    DataType bq_ = @this?.Performed;
-                    object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                    return (br_ as CqlDateTime) as object;
+                    DataType bp_ = @this?.Performed;
+                    object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+                    return (bq_ as CqlDateTime) as object;
+                }
+                else if (ba_())
+                {
+                    DataType br_ = @this?.Performed;
+                    object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                    return (bs_ as CqlInterval<CqlDateTime>) as object;
                 }
                 else if (bb_())
                 {
-                    DataType bs_ = @this?.Performed;
-                    object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                    return (bt_ as CqlInterval<CqlDateTime>) as object;
+                    DataType bt_ = @this?.Performed;
+                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                    return (bu_ as CqlQuantity) as object;
                 }
                 else if (bc_())
                 {
-                    DataType bu_ = @this?.Performed;
-                    object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                    return (bv_ as CqlQuantity) as object;
-                }
-                else if (bd_())
-                {
-                    DataType bw_ = @this?.Performed;
-                    object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                    return (bx_ as CqlInterval<CqlQuantity>) as object;
+                    DataType bv_ = @this?.Performed;
+                    object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                    return (bw_ as CqlInterval<CqlQuantity>) as object;
                 }
                 else
                 {
@@ -448,9 +447,9 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 };
             }
 
-            CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_());
-            CqlDateTime az_ = context.Operators.Start(ay_);
-            return az_;
+            CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_());
+            CqlDateTime ay_ = context.Operators.Start(ax_);
+            return ay_;
         }
 
         IEnumerable<Procedure> i_ = context.Operators.SortBy<Procedure>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
@@ -724,71 +723,71 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
         IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
 
-        IEnumerable<Condition> f_(Condition ActiveTuberculosis) {
+        bool? f_(Condition ActiveTuberculosis) {
             Procedure j_ = this.First_Bladder_Cancer_Staging_Procedure(context);
             Procedure[] k_ = [
                 j_,
             ];
 
             bool? l_(Procedure FirstBladderCancerStaging) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveTuberculosis);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveTuberculosis);
 
-                object q_() {
+                object p_() {
+
+                    bool aj_() {
+                        DataType an_ = FirstBladderCancerStaging?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        bool ap_ = ao_ is CqlDateTime;
+                        return ap_;
+                    }
+
 
                     bool ak_() {
-                        DataType ao_ = FirstBladderCancerStaging?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        bool aq_ = ap_ is CqlDateTime;
-                        return aq_;
+                        DataType aq_ = FirstBladderCancerStaging?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        bool as_ = ar_ is CqlInterval<CqlDateTime>;
+                        return as_;
                     }
 
 
                     bool al_() {
-                        DataType ar_ = FirstBladderCancerStaging?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlInterval<CqlDateTime>;
-                        return at_;
+                        DataType at_ = FirstBladderCancerStaging?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        bool av_ = au_ is CqlQuantity;
+                        return av_;
                     }
 
 
                     bool am_() {
-                        DataType au_ = FirstBladderCancerStaging?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlQuantity;
-                        return aw_;
+                        DataType aw_ = FirstBladderCancerStaging?.Performed;
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        bool ay_ = ax_ is CqlInterval<CqlQuantity>;
+                        return ay_;
                     }
 
-
-                    bool an_() {
-                        DataType ax_ = FirstBladderCancerStaging?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        bool az_ = ay_ is CqlInterval<CqlQuantity>;
-                        return az_;
-                    }
-
-                    if (ak_())
+                    if (aj_())
                     {
-                        DataType ba_ = FirstBladderCancerStaging?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        return (bb_ as CqlDateTime) as object;
+                        DataType az_ = FirstBladderCancerStaging?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        return (ba_ as CqlDateTime) as object;
+                    }
+                    else if (ak_())
+                    {
+                        DataType bb_ = FirstBladderCancerStaging?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        return (bc_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (al_())
                     {
-                        DataType bc_ = FirstBladderCancerStaging?.Performed;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        return (bd_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bd_ = FirstBladderCancerStaging?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        return (be_ as CqlQuantity) as object;
                     }
                     else if (am_())
                     {
-                        DataType be_ = FirstBladderCancerStaging?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        return (bf_ as CqlQuantity) as object;
-                    }
-                    else if (an_())
-                    {
-                        DataType bg_ = FirstBladderCancerStaging?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        return (bh_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bf_ = FirstBladderCancerStaging?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        return (bg_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -796,68 +795,68 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                bool? s_ = context.Operators.OverlapsAfter(p_, r_, "day");
-                DataType t_ = ActiveTuberculosis?.Onset;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                bool? r_ = context.Operators.OverlapsAfter(o_, q_, "day");
+                DataType s_ = ActiveTuberculosis?.Onset;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
 
-                object w_() {
+                object v_() {
+
+                    bool bh_() {
+                        DataType bl_ = FirstBladderCancerStaging?.Performed;
+                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+                        bool bn_ = bm_ is CqlDateTime;
+                        return bn_;
+                    }
+
 
                     bool bi_() {
-                        DataType bm_ = FirstBladderCancerStaging?.Performed;
-                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                        bool bo_ = bn_ is CqlDateTime;
-                        return bo_;
+                        DataType bo_ = FirstBladderCancerStaging?.Performed;
+                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                        bool bq_ = bp_ is CqlInterval<CqlDateTime>;
+                        return bq_;
                     }
 
 
                     bool bj_() {
-                        DataType bp_ = FirstBladderCancerStaging?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        bool br_ = bq_ is CqlInterval<CqlDateTime>;
-                        return br_;
+                        DataType br_ = FirstBladderCancerStaging?.Performed;
+                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                        bool bt_ = bs_ is CqlQuantity;
+                        return bt_;
                     }
 
 
                     bool bk_() {
-                        DataType bs_ = FirstBladderCancerStaging?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        bool bu_ = bt_ is CqlQuantity;
-                        return bu_;
+                        DataType bu_ = FirstBladderCancerStaging?.Performed;
+                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                        bool bw_ = bv_ is CqlInterval<CqlQuantity>;
+                        return bw_;
                     }
 
-
-                    bool bl_() {
-                        DataType bv_ = FirstBladderCancerStaging?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        bool bx_ = bw_ is CqlInterval<CqlQuantity>;
-                        return bx_;
-                    }
-
-                    if (bi_())
+                    if (bh_())
                     {
-                        DataType by_ = FirstBladderCancerStaging?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        return (bz_ as CqlDateTime) as object;
+                        DataType bx_ = FirstBladderCancerStaging?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        return (by_ as CqlDateTime) as object;
+                    }
+                    else if (bi_())
+                    {
+                        DataType bz_ = FirstBladderCancerStaging?.Performed;
+                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                        return (ca_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bj_())
                     {
-                        DataType ca_ = FirstBladderCancerStaging?.Performed;
-                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                        return (cb_ as CqlInterval<CqlDateTime>) as object;
+                        DataType cb_ = FirstBladderCancerStaging?.Performed;
+                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+                        return (cc_ as CqlQuantity) as object;
                     }
                     else if (bk_())
                     {
-                        DataType cc_ = FirstBladderCancerStaging?.Performed;
-                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        return (cd_ as CqlQuantity) as object;
-                    }
-                    else if (bl_())
-                    {
-                        DataType ce_ = FirstBladderCancerStaging?.Performed;
-                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
-                        return (cf_ as CqlInterval<CqlQuantity>) as object;
+                        DataType cd_ = FirstBladderCancerStaging?.Performed;
+                        object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                        return (ce_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -865,68 +864,68 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_());
-                bool? y_ = context.Operators.OverlapsAfter(v_, x_, "day");
-                DataType z_ = ActiveTuberculosis?.Abatement;
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_());
+                bool? x_ = context.Operators.OverlapsAfter(u_, w_, "day");
+                DataType y_ = ActiveTuberculosis?.Abatement;
+                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
 
-                object ac_() {
+                object ab_() {
+
+                    bool cf_() {
+                        DataType cj_ = FirstBladderCancerStaging?.Performed;
+                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                        bool cl_ = ck_ is CqlDateTime;
+                        return cl_;
+                    }
+
 
                     bool cg_() {
-                        DataType ck_ = FirstBladderCancerStaging?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        bool cm_ = cl_ is CqlDateTime;
-                        return cm_;
+                        DataType cm_ = FirstBladderCancerStaging?.Performed;
+                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
+                        bool co_ = cn_ is CqlInterval<CqlDateTime>;
+                        return co_;
                     }
 
 
                     bool ch_() {
-                        DataType cn_ = FirstBladderCancerStaging?.Performed;
-                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                        bool cp_ = co_ is CqlInterval<CqlDateTime>;
-                        return cp_;
+                        DataType cp_ = FirstBladderCancerStaging?.Performed;
+                        object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+                        bool cr_ = cq_ is CqlQuantity;
+                        return cr_;
                     }
 
 
                     bool ci_() {
-                        DataType cq_ = FirstBladderCancerStaging?.Performed;
-                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                        bool cs_ = cr_ is CqlQuantity;
-                        return cs_;
+                        DataType cs_ = FirstBladderCancerStaging?.Performed;
+                        object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
+                        bool cu_ = ct_ is CqlInterval<CqlQuantity>;
+                        return cu_;
                     }
 
-
-                    bool cj_() {
-                        DataType ct_ = FirstBladderCancerStaging?.Performed;
-                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                        bool cv_ = cu_ is CqlInterval<CqlQuantity>;
-                        return cv_;
-                    }
-
-                    if (cg_())
+                    if (cf_())
                     {
-                        DataType cw_ = FirstBladderCancerStaging?.Performed;
-                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                        return (cx_ as CqlDateTime) as object;
+                        DataType cv_ = FirstBladderCancerStaging?.Performed;
+                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                        return (cw_ as CqlDateTime) as object;
+                    }
+                    else if (cg_())
+                    {
+                        DataType cx_ = FirstBladderCancerStaging?.Performed;
+                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
+                        return (cy_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ch_())
                     {
-                        DataType cy_ = FirstBladderCancerStaging?.Performed;
-                        object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
-                        return (cz_ as CqlInterval<CqlDateTime>) as object;
+                        DataType cz_ = FirstBladderCancerStaging?.Performed;
+                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
+                        return (da_ as CqlQuantity) as object;
                     }
                     else if (ci_())
                     {
-                        DataType da_ = FirstBladderCancerStaging?.Performed;
-                        object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-                        return (db_ as CqlQuantity) as object;
-                    }
-                    else if (cj_())
-                    {
-                        DataType dc_ = FirstBladderCancerStaging?.Performed;
-                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
-                        return (dd_ as CqlInterval<CqlQuantity>) as object;
+                        DataType db_ = FirstBladderCancerStaging?.Performed;
+                        object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                        return (dc_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -934,26 +933,25 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_());
-                bool? ae_ = context.Operators.OverlapsAfter(ab_, ad_, "day");
-                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                bool? ah_ = context.Operators.Or(ae_, (bool?)(ag_ is null));
-                bool? ai_ = context.Operators.And(y_, ah_);
-                bool? aj_ = context.Operators.Or(s_, ai_);
-                return aj_;
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_());
+                bool? ad_ = context.Operators.OverlapsAfter(aa_, ac_, "day");
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                bool? ag_ = context.Operators.Or(ad_, (bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(x_, ag_);
+                bool? ai_ = context.Operators.Or(r_, ah_);
+                return ai_;
             }
 
             IEnumerable<Procedure> m_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)k_, l_);
-            Condition n_(Procedure FirstBladderCancerStaging) => ActiveTuberculosis;
-            IEnumerable<Condition> o_ = context.Operators.Select<Procedure, Condition>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Procedure>(m_);
+            return n_;
         }
 
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 
         bool? h_(Condition ActiveTuberculosis) {
-            bool? de_ = this.isVerified(context, ActiveTuberculosis);
-            return de_;
+            bool? dd_ = this.isVerified(context, ActiveTuberculosis);
+            return dd_;
         }
 
         IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
@@ -973,204 +971,203 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> k_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? l_(Medication M) {
-                object p_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object q_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
-                string s_ = context.Operators.Last<string>(r_);
-                bool? t_ = context.Operators.Equal(p_, s_);
-                CodeableConcept u_ = M?.Code;
-                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                CqlValueSet w_ = this.Immunosuppressive_Drugs_for_Urology_Care(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
+                string r_ = context.Operators.Last<string>(q_);
+                bool? s_ = context.Operators.Equal(o_, r_);
+                CodeableConcept t_ = M?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlValueSet v_ = this.Immunosuppressive_Drugs_for_Urology_Care(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Medication> m_ = context.Operators.Where<Medication>(k_, l_);
-            MedicationRequest n_(Medication M) => MR;
-            IEnumerable<MedicationRequest> o_ = context.Operators.Select<Medication, MedicationRequest>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Medication>(m_);
+            return n_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
-        IEnumerable<MedicationRequest> g_(MedicationRequest ImmunosuppressiveDrugs) {
-            Procedure z_ = this.First_Bladder_Cancer_Staging_Procedure(context);
-            Procedure[] aa_ = [
-                z_,
+        bool? g_(MedicationRequest ImmunosuppressiveDrugs) {
+            Procedure y_ = this.First_Bladder_Cancer_Staging_Procedure(context);
+            Procedure[] z_ = [
+                y_,
             ];
 
-            bool? ab_(Procedure FirstBladderCancerStaging) {
-                List<Dosage> af_ = ImmunosuppressiveDrugs?.DosageInstruction;
+            bool? aa_(Procedure FirstBladderCancerStaging) {
+                List<Dosage> ad_ = ImmunosuppressiveDrugs?.DosageInstruction;
 
-                bool? ag_(Dosage @this) {
+                bool? ae_(Dosage @this) {
+                    Timing bn_ = @this?.Timing;
+                    bool? bo_ = context.Operators.Not((bool?)(bn_ is null));
+                    return bo_;
+                }
+
+                IEnumerable<Dosage> af_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)ad_, ae_);
+
+                Timing ag_(Dosage @this) {
                     Timing bp_ = @this?.Timing;
-                    bool? bq_ = context.Operators.Not((bool?)(bp_ is null));
-                    return bq_;
+                    return bp_;
                 }
 
-                IEnumerable<Dosage> ah_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)af_, ag_);
+                IEnumerable<Timing> ah_ = context.Operators.Select<Dosage, Timing>(af_, ag_);
 
-                Timing ai_(Dosage @this) {
-                    Timing br_ = @this?.Timing;
-                    return br_;
-                }
+                CqlDateTime ai_(Timing dosageTiming) {
+                    List<FhirDateTime> bq_ = dosageTiming?.EventElement;
 
-                IEnumerable<Timing> aj_ = context.Operators.Select<Dosage, Timing>(ah_, ai_);
-
-                CqlDateTime ak_(Timing dosageTiming) {
-                    List<FhirDateTime> bs_ = dosageTiming?.EventElement;
-
-                    string bt_(FhirDateTime @this) {
-                        string bz_ = @this?.Value;
-                        return bz_;
+                    string br_(FhirDateTime @this) {
+                        string bx_ = @this?.Value;
+                        return bx_;
                     }
 
-                    IEnumerable<string> bu_ = context.Operators.Select<FhirDateTime, string>((IEnumerable<FhirDateTime>)bs_, bt_);
+                    IEnumerable<string> bs_ = context.Operators.Select<FhirDateTime, string>((IEnumerable<FhirDateTime>)bq_, br_);
 
-                    CqlDateTime bv_(string @string) {
-                        CqlDateTime ca_ = context.Operators.ConvertStringToDateTime(@string);
-                        return ca_;
+                    CqlDateTime bt_(string @string) {
+                        CqlDateTime by_ = context.Operators.ConvertStringToDateTime(@string);
+                        return by_;
                     }
 
-                    IEnumerable<CqlDateTime> bw_ = context.Operators.Select<string, CqlDateTime>(bu_, bv_);
-                    IEnumerable<CqlDateTime> bx_ = context.Operators.ListSort<CqlDateTime>(bw_, System.ComponentModel.ListSortDirection.Ascending);
-                    CqlDateTime by_ = context.Operators.First<CqlDateTime>(bx_);
-                    return by_;
+                    IEnumerable<CqlDateTime> bu_ = context.Operators.Select<string, CqlDateTime>(bs_, bt_);
+                    IEnumerable<CqlDateTime> bv_ = context.Operators.ListSort<CqlDateTime>(bu_, System.ComponentModel.ListSortDirection.Ascending);
+                    CqlDateTime bw_ = context.Operators.First<CqlDateTime>(bv_);
+                    return bw_;
                 }
 
-                IEnumerable<CqlDateTime> al_ = context.Operators.Select<Timing, CqlDateTime>(aj_, ak_);
-                IEnumerable<CqlDateTime> am_ = context.Operators.Distinct<CqlDateTime>(al_);
-                IEnumerable<CqlDateTime> an_ = context.Operators.ListSort<CqlDateTime>(am_, System.ComponentModel.ListSortDirection.Ascending);
-                CqlDateTime ao_ = context.Operators.First<CqlDateTime>(an_);
-                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_ as object);
+                IEnumerable<CqlDateTime> aj_ = context.Operators.Select<Timing, CqlDateTime>(ah_, ai_);
+                IEnumerable<CqlDateTime> ak_ = context.Operators.Distinct<CqlDateTime>(aj_);
+                IEnumerable<CqlDateTime> al_ = context.Operators.ListSort<CqlDateTime>(ak_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlDateTime am_ = context.Operators.First<CqlDateTime>(al_);
+                CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_ as object);
 
-                bool? ar_(Dosage @this) {
+                bool? ap_(Dosage @this) {
+                    Timing bz_ = @this?.Timing;
+                    bool? ca_ = context.Operators.Not((bool?)(bz_ is null));
+                    return ca_;
+                }
+
+                IEnumerable<Dosage> aq_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)ad_, ap_);
+
+                Timing ar_(Dosage @this) {
                     Timing cb_ = @this?.Timing;
-                    bool? cc_ = context.Operators.Not((bool?)(cb_ is null));
-                    return cc_;
+                    return cb_;
                 }
 
-                IEnumerable<Dosage> as_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)af_, ar_);
+                IEnumerable<Timing> as_ = context.Operators.Select<Dosage, Timing>(aq_, ar_);
 
-                Timing at_(Dosage @this) {
-                    Timing cd_ = @this?.Timing;
+                bool? at_(Timing @this) {
+                    Timing.RepeatComponent cc_ = @this?.Repeat;
+                    bool? cd_ = context.Operators.Not((bool?)(cc_ is null));
                     return cd_;
                 }
 
-                IEnumerable<Timing> au_ = context.Operators.Select<Dosage, Timing>(as_, at_);
+                IEnumerable<Timing> au_ = context.Operators.Where<Timing>(as_, at_);
 
-                bool? av_(Timing @this) {
+                Timing.RepeatComponent av_(Timing @this) {
                     Timing.RepeatComponent ce_ = @this?.Repeat;
-                    bool? cf_ = context.Operators.Not((bool?)(ce_ is null));
-                    return cf_;
+                    return ce_;
                 }
 
-                IEnumerable<Timing> aw_ = context.Operators.Where<Timing>(au_, av_);
+                IEnumerable<Timing.RepeatComponent> aw_ = context.Operators.Select<Timing, Timing.RepeatComponent>(au_, av_);
 
-                Timing.RepeatComponent ax_(Timing @this) {
-                    Timing.RepeatComponent cg_ = @this?.Repeat;
-                    return cg_;
+                bool? ax_(Timing.RepeatComponent @this) {
+                    DataType cf_ = @this?.Bounds;
+                    object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                    bool? ch_ = context.Operators.Not((bool?)(cg_ is null));
+                    return ch_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> ay_ = context.Operators.Select<Timing, Timing.RepeatComponent>(aw_, ax_);
+                IEnumerable<Timing.RepeatComponent> ay_ = context.Operators.Where<Timing.RepeatComponent>(aw_, ax_);
 
-                bool? az_(Timing.RepeatComponent @this) {
-                    DataType ch_ = @this?.Bounds;
-                    object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                    bool? cj_ = context.Operators.Not((bool?)(ci_ is null));
+                object az_(Timing.RepeatComponent @this) {
+                    DataType ci_ = @this?.Bounds;
+                    object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
                     return cj_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> ba_ = context.Operators.Where<Timing.RepeatComponent>(ay_, az_);
+                IEnumerable<object> ba_ = context.Operators.Select<Timing.RepeatComponent, object>(ay_, az_);
 
-                object bb_(Timing.RepeatComponent @this) {
-                    DataType ck_ = @this?.Bounds;
-                    object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+                CqlInterval<CqlDateTime> bb_(object DoseTime) {
+                    CqlInterval<CqlDateTime> ck_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+                    return ck_;
+                }
+
+                IEnumerable<CqlInterval<CqlDateTime>> bc_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(ba_, bb_);
+                IEnumerable<CqlInterval<CqlDateTime>> bd_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bc_);
+                IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.Collapse(bd_, (string)default);
+
+                object bf_(CqlInterval<CqlDateTime> @this) {
+                    CqlDateTime cl_ = context.Operators.Start(@this);
                     return cl_;
                 }
 
-                IEnumerable<object> bc_ = context.Operators.Select<Timing.RepeatComponent, object>(ba_, bb_);
+                IEnumerable<CqlInterval<CqlDateTime>> bg_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> bh_ = context.Operators.First<CqlInterval<CqlDateTime>>(bg_);
+                CqlDateTime bi_ = context.Operators.Start(an_ ?? bh_);
 
-                CqlInterval<CqlDateTime> bd_(object DoseTime) {
-                    CqlInterval<CqlDateTime> cm_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
-                    return cm_;
-                }
+                object bj_() {
 
-                IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bc_, bd_);
-                IEnumerable<CqlInterval<CqlDateTime>> bf_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(be_);
-                IEnumerable<CqlInterval<CqlDateTime>> bg_ = context.Operators.Collapse(bf_, (string)default);
+                    bool cm_() {
+                        DataType cq_ = FirstBladderCancerStaging?.Performed;
+                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                        bool cs_ = cr_ is CqlDateTime;
+                        return cs_;
+                    }
 
-                object bh_(CqlInterval<CqlDateTime> @this) {
-                    CqlDateTime cn_ = context.Operators.Start(@this);
-                    return cn_;
-                }
 
-                IEnumerable<CqlInterval<CqlDateTime>> bi_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(bg_, bh_, System.ComponentModel.ListSortDirection.Ascending);
-                CqlInterval<CqlDateTime> bj_ = context.Operators.First<CqlInterval<CqlDateTime>>(bi_);
-                CqlDateTime bk_ = context.Operators.Start(ap_ ?? bj_);
+                    bool cn_() {
+                        DataType ct_ = FirstBladderCancerStaging?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        bool cv_ = cu_ is CqlInterval<CqlDateTime>;
+                        return cv_;
+                    }
 
-                object bl_() {
 
                     bool co_() {
-                        DataType cs_ = FirstBladderCancerStaging?.Performed;
-                        object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
-                        bool cu_ = ct_ is CqlDateTime;
-                        return cu_;
+                        DataType cw_ = FirstBladderCancerStaging?.Performed;
+                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                        bool cy_ = cx_ is CqlQuantity;
+                        return cy_;
                     }
 
 
                     bool cp_() {
-                        DataType cv_ = FirstBladderCancerStaging?.Performed;
-                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                        bool cx_ = cw_ is CqlInterval<CqlDateTime>;
-                        return cx_;
+                        DataType cz_ = FirstBladderCancerStaging?.Performed;
+                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
+                        bool db_ = da_ is CqlInterval<CqlQuantity>;
+                        return db_;
                     }
 
-
-                    bool cq_() {
-                        DataType cy_ = FirstBladderCancerStaging?.Performed;
-                        object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
-                        bool da_ = cz_ is CqlQuantity;
-                        return da_;
+                    if (cm_())
+                    {
+                        DataType dc_ = FirstBladderCancerStaging?.Performed;
+                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
+                        return (dd_ as CqlDateTime) as object;
                     }
-
-
-                    bool cr_() {
-                        DataType db_ = FirstBladderCancerStaging?.Performed;
-                        object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
-                        bool dd_ = dc_ is CqlInterval<CqlQuantity>;
-                        return dd_;
-                    }
-
-                    if (co_())
+                    else if (cn_())
                     {
                         DataType de_ = FirstBladderCancerStaging?.Performed;
                         object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
-                        return (df_ as CqlDateTime) as object;
+                        return (df_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (cp_())
+                    else if (co_())
                     {
                         DataType dg_ = FirstBladderCancerStaging?.Performed;
                         object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
-                        return (dh_ as CqlInterval<CqlDateTime>) as object;
+                        return (dh_ as CqlQuantity) as object;
                     }
-                    else if (cq_())
+                    else if (cp_())
                     {
                         DataType di_ = FirstBladderCancerStaging?.Performed;
                         object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                        return (dj_ as CqlQuantity) as object;
-                    }
-                    else if (cr_())
-                    {
-                        DataType dk_ = FirstBladderCancerStaging?.Performed;
-                        object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
-                        return (dl_ as CqlInterval<CqlQuantity>) as object;
+                        return (dj_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1178,35 +1175,34 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_());
-                CqlDateTime bn_ = context.Operators.Start(bm_);
-                bool? bo_ = context.Operators.SameOrBefore(bk_, bn_, "day");
-                return bo_;
+                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_());
+                CqlDateTime bl_ = context.Operators.Start(bk_);
+                bool? bm_ = context.Operators.SameOrBefore(bi_, bl_, "day");
+                return bm_;
             }
 
-            IEnumerable<Procedure> ac_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)aa_, ab_);
-            MedicationRequest ad_(Procedure FirstBladderCancerStaging) => ImmunosuppressiveDrugs;
-            IEnumerable<MedicationRequest> ae_ = context.Operators.Select<Procedure, MedicationRequest>(ac_, ad_);
-            return ae_;
+            IEnumerable<Procedure> ab_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)z_, aa_);
+            bool? ac_ = context.Operators.Exists<Procedure>(ab_);
+            return ac_;
         }
 
-        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 
         bool? i_(MedicationRequest ImmunosuppressiveDrugs) {
-            Code<MedicationRequest.MedicationrequestStatus> dm_ = ImmunosuppressiveDrugs?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? dn_ = dm_?.Value;
-            string do_ = context.Operators.Convert<string>(dn_);
-            string[] dp_ = [
+            Code<MedicationRequest.MedicationrequestStatus> dk_ = ImmunosuppressiveDrugs?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? dl_ = dk_?.Value;
+            string dm_ = context.Operators.Convert<string>(dl_);
+            string[] dn_ = [
                 "active",
                 "completed",
             ];
-            bool? dq_ = context.Operators.In<string>(do_, (IEnumerable<string>)dp_);
-            Code<MedicationRequest.MedicationRequestIntent> dr_ = ImmunosuppressiveDrugs?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? ds_ = dr_?.Value;
-            string dt_ = context.Operators.Convert<string>(ds_);
-            bool? du_ = context.Operators.Equal(dt_, "order");
-            bool? dv_ = context.Operators.And(dq_, du_);
-            return dv_;
+            bool? do_ = context.Operators.In<string>(dm_, (IEnumerable<string>)dn_);
+            Code<MedicationRequest.MedicationRequestIntent> dp_ = ImmunosuppressiveDrugs?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? dq_ = dp_?.Value;
+            string dr_ = context.Operators.Convert<string>(dq_);
+            bool? ds_ = context.Operators.Equal(dr_, "order");
+            bool? dt_ = context.Operators.And(do_, ds_);
+            return dt_;
         }
 
         IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
@@ -1225,7 +1221,7 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         CqlValueSet a_ = this.Cystectomy_for_Urology_Care(context);
         IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> c_(Procedure Cystectomy) {
+        bool? c_(Procedure Cystectomy) {
             Procedure g_ = this.First_Bladder_Cancer_Staging_Procedure(context);
             Procedure[] h_ = [
                 g_,
@@ -1233,62 +1229,62 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
             bool? i_(Procedure FirstBladderCancerStaging) {
 
-                object m_() {
+                object l_() {
+
+                    bool ad_() {
+                        DataType ah_ = Cystectomy?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        bool aj_ = ai_ is CqlDateTime;
+                        return aj_;
+                    }
+
 
                     bool ae_() {
-                        DataType ai_ = Cystectomy?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        bool ak_ = aj_ is CqlDateTime;
-                        return ak_;
+                        DataType ak_ = Cystectomy?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        bool am_ = al_ is CqlInterval<CqlDateTime>;
+                        return am_;
                     }
 
 
                     bool af_() {
-                        DataType al_ = Cystectomy?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        bool an_ = am_ is CqlInterval<CqlDateTime>;
-                        return an_;
+                        DataType an_ = Cystectomy?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        bool ap_ = ao_ is CqlQuantity;
+                        return ap_;
                     }
 
 
                     bool ag_() {
-                        DataType ao_ = Cystectomy?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        bool aq_ = ap_ is CqlQuantity;
-                        return aq_;
+                        DataType aq_ = Cystectomy?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        bool as_ = ar_ is CqlInterval<CqlQuantity>;
+                        return as_;
                     }
 
-
-                    bool ah_() {
-                        DataType ar_ = Cystectomy?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlInterval<CqlQuantity>;
-                        return at_;
-                    }
-
-                    if (ae_())
+                    if (ad_())
                     {
-                        DataType au_ = Cystectomy?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        return (av_ as CqlDateTime) as object;
+                        DataType at_ = Cystectomy?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        return (au_ as CqlDateTime) as object;
+                    }
+                    else if (ae_())
+                    {
+                        DataType av_ = Cystectomy?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        return (aw_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (af_())
                     {
-                        DataType aw_ = Cystectomy?.Performed;
-                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                        return (ax_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ax_ = Cystectomy?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        return (ay_ as CqlQuantity) as object;
                     }
                     else if (ag_())
                     {
-                        DataType ay_ = Cystectomy?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        return (az_ as CqlQuantity) as object;
-                    }
-                    else if (ah_())
-                    {
-                        DataType ba_ = Cystectomy?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        return (bb_ as CqlInterval<CqlQuantity>) as object;
+                        DataType az_ = Cystectomy?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        return (ba_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1296,65 +1292,65 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
-                CqlDateTime o_ = context.Operators.End(n_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
+                CqlDateTime n_ = context.Operators.End(m_);
 
-                object p_() {
+                object o_() {
+
+                    bool bb_() {
+                        DataType bf_ = FirstBladderCancerStaging?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        bool bh_ = bg_ is CqlDateTime;
+                        return bh_;
+                    }
+
 
                     bool bc_() {
-                        DataType bg_ = FirstBladderCancerStaging?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        bool bi_ = bh_ is CqlDateTime;
-                        return bi_;
+                        DataType bi_ = FirstBladderCancerStaging?.Performed;
+                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                        bool bk_ = bj_ is CqlInterval<CqlDateTime>;
+                        return bk_;
                     }
 
 
                     bool bd_() {
-                        DataType bj_ = FirstBladderCancerStaging?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        bool bl_ = bk_ is CqlInterval<CqlDateTime>;
-                        return bl_;
+                        DataType bl_ = FirstBladderCancerStaging?.Performed;
+                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+                        bool bn_ = bm_ is CqlQuantity;
+                        return bn_;
                     }
 
 
                     bool be_() {
-                        DataType bm_ = FirstBladderCancerStaging?.Performed;
-                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                        bool bo_ = bn_ is CqlQuantity;
-                        return bo_;
+                        DataType bo_ = FirstBladderCancerStaging?.Performed;
+                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                        bool bq_ = bp_ is CqlInterval<CqlQuantity>;
+                        return bq_;
                     }
 
-
-                    bool bf_() {
-                        DataType bp_ = FirstBladderCancerStaging?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        bool br_ = bq_ is CqlInterval<CqlQuantity>;
-                        return br_;
-                    }
-
-                    if (bc_())
+                    if (bb_())
                     {
-                        DataType bs_ = FirstBladderCancerStaging?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        return (bt_ as CqlDateTime) as object;
+                        DataType br_ = FirstBladderCancerStaging?.Performed;
+                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                        return (bs_ as CqlDateTime) as object;
+                    }
+                    else if (bc_())
+                    {
+                        DataType bt_ = FirstBladderCancerStaging?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        return (bu_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bd_())
                     {
-                        DataType bu_ = FirstBladderCancerStaging?.Performed;
-                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                        return (bv_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bv_ = FirstBladderCancerStaging?.Performed;
+                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                        return (bw_ as CqlQuantity) as object;
                     }
                     else if (be_())
                     {
-                        DataType bw_ = FirstBladderCancerStaging?.Performed;
-                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                        return (bx_ as CqlQuantity) as object;
-                    }
-                    else if (bf_())
-                    {
-                        DataType by_ = FirstBladderCancerStaging?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        return (bz_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bx_ = FirstBladderCancerStaging?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        return (by_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1362,67 +1358,67 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(6m, "months");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlQuantity r_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
 
-                object u_() {
+                object t_() {
+
+                    bool bz_() {
+                        DataType cd_ = FirstBladderCancerStaging?.Performed;
+                        object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                        bool cf_ = ce_ is CqlDateTime;
+                        return cf_;
+                    }
+
 
                     bool ca_() {
-                        DataType ce_ = FirstBladderCancerStaging?.Performed;
-                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
-                        bool cg_ = cf_ is CqlDateTime;
-                        return cg_;
+                        DataType cg_ = FirstBladderCancerStaging?.Performed;
+                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                        bool ci_ = ch_ is CqlInterval<CqlDateTime>;
+                        return ci_;
                     }
 
 
                     bool cb_() {
-                        DataType ch_ = FirstBladderCancerStaging?.Performed;
-                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                        bool cj_ = ci_ is CqlInterval<CqlDateTime>;
-                        return cj_;
+                        DataType cj_ = FirstBladderCancerStaging?.Performed;
+                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                        bool cl_ = ck_ is CqlQuantity;
+                        return cl_;
                     }
 
 
                     bool cc_() {
-                        DataType ck_ = FirstBladderCancerStaging?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        bool cm_ = cl_ is CqlQuantity;
-                        return cm_;
+                        DataType cm_ = FirstBladderCancerStaging?.Performed;
+                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
+                        bool co_ = cn_ is CqlInterval<CqlQuantity>;
+                        return co_;
                     }
 
-
-                    bool cd_() {
-                        DataType cn_ = FirstBladderCancerStaging?.Performed;
-                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                        bool cp_ = co_ is CqlInterval<CqlQuantity>;
-                        return cp_;
-                    }
-
-                    if (ca_())
+                    if (bz_())
                     {
-                        DataType cq_ = FirstBladderCancerStaging?.Performed;
-                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                        return (cr_ as CqlDateTime) as object;
+                        DataType cp_ = FirstBladderCancerStaging?.Performed;
+                        object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+                        return (cq_ as CqlDateTime) as object;
+                    }
+                    else if (ca_())
+                    {
+                        DataType cr_ = FirstBladderCancerStaging?.Performed;
+                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+                        return (cs_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (cb_())
                     {
-                        DataType cs_ = FirstBladderCancerStaging?.Performed;
-                        object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
-                        return (ct_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ct_ = FirstBladderCancerStaging?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        return (cu_ as CqlQuantity) as object;
                     }
                     else if (cc_())
                     {
-                        DataType cu_ = FirstBladderCancerStaging?.Performed;
-                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
-                        return (cv_ as CqlQuantity) as object;
-                    }
-                    else if (cd_())
-                    {
-                        DataType cw_ = FirstBladderCancerStaging?.Performed;
-                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                        return (cx_ as CqlInterval<CqlQuantity>) as object;
+                        DataType cv_ = FirstBladderCancerStaging?.Performed;
+                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                        return (cw_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1430,67 +1426,67 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, false);
-                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, false);
+                bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, "day");
 
-                object z_() {
+                object y_() {
+
+                    bool cx_() {
+                        DataType db_ = FirstBladderCancerStaging?.Performed;
+                        object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                        bool dd_ = dc_ is CqlDateTime;
+                        return dd_;
+                    }
+
 
                     bool cy_() {
-                        DataType dc_ = FirstBladderCancerStaging?.Performed;
-                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
-                        bool de_ = dd_ is CqlDateTime;
-                        return de_;
+                        DataType de_ = FirstBladderCancerStaging?.Performed;
+                        object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                        bool dg_ = df_ is CqlInterval<CqlDateTime>;
+                        return dg_;
                     }
 
 
                     bool cz_() {
-                        DataType df_ = FirstBladderCancerStaging?.Performed;
-                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                        bool dh_ = dg_ is CqlInterval<CqlDateTime>;
-                        return dh_;
+                        DataType dh_ = FirstBladderCancerStaging?.Performed;
+                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+                        bool dj_ = di_ is CqlQuantity;
+                        return dj_;
                     }
 
 
                     bool da_() {
-                        DataType di_ = FirstBladderCancerStaging?.Performed;
-                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                        bool dk_ = dj_ is CqlQuantity;
-                        return dk_;
+                        DataType dk_ = FirstBladderCancerStaging?.Performed;
+                        object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
+                        bool dm_ = dl_ is CqlInterval<CqlQuantity>;
+                        return dm_;
                     }
 
-
-                    bool db_() {
-                        DataType dl_ = FirstBladderCancerStaging?.Performed;
-                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                        bool dn_ = dm_ is CqlInterval<CqlQuantity>;
-                        return dn_;
-                    }
-
-                    if (cy_())
+                    if (cx_())
                     {
-                        DataType do_ = FirstBladderCancerStaging?.Performed;
-                        object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
-                        return (dp_ as CqlDateTime) as object;
+                        DataType dn_ = FirstBladderCancerStaging?.Performed;
+                        object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+                        return (do_ as CqlDateTime) as object;
+                    }
+                    else if (cy_())
+                    {
+                        DataType dp_ = FirstBladderCancerStaging?.Performed;
+                        object dq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dp_);
+                        return (dq_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (cz_())
                     {
-                        DataType dq_ = FirstBladderCancerStaging?.Performed;
-                        object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
-                        return (dr_ as CqlInterval<CqlDateTime>) as object;
+                        DataType dr_ = FirstBladderCancerStaging?.Performed;
+                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                        return (ds_ as CqlQuantity) as object;
                     }
                     else if (da_())
                     {
-                        DataType ds_ = FirstBladderCancerStaging?.Performed;
-                        object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
-                        return (dt_ as CqlQuantity) as object;
-                    }
-                    else if (db_())
-                    {
-                        DataType du_ = FirstBladderCancerStaging?.Performed;
-                        object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                        return (dv_ as CqlInterval<CqlQuantity>) as object;
+                        DataType dt_ = FirstBladderCancerStaging?.Performed;
+                        object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                        return (du_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1498,27 +1494,26 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
-                bool? ad_ = context.Operators.And(y_, ac_);
-                return ad_;
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+                bool? ac_ = context.Operators.And(x_, ab_);
+                return ac_;
             }
 
             IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)h_, i_);
-            Procedure k_(Procedure FirstBladderCancerStaging) => Cystectomy;
-            IEnumerable<Procedure> l_ = context.Operators.Select<Procedure, Procedure>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Procedure>(j_);
+            return k_;
         }
 
-        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 
         bool? e_(Procedure Cystectomy) {
-            Code<EventStatus> dw_ = Cystectomy?.StatusElement;
-            EventStatus? dx_ = dw_?.Value;
-            string dy_ = context.Operators.Convert<string>(dx_);
-            bool? dz_ = context.Operators.Equal(dy_, "completed");
-            return dz_;
+            Code<EventStatus> dv_ = Cystectomy?.StatusElement;
+            EventStatus? dw_ = dv_?.Value;
+            string dx_ = context.Operators.Convert<string>(dw_);
+            bool? dy_ = context.Operators.Equal(dx_, "completed");
+            return dy_;
         }
 
         IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
@@ -1549,72 +1544,72 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> p_ = context.Operators.Union<Condition>(m_ as IEnumerable<Condition>, o_ as IEnumerable<Condition>);
         IEnumerable<Condition> q_ = context.Operators.Union<Condition>(k_, p_);
 
-        IEnumerable<Condition> r_(Condition ExclusionDiagnosis) {
+        bool? r_(Condition ExclusionDiagnosis) {
             Procedure w_ = this.First_Bladder_Cancer_Staging_Procedure(context);
             Procedure[] x_ = [
                 w_,
             ];
 
             bool? y_(Procedure FirstBladderCancerStaging) {
-                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionDiagnosis);
-                CqlDateTime ad_ = context.Operators.Start(ac_);
+                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionDiagnosis);
+                CqlDateTime ac_ = context.Operators.Start(ab_);
 
-                object ae_() {
+                object ad_() {
+
+                    bool aq_() {
+                        DataType au_ = FirstBladderCancerStaging?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlDateTime;
+                        return aw_;
+                    }
+
 
                     bool ar_() {
-                        DataType av_ = FirstBladderCancerStaging?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlDateTime;
-                        return ax_;
+                        DataType ax_ = FirstBladderCancerStaging?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlInterval<CqlDateTime>;
+                        return az_;
                     }
 
 
                     bool as_() {
-                        DataType ay_ = FirstBladderCancerStaging?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlInterval<CqlDateTime>;
-                        return ba_;
+                        DataType ba_ = FirstBladderCancerStaging?.Performed;
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlQuantity;
+                        return bc_;
                     }
 
 
                     bool at_() {
-                        DataType bb_ = FirstBladderCancerStaging?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlQuantity;
-                        return bd_;
+                        DataType bd_ = FirstBladderCancerStaging?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        bool bf_ = be_ is CqlInterval<CqlQuantity>;
+                        return bf_;
                     }
 
-
-                    bool au_() {
-                        DataType be_ = FirstBladderCancerStaging?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        bool bg_ = bf_ is CqlInterval<CqlQuantity>;
-                        return bg_;
-                    }
-
-                    if (ar_())
+                    if (aq_())
                     {
-                        DataType bh_ = FirstBladderCancerStaging?.Performed;
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        return (bi_ as CqlDateTime) as object;
+                        DataType bg_ = FirstBladderCancerStaging?.Performed;
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        return (bh_ as CqlDateTime) as object;
+                    }
+                    else if (ar_())
+                    {
+                        DataType bi_ = FirstBladderCancerStaging?.Performed;
+                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                        return (bj_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (as_())
                     {
-                        DataType bj_ = FirstBladderCancerStaging?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        return (bk_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bk_ = FirstBladderCancerStaging?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        return (bl_ as CqlQuantity) as object;
                     }
                     else if (at_())
                     {
-                        DataType bl_ = FirstBladderCancerStaging?.Performed;
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        return (bm_ as CqlQuantity) as object;
-                    }
-                    else if (au_())
-                    {
-                        DataType bn_ = FirstBladderCancerStaging?.Performed;
-                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                        return (bo_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bm_ = FirstBladderCancerStaging?.Performed;
+                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                        return (bn_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1622,70 +1617,70 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_());
-                CqlDateTime ag_ = context.Operators.Start(af_);
-                bool? ah_ = context.Operators.SameOrBefore(ad_, ag_, "day");
-                DataType ai_ = ExclusionDiagnosis?.Onset;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.Start(ak_);
+                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_());
+                CqlDateTime af_ = context.Operators.Start(ae_);
+                bool? ag_ = context.Operators.SameOrBefore(ac_, af_, "day");
+                DataType ah_ = ExclusionDiagnosis?.Onset;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+                CqlDateTime ak_ = context.Operators.Start(aj_);
 
-                object am_() {
+                object al_() {
+
+                    bool bo_() {
+                        DataType bs_ = FirstBladderCancerStaging?.Performed;
+                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                        bool bu_ = bt_ is CqlDateTime;
+                        return bu_;
+                    }
+
 
                     bool bp_() {
-                        DataType bt_ = FirstBladderCancerStaging?.Performed;
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        bool bv_ = bu_ is CqlDateTime;
-                        return bv_;
+                        DataType bv_ = FirstBladderCancerStaging?.Performed;
+                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                        bool bx_ = bw_ is CqlInterval<CqlDateTime>;
+                        return bx_;
                     }
 
 
                     bool bq_() {
-                        DataType bw_ = FirstBladderCancerStaging?.Performed;
-                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                        bool by_ = bx_ is CqlInterval<CqlDateTime>;
-                        return by_;
+                        DataType by_ = FirstBladderCancerStaging?.Performed;
+                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
+                        bool ca_ = bz_ is CqlQuantity;
+                        return ca_;
                     }
 
 
                     bool br_() {
-                        DataType bz_ = FirstBladderCancerStaging?.Performed;
-                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                        bool cb_ = ca_ is CqlQuantity;
-                        return cb_;
+                        DataType cb_ = FirstBladderCancerStaging?.Performed;
+                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+                        bool cd_ = cc_ is CqlInterval<CqlQuantity>;
+                        return cd_;
                     }
 
-
-                    bool bs_() {
-                        DataType cc_ = FirstBladderCancerStaging?.Performed;
-                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        bool ce_ = cd_ is CqlInterval<CqlQuantity>;
-                        return ce_;
-                    }
-
-                    if (bp_())
+                    if (bo_())
                     {
-                        DataType cf_ = FirstBladderCancerStaging?.Performed;
-                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                        return (cg_ as CqlDateTime) as object;
+                        DataType ce_ = FirstBladderCancerStaging?.Performed;
+                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                        return (cf_ as CqlDateTime) as object;
+                    }
+                    else if (bp_())
+                    {
+                        DataType cg_ = FirstBladderCancerStaging?.Performed;
+                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                        return (ch_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bq_())
                     {
-                        DataType ch_ = FirstBladderCancerStaging?.Performed;
-                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                        return (ci_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ci_ = FirstBladderCancerStaging?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        return (cj_ as CqlQuantity) as object;
                     }
                     else if (br_())
                     {
-                        DataType cj_ = FirstBladderCancerStaging?.Performed;
-                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                        return (ck_ as CqlQuantity) as object;
-                    }
-                    else if (bs_())
-                    {
-                        DataType cl_ = FirstBladderCancerStaging?.Performed;
-                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                        return (cm_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ck_ = FirstBladderCancerStaging?.Performed;
+                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+                        return (cl_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1693,24 +1688,23 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
-                CqlDateTime ao_ = context.Operators.Start(an_);
-                bool? ap_ = context.Operators.SameOrBefore(al_, ao_, "day");
-                bool? aq_ = context.Operators.Or(ah_, ap_);
-                return aq_;
+                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_());
+                CqlDateTime an_ = context.Operators.Start(am_);
+                bool? ao_ = context.Operators.SameOrBefore(ak_, an_, "day");
+                bool? ap_ = context.Operators.Or(ag_, ao_);
+                return ap_;
             }
 
             IEnumerable<Procedure> z_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)x_, y_);
-            Condition aa_(Procedure FirstBladderCancerStaging) => ExclusionDiagnosis;
-            IEnumerable<Condition> ab_ = context.Operators.Select<Procedure, Condition>(z_, aa_);
-            return ab_;
+            bool? aa_ = context.Operators.Exists<Procedure>(z_);
+            return aa_;
         }
 
-        IEnumerable<Condition> s_ = context.Operators.SelectMany<Condition, Condition>(q_, r_);
+        IEnumerable<Condition> s_ = context.Operators.Where<Condition>(q_, r_);
 
         bool? t_(Condition ExclusionDiagnosis) {
-            bool? cn_ = this.isVerified(context, ExclusionDiagnosis);
-            return cn_;
+            bool? cm_ = this.isVerified(context, ExclusionDiagnosis);
+            return cm_;
         }
 
         IEnumerable<Condition> u_ = context.Operators.Where<Condition>(s_, t_);
@@ -1731,162 +1725,161 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+        bool? d_(MedicationRequest MR) {
             IEnumerable<Medication> t_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? u_(Medication M) {
-                object y_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object z_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> aa_ = context.Operators.Split((string)z_, "/");
-                string ab_ = context.Operators.Last<string>(aa_);
-                bool? ac_ = context.Operators.Equal(y_, ab_);
-                CodeableConcept ad_ = M?.Code;
-                CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
-                CqlValueSet af_ = this.Chemotherapy_Agents_for_Advanced_Cancer(context);
-                bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-                bool? ah_ = context.Operators.And(ac_, ag_);
-                return ah_;
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Chemotherapy_Agents_for_Advanced_Cancer(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+                return ag_;
             }
 
             IEnumerable<Medication> v_ = context.Operators.Where<Medication>(t_, u_);
-            MedicationRequest w_(Medication M) => MR;
-            IEnumerable<MedicationRequest> x_ = context.Operators.Select<Medication, MedicationRequest>(v_, w_);
-            return x_;
+            bool? w_ = context.Operators.Exists<Medication>(v_);
+            return w_;
         }
 
-        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
 
-        IEnumerable<MedicationRequest> g_(MedicationRequest ExclusionMed) {
-            Procedure ai_ = this.First_Bladder_Cancer_Staging_Procedure(context);
-            Procedure[] aj_ = [
-                ai_,
+        bool? g_(MedicationRequest ExclusionMed) {
+            Procedure ah_ = this.First_Bladder_Cancer_Staging_Procedure(context);
+            Procedure[] ai_ = [
+                ah_,
             ];
 
-            bool? ak_(Procedure FirstBladderCancerStaging) {
-                List<Dosage> ao_ = ExclusionMed?.DosageInstruction;
+            bool? aj_(Procedure FirstBladderCancerStaging) {
+                List<Dosage> am_ = ExclusionMed?.DosageInstruction;
 
-                bool? ap_(Dosage @this) {
-                    Timing by_ = @this?.Timing;
-                    bool? bz_ = context.Operators.Not((bool?)(by_ is null));
-                    return bz_;
+                bool? an_(Dosage @this) {
+                    Timing bw_ = @this?.Timing;
+                    bool? bx_ = context.Operators.Not((bool?)(bw_ is null));
+                    return bx_;
                 }
 
-                IEnumerable<Dosage> aq_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)ao_, ap_);
+                IEnumerable<Dosage> ao_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)am_, an_);
 
-                Timing ar_(Dosage @this) {
-                    Timing ca_ = @this?.Timing;
+                Timing ap_(Dosage @this) {
+                    Timing by_ = @this?.Timing;
+                    return by_;
+                }
+
+                IEnumerable<Timing> aq_ = context.Operators.Select<Dosage, Timing>(ao_, ap_);
+
+                bool? ar_(Timing @this) {
+                    Timing.RepeatComponent bz_ = @this?.Repeat;
+                    bool? ca_ = context.Operators.Not((bool?)(bz_ is null));
                     return ca_;
                 }
 
-                IEnumerable<Timing> as_ = context.Operators.Select<Dosage, Timing>(aq_, ar_);
+                IEnumerable<Timing> as_ = context.Operators.Where<Timing>(aq_, ar_);
 
-                bool? at_(Timing @this) {
+                Timing.RepeatComponent at_(Timing @this) {
                     Timing.RepeatComponent cb_ = @this?.Repeat;
-                    bool? cc_ = context.Operators.Not((bool?)(cb_ is null));
-                    return cc_;
+                    return cb_;
                 }
 
-                IEnumerable<Timing> au_ = context.Operators.Where<Timing>(as_, at_);
+                IEnumerable<Timing.RepeatComponent> au_ = context.Operators.Select<Timing, Timing.RepeatComponent>(as_, at_);
 
-                Timing.RepeatComponent av_(Timing @this) {
-                    Timing.RepeatComponent cd_ = @this?.Repeat;
-                    return cd_;
+                bool? av_(Timing.RepeatComponent @this) {
+                    DataType cc_ = @this?.Bounds;
+                    object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
+                    bool? ce_ = context.Operators.Not((bool?)(cd_ is null));
+                    return ce_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> aw_ = context.Operators.Select<Timing, Timing.RepeatComponent>(au_, av_);
+                IEnumerable<Timing.RepeatComponent> aw_ = context.Operators.Where<Timing.RepeatComponent>(au_, av_);
 
-                bool? ax_(Timing.RepeatComponent @this) {
-                    DataType ce_ = @this?.Bounds;
-                    object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
-                    bool? cg_ = context.Operators.Not((bool?)(cf_ is null));
+                object ax_(Timing.RepeatComponent @this) {
+                    DataType cf_ = @this?.Bounds;
+                    object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
                     return cg_;
                 }
 
-                IEnumerable<Timing.RepeatComponent> ay_ = context.Operators.Where<Timing.RepeatComponent>(aw_, ax_);
+                IEnumerable<object> ay_ = context.Operators.Select<Timing.RepeatComponent, object>(aw_, ax_);
 
-                object az_(Timing.RepeatComponent @this) {
-                    DataType ch_ = @this?.Bounds;
-                    object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                CqlInterval<CqlDateTime> az_(object DoseTime) {
+                    CqlInterval<CqlDateTime> ch_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+                    return ch_;
+                }
+
+                IEnumerable<CqlInterval<CqlDateTime>> ba_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(ay_, az_);
+                IEnumerable<CqlInterval<CqlDateTime>> bb_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(ba_);
+                IEnumerable<CqlInterval<CqlDateTime>> bc_ = context.Operators.Collapse(bb_, (string)default);
+
+                object bd_(CqlInterval<CqlDateTime> @this) {
+                    CqlDateTime ci_ = context.Operators.Start(@this);
                     return ci_;
                 }
 
-                IEnumerable<object> ba_ = context.Operators.Select<Timing.RepeatComponent, object>(ay_, az_);
+                IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(bc_, bd_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> bf_ = context.Operators.First<CqlInterval<CqlDateTime>>(be_);
+                CqlDateTime bg_ = context.Operators.Start(bf_);
 
-                CqlInterval<CqlDateTime> bb_(object DoseTime) {
-                    CqlInterval<CqlDateTime> cj_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
-                    return cj_;
-                }
+                object bh_() {
 
-                IEnumerable<CqlInterval<CqlDateTime>> bc_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(ba_, bb_);
-                IEnumerable<CqlInterval<CqlDateTime>> bd_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bc_);
-                IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.Collapse(bd_, (string)default);
+                    bool cj_() {
+                        DataType cn_ = FirstBladderCancerStaging?.Performed;
+                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+                        bool cp_ = co_ is CqlDateTime;
+                        return cp_;
+                    }
 
-                object bf_(CqlInterval<CqlDateTime> @this) {
-                    CqlDateTime ck_ = context.Operators.Start(@this);
-                    return ck_;
-                }
 
-                IEnumerable<CqlInterval<CqlDateTime>> bg_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
-                CqlInterval<CqlDateTime> bh_ = context.Operators.First<CqlInterval<CqlDateTime>>(bg_);
-                CqlDateTime bi_ = context.Operators.Start(bh_);
+                    bool ck_() {
+                        DataType cq_ = FirstBladderCancerStaging?.Performed;
+                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                        bool cs_ = cr_ is CqlInterval<CqlDateTime>;
+                        return cs_;
+                    }
 
-                object bj_() {
 
                     bool cl_() {
-                        DataType cp_ = FirstBladderCancerStaging?.Performed;
-                        object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
-                        bool cr_ = cq_ is CqlDateTime;
-                        return cr_;
+                        DataType ct_ = FirstBladderCancerStaging?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        bool cv_ = cu_ is CqlQuantity;
+                        return cv_;
                     }
 
 
                     bool cm_() {
-                        DataType cs_ = FirstBladderCancerStaging?.Performed;
-                        object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
-                        bool cu_ = ct_ is CqlInterval<CqlDateTime>;
-                        return cu_;
+                        DataType cw_ = FirstBladderCancerStaging?.Performed;
+                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                        bool cy_ = cx_ is CqlInterval<CqlQuantity>;
+                        return cy_;
                     }
 
-
-                    bool cn_() {
-                        DataType cv_ = FirstBladderCancerStaging?.Performed;
-                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                        bool cx_ = cw_ is CqlQuantity;
-                        return cx_;
+                    if (cj_())
+                    {
+                        DataType cz_ = FirstBladderCancerStaging?.Performed;
+                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
+                        return (da_ as CqlDateTime) as object;
                     }
-
-
-                    bool co_() {
-                        DataType cy_ = FirstBladderCancerStaging?.Performed;
-                        object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
-                        bool da_ = cz_ is CqlInterval<CqlQuantity>;
-                        return da_;
-                    }
-
-                    if (cl_())
+                    else if (ck_())
                     {
                         DataType db_ = FirstBladderCancerStaging?.Performed;
                         object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
-                        return (dc_ as CqlDateTime) as object;
+                        return (dc_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (cm_())
+                    else if (cl_())
                     {
                         DataType dd_ = FirstBladderCancerStaging?.Performed;
                         object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
-                        return (de_ as CqlInterval<CqlDateTime>) as object;
+                        return (de_ as CqlQuantity) as object;
                     }
-                    else if (cn_())
+                    else if (cm_())
                     {
                         DataType df_ = FirstBladderCancerStaging?.Performed;
                         object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                        return (dg_ as CqlQuantity) as object;
-                    }
-                    else if (co_())
-                    {
-                        DataType dh_ = FirstBladderCancerStaging?.Performed;
-                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
-                        return (di_ as CqlInterval<CqlQuantity>) as object;
+                        return (dg_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1894,67 +1887,67 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_());
-                CqlDateTime bl_ = context.Operators.Start(bk_);
-                CqlQuantity bm_ = context.Operators.Quantity(6m, "months");
-                CqlDateTime bn_ = context.Operators.Subtract(bl_, bm_);
+                CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_());
+                CqlDateTime bj_ = context.Operators.Start(bi_);
+                CqlQuantity bk_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
 
-                object bo_() {
+                object bm_() {
+
+                    bool dh_() {
+                        DataType dl_ = FirstBladderCancerStaging?.Performed;
+                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+                        bool dn_ = dm_ is CqlDateTime;
+                        return dn_;
+                    }
+
+
+                    bool di_() {
+                        DataType do_ = FirstBladderCancerStaging?.Performed;
+                        object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
+                        bool dq_ = dp_ is CqlInterval<CqlDateTime>;
+                        return dq_;
+                    }
+
 
                     bool dj_() {
-                        DataType dn_ = FirstBladderCancerStaging?.Performed;
-                        object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
-                        bool dp_ = do_ is CqlDateTime;
-                        return dp_;
+                        DataType dr_ = FirstBladderCancerStaging?.Performed;
+                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                        bool dt_ = ds_ is CqlQuantity;
+                        return dt_;
                     }
 
 
                     bool dk_() {
-                        DataType dq_ = FirstBladderCancerStaging?.Performed;
-                        object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
-                        bool ds_ = dr_ is CqlInterval<CqlDateTime>;
-                        return ds_;
+                        DataType du_ = FirstBladderCancerStaging?.Performed;
+                        object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
+                        bool dw_ = dv_ is CqlInterval<CqlQuantity>;
+                        return dw_;
                     }
 
-
-                    bool dl_() {
-                        DataType dt_ = FirstBladderCancerStaging?.Performed;
-                        object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
-                        bool dv_ = du_ is CqlQuantity;
-                        return dv_;
+                    if (dh_())
+                    {
+                        DataType dx_ = FirstBladderCancerStaging?.Performed;
+                        object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
+                        return (dy_ as CqlDateTime) as object;
                     }
-
-
-                    bool dm_() {
-                        DataType dw_ = FirstBladderCancerStaging?.Performed;
-                        object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                        bool dy_ = dx_ is CqlInterval<CqlQuantity>;
-                        return dy_;
-                    }
-
-                    if (dj_())
+                    else if (di_())
                     {
                         DataType dz_ = FirstBladderCancerStaging?.Performed;
                         object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
-                        return (ea_ as CqlDateTime) as object;
+                        return (ea_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (dk_())
+                    else if (dj_())
                     {
                         DataType eb_ = FirstBladderCancerStaging?.Performed;
                         object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
-                        return (ec_ as CqlInterval<CqlDateTime>) as object;
+                        return (ec_ as CqlQuantity) as object;
                     }
-                    else if (dl_())
+                    else if (dk_())
                     {
                         DataType ed_ = FirstBladderCancerStaging?.Performed;
                         object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
-                        return (ee_ as CqlQuantity) as object;
-                    }
-                    else if (dm_())
-                    {
-                        DataType ef_ = FirstBladderCancerStaging?.Performed;
-                        object eg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ef_);
-                        return (eg_ as CqlInterval<CqlQuantity>) as object;
+                        return (ee_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1962,67 +1955,67 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_());
-                CqlDateTime bq_ = context.Operators.Start(bp_);
-                CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bn_, bq_, true, false);
-                bool? bs_ = context.Operators.In<CqlDateTime>(bi_, br_, (string)default);
+                CqlInterval<CqlDateTime> bn_ = QICoreCommon_4_0_000.Instance.toInterval(context, bm_());
+                CqlDateTime bo_ = context.Operators.Start(bn_);
+                CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bl_, bo_, true, false);
+                bool? bq_ = context.Operators.In<CqlDateTime>(bg_, bp_, (string)default);
 
-                object bt_() {
+                object br_() {
+
+                    bool ef_() {
+                        DataType ej_ = FirstBladderCancerStaging?.Performed;
+                        object ek_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ej_);
+                        bool el_ = ek_ is CqlDateTime;
+                        return el_;
+                    }
+
+
+                    bool eg_() {
+                        DataType em_ = FirstBladderCancerStaging?.Performed;
+                        object en_ = FHIRHelpers_4_4_000.Instance.ToValue(context, em_);
+                        bool eo_ = en_ is CqlInterval<CqlDateTime>;
+                        return eo_;
+                    }
+
 
                     bool eh_() {
-                        DataType el_ = FirstBladderCancerStaging?.Performed;
-                        object em_ = FHIRHelpers_4_4_000.Instance.ToValue(context, el_);
-                        bool en_ = em_ is CqlDateTime;
-                        return en_;
+                        DataType ep_ = FirstBladderCancerStaging?.Performed;
+                        object eq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ep_);
+                        bool er_ = eq_ is CqlQuantity;
+                        return er_;
                     }
 
 
                     bool ei_() {
-                        DataType eo_ = FirstBladderCancerStaging?.Performed;
-                        object ep_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eo_);
-                        bool eq_ = ep_ is CqlInterval<CqlDateTime>;
-                        return eq_;
+                        DataType es_ = FirstBladderCancerStaging?.Performed;
+                        object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
+                        bool eu_ = et_ is CqlInterval<CqlQuantity>;
+                        return eu_;
                     }
 
-
-                    bool ej_() {
-                        DataType er_ = FirstBladderCancerStaging?.Performed;
-                        object es_ = FHIRHelpers_4_4_000.Instance.ToValue(context, er_);
-                        bool et_ = es_ is CqlQuantity;
-                        return et_;
+                    if (ef_())
+                    {
+                        DataType ev_ = FirstBladderCancerStaging?.Performed;
+                        object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
+                        return (ew_ as CqlDateTime) as object;
                     }
-
-
-                    bool ek_() {
-                        DataType eu_ = FirstBladderCancerStaging?.Performed;
-                        object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
-                        bool ew_ = ev_ is CqlInterval<CqlQuantity>;
-                        return ew_;
-                    }
-
-                    if (eh_())
+                    else if (eg_())
                     {
                         DataType ex_ = FirstBladderCancerStaging?.Performed;
                         object ey_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ex_);
-                        return (ey_ as CqlDateTime) as object;
+                        return (ey_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (ei_())
+                    else if (eh_())
                     {
                         DataType ez_ = FirstBladderCancerStaging?.Performed;
                         object fa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ez_);
-                        return (fa_ as CqlInterval<CqlDateTime>) as object;
+                        return (fa_ as CqlQuantity) as object;
                     }
-                    else if (ej_())
+                    else if (ei_())
                     {
                         DataType fb_ = FirstBladderCancerStaging?.Performed;
                         object fc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fb_);
-                        return (fc_ as CqlQuantity) as object;
-                    }
-                    else if (ek_())
-                    {
-                        DataType fd_ = FirstBladderCancerStaging?.Performed;
-                        object fe_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fd_);
-                        return (fe_ as CqlInterval<CqlQuantity>) as object;
+                        return (fc_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2030,36 +2023,35 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, bt_());
-                CqlDateTime bv_ = context.Operators.Start(bu_);
-                bool? bw_ = context.Operators.Not((bool?)(bv_ is null));
-                bool? bx_ = context.Operators.And(bs_, bw_);
-                return bx_;
+                CqlInterval<CqlDateTime> bs_ = QICoreCommon_4_0_000.Instance.toInterval(context, br_());
+                CqlDateTime bt_ = context.Operators.Start(bs_);
+                bool? bu_ = context.Operators.Not((bool?)(bt_ is null));
+                bool? bv_ = context.Operators.And(bq_, bu_);
+                return bv_;
             }
 
-            IEnumerable<Procedure> al_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)aj_, ak_);
-            MedicationRequest am_(Procedure FirstBladderCancerStaging) => ExclusionMed;
-            IEnumerable<MedicationRequest> an_ = context.Operators.Select<Procedure, MedicationRequest>(al_, am_);
-            return an_;
+            IEnumerable<Procedure> ak_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)ai_, aj_);
+            bool? al_ = context.Operators.Exists<Procedure>(ak_);
+            return al_;
         }
 
-        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 
         bool? i_(MedicationRequest ExclusionMed) {
-            Code<MedicationRequest.MedicationrequestStatus> ff_ = ExclusionMed?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? fg_ = ff_?.Value;
-            string fh_ = context.Operators.Convert<string>(fg_);
-            string[] fi_ = [
+            Code<MedicationRequest.MedicationrequestStatus> fd_ = ExclusionMed?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? fe_ = fd_?.Value;
+            string ff_ = context.Operators.Convert<string>(fe_);
+            string[] fg_ = [
                 "active",
                 "completed",
             ];
-            bool? fj_ = context.Operators.In<string>(fh_, (IEnumerable<string>)fi_);
-            Code<MedicationRequest.MedicationRequestIntent> fk_ = ExclusionMed?.IntentElement;
-            MedicationRequest.MedicationRequestIntent? fl_ = fk_?.Value;
-            string fm_ = context.Operators.Convert<string>(fl_);
-            bool? fn_ = context.Operators.Equal(fm_, "order");
-            bool? fo_ = context.Operators.And(fj_, fn_);
-            return fo_;
+            bool? fh_ = context.Operators.In<string>(ff_, (IEnumerable<string>)fg_);
+            Code<MedicationRequest.MedicationRequestIntent> fi_ = ExclusionMed?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? fj_ = fi_?.Value;
+            string fk_ = context.Operators.Convert<string>(fj_);
+            bool? fl_ = context.Operators.Equal(fk_, "order");
+            bool? fm_ = context.Operators.And(fh_, fl_);
+            return fm_;
         }
 
         IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
@@ -2067,70 +2059,136 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<CqlCode> l_ = context.Operators.ToList<CqlCode>(k_);
         IEnumerable<Procedure> m_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, l_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        IEnumerable<Procedure> n_(Procedure ExclusionProcedure) {
-            Procedure fp_ = this.First_Bladder_Cancer_Staging_Procedure(context);
-            Procedure[] fq_ = [
-                fp_,
+        bool? n_(Procedure ExclusionProcedure) {
+            Procedure fn_ = this.First_Bladder_Cancer_Staging_Procedure(context);
+            Procedure[] fo_ = [
+                fn_,
             ];
 
-            bool? fr_(Procedure FirstBladderCancerStaging) {
+            bool? fp_(Procedure FirstBladderCancerStaging) {
 
-                object fv_() {
+                object fs_() {
 
-                    bool gn_() {
+                    bool gk_() {
+                        DataType go_ = ExclusionProcedure?.Performed;
+                        object gp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, go_);
+                        bool gq_ = gp_ is CqlDateTime;
+                        return gq_;
+                    }
+
+
+                    bool gl_() {
                         DataType gr_ = ExclusionProcedure?.Performed;
                         object gs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gr_);
-                        bool gt_ = gs_ is CqlDateTime;
+                        bool gt_ = gs_ is CqlInterval<CqlDateTime>;
                         return gt_;
                     }
 
 
-                    bool go_() {
+                    bool gm_() {
                         DataType gu_ = ExclusionProcedure?.Performed;
                         object gv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gu_);
-                        bool gw_ = gv_ is CqlInterval<CqlDateTime>;
+                        bool gw_ = gv_ is CqlQuantity;
                         return gw_;
                     }
 
 
-                    bool gp_() {
+                    bool gn_() {
                         DataType gx_ = ExclusionProcedure?.Performed;
                         object gy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gx_);
-                        bool gz_ = gy_ is CqlQuantity;
+                        bool gz_ = gy_ is CqlInterval<CqlQuantity>;
                         return gz_;
                     }
 
-
-                    bool gq_() {
+                    if (gk_())
+                    {
                         DataType ha_ = ExclusionProcedure?.Performed;
                         object hb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ha_);
-                        bool hc_ = hb_ is CqlInterval<CqlQuantity>;
-                        return hc_;
+                        return (hb_ as CqlDateTime) as object;
+                    }
+                    else if (gl_())
+                    {
+                        DataType hc_ = ExclusionProcedure?.Performed;
+                        object hd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hc_);
+                        return (hd_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (gm_())
+                    {
+                        DataType he_ = ExclusionProcedure?.Performed;
+                        object hf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, he_);
+                        return (hf_ as CqlQuantity) as object;
+                    }
+                    else if (gn_())
+                    {
+                        DataType hg_ = ExclusionProcedure?.Performed;
+                        object hh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hg_);
+                        return (hh_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> ft_ = QICoreCommon_4_0_000.Instance.toInterval(context, fs_());
+                CqlDateTime fu_ = context.Operators.Start(ft_);
+
+                object fv_() {
+
+                    bool hi_() {
+                        DataType hm_ = FirstBladderCancerStaging?.Performed;
+                        object hn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hm_);
+                        bool ho_ = hn_ is CqlDateTime;
+                        return ho_;
                     }
 
-                    if (gn_())
-                    {
-                        DataType hd_ = ExclusionProcedure?.Performed;
-                        object he_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hd_);
-                        return (he_ as CqlDateTime) as object;
+
+                    bool hj_() {
+                        DataType hp_ = FirstBladderCancerStaging?.Performed;
+                        object hq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hp_);
+                        bool hr_ = hq_ is CqlInterval<CqlDateTime>;
+                        return hr_;
                     }
-                    else if (go_())
-                    {
-                        DataType hf_ = ExclusionProcedure?.Performed;
-                        object hg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hf_);
-                        return (hg_ as CqlInterval<CqlDateTime>) as object;
+
+
+                    bool hk_() {
+                        DataType hs_ = FirstBladderCancerStaging?.Performed;
+                        object ht_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hs_);
+                        bool hu_ = ht_ is CqlQuantity;
+                        return hu_;
                     }
-                    else if (gp_())
-                    {
-                        DataType hh_ = ExclusionProcedure?.Performed;
-                        object hi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hh_);
-                        return (hi_ as CqlQuantity) as object;
+
+
+                    bool hl_() {
+                        DataType hv_ = FirstBladderCancerStaging?.Performed;
+                        object hw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hv_);
+                        bool hx_ = hw_ is CqlInterval<CqlQuantity>;
+                        return hx_;
                     }
-                    else if (gq_())
+
+                    if (hi_())
                     {
-                        DataType hj_ = ExclusionProcedure?.Performed;
-                        object hk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hj_);
-                        return (hk_ as CqlInterval<CqlQuantity>) as object;
+                        DataType hy_ = FirstBladderCancerStaging?.Performed;
+                        object hz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hy_);
+                        return (hz_ as CqlDateTime) as object;
+                    }
+                    else if (hj_())
+                    {
+                        DataType ia_ = FirstBladderCancerStaging?.Performed;
+                        object ib_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ia_);
+                        return (ib_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (hk_())
+                    {
+                        DataType ic_ = FirstBladderCancerStaging?.Performed;
+                        object id_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ic_);
+                        return (id_ as CqlQuantity) as object;
+                    }
+                    else if (hl_())
+                    {
+                        DataType ie_ = FirstBladderCancerStaging?.Performed;
+                        object if_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ie_);
+                        return (if_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2140,131 +2198,65 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
                 CqlInterval<CqlDateTime> fw_ = QICoreCommon_4_0_000.Instance.toInterval(context, fv_());
                 CqlDateTime fx_ = context.Operators.Start(fw_);
+                CqlQuantity fy_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime fz_ = context.Operators.Subtract(fx_, fy_);
 
-                object fy_() {
+                object ga_() {
 
-                    bool hl_() {
-                        DataType hp_ = FirstBladderCancerStaging?.Performed;
-                        object hq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hp_);
-                        bool hr_ = hq_ is CqlDateTime;
-                        return hr_;
+                    bool ig_() {
+                        DataType ik_ = FirstBladderCancerStaging?.Performed;
+                        object il_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ik_);
+                        bool im_ = il_ is CqlDateTime;
+                        return im_;
                     }
 
 
-                    bool hm_() {
-                        DataType hs_ = FirstBladderCancerStaging?.Performed;
-                        object ht_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hs_);
-                        bool hu_ = ht_ is CqlInterval<CqlDateTime>;
-                        return hu_;
-                    }
-
-
-                    bool hn_() {
-                        DataType hv_ = FirstBladderCancerStaging?.Performed;
-                        object hw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hv_);
-                        bool hx_ = hw_ is CqlQuantity;
-                        return hx_;
-                    }
-
-
-                    bool ho_() {
-                        DataType hy_ = FirstBladderCancerStaging?.Performed;
-                        object hz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hy_);
-                        bool ia_ = hz_ is CqlInterval<CqlQuantity>;
-                        return ia_;
-                    }
-
-                    if (hl_())
-                    {
-                        DataType ib_ = FirstBladderCancerStaging?.Performed;
-                        object ic_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ib_);
-                        return (ic_ as CqlDateTime) as object;
-                    }
-                    else if (hm_())
-                    {
-                        DataType id_ = FirstBladderCancerStaging?.Performed;
-                        object ie_ = FHIRHelpers_4_4_000.Instance.ToValue(context, id_);
-                        return (ie_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (hn_())
-                    {
-                        DataType if_ = FirstBladderCancerStaging?.Performed;
-                        object ig_ = FHIRHelpers_4_4_000.Instance.ToValue(context, if_);
-                        return (ig_ as CqlQuantity) as object;
-                    }
-                    else if (ho_())
-                    {
-                        DataType ih_ = FirstBladderCancerStaging?.Performed;
-                        object ii_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ih_);
-                        return (ii_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> fz_ = QICoreCommon_4_0_000.Instance.toInterval(context, fy_());
-                CqlDateTime ga_ = context.Operators.Start(fz_);
-                CqlQuantity gb_ = context.Operators.Quantity(6m, "months");
-                CqlDateTime gc_ = context.Operators.Subtract(ga_, gb_);
-
-                object gd_() {
-
-                    bool ij_() {
+                    bool ih_() {
                         DataType in_ = FirstBladderCancerStaging?.Performed;
                         object io_ = FHIRHelpers_4_4_000.Instance.ToValue(context, in_);
-                        bool ip_ = io_ is CqlDateTime;
+                        bool ip_ = io_ is CqlInterval<CqlDateTime>;
                         return ip_;
                     }
 
 
-                    bool ik_() {
+                    bool ii_() {
                         DataType iq_ = FirstBladderCancerStaging?.Performed;
                         object ir_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iq_);
-                        bool is_ = ir_ is CqlInterval<CqlDateTime>;
+                        bool is_ = ir_ is CqlQuantity;
                         return is_;
                     }
 
 
-                    bool il_() {
+                    bool ij_() {
                         DataType it_ = FirstBladderCancerStaging?.Performed;
                         object iu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, it_);
-                        bool iv_ = iu_ is CqlQuantity;
+                        bool iv_ = iu_ is CqlInterval<CqlQuantity>;
                         return iv_;
                     }
 
-
-                    bool im_() {
+                    if (ig_())
+                    {
                         DataType iw_ = FirstBladderCancerStaging?.Performed;
                         object ix_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iw_);
-                        bool iy_ = ix_ is CqlInterval<CqlQuantity>;
-                        return iy_;
+                        return (ix_ as CqlDateTime) as object;
                     }
-
-                    if (ij_())
+                    else if (ih_())
                     {
-                        DataType iz_ = FirstBladderCancerStaging?.Performed;
-                        object ja_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iz_);
-                        return (ja_ as CqlDateTime) as object;
+                        DataType iy_ = FirstBladderCancerStaging?.Performed;
+                        object iz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, iy_);
+                        return (iz_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (ik_())
+                    else if (ii_())
                     {
-                        DataType jb_ = FirstBladderCancerStaging?.Performed;
-                        object jc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jb_);
-                        return (jc_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ja_ = FirstBladderCancerStaging?.Performed;
+                        object jb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ja_);
+                        return (jb_ as CqlQuantity) as object;
                     }
-                    else if (il_())
+                    else if (ij_())
                     {
-                        DataType jd_ = FirstBladderCancerStaging?.Performed;
-                        object je_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jd_);
-                        return (je_ as CqlQuantity) as object;
-                    }
-                    else if (im_())
-                    {
-                        DataType jf_ = FirstBladderCancerStaging?.Performed;
-                        object jg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jf_);
-                        return (jg_ as CqlInterval<CqlQuantity>) as object;
+                        DataType jc_ = FirstBladderCancerStaging?.Performed;
+                        object jd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jc_);
+                        return (jd_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2272,67 +2264,67 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> ge_ = QICoreCommon_4_0_000.Instance.toInterval(context, gd_());
-                CqlDateTime gf_ = context.Operators.Start(ge_);
-                CqlInterval<CqlDateTime> gg_ = context.Operators.Interval(gc_, gf_, true, false);
-                bool? gh_ = context.Operators.In<CqlDateTime>(fx_, gg_, (string)default);
+                CqlInterval<CqlDateTime> gb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ga_());
+                CqlDateTime gc_ = context.Operators.Start(gb_);
+                CqlInterval<CqlDateTime> gd_ = context.Operators.Interval(fz_, gc_, true, false);
+                bool? ge_ = context.Operators.In<CqlDateTime>(fu_, gd_, (string)default);
 
-                object gi_() {
+                object gf_() {
 
-                    bool jh_() {
+                    bool je_() {
+                        DataType ji_ = FirstBladderCancerStaging?.Performed;
+                        object jj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ji_);
+                        bool jk_ = jj_ is CqlDateTime;
+                        return jk_;
+                    }
+
+
+                    bool jf_() {
                         DataType jl_ = FirstBladderCancerStaging?.Performed;
                         object jm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jl_);
-                        bool jn_ = jm_ is CqlDateTime;
+                        bool jn_ = jm_ is CqlInterval<CqlDateTime>;
                         return jn_;
                     }
 
 
-                    bool ji_() {
+                    bool jg_() {
                         DataType jo_ = FirstBladderCancerStaging?.Performed;
                         object jp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jo_);
-                        bool jq_ = jp_ is CqlInterval<CqlDateTime>;
+                        bool jq_ = jp_ is CqlQuantity;
                         return jq_;
                     }
 
 
-                    bool jj_() {
+                    bool jh_() {
                         DataType jr_ = FirstBladderCancerStaging?.Performed;
                         object js_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jr_);
-                        bool jt_ = js_ is CqlQuantity;
+                        bool jt_ = js_ is CqlInterval<CqlQuantity>;
                         return jt_;
                     }
 
-
-                    bool jk_() {
+                    if (je_())
+                    {
                         DataType ju_ = FirstBladderCancerStaging?.Performed;
                         object jv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ju_);
-                        bool jw_ = jv_ is CqlInterval<CqlQuantity>;
-                        return jw_;
+                        return (jv_ as CqlDateTime) as object;
                     }
-
-                    if (jh_())
+                    else if (jf_())
                     {
-                        DataType jx_ = FirstBladderCancerStaging?.Performed;
-                        object jy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jx_);
-                        return (jy_ as CqlDateTime) as object;
+                        DataType jw_ = FirstBladderCancerStaging?.Performed;
+                        object jx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jw_);
+                        return (jx_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (ji_())
+                    else if (jg_())
                     {
-                        DataType jz_ = FirstBladderCancerStaging?.Performed;
-                        object ka_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jz_);
-                        return (ka_ as CqlInterval<CqlDateTime>) as object;
+                        DataType jy_ = FirstBladderCancerStaging?.Performed;
+                        object jz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jy_);
+                        return (jz_ as CqlQuantity) as object;
                     }
-                    else if (jj_())
+                    else if (jh_())
                     {
-                        DataType kb_ = FirstBladderCancerStaging?.Performed;
-                        object kc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, kb_);
-                        return (kc_ as CqlQuantity) as object;
-                    }
-                    else if (jk_())
-                    {
-                        DataType kd_ = FirstBladderCancerStaging?.Performed;
-                        object ke_ = FHIRHelpers_4_4_000.Instance.ToValue(context, kd_);
-                        return (ke_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ka_ = FirstBladderCancerStaging?.Performed;
+                        object kb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ka_);
+                        return (kb_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2340,31 +2332,30 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> gj_ = QICoreCommon_4_0_000.Instance.toInterval(context, gi_());
-                CqlDateTime gk_ = context.Operators.Start(gj_);
-                bool? gl_ = context.Operators.Not((bool?)(gk_ is null));
-                bool? gm_ = context.Operators.And(gh_, gl_);
-                return gm_;
+                CqlInterval<CqlDateTime> gg_ = QICoreCommon_4_0_000.Instance.toInterval(context, gf_());
+                CqlDateTime gh_ = context.Operators.Start(gg_);
+                bool? gi_ = context.Operators.Not((bool?)(gh_ is null));
+                bool? gj_ = context.Operators.And(ge_, gi_);
+                return gj_;
             }
 
-            IEnumerable<Procedure> fs_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)fq_, fr_);
-            Procedure ft_(Procedure FirstBladderCancerStaging) => ExclusionProcedure;
-            IEnumerable<Procedure> fu_ = context.Operators.Select<Procedure, Procedure>(fs_, ft_);
-            return fu_;
+            IEnumerable<Procedure> fq_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)fo_, fp_);
+            bool? fr_ = context.Operators.Exists<Procedure>(fq_);
+            return fr_;
         }
 
-        IEnumerable<Procedure> o_ = context.Operators.SelectMany<Procedure, Procedure>(m_, n_);
+        IEnumerable<Procedure> o_ = context.Operators.Where<Procedure>(m_, n_);
 
         bool? p_(Procedure ExclusionProcedure) {
-            Code<EventStatus> kf_ = ExclusionProcedure?.StatusElement;
-            EventStatus? kg_ = kf_?.Value;
-            string kh_ = context.Operators.Convert<string>(kg_);
-            string[] ki_ = [
+            Code<EventStatus> kc_ = ExclusionProcedure?.StatusElement;
+            EventStatus? kd_ = kc_?.Value;
+            string ke_ = context.Operators.Convert<string>(kd_);
+            string[] kf_ = [
                 "completed",
                 "in-progress",
             ];
-            bool? kj_ = context.Operators.In<string>(kh_, (IEnumerable<string>)ki_);
-            return kj_;
+            bool? kg_ = context.Operators.In<string>(ke_, (IEnumerable<string>)kf_);
+            return kg_;
         }
 
         IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
@@ -2411,7 +2402,7 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationAdministration> d_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministrationnotdone"));
         IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 
-        IEnumerable<MedicationAdministration> f_(MedicationAdministration BCGNotGiven) {
+        bool? f_(MedicationAdministration BCGNotGiven) {
             Procedure j_ = this.First_Bladder_Cancer_Staging_Procedure(context);
             Procedure[] k_ = [
                 j_,
@@ -2419,83 +2410,83 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
             bool? l_(Procedure FirstBladderCancerStaging) {
 
-                bool? p_(Extension @this) {
-                    FhirUri al_ = @this?.UrlElement;
-                    string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
-                    bool? an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                bool? o_(Extension @this) {
+                    FhirUri ak_ = @this?.UrlElement;
+                    string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
+                    bool? am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return am_;
+                }
+
+                IEnumerable<Extension> p_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(BCGNotGiven is DomainResource
+                    ? (BCGNotGiven as DomainResource).Extension
+                    : default), o_);
+
+                DataType q_(Extension @this) {
+                    DataType an_ = @this?.Value;
                     return an_;
                 }
 
-                IEnumerable<Extension> q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(BCGNotGiven is DomainResource
-                    ? (BCGNotGiven as DomainResource).Extension
-                    : default), p_);
+                IEnumerable<DataType> r_ = context.Operators.Select<Extension, DataType>(p_, q_);
+                DataType s_ = context.Operators.SingletonFrom<DataType>(r_);
+                FhirDateTime t_ = context.Operators.Convert<FhirDateTime>(s_);
+                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
 
-                DataType r_(Extension @this) {
-                    DataType ao_ = @this?.Value;
-                    return ao_;
-                }
+                object v_() {
 
-                IEnumerable<DataType> s_ = context.Operators.Select<Extension, DataType>(q_, r_);
-                DataType t_ = context.Operators.SingletonFrom<DataType>(s_);
-                FhirDateTime u_ = context.Operators.Convert<FhirDateTime>(t_);
-                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                    bool ao_() {
+                        DataType as_ = FirstBladderCancerStaging?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        bool au_ = at_ is CqlDateTime;
+                        return au_;
+                    }
 
-                object w_() {
 
                     bool ap_() {
-                        DataType at_ = FirstBladderCancerStaging?.Performed;
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        bool av_ = au_ is CqlDateTime;
-                        return av_;
+                        DataType av_ = FirstBladderCancerStaging?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        bool ax_ = aw_ is CqlInterval<CqlDateTime>;
+                        return ax_;
                     }
 
 
                     bool aq_() {
-                        DataType aw_ = FirstBladderCancerStaging?.Performed;
-                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                        bool ay_ = ax_ is CqlInterval<CqlDateTime>;
-                        return ay_;
+                        DataType ay_ = FirstBladderCancerStaging?.Performed;
+                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+                        bool ba_ = az_ is CqlQuantity;
+                        return ba_;
                     }
 
 
                     bool ar_() {
-                        DataType az_ = FirstBladderCancerStaging?.Performed;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        bool bb_ = ba_ is CqlQuantity;
-                        return bb_;
+                        DataType bb_ = FirstBladderCancerStaging?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        bool bd_ = bc_ is CqlInterval<CqlQuantity>;
+                        return bd_;
                     }
 
-
-                    bool as_() {
-                        DataType bc_ = FirstBladderCancerStaging?.Performed;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        bool be_ = bd_ is CqlInterval<CqlQuantity>;
-                        return be_;
-                    }
-
-                    if (ap_())
+                    if (ao_())
                     {
-                        DataType bf_ = FirstBladderCancerStaging?.Performed;
-                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                        return (bg_ as CqlDateTime) as object;
+                        DataType be_ = FirstBladderCancerStaging?.Performed;
+                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+                        return (bf_ as CqlDateTime) as object;
+                    }
+                    else if (ap_())
+                    {
+                        DataType bg_ = FirstBladderCancerStaging?.Performed;
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        return (bh_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (aq_())
                     {
-                        DataType bh_ = FirstBladderCancerStaging?.Performed;
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        return (bi_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bi_ = FirstBladderCancerStaging?.Performed;
+                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                        return (bj_ as CqlQuantity) as object;
                     }
                     else if (ar_())
                     {
-                        DataType bj_ = FirstBladderCancerStaging?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        return (bk_ as CqlQuantity) as object;
-                    }
-                    else if (as_())
-                    {
-                        DataType bl_ = FirstBladderCancerStaging?.Performed;
-                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                        return (bm_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bk_ = FirstBladderCancerStaging?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        return (bl_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2503,65 +2494,65 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_());
-                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_());
+                CqlDateTime x_ = context.Operators.Start(w_);
 
-                object z_() {
+                object y_() {
+
+                    bool bm_() {
+                        DataType bq_ = FirstBladderCancerStaging?.Performed;
+                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                        bool bs_ = br_ is CqlDateTime;
+                        return bs_;
+                    }
+
 
                     bool bn_() {
-                        DataType br_ = FirstBladderCancerStaging?.Performed;
-                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
-                        bool bt_ = bs_ is CqlDateTime;
-                        return bt_;
+                        DataType bt_ = FirstBladderCancerStaging?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        bool bv_ = bu_ is CqlInterval<CqlDateTime>;
+                        return bv_;
                     }
 
 
                     bool bo_() {
-                        DataType bu_ = FirstBladderCancerStaging?.Performed;
-                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                        bool bw_ = bv_ is CqlInterval<CqlDateTime>;
-                        return bw_;
+                        DataType bw_ = FirstBladderCancerStaging?.Performed;
+                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+                        bool by_ = bx_ is CqlQuantity;
+                        return by_;
                     }
 
 
                     bool bp_() {
-                        DataType bx_ = FirstBladderCancerStaging?.Performed;
-                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                        bool bz_ = by_ is CqlQuantity;
-                        return bz_;
+                        DataType bz_ = FirstBladderCancerStaging?.Performed;
+                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                        bool cb_ = ca_ is CqlInterval<CqlQuantity>;
+                        return cb_;
                     }
 
-
-                    bool bq_() {
-                        DataType ca_ = FirstBladderCancerStaging?.Performed;
-                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                        bool cc_ = cb_ is CqlInterval<CqlQuantity>;
-                        return cc_;
-                    }
-
-                    if (bn_())
+                    if (bm_())
                     {
-                        DataType cd_ = FirstBladderCancerStaging?.Performed;
-                        object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
-                        return (ce_ as CqlDateTime) as object;
+                        DataType cc_ = FirstBladderCancerStaging?.Performed;
+                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
+                        return (cd_ as CqlDateTime) as object;
+                    }
+                    else if (bn_())
+                    {
+                        DataType ce_ = FirstBladderCancerStaging?.Performed;
+                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                        return (cf_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bo_())
                     {
-                        DataType cf_ = FirstBladderCancerStaging?.Performed;
-                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                        return (cg_ as CqlInterval<CqlDateTime>) as object;
+                        DataType cg_ = FirstBladderCancerStaging?.Performed;
+                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                        return (ch_ as CqlQuantity) as object;
                     }
                     else if (bp_())
                     {
-                        DataType ch_ = FirstBladderCancerStaging?.Performed;
-                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                        return (ci_ as CqlQuantity) as object;
-                    }
-                    else if (bq_())
-                    {
-                        DataType cj_ = FirstBladderCancerStaging?.Performed;
-                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                        return (ck_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ci_ = FirstBladderCancerStaging?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        return (cj_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2569,69 +2560,69 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlQuantity ac_ = context.Operators.Quantity(6m, "months");
-                CqlDateTime ad_ = context.Operators.Add(ab_, ac_);
-                CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(y_, ad_, false, true);
-                bool? af_ = context.Operators.In<CqlDateTime>(v_, ae_, "day");
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlQuantity ab_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
+                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, false, true);
+                bool? ae_ = context.Operators.In<CqlDateTime>(u_, ad_, "day");
 
-                object ag_() {
+                object af_() {
+
+                    bool ck_() {
+                        DataType co_ = FirstBladderCancerStaging?.Performed;
+                        object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+                        bool cq_ = cp_ is CqlDateTime;
+                        return cq_;
+                    }
+
 
                     bool cl_() {
-                        DataType cp_ = FirstBladderCancerStaging?.Performed;
-                        object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
-                        bool cr_ = cq_ is CqlDateTime;
-                        return cr_;
+                        DataType cr_ = FirstBladderCancerStaging?.Performed;
+                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+                        bool ct_ = cs_ is CqlInterval<CqlDateTime>;
+                        return ct_;
                     }
 
 
                     bool cm_() {
-                        DataType cs_ = FirstBladderCancerStaging?.Performed;
-                        object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
-                        bool cu_ = ct_ is CqlInterval<CqlDateTime>;
-                        return cu_;
+                        DataType cu_ = FirstBladderCancerStaging?.Performed;
+                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+                        bool cw_ = cv_ is CqlQuantity;
+                        return cw_;
                     }
 
 
                     bool cn_() {
-                        DataType cv_ = FirstBladderCancerStaging?.Performed;
-                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                        bool cx_ = cw_ is CqlQuantity;
-                        return cx_;
+                        DataType cx_ = FirstBladderCancerStaging?.Performed;
+                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
+                        bool cz_ = cy_ is CqlInterval<CqlQuantity>;
+                        return cz_;
                     }
 
-
-                    bool co_() {
-                        DataType cy_ = FirstBladderCancerStaging?.Performed;
-                        object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
-                        bool da_ = cz_ is CqlInterval<CqlQuantity>;
-                        return da_;
-                    }
-
-                    if (cl_())
+                    if (ck_())
                     {
-                        DataType db_ = FirstBladderCancerStaging?.Performed;
-                        object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
-                        return (dc_ as CqlDateTime) as object;
+                        DataType da_ = FirstBladderCancerStaging?.Performed;
+                        object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
+                        return (db_ as CqlDateTime) as object;
+                    }
+                    else if (cl_())
+                    {
+                        DataType dc_ = FirstBladderCancerStaging?.Performed;
+                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
+                        return (dd_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (cm_())
                     {
-                        DataType dd_ = FirstBladderCancerStaging?.Performed;
-                        object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
-                        return (de_ as CqlInterval<CqlDateTime>) as object;
+                        DataType de_ = FirstBladderCancerStaging?.Performed;
+                        object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                        return (df_ as CqlQuantity) as object;
                     }
                     else if (cn_())
                     {
-                        DataType df_ = FirstBladderCancerStaging?.Performed;
-                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                        return (dg_ as CqlQuantity) as object;
-                    }
-                    else if (co_())
-                    {
-                        DataType dh_ = FirstBladderCancerStaging?.Performed;
-                        object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
-                        return (di_ as CqlInterval<CqlQuantity>) as object;
+                        DataType dg_ = FirstBladderCancerStaging?.Performed;
+                        object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
+                        return (dh_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2639,33 +2630,32 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_());
-                CqlDateTime ai_ = context.Operators.Start(ah_);
-                bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
-                bool? ak_ = context.Operators.And(af_, aj_);
-                return ak_;
+                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_());
+                CqlDateTime ah_ = context.Operators.Start(ag_);
+                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+                bool? aj_ = context.Operators.And(ae_, ai_);
+                return aj_;
             }
 
             IEnumerable<Procedure> m_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)k_, l_);
-            MedicationAdministration n_(Procedure FirstBladderCancerStaging) => BCGNotGiven;
-            IEnumerable<MedicationAdministration> o_ = context.Operators.Select<Procedure, MedicationAdministration>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Procedure>(m_);
+            return n_;
         }
 
-        IEnumerable<MedicationAdministration> g_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(e_, f_);
+        IEnumerable<MedicationAdministration> g_ = context.Operators.Where<MedicationAdministration>(e_, f_);
 
         bool? h_(MedicationAdministration BCGNotGiven) {
-            List<CodeableConcept> dj_ = BCGNotGiven?.StatusReason;
+            List<CodeableConcept> di_ = BCGNotGiven?.StatusReason;
 
-            CqlConcept dk_(CodeableConcept @this) {
-                CqlConcept do_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return do_;
+            CqlConcept dj_(CodeableConcept @this) {
+                CqlConcept dn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return dn_;
             }
 
-            IEnumerable<CqlConcept> dl_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)dj_, dk_);
-            CqlValueSet dm_ = this.Unavailability_of_Bacillus_Calmette_Guerin_for_Urology_Care(context);
-            bool? dn_ = context.Operators.ConceptsInValueSet(dl_, dm_);
-            return dn_;
+            IEnumerable<CqlConcept> dk_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)di_, dj_);
+            CqlValueSet dl_ = this.Unavailability_of_Bacillus_Calmette_Guerin_for_Urology_Care(context);
+            bool? dm_ = context.Operators.ConceptsInValueSet(dk_, dl_);
+            return dm_;
         }
 
         IEnumerable<MedicationAdministration> i_ = context.Operators.Where<MedicationAdministration>(g_, h_);
@@ -2699,100 +2689,99 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationAdministration> b_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> d_(MedicationAdministration MR) {
+        bool? d_(MedicationAdministration MR) {
             IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? o_(Medication M) {
-                object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                string v_ = context.Operators.Last<string>(u_);
-                bool? w_ = context.Operators.Equal(s_, v_);
-                CodeableConcept x_ = M?.Code;
-                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                CqlValueSet z_ = this.Bacillus_Calmette_Guerin_for_Urology_Care(context);
-                bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                bool? ab_ = context.Operators.And(w_, aa_);
-                return ab_;
+                object r_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object s_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> t_ = context.Operators.Split((string)s_, "/");
+                string u_ = context.Operators.Last<string>(t_);
+                bool? v_ = context.Operators.Equal(r_, u_);
+                CodeableConcept w_ = M?.Code;
+                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
+                CqlValueSet y_ = this.Bacillus_Calmette_Guerin_for_Urology_Care(context);
+                bool? z_ = context.Operators.ConceptInValueSet(x_, y_);
+                bool? aa_ = context.Operators.And(v_, z_);
+                return aa_;
             }
 
             IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-            MedicationAdministration q_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> r_ = context.Operators.Select<Medication, MedicationAdministration>(p_, q_);
-            return r_;
+            bool? q_ = context.Operators.Exists<Medication>(p_);
+            return q_;
         }
 
-        IEnumerable<MedicationAdministration> e_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, d_);
+        IEnumerable<MedicationAdministration> e_ = context.Operators.Where<MedicationAdministration>(c_, d_);
         IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(b_, e_);
 
-        IEnumerable<MedicationAdministration> g_(MedicationAdministration BCG) {
-            Procedure ac_ = this.First_Bladder_Cancer_Staging_Procedure(context);
-            Procedure[] ad_ = [
-                ac_,
+        bool? g_(MedicationAdministration BCG) {
+            Procedure ab_ = this.First_Bladder_Cancer_Staging_Procedure(context);
+            Procedure[] ac_ = [
+                ab_,
             ];
 
-            bool? ae_(Procedure FirstBladderCancerStaging) {
-                DataType ai_ = BCG?.Effective;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.Start(ak_);
+            bool? ad_(Procedure FirstBladderCancerStaging) {
+                DataType ag_ = BCG?.Effective;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
+                CqlDateTime aj_ = context.Operators.Start(ai_);
 
-                object am_() {
+                object ak_() {
+
+                    bool bg_() {
+                        DataType bk_ = FirstBladderCancerStaging?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        bool bm_ = bl_ is CqlDateTime;
+                        return bm_;
+                    }
+
+
+                    bool bh_() {
+                        DataType bn_ = FirstBladderCancerStaging?.Performed;
+                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                        bool bp_ = bo_ is CqlInterval<CqlDateTime>;
+                        return bp_;
+                    }
+
 
                     bool bi_() {
-                        DataType bm_ = FirstBladderCancerStaging?.Performed;
-                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                        bool bo_ = bn_ is CqlDateTime;
-                        return bo_;
+                        DataType bq_ = FirstBladderCancerStaging?.Performed;
+                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                        bool bs_ = br_ is CqlQuantity;
+                        return bs_;
                     }
 
 
                     bool bj_() {
-                        DataType bp_ = FirstBladderCancerStaging?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        bool br_ = bq_ is CqlInterval<CqlDateTime>;
-                        return br_;
+                        DataType bt_ = FirstBladderCancerStaging?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        bool bv_ = bu_ is CqlInterval<CqlQuantity>;
+                        return bv_;
                     }
 
-
-                    bool bk_() {
-                        DataType bs_ = FirstBladderCancerStaging?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        bool bu_ = bt_ is CqlQuantity;
-                        return bu_;
+                    if (bg_())
+                    {
+                        DataType bw_ = FirstBladderCancerStaging?.Performed;
+                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+                        return (bx_ as CqlDateTime) as object;
                     }
-
-
-                    bool bl_() {
-                        DataType bv_ = FirstBladderCancerStaging?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        bool bx_ = bw_ is CqlInterval<CqlQuantity>;
-                        return bx_;
-                    }
-
-                    if (bi_())
+                    else if (bh_())
                     {
                         DataType by_ = FirstBladderCancerStaging?.Performed;
                         object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        return (bz_ as CqlDateTime) as object;
+                        return (bz_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (bj_())
+                    else if (bi_())
                     {
                         DataType ca_ = FirstBladderCancerStaging?.Performed;
                         object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                        return (cb_ as CqlInterval<CqlDateTime>) as object;
+                        return (cb_ as CqlQuantity) as object;
                     }
-                    else if (bk_())
+                    else if (bj_())
                     {
                         DataType cc_ = FirstBladderCancerStaging?.Performed;
                         object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                        return (cd_ as CqlQuantity) as object;
-                    }
-                    else if (bl_())
-                    {
-                        DataType ce_ = FirstBladderCancerStaging?.Performed;
-                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
-                        return (cf_ as CqlInterval<CqlQuantity>) as object;
+                        return (cd_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2800,65 +2789,65 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
-                CqlDateTime ao_ = context.Operators.Start(an_);
+                CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_());
+                CqlDateTime am_ = context.Operators.Start(al_);
 
-                object ap_() {
+                object an_() {
+
+                    bool ce_() {
+                        DataType ci_ = FirstBladderCancerStaging?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        bool ck_ = cj_ is CqlDateTime;
+                        return ck_;
+                    }
+
+
+                    bool cf_() {
+                        DataType cl_ = FirstBladderCancerStaging?.Performed;
+                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                        bool cn_ = cm_ is CqlInterval<CqlDateTime>;
+                        return cn_;
+                    }
+
 
                     bool cg_() {
-                        DataType ck_ = FirstBladderCancerStaging?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        bool cm_ = cl_ is CqlDateTime;
-                        return cm_;
+                        DataType co_ = FirstBladderCancerStaging?.Performed;
+                        object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+                        bool cq_ = cp_ is CqlQuantity;
+                        return cq_;
                     }
 
 
                     bool ch_() {
-                        DataType cn_ = FirstBladderCancerStaging?.Performed;
-                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                        bool cp_ = co_ is CqlInterval<CqlDateTime>;
-                        return cp_;
+                        DataType cr_ = FirstBladderCancerStaging?.Performed;
+                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+                        bool ct_ = cs_ is CqlInterval<CqlQuantity>;
+                        return ct_;
                     }
 
-
-                    bool ci_() {
-                        DataType cq_ = FirstBladderCancerStaging?.Performed;
-                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                        bool cs_ = cr_ is CqlQuantity;
-                        return cs_;
+                    if (ce_())
+                    {
+                        DataType cu_ = FirstBladderCancerStaging?.Performed;
+                        object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+                        return (cv_ as CqlDateTime) as object;
                     }
-
-
-                    bool cj_() {
-                        DataType ct_ = FirstBladderCancerStaging?.Performed;
-                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                        bool cv_ = cu_ is CqlInterval<CqlQuantity>;
-                        return cv_;
-                    }
-
-                    if (cg_())
+                    else if (cf_())
                     {
                         DataType cw_ = FirstBladderCancerStaging?.Performed;
                         object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                        return (cx_ as CqlDateTime) as object;
+                        return (cx_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (ch_())
+                    else if (cg_())
                     {
                         DataType cy_ = FirstBladderCancerStaging?.Performed;
                         object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
-                        return (cz_ as CqlInterval<CqlDateTime>) as object;
+                        return (cz_ as CqlQuantity) as object;
                     }
-                    else if (ci_())
+                    else if (ch_())
                     {
                         DataType da_ = FirstBladderCancerStaging?.Performed;
                         object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-                        return (db_ as CqlQuantity) as object;
-                    }
-                    else if (cj_())
-                    {
-                        DataType dc_ = FirstBladderCancerStaging?.Performed;
-                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
-                        return (dd_ as CqlInterval<CqlQuantity>) as object;
+                        return (db_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2866,69 +2855,69 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_());
-                CqlDateTime ar_ = context.Operators.Start(aq_);
-                CqlQuantity as_ = context.Operators.Quantity(6m, "months");
-                CqlDateTime at_ = context.Operators.Add(ar_, as_);
-                CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ao_, at_, false, true);
-                bool? av_ = context.Operators.In<CqlDateTime>(al_, au_, "day");
+                CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_());
+                CqlDateTime ap_ = context.Operators.Start(ao_);
+                CqlQuantity aq_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime ar_ = context.Operators.Add(ap_, aq_);
+                CqlInterval<CqlDateTime> as_ = context.Operators.Interval(am_, ar_, false, true);
+                bool? at_ = context.Operators.In<CqlDateTime>(aj_, as_, "day");
 
-                object aw_() {
+                object au_() {
+
+                    bool dc_() {
+                        DataType dg_ = FirstBladderCancerStaging?.Performed;
+                        object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
+                        bool di_ = dh_ is CqlDateTime;
+                        return di_;
+                    }
+
+
+                    bool dd_() {
+                        DataType dj_ = FirstBladderCancerStaging?.Performed;
+                        object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+                        bool dl_ = dk_ is CqlInterval<CqlDateTime>;
+                        return dl_;
+                    }
+
 
                     bool de_() {
-                        DataType di_ = FirstBladderCancerStaging?.Performed;
-                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                        bool dk_ = dj_ is CqlDateTime;
-                        return dk_;
+                        DataType dm_ = FirstBladderCancerStaging?.Performed;
+                        object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
+                        bool do_ = dn_ is CqlQuantity;
+                        return do_;
                     }
 
 
                     bool df_() {
-                        DataType dl_ = FirstBladderCancerStaging?.Performed;
-                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                        bool dn_ = dm_ is CqlInterval<CqlDateTime>;
-                        return dn_;
+                        DataType dp_ = FirstBladderCancerStaging?.Performed;
+                        object dq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dp_);
+                        bool dr_ = dq_ is CqlInterval<CqlQuantity>;
+                        return dr_;
                     }
 
-
-                    bool dg_() {
-                        DataType do_ = FirstBladderCancerStaging?.Performed;
-                        object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
-                        bool dq_ = dp_ is CqlQuantity;
-                        return dq_;
+                    if (dc_())
+                    {
+                        DataType ds_ = FirstBladderCancerStaging?.Performed;
+                        object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
+                        return (dt_ as CqlDateTime) as object;
                     }
-
-
-                    bool dh_() {
-                        DataType dr_ = FirstBladderCancerStaging?.Performed;
-                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
-                        bool dt_ = ds_ is CqlInterval<CqlQuantity>;
-                        return dt_;
-                    }
-
-                    if (de_())
+                    else if (dd_())
                     {
                         DataType du_ = FirstBladderCancerStaging?.Performed;
                         object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                        return (dv_ as CqlDateTime) as object;
+                        return (dv_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (df_())
+                    else if (de_())
                     {
                         DataType dw_ = FirstBladderCancerStaging?.Performed;
                         object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                        return (dx_ as CqlInterval<CqlDateTime>) as object;
+                        return (dx_ as CqlQuantity) as object;
                     }
-                    else if (dg_())
+                    else if (df_())
                     {
                         DataType dy_ = FirstBladderCancerStaging?.Performed;
                         object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
-                        return (dz_ as CqlQuantity) as object;
-                    }
-                    else if (dh_())
-                    {
-                        DataType ea_ = FirstBladderCancerStaging?.Performed;
-                        object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                        return (eb_ as CqlInterval<CqlQuantity>) as object;
+                        return (dz_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2936,47 +2925,46 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_());
-                CqlDateTime ay_ = context.Operators.Start(ax_);
-                bool? az_ = context.Operators.Not((bool?)(ay_ is null));
-                bool? ba_ = context.Operators.And(av_, az_);
-                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-                CqlDateTime be_ = context.Operators.Start(bd_);
-                CqlInterval<CqlDateTime> bf_ = this.Measurement_Period(context);
-                bool? bg_ = context.Operators.In<CqlDateTime>(be_, bf_, "day");
-                bool? bh_ = context.Operators.And(ba_, bg_);
-                return bh_;
+                CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.toInterval(context, au_());
+                CqlDateTime aw_ = context.Operators.Start(av_);
+                bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+                bool? ay_ = context.Operators.And(at_, ax_);
+                object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
+                CqlDateTime bc_ = context.Operators.Start(bb_);
+                CqlInterval<CqlDateTime> bd_ = this.Measurement_Period(context);
+                bool? be_ = context.Operators.In<CqlDateTime>(bc_, bd_, "day");
+                bool? bf_ = context.Operators.And(ay_, be_);
+                return bf_;
             }
 
-            IEnumerable<Procedure> af_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)ad_, ae_);
-            MedicationAdministration ag_(Procedure FirstBladderCancerStaging) => BCG;
-            IEnumerable<MedicationAdministration> ah_ = context.Operators.Select<Procedure, MedicationAdministration>(af_, ag_);
-            return ah_;
+            IEnumerable<Procedure> ae_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)ac_, ad_);
+            bool? af_ = context.Operators.Exists<Procedure>(ae_);
+            return af_;
         }
 
-        IEnumerable<MedicationAdministration> h_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(f_, g_);
+        IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
 
         bool? i_(MedicationAdministration BCG) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ec_ = BCG?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ed_ = ec_?.Value;
-            string ee_ = context.Operators.Convert<string>(ed_);
-            string[] ef_ = [
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ea_ = BCG?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? eb_ = ea_?.Value;
+            string ec_ = context.Operators.Convert<string>(eb_);
+            string[] ed_ = [
                 "in-progress",
                 "completed",
             ];
-            bool? eg_ = context.Operators.In<string>(ee_, (IEnumerable<string>)ef_);
-            return eg_;
+            bool? ee_ = context.Operators.In<string>(ec_, (IEnumerable<string>)ed_);
+            return ee_;
         }
 
         IEnumerable<MedicationAdministration> j_ = context.Operators.Where<MedicationAdministration>(h_, i_);
 
         object k_(MedicationAdministration @this) {
-            DataType eh_ = @this?.Effective;
-            object ei_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eh_);
-            CqlInterval<CqlDateTime> ej_ = QICoreCommon_4_0_000.Instance.toInterval(context, ei_);
-            CqlDateTime ek_ = context.Operators.Start(ej_);
-            return ek_;
+            DataType ef_ = @this?.Effective;
+            object eg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ef_);
+            CqlInterval<CqlDateTime> eh_ = QICoreCommon_4_0_000.Instance.toInterval(context, eg_);
+            CqlDateTime ei_ = context.Operators.Start(eh_);
+            return ei_;
         }
 
         IEnumerable<MedicationAdministration> l_ = context.Operators.SortBy<MedicationAdministration>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS68FHIRDocumentationCurrentMeds-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS68FHIRDocumentationCurrentMeds-1.0.000.g.cs
@@ -200,69 +200,69 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlCode d_ = this.Documentation_of_current_medications__procedure_(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? g_(Procedure MedicationsDocumented) {
 
-                object k_() {
+                object j_() {
+
+                    bool y_() {
+                        DataType ac_ = MedicationsDocumented?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlDateTime;
+                        return ae_;
+                    }
+
 
                     bool z_() {
-                        DataType ad_ = MedicationsDocumented?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlDateTime;
-                        return af_;
+                        DataType af_ = MedicationsDocumented?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlDateTime>;
+                        return ah_;
                     }
 
 
                     bool aa_() {
-                        DataType ag_ = MedicationsDocumented?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlDateTime>;
-                        return ai_;
+                        DataType ai_ = MedicationsDocumented?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        bool ak_ = aj_ is CqlQuantity;
+                        return ak_;
                     }
 
 
                     bool ab_() {
-                        DataType aj_ = MedicationsDocumented?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        bool al_ = ak_ is CqlQuantity;
-                        return al_;
+                        DataType al_ = MedicationsDocumented?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        bool an_ = am_ is CqlInterval<CqlQuantity>;
+                        return an_;
                     }
 
-
-                    bool ac_() {
-                        DataType am_ = MedicationsDocumented?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        bool ao_ = an_ is CqlInterval<CqlQuantity>;
-                        return ao_;
-                    }
-
-                    if (z_())
+                    if (y_())
                     {
-                        DataType ap_ = MedicationsDocumented?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlDateTime) as object;
+                        DataType ao_ = MedicationsDocumented?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlDateTime) as object;
+                    }
+                    else if (z_())
+                    {
+                        DataType aq_ = MedicationsDocumented?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (aa_())
                     {
-                        DataType ar_ = MedicationsDocumented?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlInterval<CqlDateTime>) as object;
+                        DataType as_ = MedicationsDocumented?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        return (at_ as CqlQuantity) as object;
                     }
                     else if (ab_())
                     {
-                        DataType at_ = MedicationsDocumented?.Performed;
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        return (au_ as CqlQuantity) as object;
-                    }
-                    else if (ac_())
-                    {
-                        DataType av_ = MedicationsDocumented?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        return (aw_ as CqlInterval<CqlQuantity>) as object;
+                        DataType au_ = MedicationsDocumented?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        return (av_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -270,68 +270,68 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
                     };
                 }
 
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                CqlDateTime m_ = context.Operators.Start(l_);
-                Period n_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, "day");
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                CqlDateTime l_ = context.Operators.Start(k_);
+                Period m_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                bool? o_ = context.Operators.In<CqlDateTime>(l_, n_, "day");
 
-                object q_() {
+                object p_() {
+
+                    bool aw_() {
+                        DataType ba_ = MedicationsDocumented?.Performed;
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlDateTime;
+                        return bc_;
+                    }
+
 
                     bool ax_() {
-                        DataType bb_ = MedicationsDocumented?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlDateTime;
-                        return bd_;
+                        DataType bd_ = MedicationsDocumented?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        bool bf_ = be_ is CqlInterval<CqlDateTime>;
+                        return bf_;
                     }
 
 
                     bool ay_() {
-                        DataType be_ = MedicationsDocumented?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        bool bg_ = bf_ is CqlInterval<CqlDateTime>;
-                        return bg_;
+                        DataType bg_ = MedicationsDocumented?.Performed;
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        bool bi_ = bh_ is CqlQuantity;
+                        return bi_;
                     }
 
 
                     bool az_() {
-                        DataType bh_ = MedicationsDocumented?.Performed;
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        bool bj_ = bi_ is CqlQuantity;
-                        return bj_;
+                        DataType bj_ = MedicationsDocumented?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        bool bl_ = bk_ is CqlInterval<CqlQuantity>;
+                        return bl_;
                     }
 
-
-                    bool ba_() {
-                        DataType bk_ = MedicationsDocumented?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        bool bm_ = bl_ is CqlInterval<CqlQuantity>;
-                        return bm_;
-                    }
-
-                    if (ax_())
+                    if (aw_())
                     {
-                        DataType bn_ = MedicationsDocumented?.Performed;
-                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                        return (bo_ as CqlDateTime) as object;
+                        DataType bm_ = MedicationsDocumented?.Performed;
+                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+                        return (bn_ as CqlDateTime) as object;
+                    }
+                    else if (ax_())
+                    {
+                        DataType bo_ = MedicationsDocumented?.Performed;
+                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                        return (bp_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ay_())
                     {
-                        DataType bp_ = MedicationsDocumented?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        return (bq_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bq_ = MedicationsDocumented?.Performed;
+                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                        return (br_ as CqlQuantity) as object;
                     }
                     else if (az_())
                     {
-                        DataType br_ = MedicationsDocumented?.Performed;
-                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
-                        return (bs_ as CqlQuantity) as object;
-                    }
-                    else if (ba_())
-                    {
-                        DataType bt_ = MedicationsDocumented?.Performed;
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        return (bu_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bs_ = MedicationsDocumented?.Performed;
+                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                        return (bt_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -339,24 +339,23 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
                     };
                 }
 
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                bool? s_ = QICoreCommon_4_0_000.Instance.hasEnd(context, r_);
-                bool? t_ = context.Operators.And(p_, s_);
-                Code<EventStatus> u_ = MedicationsDocumented?.StatusElement;
-                EventStatus? v_ = u_?.Value;
-                string w_ = context.Operators.Convert<string>(v_);
-                bool? x_ = context.Operators.Equal(w_, "completed");
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
+                bool? r_ = QICoreCommon_4_0_000.Instance.hasEnd(context, q_);
+                bool? s_ = context.Operators.And(o_, r_);
+                Code<EventStatus> t_ = MedicationsDocumented?.StatusElement;
+                EventStatus? u_ = t_?.Value;
+                string v_ = context.Operators.Convert<string>(u_);
+                bool? w_ = context.Operators.Equal(v_, "completed");
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
-            Encounter i_(Procedure MedicationsDocumented) => QualifyingEncounter;
-            IEnumerable<Encounter> j_ = context.Operators.Select<Procedure, Encounter>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Procedure>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -371,70 +370,69 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlCode d_ = this.Documentation_of_current_medications__procedure_(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone"));
 
             bool? g_(Procedure MedicationsNotDocumented) {
 
-                bool? k_(Extension @this) {
-                    FhirUri ag_ = @this?.UrlElement;
-                    string ah_ = FHIRHelpers_4_4_000.Instance.ToString(context, ag_);
-                    bool? ai_ = context.Operators.Equal(ah_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                bool? j_(Extension @this) {
+                    FhirUri af_ = @this?.UrlElement;
+                    string ag_ = FHIRHelpers_4_4_000.Instance.ToString(context, af_);
+                    bool? ah_ = context.Operators.Equal(ag_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return ah_;
+                }
+
+                IEnumerable<Extension> k_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(MedicationsNotDocumented is DomainResource
+                    ? (MedicationsNotDocumented as DomainResource).Extension
+                    : default), j_);
+
+                DataType l_(Extension @this) {
+                    DataType ai_ = @this?.Value;
                     return ai_;
                 }
 
-                IEnumerable<Extension> l_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(MedicationsNotDocumented is DomainResource
-                    ? (MedicationsNotDocumented as DomainResource).Extension
-                    : default), k_);
+                IEnumerable<DataType> m_ = context.Operators.Select<Extension, DataType>(k_, l_);
+                DataType n_ = context.Operators.SingletonFrom<DataType>(m_);
+                FhirDateTime o_ = context.Operators.Convert<FhirDateTime>(n_);
+                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+                Period q_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
+                Code<EventStatus> t_ = MedicationsNotDocumented?.StatusElement;
+                EventStatus? u_ = t_?.Value;
+                string v_ = context.Operators.Convert<string>(u_);
+                bool? w_ = context.Operators.Equal(v_, "not-done");
+                bool? x_ = context.Operators.And(s_, w_);
+                List<CodeableConcept> y_ = MedicationsNotDocumented?.ReasonCode;
 
-                DataType m_(Extension @this) {
-                    DataType aj_ = @this?.Value;
+                CqlConcept z_(CodeableConcept @this) {
+                    CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                     return aj_;
                 }
 
-                IEnumerable<DataType> n_ = context.Operators.Select<Extension, DataType>(l_, m_);
-                DataType o_ = context.Operators.SingletonFrom<DataType>(n_);
-                FhirDateTime p_ = context.Operators.Convert<FhirDateTime>(o_);
-                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                Period r_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
-                Code<EventStatus> u_ = MedicationsNotDocumented?.StatusElement;
-                EventStatus? v_ = u_?.Value;
-                string w_ = context.Operators.Convert<string>(v_);
-                bool? x_ = context.Operators.Equal(w_, "not-done");
-                bool? y_ = context.Operators.And(t_, x_);
-                List<CodeableConcept> z_ = MedicationsNotDocumented?.ReasonCode;
+                IEnumerable<CqlConcept> aa_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)y_, z_);
 
-                CqlConcept aa_(CodeableConcept @this) {
-                    CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return ak_;
+                bool? ab_(CqlConcept reasonItem) {
+                    CqlCode ak_ = this.Acute_health_crisis__finding_(context);
+                    CqlConcept al_ = context.Operators.ConvertCodeToConcept(ak_);
+                    bool? am_ = context.Operators.Equivalent(reasonItem, al_);
+                    return am_;
                 }
 
-                IEnumerable<CqlConcept> ab_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)z_, aa_);
-
-                bool? ac_(CqlConcept reasonItem) {
-                    CqlCode al_ = this.Acute_health_crisis__finding_(context);
-                    CqlConcept am_ = context.Operators.ConvertCodeToConcept(al_);
-                    bool? an_ = context.Operators.Equivalent(reasonItem, am_);
-                    return an_;
-                }
-
-                IEnumerable<CqlConcept> ad_ = context.Operators.Where<CqlConcept>(ab_, ac_);
-                bool? ae_ = context.Operators.Exists<CqlConcept>(ad_);
-                bool? af_ = context.Operators.And(y_, ae_);
-                return af_;
+                IEnumerable<CqlConcept> ac_ = context.Operators.Where<CqlConcept>(aa_, ab_);
+                bool? ad_ = context.Operators.Exists<CqlConcept>(ac_);
+                bool? ae_ = context.Operators.And(x_, ad_);
+                return ae_;
             }
 
             IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
-            Encounter i_(Procedure MedicationsNotDocumented) => QualifyingEncounter;
-            IEnumerable<Encounter> j_ = context.Operators.Select<Procedure, Encounter>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<Procedure>(h_);
+            return i_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS69FHIRPCSBMIScreenAndFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS69FHIRPCSBMIScreenAndFollowUp-1.0.000.g.cs
@@ -359,68 +359,67 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationRequest> g_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> i_(MedicationRequest MR) {
+        bool? i_(MedicationRequest MR) {
             IEnumerable<Medication> o_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? p_(Medication M) {
-                object t_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object u_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> v_ = context.Operators.Split((string)u_, "/");
-                string w_ = context.Operators.Last<string>(v_);
-                bool? x_ = context.Operators.Equal(t_, w_);
-                CodeableConcept y_ = M?.Code;
-                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                CqlValueSet aa_ = this.Medications_for_Above_Normal_BMI(context);
-                bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-                bool? ac_ = context.Operators.And(x_, ab_);
-                return ac_;
+                object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
+                string v_ = context.Operators.Last<string>(u_);
+                bool? w_ = context.Operators.Equal(s_, v_);
+                CodeableConcept x_ = M?.Code;
+                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
+                CqlValueSet z_ = this.Medications_for_Above_Normal_BMI(context);
+                bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
+                bool? ab_ = context.Operators.And(w_, aa_);
+                return ab_;
             }
 
             IEnumerable<Medication> q_ = context.Operators.Where<Medication>(o_, p_);
-            MedicationRequest r_(Medication M) => MR;
-            IEnumerable<MedicationRequest> s_ = context.Operators.Select<Medication, MedicationRequest>(q_, r_);
-            return s_;
+            bool? r_ = context.Operators.Exists<Medication>(q_);
+            return r_;
         }
 
-        IEnumerable<MedicationRequest> j_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(h_, i_);
+        IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
         IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(g_, j_);
         IEnumerable<object> l_ = context.Operators.Union<object>(e_ as IEnumerable<object>, k_ as IEnumerable<object>);
 
         bool? m_(object HighInterventionsOrdered) {
-            object ad_ = context.Operators.LateBoundProperty<object>(HighInterventionsOrdered, "reasonCode");
-            object[] ae_ = [
-                ad_,
+            object ac_ = context.Operators.LateBoundProperty<object>(HighInterventionsOrdered, "reasonCode");
+            object[] ad_ = [
+                ac_,
             ];
 
-            CqlConcept af_(object @this) {
-                CqlConcept au_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
-                return au_;
+            CqlConcept ae_(object @this) {
+                CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
+                return at_;
             }
 
-            IEnumerable<CqlConcept> ag_ = context.Operators.Select<object, CqlConcept>((IEnumerable<object>)ae_, af_);
-            CqlConcept ah_ = context.Operators.SingletonFrom<CqlConcept>(ag_);
-            CqlConcept[] ai_ = [
-                ah_,
+            IEnumerable<CqlConcept> af_ = context.Operators.Select<object, CqlConcept>((IEnumerable<object>)ad_, ae_);
+            CqlConcept ag_ = context.Operators.SingletonFrom<CqlConcept>(af_);
+            CqlConcept[] ah_ = [
+                ag_,
             ];
-            CqlValueSet aj_ = this.Overweight_or_Obese(context);
-            bool? ak_ = context.Operators.ConceptsInValueSet((IEnumerable<CqlConcept>)ai_, aj_);
-            IEnumerable<Condition> am_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> ao_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> ap_ = context.Operators.Union<Condition>(am_ as IEnumerable<Condition>, ao_ as IEnumerable<Condition>);
+            CqlValueSet ai_ = this.Overweight_or_Obese(context);
+            bool? aj_ = context.Operators.ConceptsInValueSet((IEnumerable<CqlConcept>)ah_, ai_);
+            IEnumerable<Condition> al_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            IEnumerable<Condition> an_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+            IEnumerable<Condition> ao_ = context.Operators.Union<Condition>(al_ as IEnumerable<Condition>, an_ as IEnumerable<Condition>);
 
-            bool? aq_(Condition OverweightObese) {
-                CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OverweightObese);
-                CqlDateTime aw_ = context.Operators.Start(av_);
-                object ax_ = context.Operators.LateBoundProperty<object>(HighInterventionsOrdered, "authoredOn");
-                CqlDateTime ay_ = context.Operators.LateBoundProperty<CqlDateTime>(ax_, "value");
-                bool? az_ = context.Operators.SameOrBefore(aw_, ay_, "day");
-                return az_;
+            bool? ap_(Condition OverweightObese) {
+                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OverweightObese);
+                CqlDateTime av_ = context.Operators.Start(au_);
+                object aw_ = context.Operators.LateBoundProperty<object>(HighInterventionsOrdered, "authoredOn");
+                CqlDateTime ax_ = context.Operators.LateBoundProperty<CqlDateTime>(aw_, "value");
+                bool? ay_ = context.Operators.SameOrBefore(av_, ax_, "day");
+                return ay_;
             }
 
-            IEnumerable<Condition> ar_ = context.Operators.Where<Condition>(ap_, aq_);
-            bool? as_ = context.Operators.Exists<Condition>(ar_);
-            bool? at_ = context.Operators.Or(ak_, as_);
-            return at_;
+            IEnumerable<Condition> aq_ = context.Operators.Where<Condition>(ao_, ap_);
+            bool? ar_ = context.Operators.Exists<Condition>(aq_);
+            bool? as_ = context.Operators.Or(aj_, ar_);
+            return as_;
         }
 
         IEnumerable<object> n_ = context.Operators.Where<object>(l_, m_);
@@ -616,69 +615,69 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Observation> a_ = this.Documented_High_BMI_During_Measurement_Period(context);
 
-        IEnumerable<Observation> b_(Observation HighBMI) {
+        bool? b_(Observation HighBMI) {
             IEnumerable<object> d_ = this.High_BMI_Interventions_Ordered(context);
             IEnumerable<Procedure> e_ = this.High_BMI_Interventions_Performed(context);
             IEnumerable<object> f_ = context.Operators.Union<object>(d_ as IEnumerable<object>, e_ as IEnumerable<object>);
 
             bool? g_(object HighBMIInterventions) {
 
-                object k_() {
+                object j_() {
+
+                    bool r_() {
+                        object v_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlDateTime;
+                        return x_;
+                    }
+
 
                     bool s_() {
-                        object w_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                        bool y_ = x_ is CqlDateTime;
-                        return y_;
+                        object y_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlInterval<CqlDateTime>;
+                        return aa_;
                     }
 
 
                     bool t_() {
-                        object z_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
-                        return ab_;
+                        object ab_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlQuantity;
+                        return ad_;
                     }
 
 
                     bool u_() {
-                        object ac_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlQuantity;
-                        return ae_;
+                        object ae_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
+                        return ag_;
                     }
 
-
-                    bool v_() {
-                        object af_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
-                        return ah_;
-                    }
-
-                    if (s_())
+                    if (r_())
                     {
-                        object ai_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlDateTime) as object;
+                        object ah_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlDateTime) as object;
+                    }
+                    else if (s_())
+                    {
+                        object aj_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (t_())
                     {
-                        object ak_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                        object al_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlQuantity) as object;
                     }
                     else if (u_())
                     {
-                        object am_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlQuantity) as object;
-                    }
-                    else if (v_())
-                    {
-                        object ao_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                        object an_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "performed");
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -686,23 +685,22 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                object m_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "authoredOn");
-                CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_ as object);
-                CqlDateTime p_ = context.Operators.Start(l_ ?? o_);
-                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
-                return r_;
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                object l_ = context.Operators.LateBoundProperty<object>(HighBMIInterventions, "authoredOn");
+                CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_ as object);
+                CqlDateTime o_ = context.Operators.Start(k_ ?? n_);
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+                return q_;
             }
 
             IEnumerable<object> h_ = context.Operators.Where<object>(f_, g_);
-            Observation i_(object HighBMIInterventions) => HighBMI;
-            IEnumerable<Observation> j_ = context.Operators.Select<object, Observation>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<object>(h_);
+            return i_;
         }
 
-        IEnumerable<Observation> c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
         return c_;
     }
 
@@ -747,72 +745,71 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationRequest> g_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> i_(MedicationRequest MR) {
+        bool? i_(MedicationRequest MR) {
             IEnumerable<Medication> o_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? p_(Medication M) {
-                object t_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object u_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> v_ = context.Operators.Split((string)u_, "/");
-                string w_ = context.Operators.Last<string>(v_);
-                bool? x_ = context.Operators.Equal(t_, w_);
-                CodeableConcept y_ = M?.Code;
-                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                CqlValueSet aa_ = this.Medications_for_Below_Normal_BMI(context);
-                bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-                bool? ac_ = context.Operators.And(x_, ab_);
-                return ac_;
+                object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
+                string v_ = context.Operators.Last<string>(u_);
+                bool? w_ = context.Operators.Equal(s_, v_);
+                CodeableConcept x_ = M?.Code;
+                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
+                CqlValueSet z_ = this.Medications_for_Below_Normal_BMI(context);
+                bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
+                bool? ab_ = context.Operators.And(w_, aa_);
+                return ab_;
             }
 
             IEnumerable<Medication> q_ = context.Operators.Where<Medication>(o_, p_);
-            MedicationRequest r_(Medication M) => MR;
-            IEnumerable<MedicationRequest> s_ = context.Operators.Select<Medication, MedicationRequest>(q_, r_);
-            return s_;
+            bool? r_ = context.Operators.Exists<Medication>(q_);
+            return r_;
         }
 
-        IEnumerable<MedicationRequest> j_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(h_, i_);
+        IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
         IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(g_, j_);
         IEnumerable<object> l_ = context.Operators.Union<object>(e_ as IEnumerable<object>, k_ as IEnumerable<object>);
 
         bool? m_(object LowInterventionsOrdered) {
-            object ad_ = context.Operators.LateBoundProperty<object>(LowInterventionsOrdered, "reasonCode");
-            object[] ae_ = [
-                ad_,
+            object ac_ = context.Operators.LateBoundProperty<object>(LowInterventionsOrdered, "reasonCode");
+            object[] ad_ = [
+                ac_,
             ];
 
-            CqlConcept af_(object @this) {
-                CqlConcept au_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
-                return au_;
+            CqlConcept ae_(object @this) {
+                CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
+                return at_;
             }
 
-            IEnumerable<CqlConcept> ag_ = context.Operators.Select<object, CqlConcept>((IEnumerable<object>)ae_, af_);
-            CqlConcept ah_ = context.Operators.SingletonFrom<CqlConcept>(ag_);
-            CqlConcept[] ai_ = [
-                ah_,
+            IEnumerable<CqlConcept> af_ = context.Operators.Select<object, CqlConcept>((IEnumerable<object>)ad_, ae_);
+            CqlConcept ag_ = context.Operators.SingletonFrom<CqlConcept>(af_);
+            CqlConcept[] ah_ = [
+                ag_,
             ];
-            CqlValueSet aj_ = this.Underweight(context);
-            bool? ak_ = context.Operators.ConceptsInValueSet((IEnumerable<CqlConcept>)ai_, aj_);
-            IEnumerable<Condition> am_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> ao_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> ap_ = context.Operators.Union<Condition>(am_ as IEnumerable<Condition>, ao_ as IEnumerable<Condition>);
+            CqlValueSet ai_ = this.Underweight(context);
+            bool? aj_ = context.Operators.ConceptsInValueSet((IEnumerable<CqlConcept>)ah_, ai_);
+            IEnumerable<Condition> al_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            IEnumerable<Condition> an_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+            IEnumerable<Condition> ao_ = context.Operators.Union<Condition>(al_ as IEnumerable<Condition>, an_ as IEnumerable<Condition>);
 
-            bool? aq_(Condition UnderweightDiagnosis) {
-                CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UnderweightDiagnosis);
-                CqlDateTime aw_ = context.Operators.Start(av_);
-                object ax_ = context.Operators.LateBoundProperty<object>(LowInterventionsOrdered, "authoredOn");
-                CqlDateTime ay_ = context.Operators.LateBoundProperty<CqlDateTime>(ax_, "value");
-                bool? az_ = context.Operators.SameOrBefore(aw_, ay_, "day");
-                CqlDateTime bb_ = context.Operators.LateBoundProperty<CqlDateTime>(ax_, "value");
-                CqlInterval<CqlDateTime> bc_ = this.Measurement_Period(context);
-                bool? bd_ = context.Operators.In<CqlDateTime>(bb_, bc_, "day");
-                bool? be_ = context.Operators.And(az_, bd_);
-                return be_;
+            bool? ap_(Condition UnderweightDiagnosis) {
+                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UnderweightDiagnosis);
+                CqlDateTime av_ = context.Operators.Start(au_);
+                object aw_ = context.Operators.LateBoundProperty<object>(LowInterventionsOrdered, "authoredOn");
+                CqlDateTime ax_ = context.Operators.LateBoundProperty<CqlDateTime>(aw_, "value");
+                bool? ay_ = context.Operators.SameOrBefore(av_, ax_, "day");
+                CqlDateTime ba_ = context.Operators.LateBoundProperty<CqlDateTime>(aw_, "value");
+                CqlInterval<CqlDateTime> bb_ = this.Measurement_Period(context);
+                bool? bc_ = context.Operators.In<CqlDateTime>(ba_, bb_, "day");
+                bool? bd_ = context.Operators.And(ay_, bc_);
+                return bd_;
             }
 
-            IEnumerable<Condition> ar_ = context.Operators.Where<Condition>(ap_, aq_);
-            bool? as_ = context.Operators.Exists<Condition>(ar_);
-            bool? at_ = context.Operators.Or(ak_, as_);
-            return at_;
+            IEnumerable<Condition> aq_ = context.Operators.Where<Condition>(ao_, ap_);
+            bool? ar_ = context.Operators.Exists<Condition>(aq_);
+            bool? as_ = context.Operators.Or(aj_, ar_);
+            return as_;
         }
 
         IEnumerable<object> n_ = context.Operators.Where<object>(l_, m_);
@@ -1083,69 +1080,69 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Observation> a_ = this.Documented_Low_BMI_During_Measurement_Period(context);
 
-        IEnumerable<Observation> b_(Observation LowBMI) {
+        bool? b_(Observation LowBMI) {
             IEnumerable<object> d_ = this.Low_BMI_Interventions_Ordered(context);
             IEnumerable<Procedure> e_ = this.Low_BMI_Interventions_Performed(context);
             IEnumerable<object> f_ = context.Operators.Union<object>(d_ as IEnumerable<object>, e_ as IEnumerable<object>);
 
             bool? g_(object LowBMIInterventions) {
 
-                object k_() {
+                object j_() {
+
+                    bool r_() {
+                        object v_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlDateTime;
+                        return x_;
+                    }
+
 
                     bool s_() {
-                        object w_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                        bool y_ = x_ is CqlDateTime;
-                        return y_;
+                        object y_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlInterval<CqlDateTime>;
+                        return aa_;
                     }
 
 
                     bool t_() {
-                        object z_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
-                        return ab_;
+                        object ab_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlQuantity;
+                        return ad_;
                     }
 
 
                     bool u_() {
-                        object ac_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlQuantity;
-                        return ae_;
+                        object ae_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
+                        return ag_;
                     }
 
-
-                    bool v_() {
-                        object af_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
-                        return ah_;
-                    }
-
-                    if (s_())
+                    if (r_())
                     {
-                        object ai_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlDateTime) as object;
+                        object ah_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlDateTime) as object;
+                    }
+                    else if (s_())
+                    {
+                        object aj_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (t_())
                     {
-                        object ak_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                        object al_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlQuantity) as object;
                     }
                     else if (u_())
                     {
-                        object am_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlQuantity) as object;
-                    }
-                    else if (v_())
-                    {
-                        object ao_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                        object an_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "performed");
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        return (ao_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1153,23 +1150,22 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
                     };
                 }
 
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                object m_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "authoredOn");
-                CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_ as object);
-                CqlDateTime p_ = context.Operators.Start(l_ ?? o_);
-                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
-                return r_;
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                object l_ = context.Operators.LateBoundProperty<object>(LowBMIInterventions, "authoredOn");
+                CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_ as object);
+                CqlDateTime o_ = context.Operators.Start(k_ ?? n_);
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+                return q_;
             }
 
             IEnumerable<object> h_ = context.Operators.Where<object>(f_, g_);
-            Observation i_(object LowBMIInterventions) => LowBMI;
-            IEnumerable<Observation> j_ = context.Operators.Select<object, Observation>(h_, i_);
-            return j_;
+            bool? i_ = context.Operators.Exists<object>(h_);
+            return i_;
         }
 
-        IEnumerable<Observation> c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
         return c_;
     }
 
@@ -1251,56 +1247,55 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         IEnumerable<ServiceRequest> p_ = context.Operators.Union<ServiceRequest>(m_, o_);
         IEnumerable<ServiceRequest> q_ = context.Operators.Union<ServiceRequest>(k_, p_);
 
-        IEnumerable<ServiceRequest> r_(ServiceRequest NoBMIFollowUp) {
+        bool? r_(ServiceRequest NoBMIFollowUp) {
             IEnumerable<Encounter> al_ = this.Qualifying_Encounter_During_Day_Of_Measurement_Period(context);
 
             bool? am_(Encounter QualifyingEncounter) {
-                FhirDateTime aq_ = NoBMIFollowUp?.AuthoredOnElement;
-                CqlDateTime ar_ = context.Operators.Convert<CqlDateTime>(aq_);
-                Period as_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
-                CqlDateTime au_ = context.Operators.Start(at_);
-                bool? av_ = context.Operators.SameAs(ar_, au_, "day");
-                return av_;
+                FhirDateTime ap_ = NoBMIFollowUp?.AuthoredOnElement;
+                CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(ap_);
+                Period ar_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                bool? au_ = context.Operators.SameAs(aq_, at_, "day");
+                return au_;
             }
 
             IEnumerable<Encounter> an_ = context.Operators.Where<Encounter>(al_, am_);
-            ServiceRequest ao_(Encounter QualifyingEncounter) => NoBMIFollowUp;
-            IEnumerable<ServiceRequest> ap_ = context.Operators.Select<Encounter, ServiceRequest>(an_, ao_);
-            return ap_;
+            bool? ao_ = context.Operators.Exists<Encounter>(an_);
+            return ao_;
         }
 
-        IEnumerable<ServiceRequest> s_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(q_, r_);
+        IEnumerable<ServiceRequest> s_ = context.Operators.Where<ServiceRequest>(q_, r_);
 
         bool? t_(ServiceRequest NoBMIFollowUp) {
-            Code<RequestStatus> aw_ = NoBMIFollowUp?.StatusElement;
-            RequestStatus? ax_ = aw_?.Value;
-            Code<RequestStatus> ay_ = context.Operators.Convert<Code<RequestStatus>>(ax_);
-            bool? az_ = context.Operators.Equivalent(ay_, "completed");
+            Code<RequestStatus> av_ = NoBMIFollowUp?.StatusElement;
+            RequestStatus? aw_ = av_?.Value;
+            Code<RequestStatus> ax_ = context.Operators.Convert<Code<RequestStatus>>(aw_);
+            bool? ay_ = context.Operators.Equivalent(ax_, "completed");
 
-            bool? ba_(Extension @this) {
-                FhirUri bj_ = @this?.UrlElement;
-                string bk_ = FHIRHelpers_4_4_000.Instance.ToString(context, bj_);
-                bool? bl_ = context.Operators.Equal(bk_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+            bool? az_(Extension @this) {
+                FhirUri bi_ = @this?.UrlElement;
+                string bj_ = FHIRHelpers_4_4_000.Instance.ToString(context, bi_);
+                bool? bk_ = context.Operators.Equal(bj_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                return bk_;
+            }
+
+            IEnumerable<Extension> ba_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBMIFollowUp is DomainResource
+                ? (NoBMIFollowUp as DomainResource).Extension
+                : default), az_);
+
+            object bb_(Extension @this) {
+                DataType bl_ = @this?.Value;
                 return bl_;
             }
 
-            IEnumerable<Extension> bb_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBMIFollowUp is DomainResource
-                ? (NoBMIFollowUp as DomainResource).Extension
-                : default), ba_);
-
-            object bc_(Extension @this) {
-                DataType bm_ = @this?.Value;
-                return bm_;
-            }
-
-            IEnumerable<object> bd_ = context.Operators.Select<Extension, object>(bb_, bc_);
-            object be_ = context.Operators.SingletonFrom<object>(bd_);
-            CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, be_ as CodeableConcept);
-            CqlValueSet bg_ = this.Medical_Reason(context);
-            bool? bh_ = context.Operators.ConceptInValueSet(bf_, bg_);
-            bool? bi_ = context.Operators.And(az_, bh_);
-            return bi_;
+            IEnumerable<object> bc_ = context.Operators.Select<Extension, object>(ba_, bb_);
+            object bd_ = context.Operators.SingletonFrom<object>(bc_);
+            CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_ as CodeableConcept);
+            CqlValueSet bf_ = this.Medical_Reason(context);
+            bool? bg_ = context.Operators.ConceptInValueSet(be_, bf_);
+            bool? bh_ = context.Operators.And(ay_, bg_);
+            return bh_;
         }
 
         IEnumerable<ServiceRequest> u_ = context.Operators.Where<ServiceRequest>(s_, t_);
@@ -1314,44 +1309,43 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationRequest> ae_ = context.Operators.Union<MedicationRequest>(ab_, ad_);
         IEnumerable<MedicationRequest> af_ = context.Operators.Union<MedicationRequest>(z_, ae_);
 
-        IEnumerable<MedicationRequest> ag_(MedicationRequest NoBMIFollowUp) {
-            IEnumerable<Encounter> bn_ = this.Qualifying_Encounter_During_Day_Of_Measurement_Period(context);
+        bool? ag_(MedicationRequest NoBMIFollowUp) {
+            IEnumerable<Encounter> bm_ = this.Qualifying_Encounter_During_Day_Of_Measurement_Period(context);
 
-            bool? bo_(Encounter QualifyingEncounter) {
-                FhirDateTime bs_ = NoBMIFollowUp?.AuthoredOnElement;
-                CqlDateTime bt_ = context.Operators.Convert<CqlDateTime>(bs_);
-                Period bu_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> bv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bu_);
-                CqlDateTime bw_ = context.Operators.Start(bv_);
-                bool? bx_ = context.Operators.SameAs(bt_, bw_, "day");
-                return bx_;
+            bool? bn_(Encounter QualifyingEncounter) {
+                FhirDateTime bq_ = NoBMIFollowUp?.AuthoredOnElement;
+                CqlDateTime br_ = context.Operators.Convert<CqlDateTime>(bq_);
+                Period bs_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
+                CqlDateTime bu_ = context.Operators.Start(bt_);
+                bool? bv_ = context.Operators.SameAs(br_, bu_, "day");
+                return bv_;
             }
 
-            IEnumerable<Encounter> bp_ = context.Operators.Where<Encounter>(bn_, bo_);
-            MedicationRequest bq_(Encounter QualifyingEncounter) => NoBMIFollowUp;
-            IEnumerable<MedicationRequest> br_ = context.Operators.Select<Encounter, MedicationRequest>(bp_, bq_);
-            return br_;
+            IEnumerable<Encounter> bo_ = context.Operators.Where<Encounter>(bm_, bn_);
+            bool? bp_ = context.Operators.Exists<Encounter>(bo_);
+            return bp_;
         }
 
-        IEnumerable<MedicationRequest> ah_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(af_, ag_);
+        IEnumerable<MedicationRequest> ah_ = context.Operators.Where<MedicationRequest>(af_, ag_);
 
         bool? ai_(MedicationRequest NoBMIFollowUp) {
-            Code<MedicationRequest.MedicationrequestStatus> by_ = NoBMIFollowUp?.StatusElement;
-            MedicationRequest.MedicationrequestStatus? bz_ = by_?.Value;
-            string ca_ = context.Operators.Convert<string>(bz_);
-            bool? cb_ = context.Operators.Equivalent(ca_, "completed");
-            List<CodeableConcept> cc_ = NoBMIFollowUp?.ReasonCode;
+            Code<MedicationRequest.MedicationrequestStatus> bw_ = NoBMIFollowUp?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? bx_ = bw_?.Value;
+            string by_ = context.Operators.Convert<string>(bx_);
+            bool? bz_ = context.Operators.Equivalent(by_, "completed");
+            List<CodeableConcept> ca_ = NoBMIFollowUp?.ReasonCode;
 
-            CqlConcept cd_(CodeableConcept @this) {
-                CqlConcept ci_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return ci_;
+            CqlConcept cb_(CodeableConcept @this) {
+                CqlConcept cg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return cg_;
             }
 
-            IEnumerable<CqlConcept> ce_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)cc_, cd_);
-            CqlValueSet cf_ = this.Medical_Reason(context);
-            bool? cg_ = context.Operators.ConceptsInValueSet(ce_, cf_);
-            bool? ch_ = context.Operators.And(cb_, cg_);
-            return ch_;
+            IEnumerable<CqlConcept> cc_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ca_, cb_);
+            CqlValueSet cd_ = this.Medical_Reason(context);
+            bool? ce_ = context.Operators.ConceptsInValueSet(cc_, cd_);
+            bool? cf_ = context.Operators.And(bz_, ce_);
+            return cf_;
         }
 
         IEnumerable<MedicationRequest> aj_ = context.Operators.Where<MedicationRequest>(ah_, ai_);
@@ -1372,76 +1366,75 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
 
-        IEnumerable<Observation> d_(Observation NoBMI) {
+        bool? d_(Observation NoBMI) {
             IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Day_Of_Measurement_Period(context);
 
             bool? i_(Encounter QualifyingEncounter) {
-                DataType m_ = NoBMI?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                Period q_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                bool? t_ = context.Operators.SameAs(p_, s_, "day");
-                return t_;
+                DataType l_ = NoBMI?.Effective;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                bool? s_ = context.Operators.SameAs(o_, r_, "day");
+                return s_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
-            Observation k_(Encounter QualifyingEncounter) => NoBMI;
-            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Encounter>(j_);
+            return k_;
         }
 
-        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         bool? f_(Observation NoBMI) {
 
-            bool? u_(Extension @this) {
-                FhirUri al_ = @this?.UrlElement;
-                string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
-                bool? an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            bool? t_(Extension @this) {
+                FhirUri ak_ = @this?.UrlElement;
+                string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
+                bool? am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return am_;
+            }
+
+            IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBMI is DomainResource
+                ? (NoBMI as DomainResource).Extension
+                : default), t_);
+
+            object v_(Extension @this) {
+                DataType an_ = @this?.Value;
                 return an_;
             }
 
-            IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBMI is DomainResource
-                ? (NoBMI as DomainResource).Extension
-                : default), u_);
+            IEnumerable<object> w_ = context.Operators.Select<Extension, object>(u_, v_);
+            object x_ = context.Operators.SingletonFrom<object>(w_);
+            CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
+            CqlValueSet z_ = this.Patient_Declined(context);
+            bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
 
-            object w_(Extension @this) {
-                DataType ao_ = @this?.Value;
-                return ao_;
+            bool? ab_(Extension @this) {
+                FhirUri ao_ = @this?.UrlElement;
+                string ap_ = FHIRHelpers_4_4_000.Instance.ToString(context, ao_);
+                bool? aq_ = context.Operators.Equal(ap_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return aq_;
             }
 
-            IEnumerable<object> x_ = context.Operators.Select<Extension, object>(v_, w_);
-            object y_ = context.Operators.SingletonFrom<object>(x_);
-            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_ as CodeableConcept);
-            CqlValueSet aa_ = this.Patient_Declined(context);
-            bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBMI is DomainResource
+                ? (NoBMI as DomainResource).Extension
+                : default), ab_);
 
-            bool? ac_(Extension @this) {
-                FhirUri ap_ = @this?.UrlElement;
-                string aq_ = FHIRHelpers_4_4_000.Instance.ToString(context, ap_);
-                bool? ar_ = context.Operators.Equal(aq_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+            object ad_(Extension @this) {
+                DataType ar_ = @this?.Value;
                 return ar_;
             }
 
-            IEnumerable<Extension> ad_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoBMI is DomainResource
-                ? (NoBMI as DomainResource).Extension
-                : default), ac_);
-
-            object ae_(Extension @this) {
-                DataType as_ = @this?.Value;
-                return as_;
-            }
-
-            IEnumerable<object> af_ = context.Operators.Select<Extension, object>(ad_, ae_);
-            object ag_ = context.Operators.SingletonFrom<object>(af_);
-            CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_ as CodeableConcept);
-            CqlValueSet ai_ = this.Medical_Reason(context);
-            bool? aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
-            bool? ak_ = context.Operators.Or(ab_, aj_);
-            return ak_;
+            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
+            object af_ = context.Operators.SingletonFrom<object>(ae_);
+            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
+            CqlValueSet ah_ = this.Medical_Reason(context);
+            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+            bool? aj_ = context.Operators.Or(aa_, ai_);
+            return aj_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
@@ -213,104 +213,103 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
-        IEnumerable<Encounter> e_(Encounter IschemicStrokeEncounter) {
+        bool? e_(Encounter IschemicStrokeEncounter) {
             CqlValueSet be_ = this.History_of_Atrial_Ablation(context);
             IEnumerable<Condition> bf_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, be_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? bg_(Condition AtrialAblationDiagnosis) {
-                CodeableConcept bk_ = AtrialAblationDiagnosis?.VerificationStatus;
-                CqlConcept bl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bk_);
-                bool? bm_ = context.Operators.Not((bool?)(bl_ is null));
-                CqlConcept bo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bk_);
-                CqlCode bp_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept bq_ = context.Operators.ConvertCodeToConcept(bp_);
-                bool? br_ = context.Operators.Equivalent(bo_, bq_);
-                bool? bs_ = context.Operators.Not(br_);
-                CqlConcept bu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bk_);
-                CqlCode bv_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept bw_ = context.Operators.ConvertCodeToConcept(bv_);
-                bool? bx_ = context.Operators.Equivalent(bu_, bw_);
-                bool? by_ = context.Operators.Not(bx_);
-                bool? bz_ = context.Operators.And(bs_, by_);
-                DataType ca_ = AtrialAblationDiagnosis?.Onset;
-                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
-                CqlDateTime cd_ = context.Operators.Start(cc_);
-                Period ce_ = IschemicStrokeEncounter?.Period;
-                CqlInterval<CqlDateTime> cf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ce_);
-                CqlDateTime cg_ = context.Operators.Start(cf_);
-                bool? ch_ = context.Operators.Before(cd_, cg_, (string)default);
-                bool? ci_ = context.Operators.And(bz_, ch_);
-                bool? cj_ = context.Operators.Implies(bm_, ci_);
-                return cj_;
+                CodeableConcept bj_ = AtrialAblationDiagnosis?.VerificationStatus;
+                CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
+                bool? bl_ = context.Operators.Not((bool?)(bk_ is null));
+                CqlConcept bn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
+                CqlCode bo_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept bp_ = context.Operators.ConvertCodeToConcept(bo_);
+                bool? bq_ = context.Operators.Equivalent(bn_, bp_);
+                bool? br_ = context.Operators.Not(bq_);
+                CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
+                CqlCode bu_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept bv_ = context.Operators.ConvertCodeToConcept(bu_);
+                bool? bw_ = context.Operators.Equivalent(bt_, bv_);
+                bool? bx_ = context.Operators.Not(bw_);
+                bool? by_ = context.Operators.And(br_, bx_);
+                DataType bz_ = AtrialAblationDiagnosis?.Onset;
+                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                CqlInterval<CqlDateTime> cb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ca_);
+                CqlDateTime cc_ = context.Operators.Start(cb_);
+                Period cd_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> ce_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cd_);
+                CqlDateTime cf_ = context.Operators.Start(ce_);
+                bool? cg_ = context.Operators.Before(cc_, cf_, (string)default);
+                bool? ch_ = context.Operators.And(by_, cg_);
+                bool? ci_ = context.Operators.Implies(bl_, ch_);
+                return ci_;
             }
 
             IEnumerable<Condition> bh_ = context.Operators.Where<Condition>(bf_, bg_);
-            Encounter bi_(Condition AtrialAblationDiagnosis) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> bj_ = context.Operators.Select<Condition, Encounter>(bh_, bi_);
-            return bj_;
+            bool? bi_ = context.Operators.Exists<Condition>(bh_);
+            return bi_;
         }
 
-        IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+        IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
         IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 
-        IEnumerable<Encounter> i_(Encounter IschemicStrokeEncounter) {
-            CqlValueSet ck_ = this.History_of_Atrial_Ablation(context);
-            IEnumerable<Observation> cl_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, ck_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
+        bool? i_(Encounter IschemicStrokeEncounter) {
+            CqlValueSet cj_ = this.History_of_Atrial_Ablation(context);
+            IEnumerable<Observation> ck_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, cj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
 
-            bool? cm_(Observation AtrialAblationObservation) {
-                Code<ObservationStatus> cq_ = AtrialAblationObservation?.StatusElement;
-                ObservationStatus? cr_ = cq_?.Value;
-                string cs_ = context.Operators.Convert<string>(cr_);
-                string[] ct_ = [
+            bool? cl_(Observation AtrialAblationObservation) {
+                Code<ObservationStatus> co_ = AtrialAblationObservation?.StatusElement;
+                ObservationStatus? cp_ = co_?.Value;
+                string cq_ = context.Operators.Convert<string>(cp_);
+                string[] cr_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
+                bool? cs_ = context.Operators.In<string>(cq_, (IEnumerable<string>)cr_);
 
-                object cv_() {
+                object ct_() {
+
+                    bool da_() {
+                        DataType dd_ = AtrialAblationObservation?.Effective;
+                        object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
+                        bool df_ = de_ is CqlDateTime;
+                        return df_;
+                    }
+
+
+                    bool db_() {
+                        DataType dg_ = AtrialAblationObservation?.Effective;
+                        object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
+                        bool di_ = dh_ is CqlInterval<CqlDateTime>;
+                        return di_;
+                    }
+
 
                     bool dc_() {
-                        DataType df_ = AtrialAblationObservation?.Effective;
-                        object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                        bool dh_ = dg_ is CqlDateTime;
-                        return dh_;
+                        DataType dj_ = AtrialAblationObservation?.Effective;
+                        object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+                        bool dl_ = dk_ is CqlDateTime;
+                        return dl_;
                     }
 
-
-                    bool dd_() {
-                        DataType di_ = AtrialAblationObservation?.Effective;
-                        object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                        bool dk_ = dj_ is CqlInterval<CqlDateTime>;
-                        return dk_;
+                    if (da_())
+                    {
+                        DataType dm_ = AtrialAblationObservation?.Effective;
+                        object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
+                        return (dn_ as CqlDateTime) as object;
                     }
-
-
-                    bool de_() {
-                        DataType dl_ = AtrialAblationObservation?.Effective;
-                        object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                        bool dn_ = dm_ is CqlDateTime;
-                        return dn_;
-                    }
-
-                    if (dc_())
+                    else if (db_())
                     {
                         DataType do_ = AtrialAblationObservation?.Effective;
                         object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
-                        return (dp_ as CqlDateTime) as object;
+                        return (dp_ as CqlInterval<CqlDateTime>) as object;
                     }
-                    else if (dd_())
+                    else if (dc_())
                     {
                         DataType dq_ = AtrialAblationObservation?.Effective;
                         object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
-                        return (dr_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (de_())
-                    {
-                        DataType ds_ = AtrialAblationObservation?.Effective;
-                        object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
-                        return (dt_ as CqlDateTime) as object;
+                        return (dr_ as CqlDateTime) as object;
                     }
                     else
                     {
@@ -318,62 +317,60 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     };
                 }
 
-                CqlDateTime cw_ = QICoreCommon_4_0_000.Instance.earliest(context, cv_());
-                Period cx_ = IschemicStrokeEncounter?.Period;
-                CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cx_);
-                CqlDateTime cz_ = context.Operators.End(cy_);
-                bool? da_ = context.Operators.SameOrBefore(cw_, cz_, (string)default);
-                bool? db_ = context.Operators.And(cu_, da_);
-                return db_;
+                CqlDateTime cu_ = QICoreCommon_4_0_000.Instance.earliest(context, ct_());
+                Period cv_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cv_);
+                CqlDateTime cx_ = context.Operators.End(cw_);
+                bool? cy_ = context.Operators.SameOrBefore(cu_, cx_, (string)default);
+                bool? cz_ = context.Operators.And(cs_, cy_);
+                return cz_;
             }
 
-            IEnumerable<Observation> cn_ = context.Operators.Where<Observation>(cl_, cm_);
-            Encounter co_(Observation AtrialAblationObservation) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> cp_ = context.Operators.Select<Observation, Encounter>(cn_, co_);
-            return cp_;
+            IEnumerable<Observation> cm_ = context.Operators.Where<Observation>(ck_, cl_);
+            bool? cn_ = context.Operators.Exists<Observation>(cm_);
+            return cn_;
         }
 
-        IEnumerable<Encounter> j_ = context.Operators.SelectMany<Encounter, Encounter>(a_, i_);
+        IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(a_, i_);
 
-        IEnumerable<Encounter> l_(Encounter IschemicStrokeEncounter) {
-            CqlValueSet du_ = this.History_of_Atrial_Ablation(context);
-            IEnumerable<Condition> dv_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, du_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        bool? l_(Encounter IschemicStrokeEncounter) {
+            CqlValueSet ds_ = this.History_of_Atrial_Ablation(context);
+            IEnumerable<Condition> dt_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ds_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
-            bool? dw_(Condition AtrialAblationEncDiagnosis) {
-                CodeableConcept ea_ = AtrialAblationEncDiagnosis?.VerificationStatus;
-                CqlConcept eb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ea_);
-                bool? ec_ = context.Operators.Not((bool?)(eb_ is null));
-                CqlConcept ee_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ea_);
-                CqlCode ef_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept eg_ = context.Operators.ConvertCodeToConcept(ef_);
-                bool? eh_ = context.Operators.Equivalent(ee_, eg_);
-                bool? ei_ = context.Operators.Not(eh_);
-                CqlConcept ek_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ea_);
-                CqlCode el_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept em_ = context.Operators.ConvertCodeToConcept(el_);
-                bool? en_ = context.Operators.Equivalent(ek_, em_);
-                bool? eo_ = context.Operators.Not(en_);
-                bool? ep_ = context.Operators.And(ei_, eo_);
-                DataType eq_ = AtrialAblationEncDiagnosis?.Onset;
-                object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
-                CqlInterval<CqlDateTime> es_ = QICoreCommon_4_0_000.Instance.toInterval(context, er_);
+            bool? du_(Condition AtrialAblationEncDiagnosis) {
+                CodeableConcept dx_ = AtrialAblationEncDiagnosis?.VerificationStatus;
+                CqlConcept dy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dx_);
+                bool? dz_ = context.Operators.Not((bool?)(dy_ is null));
+                CqlConcept eb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dx_);
+                CqlCode ec_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept ed_ = context.Operators.ConvertCodeToConcept(ec_);
+                bool? ee_ = context.Operators.Equivalent(eb_, ed_);
+                bool? ef_ = context.Operators.Not(ee_);
+                CqlConcept eh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dx_);
+                CqlCode ei_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept ej_ = context.Operators.ConvertCodeToConcept(ei_);
+                bool? ek_ = context.Operators.Equivalent(eh_, ej_);
+                bool? el_ = context.Operators.Not(ek_);
+                bool? em_ = context.Operators.And(ef_, el_);
+                DataType en_ = AtrialAblationEncDiagnosis?.Onset;
+                object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
+                CqlInterval<CqlDateTime> ep_ = QICoreCommon_4_0_000.Instance.toInterval(context, eo_);
+                CqlDateTime eq_ = context.Operators.Start(ep_);
+                Period er_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> es_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, er_);
                 CqlDateTime et_ = context.Operators.Start(es_);
-                Period eu_ = IschemicStrokeEncounter?.Period;
-                CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eu_);
-                CqlDateTime ew_ = context.Operators.Start(ev_);
-                bool? ex_ = context.Operators.Before(et_, ew_, (string)default);
-                bool? ey_ = context.Operators.And(ep_, ex_);
-                bool? ez_ = context.Operators.Implies(ec_, ey_);
-                return ez_;
+                bool? eu_ = context.Operators.Before(eq_, et_, (string)default);
+                bool? ev_ = context.Operators.And(em_, eu_);
+                bool? ew_ = context.Operators.Implies(dz_, ev_);
+                return ew_;
             }
 
-            IEnumerable<Condition> dx_ = context.Operators.Where<Condition>(dv_, dw_);
-            Encounter dy_(Condition AtrialAblationEncDiagnosis) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> dz_ = context.Operators.Select<Condition, Encounter>(dx_, dy_);
-            return dz_;
+            IEnumerable<Condition> dv_ = context.Operators.Where<Condition>(dt_, du_);
+            bool? dw_ = context.Operators.Exists<Condition>(dv_);
+            return dw_;
         }
 
-        IEnumerable<Encounter> m_ = context.Operators.SelectMany<Encounter, Encounter>(a_, l_);
+        IEnumerable<Encounter> m_ = context.Operators.Where<Encounter>(a_, l_);
         IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(j_, m_);
         IEnumerable<Encounter> o_ = context.Operators.Union<Encounter>(g_, n_);
         return o_;
@@ -390,60 +387,59 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             CqlValueSet h_ = this.Atrial_Fibrillation_or_Flutter(context);
             IEnumerable<Condition> i_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? j_(Condition AtrialFibrillationFlutter) {
-                CodeableConcept n_ = AtrialFibrillationFlutter?.VerificationStatus;
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                bool? p_ = context.Operators.Not((bool?)(o_ is null));
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                bool? u_ = context.Operators.Equivalent(r_, t_);
-                bool? v_ = context.Operators.Not(u_);
-                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlCode y_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
-                bool? aa_ = context.Operators.Equivalent(x_, z_);
-                bool? ab_ = context.Operators.Not(aa_);
-                bool? ac_ = context.Operators.And(v_, ab_);
-                DataType ad_ = AtrialFibrillationFlutter?.Onset;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
-                CqlDateTime ag_ = context.Operators.Start(af_);
-                Period ah_ = IschemicStrokeEncounter?.Period;
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.End(ai_);
-                bool? ak_ = context.Operators.SameOrBefore(ag_, aj_, (string)default);
-                bool? al_ = context.Operators.And(ac_, ak_);
-                bool? am_ = context.Operators.Implies(p_, al_);
-                return am_;
+                CodeableConcept m_ = AtrialFibrillationFlutter?.VerificationStatus;
+                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
+                bool? o_ = context.Operators.Not((bool?)(n_ is null));
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
+                CqlCode r_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+                bool? t_ = context.Operators.Equivalent(q_, s_);
+                bool? u_ = context.Operators.Not(t_);
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
+                CqlCode x_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
+                bool? z_ = context.Operators.Equivalent(w_, y_);
+                bool? aa_ = context.Operators.Not(z_);
+                bool? ab_ = context.Operators.And(u_, aa_);
+                DataType ac_ = AtrialFibrillationFlutter?.Onset;
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
+                CqlDateTime af_ = context.Operators.Start(ae_);
+                Period ag_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
+                CqlDateTime ai_ = context.Operators.End(ah_);
+                bool? aj_ = context.Operators.SameOrBefore(af_, ai_, (string)default);
+                bool? ak_ = context.Operators.And(ab_, aj_);
+                bool? al_ = context.Operators.Implies(o_, ak_);
+                return al_;
             }
 
             IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
-            Encounter l_(Condition AtrialFibrillationFlutter) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<Condition, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Condition>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? e_(Encounter IschemicStrokeEncounter) {
-            IEnumerable<Condition> an_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, IschemicStrokeEncounter);
+            IEnumerable<Condition> am_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, IschemicStrokeEncounter);
 
-            bool? ao_(Condition EncounterDiagnosis) {
-                CodeableConcept ar_ = EncounterDiagnosis?.Code;
-                CqlConcept as_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ar_);
-                CqlValueSet at_ = this.Atrial_Fibrillation_or_Flutter(context);
-                bool? au_ = context.Operators.ConceptInValueSet(as_, at_);
-                return au_;
+            bool? an_(Condition EncounterDiagnosis) {
+                CodeableConcept aq_ = EncounterDiagnosis?.Code;
+                CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
+                CqlValueSet as_ = this.Atrial_Fibrillation_or_Flutter(context);
+                bool? at_ = context.Operators.ConceptInValueSet(ar_, as_);
+                return at_;
             }
 
-            IEnumerable<Condition> ap_ = context.Operators.Where<Condition>(an_, ao_);
-            bool? aq_ = context.Operators.Exists<Condition>(ap_);
-            return aq_;
+            IEnumerable<Condition> ao_ = context.Operators.Where<Condition>(am_, an_);
+            bool? ap_ = context.Operators.Exists<Condition>(ao_);
+            return ap_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
@@ -477,67 +473,67 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = this.Denominator(context);
 
-        IEnumerable<Encounter> b_(Encounter Encounter) {
+        bool? b_(Encounter Encounter) {
             IEnumerable<object> d_ = TJCOverall_8_25_000.Instance.Intervention_Comfort_Measures(context);
 
             bool? e_(object ComfortMeasure) {
 
-                object i_() {
+                object h_() {
+
+                    bool o_() {
+                        object s_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                        bool u_ = t_ is CqlDateTime;
+                        return u_;
+                    }
+
 
                     bool p_() {
-                        object t_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                        bool v_ = u_ is CqlDateTime;
-                        return v_;
+                        object v_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlInterval<CqlDateTime>;
+                        return x_;
                     }
 
 
                     bool q_() {
-                        object w_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                        bool y_ = x_ is CqlInterval<CqlDateTime>;
-                        return y_;
+                        object y_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlQuantity;
+                        return aa_;
                     }
 
 
                     bool r_() {
-                        object z_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        bool ab_ = aa_ is CqlQuantity;
-                        return ab_;
+                        object ab_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlInterval<CqlQuantity>;
+                        return ad_;
                     }
 
-
-                    bool s_() {
-                        object ac_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        bool ae_ = ad_ is CqlInterval<CqlQuantity>;
-                        return ae_;
-                    }
-
-                    if (p_())
+                    if (o_())
                     {
-                        object af_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                        return (ag_ as CqlDateTime) as object;
+                        object ae_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        return (af_ as CqlDateTime) as object;
+                    }
+                    else if (p_())
+                    {
+                        object ag_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        return (ah_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (q_())
                     {
-                        object ah_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        return (ai_ as CqlInterval<CqlDateTime>) as object;
+                        object ai_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlQuantity) as object;
                     }
                     else if (r_())
                     {
-                        object aj_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlQuantity) as object;
-                    }
-                    else if (s_())
-                    {
-                        object al_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlQuantity>) as object;
+                        object ak_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -545,22 +541,21 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     };
                 }
 
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
-                CqlDateTime k_ = context.Operators.Start(j_);
-                object l_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-                CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, Encounter);
-                bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, (string)default);
-                return o_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_());
+                CqlDateTime j_ = context.Operators.Start(i_);
+                object k_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+                CqlDateTime l_ = context.Operators.LateBoundProperty<CqlDateTime>(k_, "value");
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, Encounter);
+                bool? n_ = context.Operators.In<CqlDateTime>(j_ ?? l_, m_, (string)default);
+                return n_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object ComfortMeasure) => Encounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -626,96 +621,94 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = this.Denominator(context);
 
-        IEnumerable<Encounter> b_(Encounter Encounter) {
+        bool? b_(Encounter Encounter) {
             CqlValueSet d_ = this.Anticoagulant_Therapy(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Anticoagulant_Therapy(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Anticoagulant_Therapy(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest DischargeAnticoagulant) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = DischargeAnticoagulant?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = DischargeAnticoagulant?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = DischargeAnticoagulant?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                string[] ak_ = [
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = DischargeAnticoagulant?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                string[] ai_ = [
                     "order",
                     "original-order",
                     "reflex-order",
                     "filler-order",
                     "instance-order",
                 ];
-                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                bool? am_ = context.Operators.And(ag_, al_);
-                bool? an_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAnticoagulant as MedicationRequest);
-                bool? ao_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAnticoagulant as MedicationRequest);
-                bool? ap_ = context.Operators.Or(an_, ao_);
-                bool? aq_ = context.Operators.And(am_, ap_);
-                FhirDateTime ar_ = DischargeAnticoagulant?.AuthoredOnElement;
-                CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
-                Period at_ = Encounter?.Period;
-                CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, at_);
-                bool? av_ = context.Operators.In<CqlDateTime>(as_, au_, (string)default);
-                bool? aw_ = context.Operators.And(aq_, av_);
-                IEnumerable<Task> ax_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+                bool? ak_ = context.Operators.And(ae_, aj_);
+                bool? al_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAnticoagulant as MedicationRequest);
+                bool? am_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAnticoagulant as MedicationRequest);
+                bool? an_ = context.Operators.Or(al_, am_);
+                bool? ao_ = context.Operators.And(ak_, an_);
+                FhirDateTime ap_ = DischargeAnticoagulant?.AuthoredOnElement;
+                CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(ap_);
+                Period ar_ = Encounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                bool? at_ = context.Operators.In<CqlDateTime>(aq_, as_, (string)default);
+                bool? au_ = context.Operators.And(ao_, at_);
+                IEnumerable<Task> av_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-                bool? ay_(Task TaskReject) {
-                    ResourceReference bd_ = TaskReject?.Focus;
-                    bool? be_ = QICoreCommon_4_0_000.Instance.references(context, bd_, DischargeAnticoagulant);
-                    CodeableConcept bf_ = TaskReject?.Code;
-                    CqlConcept bg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bf_);
-                    CqlCode bh_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                    CqlConcept bi_ = context.Operators.ConvertCodeToConcept(bh_);
-                    bool? bj_ = context.Operators.Equivalent(bg_, bi_);
-                    bool? bk_ = context.Operators.And(be_, bj_);
-                    return bk_;
+                bool? aw_(Task TaskReject) {
+                    ResourceReference bb_ = TaskReject?.Focus;
+                    bool? bc_ = QICoreCommon_4_0_000.Instance.references(context, bb_, DischargeAnticoagulant);
+                    CodeableConcept bd_ = TaskReject?.Code;
+                    CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_);
+                    CqlCode bf_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                    CqlConcept bg_ = context.Operators.ConvertCodeToConcept(bf_);
+                    bool? bh_ = context.Operators.Equivalent(be_, bg_);
+                    bool? bi_ = context.Operators.And(bc_, bh_);
+                    return bi_;
                 }
 
-                IEnumerable<Task> az_ = context.Operators.Where<Task>(ax_, ay_);
-                bool? ba_ = context.Operators.Exists<Task>(az_);
-                bool? bb_ = context.Operators.Not(ba_);
-                bool? bc_ = context.Operators.And(aw_, bb_);
-                return bc_;
+                IEnumerable<Task> ax_ = context.Operators.Where<Task>(av_, aw_);
+                bool? ay_ = context.Operators.Exists<Task>(ax_);
+                bool? az_ = context.Operators.Not(ay_);
+                bool? ba_ = context.Operators.And(au_, az_);
+                return ba_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest DischargeAnticoagulant) => Encounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -786,72 +779,70 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> i_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> j_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> k_(MedicationRequest MR) {
+        bool? k_(MedicationRequest MR) {
             IEnumerable<Medication> at_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? au_(Medication M) {
-                object ay_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object az_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ba_ = context.Operators.Split((string)az_, "/");
-                string bb_ = context.Operators.Last<string>(ba_);
-                bool? bc_ = context.Operators.Equal(ay_, bb_);
-                CodeableConcept bd_ = M?.Code;
-                CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_);
-                CqlValueSet bf_ = this.Anticoagulant_Therapy(context);
-                bool? bg_ = context.Operators.ConceptInValueSet(be_, bf_);
-                bool? bh_ = context.Operators.And(bc_, bg_);
-                return bh_;
+                object ax_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ay_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> az_ = context.Operators.Split((string)ay_, "/");
+                string ba_ = context.Operators.Last<string>(az_);
+                bool? bb_ = context.Operators.Equal(ax_, ba_);
+                CodeableConcept bc_ = M?.Code;
+                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_);
+                CqlValueSet be_ = this.Anticoagulant_Therapy(context);
+                bool? bf_ = context.Operators.ConceptInValueSet(bd_, be_);
+                bool? bg_ = context.Operators.And(bb_, bf_);
+                return bg_;
             }
 
             IEnumerable<Medication> av_ = context.Operators.Where<Medication>(at_, au_);
-            MedicationRequest aw_(Medication M) => MR;
-            IEnumerable<MedicationRequest> ax_ = context.Operators.Select<Medication, MedicationRequest>(av_, aw_);
-            return ax_;
+            bool? aw_ = context.Operators.Exists<Medication>(av_);
+            return aw_;
         }
 
-        IEnumerable<MedicationRequest> l_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(j_, k_);
+        IEnumerable<MedicationRequest> l_ = context.Operators.Where<MedicationRequest>(j_, k_);
         IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(i_, l_);
 
-        IEnumerable<MedicationRequest> n_(MedicationRequest MedReqAntiCoagulant) {
-            IEnumerable<Task> bi_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+        bool? n_(MedicationRequest MedReqAntiCoagulant) {
+            IEnumerable<Task> bh_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            bool? bj_(Task TaskReject) {
-                ResourceReference bn_ = TaskReject?.Focus;
-                bool? bo_ = QICoreCommon_4_0_000.Instance.references(context, bn_, MedReqAntiCoagulant);
-                CodeableConcept bp_ = TaskReject?.StatusReason;
-                CqlConcept bq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bp_);
-                CqlValueSet br_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                bool? bs_ = context.Operators.ConceptInValueSet(bq_, br_);
-                CqlConcept bu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bp_);
-                CqlValueSet bv_ = this.Patient_Refusal(context);
-                bool? bw_ = context.Operators.ConceptInValueSet(bu_, bv_);
-                bool? bx_ = context.Operators.Or(bs_, bw_);
-                bool? by_ = context.Operators.And(bo_, bx_);
-                Code<MedicationRequest.MedicationrequestStatus> bz_ = MedReqAntiCoagulant?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ca_ = bz_?.Value;
-                string cb_ = context.Operators.Convert<string>(ca_);
-                string[] cc_ = [
+            bool? bi_(Task TaskReject) {
+                ResourceReference bl_ = TaskReject?.Focus;
+                bool? bm_ = QICoreCommon_4_0_000.Instance.references(context, bl_, MedReqAntiCoagulant);
+                CodeableConcept bn_ = TaskReject?.StatusReason;
+                CqlConcept bo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bn_);
+                CqlValueSet bp_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                bool? bq_ = context.Operators.ConceptInValueSet(bo_, bp_);
+                CqlConcept bs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bn_);
+                CqlValueSet bt_ = this.Patient_Refusal(context);
+                bool? bu_ = context.Operators.ConceptInValueSet(bs_, bt_);
+                bool? bv_ = context.Operators.Or(bq_, bu_);
+                bool? bw_ = context.Operators.And(bm_, bv_);
+                Code<MedicationRequest.MedicationrequestStatus> bx_ = MedReqAntiCoagulant?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? by_ = bx_?.Value;
+                string bz_ = context.Operators.Convert<string>(by_);
+                string[] ca_ = [
                     "active",
                     "completed",
                 ];
-                bool? cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
-                bool? ce_ = context.Operators.And(by_, cd_);
-                CodeableConcept cf_ = TaskReject?.Code;
-                CqlConcept cg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cf_);
-                CqlCode ch_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                CqlConcept ci_ = context.Operators.ConvertCodeToConcept(ch_);
-                bool? cj_ = context.Operators.Equivalent(cg_, ci_);
-                bool? ck_ = context.Operators.And(ce_, cj_);
-                return ck_;
+                bool? cb_ = context.Operators.In<string>(bz_, (IEnumerable<string>)ca_);
+                bool? cc_ = context.Operators.And(bw_, cb_);
+                CodeableConcept cd_ = TaskReject?.Code;
+                CqlConcept ce_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cd_);
+                CqlCode cf_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept cg_ = context.Operators.ConvertCodeToConcept(cf_);
+                bool? ch_ = context.Operators.Equivalent(ce_, cg_);
+                bool? ci_ = context.Operators.And(cc_, ch_);
+                return ci_;
             }
 
-            IEnumerable<Task> bk_ = context.Operators.Where<Task>(bi_, bj_);
-            MedicationRequest bl_(Task TaskReject) => MedReqAntiCoagulant;
-            IEnumerable<MedicationRequest> bm_ = context.Operators.Select<Task, MedicationRequest>(bk_, bl_);
-            return bm_;
+            IEnumerable<Task> bj_ = context.Operators.Where<Task>(bh_, bi_);
+            bool? bk_ = context.Operators.Exists<Task>(bj_);
+            return bk_;
         }
 
-        IEnumerable<MedicationRequest> o_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(m_, n_);
+        IEnumerable<MedicationRequest> o_ = context.Operators.Where<MedicationRequest>(m_, n_);
         IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(g_ as IEnumerable<MedicationRequest>, o_ as IEnumerable<MedicationRequest>);
         return p_;
     }
@@ -867,25 +858,24 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Encounter> a_ = this.Denominator(context);
 
-        IEnumerable<Encounter> b_(Encounter Encounter) {
+        bool? b_(Encounter Encounter) {
             IEnumerable<MedicationRequest> d_ = this.Documented_Reason_For_Not_Giving_Anticoagulant_At_Discharge(context);
 
             bool? e_(MedicationRequest NoDischargeAnticoagulant) {
-                FhirDateTime i_ = NoDischargeAnticoagulant?.AuthoredOnElement;
-                CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
-                Period k_ = Encounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
-                return m_;
+                FhirDateTime h_ = NoDischargeAnticoagulant?.AuthoredOnElement;
+                CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
+                Period j_ = Encounter?.Period;
+                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+                bool? l_ = context.Operators.In<CqlDateTime>(i_, k_, (string)default);
+                return l_;
             }
 
             IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
-            Encounter g_(MedicationRequest NoDischargeAnticoagulant) => Encounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
@@ -146,67 +146,67 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             IEnumerable<object> d_ = TJCOverall_8_25_000.Instance.Intervention_Comfort_Measures(context);
 
             bool? e_(object ComfortMeasure) {
 
-                object i_() {
+                object h_() {
+
+                    bool ag_() {
+                        object ak_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        bool am_ = al_ is CqlDateTime;
+                        return am_;
+                    }
+
 
                     bool ah_() {
-                        object al_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        bool an_ = am_ is CqlDateTime;
-                        return an_;
+                        object an_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                        bool ap_ = ao_ is CqlInterval<CqlDateTime>;
+                        return ap_;
                     }
 
 
                     bool ai_() {
-                        object ao_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        bool aq_ = ap_ is CqlInterval<CqlDateTime>;
-                        return aq_;
+                        object aq_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        bool as_ = ar_ is CqlQuantity;
+                        return as_;
                     }
 
 
                     bool aj_() {
-                        object ar_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlQuantity;
-                        return at_;
+                        object at_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        bool av_ = au_ is CqlInterval<CqlQuantity>;
+                        return av_;
                     }
 
-
-                    bool ak_() {
-                        object au_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlInterval<CqlQuantity>;
-                        return aw_;
-                    }
-
-                    if (ah_())
+                    if (ag_())
                     {
-                        object ax_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        return (ay_ as CqlDateTime) as object;
+                        object aw_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        return (ax_ as CqlDateTime) as object;
+                    }
+                    else if (ah_())
+                    {
+                        object ay_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+                        return (az_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ai_())
                     {
-                        object az_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        return (ba_ as CqlInterval<CqlDateTime>) as object;
+                        object ba_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        return (bb_ as CqlQuantity) as object;
                     }
                     else if (aj_())
                     {
-                        object bb_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        return (bc_ as CqlQuantity) as object;
-                    }
-                    else if (ak_())
-                    {
-                        object bd_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        return (be_ as CqlInterval<CqlQuantity>) as object;
+                        object bc_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                        return (bd_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -214,37 +214,36 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     };
                 }
 
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
-                CqlDateTime k_ = context.Operators.Start(j_);
-                object l_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-                CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlInterval<CqlDate> p_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, o_);
-                CqlDate q_ = p_?.low;
-                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
-                CqlDateTime t_ = context.Operators.Start(n_);
-                CqlInterval<CqlDate> u_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, t_);
-                CqlDate v_ = u_?.high;
-                CqlDateTime w_ = context.Operators.ConvertDateToDateTime(v_);
-                CqlDateTime y_ = context.Operators.Start(n_);
-                CqlInterval<CqlDate> z_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, y_);
-                bool? aa_ = z_?.lowClosed;
-                CqlDateTime ac_ = context.Operators.Start(n_);
-                CqlInterval<CqlDate> ad_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ac_);
-                bool? ae_ = ad_?.highClosed;
-                CqlInterval<CqlDateTime> af_ = context.Operators.Interval(r_, w_, aa_, ae_);
-                bool? ag_ = context.Operators.In<CqlDateTime>(k_ ?? m_, af_, "day");
-                return ag_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_());
+                CqlDateTime j_ = context.Operators.Start(i_);
+                object k_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+                CqlDateTime l_ = context.Operators.LateBoundProperty<CqlDateTime>(k_, "value");
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDate> o_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, n_);
+                CqlDate p_ = o_?.low;
+                CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+                CqlDateTime s_ = context.Operators.Start(m_);
+                CqlInterval<CqlDate> t_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, s_);
+                CqlDate u_ = t_?.high;
+                CqlDateTime v_ = context.Operators.ConvertDateToDateTime(u_);
+                CqlDateTime x_ = context.Operators.Start(m_);
+                CqlInterval<CqlDate> y_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, x_);
+                bool? z_ = y_?.lowClosed;
+                CqlDateTime ab_ = context.Operators.Start(m_);
+                CqlInterval<CqlDate> ac_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ab_);
+                bool? ad_ = ac_?.highClosed;
+                CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(q_, v_, z_, ad_);
+                bool? af_ = context.Operators.In<CqlDateTime>(j_ ?? l_, ae_, "day");
+                return af_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object ComfortMeasure) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -261,53 +260,52 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationAdministration> b_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> d_(MedicationAdministration MR) {
+        bool? d_(MedicationAdministration MR) {
             IEnumerable<Medication> t_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? u_(Medication M) {
-                object y_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object z_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> aa_ = context.Operators.Split((string)z_, "/");
-                string ab_ = context.Operators.Last<string>(aa_);
-                bool? ac_ = context.Operators.Equal(y_, ab_);
-                CodeableConcept ad_ = M?.Code;
-                CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
-                CqlValueSet af_ = this.Thrombolytic_tPA_Therapy(context);
-                bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-                bool? ah_ = context.Operators.And(ac_, ag_);
-                return ah_;
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Thrombolytic_tPA_Therapy(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+                return ag_;
             }
 
             IEnumerable<Medication> v_ = context.Operators.Where<Medication>(t_, u_);
-            MedicationAdministration w_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> x_ = context.Operators.Select<Medication, MedicationAdministration>(v_, w_);
-            return x_;
+            bool? w_ = context.Operators.Exists<Medication>(v_);
+            return w_;
         }
 
-        IEnumerable<MedicationAdministration> e_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, d_);
+        IEnumerable<MedicationAdministration> e_ = context.Operators.Where<MedicationAdministration>(c_, d_);
         IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(b_, e_);
 
         bool? g_(MedicationAdministration ThrombolyticMedication) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ai_ = ThrombolyticMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? aj_ = ai_?.Value;
-            string ak_ = context.Operators.Convert<string>(aj_);
-            string[] al_ = [
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ah_ = ThrombolyticMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? ai_ = ah_?.Value;
+            string aj_ = context.Operators.Convert<string>(ai_);
+            string[] ak_ = [
                 "in-progress",
                 "completed",
             ];
-            bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
-            return am_;
+            bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+            return al_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
 
         (CqlTupleMetadata, string id, object effective)? i_(MedicationAdministration ThrombolyticMedication) {
-            Id an_ = ThrombolyticMedication?.IdElement;
-            string ao_ = an_?.Value;
-            DataType ap_ = ThrombolyticMedication?.Effective;
-            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-            (CqlTupleMetadata, string id, object effective)? ar_ = (CqlTupleMetadata_DbNFZJaRJHECUfPGBeWSUEUQi, ao_, aq_);
-            return ar_;
+            Id am_ = ThrombolyticMedication?.IdElement;
+            string an_ = am_?.Value;
+            DataType ao_ = ThrombolyticMedication?.Effective;
+            object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+            (CqlTupleMetadata, string id, object effective)? aq_ = (CqlTupleMetadata_DbNFZJaRJHECUfPGBeWSUEUQi, an_, ap_);
+            return aq_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, object effective)?> j_ = context.Operators.Select<MedicationAdministration, (CqlTupleMetadata, string id, object effective)?>(h_, i_);
@@ -316,22 +314,22 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
         IEnumerable<Procedure> m_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
         bool? n_(Procedure ThrombolyticProcedure) {
-            Code<EventStatus> as_ = ThrombolyticProcedure?.StatusElement;
-            EventStatus? at_ = as_?.Value;
-            string au_ = context.Operators.Convert<string>(at_);
-            bool? av_ = context.Operators.Equal(au_, "completed");
-            return av_;
+            Code<EventStatus> ar_ = ThrombolyticProcedure?.StatusElement;
+            EventStatus? as_ = ar_?.Value;
+            string at_ = context.Operators.Convert<string>(as_);
+            bool? au_ = context.Operators.Equal(at_, "completed");
+            return au_;
         }
 
         IEnumerable<Procedure> o_ = context.Operators.Where<Procedure>(m_, n_);
 
         (CqlTupleMetadata, string id, object effective)? p_(Procedure ThrombolyticProcedure) {
-            Id aw_ = ThrombolyticProcedure?.IdElement;
-            string ax_ = aw_?.Value;
-            DataType ay_ = ThrombolyticProcedure?.Performed;
-            object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-            (CqlTupleMetadata, string id, object effective)? ba_ = (CqlTupleMetadata_DbNFZJaRJHECUfPGBeWSUEUQi, ax_, az_);
-            return ba_;
+            Id av_ = ThrombolyticProcedure?.IdElement;
+            string aw_ = av_?.Value;
+            DataType ax_ = ThrombolyticProcedure?.Performed;
+            object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+            (CqlTupleMetadata, string id, object effective)? az_ = (CqlTupleMetadata_DbNFZJaRJHECUfPGBeWSUEUQi, aw_, ay_);
+            return az_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, object effective)?> q_ = context.Operators.Select<Procedure, (CqlTupleMetadata, string id, object effective)?>(o_, p_);
@@ -351,83 +349,83 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             IEnumerable<(CqlTupleMetadata, string id, object effective)?> d_ = this.Thrombolytic_Therapy_Medication_Or_Procedures(context);
 
             bool? e_((CqlTupleMetadata, string id, object effective)? ThrombolyticTherapy) {
 
-                object i_() {
+                object h_() {
+
+                    bool s_() {
+                        object y_ = ThrombolyticTherapy?.effective;
+                        bool z_ = y_ is CqlDateTime;
+                        return z_;
+                    }
+
 
                     bool t_() {
-                        object z_ = ThrombolyticTherapy?.effective;
-                        bool aa_ = z_ is CqlDateTime;
-                        return aa_;
+                        object aa_ = ThrombolyticTherapy?.effective;
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        object ab_ = ThrombolyticTherapy?.effective;
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        object ac_ = ThrombolyticTherapy?.effective;
+                        bool ad_ = ac_ is CqlQuantity;
+                        return ad_;
                     }
 
 
                     bool v_() {
-                        object ad_ = ThrombolyticTherapy?.effective;
-                        bool ae_ = ad_ is CqlQuantity;
-                        return ae_;
+                        object ae_ = ThrombolyticTherapy?.effective;
+                        bool af_ = ae_ is CqlInterval<CqlQuantity>;
+                        return af_;
                     }
 
 
                     bool w_() {
-                        object af_ = ThrombolyticTherapy?.effective;
-                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
-                        return ag_;
+                        object ag_ = ThrombolyticTherapy?.effective;
+                        bool ah_ = ag_ is CqlDateTime;
+                        return ah_;
                     }
 
 
                     bool x_() {
-                        object ah_ = ThrombolyticTherapy?.effective;
-                        bool ai_ = ah_ is CqlDateTime;
-                        return ai_;
+                        object ai_ = ThrombolyticTherapy?.effective;
+                        bool aj_ = ai_ is CqlInterval<CqlDateTime>;
+                        return aj_;
                     }
 
-
-                    bool y_() {
-                        object aj_ = ThrombolyticTherapy?.effective;
-                        bool ak_ = aj_ is CqlInterval<CqlDateTime>;
-                        return ak_;
+                    if (s_())
+                    {
+                        object ak_ = ThrombolyticTherapy?.effective;
+                        return (ak_ as CqlDateTime) as object;
                     }
-
-                    if (t_())
+                    else if (t_())
                     {
                         object al_ = ThrombolyticTherapy?.effective;
-                        return (al_ as CqlDateTime) as object;
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
                         object am_ = ThrombolyticTherapy?.effective;
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        return (am_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
                         object an_ = ThrombolyticTherapy?.effective;
-                        return (an_ as CqlQuantity) as object;
+                        return (an_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else if (w_())
                     {
                         object ao_ = ThrombolyticTherapy?.effective;
-                        return (ao_ as CqlInterval<CqlQuantity>) as object;
+                        return (ao_ as CqlDateTime) as object;
                     }
                     else if (x_())
                     {
                         object ap_ = ThrombolyticTherapy?.effective;
-                        return (ap_ as CqlDateTime) as object;
-                    }
-                    else if (y_())
-                    {
-                        object aq_ = ThrombolyticTherapy?.effective;
-                        return (aq_ as CqlInterval<CqlDateTime>) as object;
+                        return (ap_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else
                     {
@@ -435,25 +433,24 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     };
                 }
 
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
-                CqlDateTime k_ = context.Operators.Start(j_);
-                CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                CqlDateTime m_ = context.Operators.Start(l_);
-                CqlQuantity n_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime o_ = context.Operators.Subtract(m_, n_);
-                CqlDateTime q_ = context.Operators.End(l_);
-                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, false);
-                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
-                return s_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_());
+                CqlDateTime j_ = context.Operators.Start(i_);
+                CqlInterval<CqlDateTime> k_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                CqlDateTime l_ = context.Operators.Start(k_);
+                CqlQuantity m_ = context.Operators.Quantity(24m, "hours");
+                CqlDateTime n_ = context.Operators.Subtract(l_, m_);
+                CqlDateTime p_ = context.Operators.End(k_);
+                CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, false);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
+                return r_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, object effective)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, object effective)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, object effective)? ThrombolyticTherapy) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, object effective)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, object effective)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -600,78 +597,76 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             CqlValueSet d_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
             IEnumerable<MedicationAdministration> e_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
             IEnumerable<MedicationAdministration> f_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-            IEnumerable<MedicationAdministration> g_(MedicationAdministration MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationAdministration MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationAdministration q_(Medication M) => MR;
-                IEnumerable<MedicationAdministration> r_ = context.Operators.Select<Medication, MedicationAdministration>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationAdministration> h_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(f_, g_);
+            IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
             IEnumerable<MedicationAdministration> i_ = context.Operators.Union<MedicationAdministration>(e_, h_);
 
             bool? j_(MedicationAdministration Antithrombotic) {
-                Code<MedicationAdministration.MedicationAdministrationStatusCodes> ac_ = Antithrombotic?.StatusElement;
-                MedicationAdministration.MedicationAdministrationStatusCodes? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationAdministration.MedicationAdministrationStatusCodes> aa_ = Antithrombotic?.StatusElement;
+                MedicationAdministration.MedicationAdministrationStatusCodes? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "in-progress",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                DataType ah_ = Antithrombotic?.Effective;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                DataType af_ = Antithrombotic?.Effective;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
+                CqlDateTime ai_ = context.Operators.Start(ah_);
+                CqlInterval<CqlDateTime> aj_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
                 CqlDateTime ak_ = context.Operators.Start(aj_);
-                CqlInterval<CqlDateTime> al_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                CqlDateTime am_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, am_);
-                CqlDate ao_ = an_?.low;
-                CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(ao_);
-                CqlDateTime ar_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> as_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ar_);
-                CqlDate at_ = as_?.high;
-                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
-                CqlDateTime aw_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> ax_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aw_);
-                bool? ay_ = ax_?.lowClosed;
-                CqlDateTime ba_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> bb_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
-                bool? bc_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(ap_, au_, ay_, bc_);
-                bool? be_ = context.Operators.In<CqlDateTime>(ak_, bd_, "day");
-                bool? bf_ = context.Operators.And(ag_, be_);
-                return bf_;
+                CqlInterval<CqlDate> al_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ak_);
+                CqlDate am_ = al_?.low;
+                CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+                CqlDateTime ap_ = context.Operators.Start(aj_);
+                CqlInterval<CqlDate> aq_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ap_);
+                CqlDate ar_ = aq_?.high;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDateTime au_ = context.Operators.Start(aj_);
+                CqlInterval<CqlDate> av_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, au_);
+                bool? aw_ = av_?.lowClosed;
+                CqlDateTime ay_ = context.Operators.Start(aj_);
+                CqlInterval<CqlDate> az_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ay_);
+                bool? ba_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(an_, as_, aw_, ba_);
+                bool? bc_ = context.Operators.In<CqlDateTime>(ai_, bb_, "day");
+                bool? bd_ = context.Operators.And(ae_, bc_);
+                return bd_;
             }
 
             IEnumerable<MedicationAdministration> k_ = context.Operators.Where<MedicationAdministration>(i_, j_);
-            Encounter l_(MedicationAdministration Antithrombotic) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationAdministration, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationAdministration>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -763,80 +758,78 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> l_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
         IEnumerable<MedicationRequest> m_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        IEnumerable<MedicationRequest> n_(MedicationRequest MR) {
+        bool? n_(MedicationRequest MR) {
             IEnumerable<Medication> ba_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? bb_(Medication M) {
-                object bf_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object bg_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> bh_ = context.Operators.Split((string)bg_, "/");
-                string bi_ = context.Operators.Last<string>(bh_);
-                bool? bj_ = context.Operators.Equal(bf_, bi_);
-                CodeableConcept bk_ = M?.Code;
-                CqlConcept bl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bk_);
-                CqlValueSet bm_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                bool? bn_ = context.Operators.ConceptInValueSet(bl_, bm_);
-                bool? bo_ = context.Operators.And(bj_, bn_);
-                return bo_;
+                object be_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object bf_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> bg_ = context.Operators.Split((string)bf_, "/");
+                string bh_ = context.Operators.Last<string>(bg_);
+                bool? bi_ = context.Operators.Equal(be_, bh_);
+                CodeableConcept bj_ = M?.Code;
+                CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
+                CqlValueSet bl_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                bool? bm_ = context.Operators.ConceptInValueSet(bk_, bl_);
+                bool? bn_ = context.Operators.And(bi_, bm_);
+                return bn_;
             }
 
             IEnumerable<Medication> bc_ = context.Operators.Where<Medication>(ba_, bb_);
-            MedicationRequest bd_(Medication M) => MR;
-            IEnumerable<MedicationRequest> be_ = context.Operators.Select<Medication, MedicationRequest>(bc_, bd_);
-            return be_;
+            bool? bd_ = context.Operators.Exists<Medication>(bc_);
+            return bd_;
         }
 
-        IEnumerable<MedicationRequest> o_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(m_, n_);
+        IEnumerable<MedicationRequest> o_ = context.Operators.Where<MedicationRequest>(m_, n_);
         IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(l_, o_);
 
-        IEnumerable<MedicationRequest> q_(MedicationRequest MedReqAntithrombotic) {
-            IEnumerable<Task> bp_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+        bool? q_(MedicationRequest MedReqAntithrombotic) {
+            IEnumerable<Task> bo_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            bool? bq_(Task TaskReject) {
-                ResourceReference bu_ = TaskReject?.Focus;
-                bool? bv_ = QICoreCommon_4_0_000.Instance.references(context, bu_, MedReqAntithrombotic);
-                CodeableConcept bw_ = TaskReject?.StatusReason;
-                CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
-                CqlValueSet by_ = this.Medical_Reason_for_Not_Providing_Treatment(context);
-                bool? bz_ = context.Operators.ConceptInValueSet(bx_, by_);
-                CqlConcept cb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
-                CqlValueSet cc_ = this.Patient_Refusal(context);
-                bool? cd_ = context.Operators.ConceptInValueSet(cb_, cc_);
-                bool? ce_ = context.Operators.Or(bz_, cd_);
-                bool? cf_ = context.Operators.And(bv_, ce_);
-                Code<MedicationRequest.MedicationrequestStatus> cg_ = MedReqAntithrombotic?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ch_ = cg_?.Value;
-                string ci_ = context.Operators.Convert<string>(ch_);
-                string[] cj_ = [
+            bool? bp_(Task TaskReject) {
+                ResourceReference bs_ = TaskReject?.Focus;
+                bool? bt_ = QICoreCommon_4_0_000.Instance.references(context, bs_, MedReqAntithrombotic);
+                CodeableConcept bu_ = TaskReject?.StatusReason;
+                CqlConcept bv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bu_);
+                CqlValueSet bw_ = this.Medical_Reason_for_Not_Providing_Treatment(context);
+                bool? bx_ = context.Operators.ConceptInValueSet(bv_, bw_);
+                CqlConcept bz_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bu_);
+                CqlValueSet ca_ = this.Patient_Refusal(context);
+                bool? cb_ = context.Operators.ConceptInValueSet(bz_, ca_);
+                bool? cc_ = context.Operators.Or(bx_, cb_);
+                bool? cd_ = context.Operators.And(bt_, cc_);
+                Code<MedicationRequest.MedicationrequestStatus> ce_ = MedReqAntithrombotic?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? cf_ = ce_?.Value;
+                string cg_ = context.Operators.Convert<string>(cf_);
+                string[] ch_ = [
                     "active",
                     "completed",
                 ];
-                bool? ck_ = context.Operators.In<string>(ci_, (IEnumerable<string>)cj_);
-                CodeableConcept cl_ = TaskReject?.Code;
-                CqlConcept cm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cl_);
-                CqlCode cn_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                CqlConcept co_ = context.Operators.ConvertCodeToConcept(cn_);
-                bool? cp_ = context.Operators.Equivalent(cm_, co_);
-                bool? cq_ = context.Operators.And(ck_, cp_);
-                bool? cr_ = context.Operators.And(cf_, cq_);
-                return cr_;
+                bool? ci_ = context.Operators.In<string>(cg_, (IEnumerable<string>)ch_);
+                CodeableConcept cj_ = TaskReject?.Code;
+                CqlConcept ck_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cj_);
+                CqlCode cl_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept cm_ = context.Operators.ConvertCodeToConcept(cl_);
+                bool? cn_ = context.Operators.Equivalent(ck_, cm_);
+                bool? co_ = context.Operators.And(ci_, cn_);
+                bool? cp_ = context.Operators.And(cd_, co_);
+                return cp_;
             }
 
-            IEnumerable<Task> br_ = context.Operators.Where<Task>(bp_, bq_);
-            MedicationRequest bs_(Task TaskReject) => MedReqAntithrombotic;
-            IEnumerable<MedicationRequest> bt_ = context.Operators.Select<Task, MedicationRequest>(br_, bs_);
-            return bt_;
+            IEnumerable<Task> bq_ = context.Operators.Where<Task>(bo_, bp_);
+            bool? br_ = context.Operators.Exists<Task>(bq_);
+            return br_;
         }
 
-        IEnumerable<MedicationRequest> r_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(p_, q_);
+        IEnumerable<MedicationRequest> r_ = context.Operators.Where<MedicationRequest>(p_, q_);
 
         (CqlTupleMetadata, string id, CqlDateTime authoredOn)? s_(MedicationRequest MedReqAntithrombotic) {
-            Id cs_ = MedReqAntithrombotic?.IdElement;
-            string ct_ = cs_?.Value;
-            FhirDateTime cu_ = MedReqAntithrombotic?.AuthoredOnElement;
-            CqlDateTime cv_ = context.Operators.Convert<CqlDateTime>(cu_);
-            (CqlTupleMetadata, string id, CqlDateTime authoredOn)? cw_ = (CqlTupleMetadata_DeYYCcJRPXYVddOGVBSgSSNfR, ct_, cv_);
-            return cw_;
+            Id cq_ = MedReqAntithrombotic?.IdElement;
+            string cr_ = cq_?.Value;
+            FhirDateTime cs_ = MedReqAntithrombotic?.AuthoredOnElement;
+            CqlDateTime ct_ = context.Operators.Convert<CqlDateTime>(cs_);
+            (CqlTupleMetadata, string id, CqlDateTime authoredOn)? cu_ = (CqlTupleMetadata_DeYYCcJRPXYVddOGVBSgSSNfR, cr_, ct_);
+            return cu_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?> t_ = context.Operators.Select<MedicationRequest, (CqlTupleMetadata, string id, CqlDateTime authoredOn)?>(r_, s_);
@@ -945,38 +938,37 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             IEnumerable<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?> d_ = this.Documented_Reason_For_No_Antithrombotic_Ordered_Or_Administered(context);
 
             bool? e_((CqlTupleMetadata, string id, CqlDateTime authoredOn)? NoAntithrombotic) {
-                CqlDateTime i_ = NoAntithrombotic?.authoredOn;
-                CqlInterval<CqlDateTime> j_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                CqlInterval<CqlDate> l_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, k_);
-                CqlDate m_ = l_?.low;
-                CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
-                CqlDateTime p_ = context.Operators.Start(j_);
-                CqlInterval<CqlDate> q_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, p_);
-                CqlDate r_ = q_?.high;
-                CqlDateTime s_ = context.Operators.ConvertDateToDateTime(r_);
-                CqlDateTime u_ = context.Operators.Start(j_);
-                CqlInterval<CqlDate> v_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, u_);
-                bool? w_ = v_?.lowClosed;
-                CqlDateTime y_ = context.Operators.Start(j_);
-                CqlInterval<CqlDate> z_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, y_);
-                bool? aa_ = z_?.highClosed;
-                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(n_, s_, w_, aa_);
-                bool? ac_ = context.Operators.In<CqlDateTime>(i_, ab_, "day");
-                return ac_;
+                CqlDateTime h_ = NoAntithrombotic?.authoredOn;
+                CqlInterval<CqlDateTime> i_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                CqlInterval<CqlDate> k_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, j_);
+                CqlDate l_ = k_?.low;
+                CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
+                CqlDateTime o_ = context.Operators.Start(i_);
+                CqlInterval<CqlDate> p_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, o_);
+                CqlDate q_ = p_?.high;
+                CqlDateTime r_ = context.Operators.ConvertDateToDateTime(q_);
+                CqlDateTime t_ = context.Operators.Start(i_);
+                CqlInterval<CqlDate> u_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, t_);
+                bool? v_ = u_?.lowClosed;
+                CqlDateTime x_ = context.Operators.Start(i_);
+                CqlInterval<CqlDate> y_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, x_);
+                bool? z_ = y_?.highClosed;
+                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(m_, r_, v_, z_);
+                bool? ab_ = context.Operators.In<CqlDateTime>(h_, aa_, "day");
+                return ab_;
             }
 
             IEnumerable<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?> f_ = context.Operators.Where<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?>(d_, e_);
-            Encounter g_((CqlTupleMetadata, string id, CqlDateTime authoredOn)? NoAntithrombotic) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -991,78 +983,76 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             CqlValueSet d_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
             IEnumerable<MedicationAdministration> e_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
             IEnumerable<MedicationAdministration> f_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-            IEnumerable<MedicationAdministration> g_(MedicationAdministration MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationAdministration MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationAdministration q_(Medication M) => MR;
-                IEnumerable<MedicationAdministration> r_ = context.Operators.Select<Medication, MedicationAdministration>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationAdministration> h_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(f_, g_);
+            IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
             IEnumerable<MedicationAdministration> i_ = context.Operators.Union<MedicationAdministration>(e_, h_);
 
             bool? j_(MedicationAdministration PharmacologicalContraindications) {
-                Code<MedicationAdministration.MedicationAdministrationStatusCodes> ac_ = PharmacologicalContraindications?.StatusElement;
-                MedicationAdministration.MedicationAdministrationStatusCodes? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationAdministration.MedicationAdministrationStatusCodes> aa_ = PharmacologicalContraindications?.StatusElement;
+                MedicationAdministration.MedicationAdministrationStatusCodes? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "in-progress",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                DataType ah_ = PharmacologicalContraindications?.Effective;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                DataType af_ = PharmacologicalContraindications?.Effective;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
+                CqlDateTime ai_ = context.Operators.Start(ah_);
+                CqlInterval<CqlDateTime> aj_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
                 CqlDateTime ak_ = context.Operators.Start(aj_);
-                CqlInterval<CqlDateTime> al_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                CqlDateTime am_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, am_);
-                CqlDate ao_ = an_?.low;
-                CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(ao_);
-                CqlDateTime ar_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> as_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ar_);
-                CqlDate at_ = as_?.high;
-                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
-                CqlDateTime aw_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> ax_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aw_);
-                bool? ay_ = ax_?.lowClosed;
-                CqlDateTime ba_ = context.Operators.Start(al_);
-                CqlInterval<CqlDate> bb_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
-                bool? bc_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(ap_, au_, ay_, bc_);
-                bool? be_ = context.Operators.In<CqlDateTime>(ak_, bd_, "day");
-                bool? bf_ = context.Operators.And(ag_, be_);
-                return bf_;
+                CqlInterval<CqlDate> al_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ak_);
+                CqlDate am_ = al_?.low;
+                CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+                CqlDateTime ap_ = context.Operators.Start(aj_);
+                CqlInterval<CqlDate> aq_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ap_);
+                CqlDate ar_ = aq_?.high;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDateTime au_ = context.Operators.Start(aj_);
+                CqlInterval<CqlDate> av_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, au_);
+                bool? aw_ = av_?.lowClosed;
+                CqlDateTime ay_ = context.Operators.Start(aj_);
+                CqlInterval<CqlDate> az_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ay_);
+                bool? ba_ = az_?.highClosed;
+                CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(an_, as_, aw_, ba_);
+                bool? bc_ = context.Operators.In<CqlDateTime>(ai_, bb_, "day");
+                bool? bd_ = context.Operators.And(ae_, bc_);
+                return bd_;
             }
 
             IEnumerable<MedicationAdministration> k_ = context.Operators.Where<MedicationAdministration>(i_, j_);
-            Encounter l_(MedicationAdministration PharmacologicalContraindications) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationAdministration, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationAdministration>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1077,56 +1067,55 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = TJCOverall_8_25_000.Instance.Ischemic_Stroke_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter) {
+        bool? b_(Encounter IschemicStrokeEncounter) {
             CqlValueSet d_ = this.INR(context);
             IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
 
             bool? f_(Observation INR) {
-                DataType j_ = INR?.Value;
-                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-                CqlQuantity l_ = context.Operators.ConvertDecimalToQuantity(3.5m);
-                bool? m_ = context.Operators.Greater(k_ as CqlQuantity, l_);
-                Code<ObservationStatus> n_ = INR?.StatusElement;
-                ObservationStatus? o_ = n_?.Value;
-                string p_ = context.Operators.Convert<string>(o_);
-                string[] q_ = [
+                DataType i_ = INR?.Value;
+                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
+                CqlQuantity k_ = context.Operators.ConvertDecimalToQuantity(3.5m);
+                bool? l_ = context.Operators.Greater(j_ as CqlQuantity, k_);
+                Code<ObservationStatus> m_ = INR?.StatusElement;
+                ObservationStatus? n_ = m_?.Value;
+                string o_ = context.Operators.Convert<string>(n_);
+                string[] p_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-                bool? s_ = context.Operators.And(m_, r_);
-                Instant t_ = INR?.IssuedElement;
-                DateTimeOffset? u_ = t_?.Value;
-                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
-                CqlInterval<CqlDateTime> w_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                CqlInterval<CqlDate> y_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, x_);
-                CqlDate z_ = y_?.low;
-                CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
-                CqlDateTime ac_ = context.Operators.Start(w_);
-                CqlInterval<CqlDate> ad_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ac_);
-                CqlDate ae_ = ad_?.high;
-                CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
-                CqlDateTime ah_ = context.Operators.Start(w_);
-                CqlInterval<CqlDate> ai_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ah_);
-                bool? aj_ = ai_?.lowClosed;
-                CqlDateTime al_ = context.Operators.Start(w_);
-                CqlInterval<CqlDate> am_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, al_);
-                bool? an_ = am_?.highClosed;
-                CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(aa_, af_, aj_, an_);
-                bool? ap_ = context.Operators.In<CqlDateTime>(v_, ao_, "day");
-                bool? aq_ = context.Operators.And(s_, ap_);
-                return aq_;
+                bool? q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+                bool? r_ = context.Operators.And(l_, q_);
+                Instant s_ = INR?.IssuedElement;
+                DateTimeOffset? t_ = s_?.Value;
+                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
+                CqlInterval<CqlDateTime> v_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDate> x_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, w_);
+                CqlDate y_ = x_?.low;
+                CqlDateTime z_ = context.Operators.ConvertDateToDateTime(y_);
+                CqlDateTime ab_ = context.Operators.Start(v_);
+                CqlInterval<CqlDate> ac_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ab_);
+                CqlDate ad_ = ac_?.high;
+                CqlDateTime ae_ = context.Operators.ConvertDateToDateTime(ad_);
+                CqlDateTime ag_ = context.Operators.Start(v_);
+                CqlInterval<CqlDate> ah_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ag_);
+                bool? ai_ = ah_?.lowClosed;
+                CqlDateTime ak_ = context.Operators.Start(v_);
+                CqlInterval<CqlDate> al_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ak_);
+                bool? am_ = al_?.highClosed;
+                CqlInterval<CqlDateTime> an_ = context.Operators.Interval(z_, ae_, ai_, am_);
+                bool? ao_ = context.Operators.In<CqlDateTime>(u_, an_, "day");
+                bool? ap_ = context.Operators.And(r_, ao_);
+                return ap_;
             }
 
             IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
-            Encounter h_(Observation INR) => IschemicStrokeEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Observation>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
@@ -675,38 +675,37 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> a_ = this.Urinary_Symptom_Score_Assessment(context);
 
-        IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> b_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? USSAssessment) {
+        bool? b_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? USSAssessment) {
             Condition g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_the_Measurement_Period(context);
             Condition[] h_ = [
                 g_,
             ];
 
             bool? i_(Condition InitialBPHDiagnosis) {
-                CqlDateTime m_ = USSAssessment?.effectiveDatetime;
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlDateTime q_ = context.Operators.Start(n_);
-                CqlQuantity r_ = context.Operators.Quantity(1m, "month");
-                CqlDateTime s_ = context.Operators.Add(q_, r_);
-                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(o_, s_, true, true);
-                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, "day");
-                CqlDateTime w_ = context.Operators.Start(n_);
-                bool? x_ = context.Operators.Not((bool?)(w_ is null));
-                bool? y_ = context.Operators.And(u_, x_);
-                return y_;
+                CqlDateTime l_ = USSAssessment?.effectiveDatetime;
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlDateTime p_ = context.Operators.Start(m_);
+                CqlQuantity q_ = context.Operators.Quantity(1m, "month");
+                CqlDateTime r_ = context.Operators.Add(p_, q_);
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, "day");
+                CqlDateTime v_ = context.Operators.Start(m_);
+                bool? w_ = context.Operators.Not((bool?)(v_ is null));
+                bool? x_ = context.Operators.And(t_, w_);
+                return x_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
-            (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? k_(Condition InitialBPHDiagnosis) => USSAssessment;
-            IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> l_ = context.Operators.Select<Condition, (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> c_ = context.Operators.SelectMany<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?, (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> c_ = context.Operators.Where<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(a_, b_);
 
         object d_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? @this) {
-            CqlDateTime z_ = @this?.effectiveDatetime;
-            return z_;
+            CqlDateTime y_ = @this?.effectiveDatetime;
+            return y_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> e_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
@@ -725,33 +724,32 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> a_ = this.Urinary_Symptom_Score_Assessment(context);
 
-        IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> b_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? USSAssessment) {
+        bool? b_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? USSAssessment) {
             Condition g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_the_Measurement_Period(context);
             Condition[] h_ = [
                 g_,
             ];
 
             bool? i_(Condition InitialBPHDiagnosis) {
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlDateTime o_ = USSAssessment?.effectiveDatetime;
-                int? p_ = context.Operators.DifferenceBetween(n_, o_, "month");
-                CqlInterval<int?> q_ = context.Operators.Interval(6, 12, true, true);
-                bool? r_ = context.Operators.In<int?>(p_, q_, (string)default);
-                return r_;
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlDateTime n_ = USSAssessment?.effectiveDatetime;
+                int? o_ = context.Operators.DifferenceBetween(m_, n_, "month");
+                CqlInterval<int?> p_ = context.Operators.Interval(6, 12, true, true);
+                bool? q_ = context.Operators.In<int?>(o_, p_, (string)default);
+                return q_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
-            (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? k_(Condition InitialBPHDiagnosis) => USSAssessment;
-            IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> l_ = context.Operators.Select<Condition, (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Condition>(j_);
+            return k_;
         }
 
-        IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> c_ = context.Operators.SelectMany<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?, (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> c_ = context.Operators.Where<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(a_, b_);
 
         object d_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? @this) {
-            CqlDateTime s_ = @this?.effectiveDatetime;
-            return s_;
+            CqlDateTime r_ = @this?.effectiveDatetime;
+            return r_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> e_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
@@ -792,39 +790,38 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
         IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
 
-        IEnumerable<Condition> f_(Condition UrinaryRetention) {
+        bool? f_(Condition UrinaryRetention) {
             Condition j_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_the_Measurement_Period(context);
             Condition[] k_ = [
                 j_,
             ];
 
             bool? l_(Condition InitialBPHDiagnosis) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UrinaryRetention);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlDateTime u_ = context.Operators.Start(r_);
-                CqlQuantity v_ = context.Operators.Quantity(1m, "year");
-                CqlDateTime w_ = context.Operators.Add(u_, v_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(s_, w_, true, true);
-                bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, "day");
-                CqlDateTime aa_ = context.Operators.Start(r_);
-                bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
-                bool? ac_ = context.Operators.And(y_, ab_);
-                return ac_;
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UrinaryRetention);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlDateTime t_ = context.Operators.Start(q_);
+                CqlQuantity u_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime v_ = context.Operators.Add(t_, u_);
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(r_, v_, true, true);
+                bool? x_ = context.Operators.In<CqlDateTime>(p_, w_, "day");
+                CqlDateTime z_ = context.Operators.Start(q_);
+                bool? aa_ = context.Operators.Not((bool?)(z_ is null));
+                bool? ab_ = context.Operators.And(x_, aa_);
+                return ab_;
             }
 
             IEnumerable<Condition> m_ = context.Operators.Where<Condition>((IEnumerable<Condition>)k_, l_);
-            Condition n_(Condition InitialBPHDiagnosis) => UrinaryRetention;
-            IEnumerable<Condition> o_ = context.Operators.Select<Condition, Condition>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Condition>(m_);
+            return n_;
         }
 
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 
         bool? h_(Condition UrinaryRetention) {
-            bool? ad_ = this.verificationStatusIsNotInvalid(context, UrinaryRetention);
-            return ad_;
+            bool? ac_ = this.verificationStatusIsNotInvalid(context, UrinaryRetention);
+            return ac_;
         }
 
         IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
@@ -845,37 +842,36 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
             a_,
         ];
 
-        IEnumerable<Condition> c_(Condition InitialBPHDiagnosis) {
+        bool? c_(Condition InitialBPHDiagnosis) {
             CqlValueSet f_ = this.Hospital_Services_for_Urology_Care(context);
             IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? h_(Encounter UrologyHospitalServices) {
-                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
-                CqlDateTime m_ = context.Operators.Start(l_);
-                Period n_ = UrologyHospitalServices?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime p_ = context.Operators.Start(o_);
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlQuantity t_ = context.Operators.Quantity(31m, "days");
-                CqlDateTime u_ = context.Operators.Add(s_, t_);
-                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(p_, u_, true, true);
-                bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, (string)default);
-                Code<Encounter.EncounterStatus> x_ = UrologyHospitalServices?.StatusElement;
-                Encounter.EncounterStatus? y_ = x_?.Value;
-                Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
-                bool? aa_ = context.Operators.Equal(z_, "finished");
-                bool? ab_ = context.Operators.And(w_, aa_);
-                return ab_;
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
+                CqlDateTime l_ = context.Operators.Start(k_);
+                Period m_ = UrologyHospitalServices?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime r_ = context.Operators.End(q_);
+                CqlQuantity s_ = context.Operators.Quantity(31m, "days");
+                CqlDateTime t_ = context.Operators.Add(r_, s_);
+                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(o_, t_, true, true);
+                bool? v_ = context.Operators.In<CqlDateTime>(l_, u_, (string)default);
+                Code<Encounter.EncounterStatus> w_ = UrologyHospitalServices?.StatusElement;
+                Encounter.EncounterStatus? x_ = w_?.Value;
+                Code<Encounter.EncounterStatus> y_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(x_);
+                bool? z_ = context.Operators.Equal(y_, "finished");
+                bool? aa_ = context.Operators.And(v_, z_);
+                return aa_;
             }
 
             IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
-            Condition j_(Encounter UrologyHospitalServices) => InitialBPHDiagnosis;
-            IEnumerable<Condition> k_ = context.Operators.Select<Encounter, Condition>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Encounter>(i_);
+            return j_;
         }
 
-        IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>((IEnumerable<Condition>)b_, c_);
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>((IEnumerable<Condition>)b_, c_);
         Condition e_ = context.Operators.SingletonFrom<Condition>(d_);
         return e_;
     }
@@ -894,34 +890,33 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
         IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
 
-        IEnumerable<Condition> f_(Condition MorbidObesityDiagnosis) {
+        bool? f_(Condition MorbidObesityDiagnosis) {
             (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? j_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis(context);
             (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?[] k_ = [
                 j_,
             ];
 
             bool? l_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? FollowUpUSSAssessment) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MorbidObesityDiagnosis);
-                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                bool? r_ = context.Operators.Overlaps(p_, q_, (string)default);
-                CqlDateTime t_ = context.Operators.Start(p_);
-                CqlDateTime u_ = FollowUpUSSAssessment?.effectiveDatetime;
-                bool? v_ = context.Operators.SameOrBefore(t_, u_, (string)default);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MorbidObesityDiagnosis);
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                bool? q_ = context.Operators.Overlaps(o_, p_, (string)default);
+                CqlDateTime s_ = context.Operators.Start(o_);
+                CqlDateTime t_ = FollowUpUSSAssessment?.effectiveDatetime;
+                bool? u_ = context.Operators.SameOrBefore(s_, t_, (string)default);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> m_ = context.Operators.Where<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>((IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>)k_, l_);
-            Condition n_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? FollowUpUSSAssessment) => MorbidObesityDiagnosis;
-            IEnumerable<Condition> o_ = context.Operators.Select<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?, Condition>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(m_);
+            return n_;
         }
 
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 
         bool? h_(Condition MorbidObesityDiagnosis) {
-            bool? x_ = this.verificationStatusIsNotInvalid(context, MorbidObesityDiagnosis);
-            return x_;
+            bool? w_ = this.verificationStatusIsNotInvalid(context, MorbidObesityDiagnosis);
+            return w_;
         }
 
         IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
@@ -941,54 +936,53 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi"));
 
-        IEnumerable<Observation> b_(Observation BMIExam) {
+        bool? b_(Observation BMIExam) {
             (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? h_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis(context);
             (CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?[] i_ = [
                 h_,
             ];
 
             bool? j_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? FollowUpUSSAssessment) {
-                DataType n_ = BMIExam?.Value;
-                CqlQuantity o_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, n_ as Quantity);
-                CqlQuantity p_ = context.Operators.Quantity(40m, "kg/m2");
-                bool? q_ = context.Operators.GreaterOrEqual(o_, p_);
-                Code<ObservationStatus> r_ = BMIExam?.StatusElement;
-                ObservationStatus? s_ = r_?.Value;
-                string t_ = context.Operators.Convert<string>(s_);
-                string[] u_ = [
+                DataType m_ = BMIExam?.Value;
+                CqlQuantity n_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, m_ as Quantity);
+                CqlQuantity o_ = context.Operators.Quantity(40m, "kg/m2");
+                bool? p_ = context.Operators.GreaterOrEqual(n_, o_);
+                Code<ObservationStatus> q_ = BMIExam?.StatusElement;
+                ObservationStatus? r_ = q_?.Value;
+                string s_ = context.Operators.Convert<string>(r_);
+                string[] t_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
-                bool? w_ = context.Operators.And(q_, v_);
-                DataType x_ = BMIExam?.Effective;
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, y_);
-                CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
-                bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
-                bool? ac_ = context.Operators.And(w_, ab_);
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                CqlDateTime af_ = QICoreCommon_4_0_000.Instance.earliest(context, ae_);
-                CqlDateTime ag_ = FollowUpUSSAssessment?.effectiveDatetime;
-                bool? ah_ = context.Operators.SameOrBefore(af_, ag_, (string)default);
-                bool? ai_ = context.Operators.And(ac_, ah_);
-                return ai_;
+                bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+                bool? v_ = context.Operators.And(p_, u_);
+                DataType w_ = BMIExam?.Effective;
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
+                CqlInterval<CqlDateTime> z_ = this.Measurement_Period(context);
+                bool? aa_ = context.Operators.In<CqlDateTime>(y_, z_, "day");
+                bool? ab_ = context.Operators.And(v_, aa_);
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
+                CqlDateTime af_ = FollowUpUSSAssessment?.effectiveDatetime;
+                bool? ag_ = context.Operators.SameOrBefore(ae_, af_, (string)default);
+                bool? ah_ = context.Operators.And(ab_, ag_);
+                return ah_;
             }
 
             IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> k_ = context.Operators.Where<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>((IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>)i_, j_);
-            Observation l_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? FollowUpUSSAssessment) => BMIExam;
-            IEnumerable<Observation> m_ = context.Operators.Select<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?, Observation>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(k_);
+            return l_;
         }
 
-        IEnumerable<Observation> c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
         CqlDateTime d_(Observation BMIExam) {
-            DataType aj_ = BMIExam?.Effective;
-            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-            CqlDateTime al_ = QICoreCommon_4_0_000.Instance.earliest(context, ak_);
-            return al_;
+            DataType ai_ = BMIExam?.Effective;
+            object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+            CqlDateTime ak_ = QICoreCommon_4_0_000.Instance.earliest(context, aj_);
+            return ak_;
         }
 
         IEnumerable<CqlDateTime> e_ = context.Operators.Select<Observation, CqlDateTime>(c_, d_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
@@ -124,38 +124,37 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
         IEnumerable<MedicationAdministration> b_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> d_(MedicationAdministration MR) {
+        bool? d_(MedicationAdministration MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Hypoglycemics_Severe_Hypoglycemia(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Hypoglycemics_Severe_Hypoglycemia(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationAdministration l_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> m_ = context.Operators.Select<Medication, MedicationAdministration>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationAdministration> e_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, d_);
+        IEnumerable<MedicationAdministration> e_ = context.Operators.Where<MedicationAdministration>(c_, d_);
         IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(b_, e_);
 
         bool? g_(MedicationAdministration HypoMedication) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> x_ = HypoMedication?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? y_ = x_?.Value;
-            string z_ = context.Operators.Convert<string>(y_);
-            bool? aa_ = context.Operators.Equal(z_, "completed");
-            return aa_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> w_ = HypoMedication?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            bool? z_ = context.Operators.Equal(y_, "completed");
+            return z_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
@@ -173,26 +172,25 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientHospitalization) {
+        bool? b_(Encounter InpatientHospitalization) {
             IEnumerable<MedicationAdministration> d_ = this.Hypoglycemic_Medication_Administration(context);
 
             bool? e_(MedicationAdministration HypoglycemicMedication) {
-                DataType i_ = HypoglycemicMedication?.Effective;
-                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
-                return n_;
+                DataType h_ = HypoglycemicMedication?.Effective;
+                object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
+                bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
+                return m_;
             }
 
             IEnumerable<MedicationAdministration> f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
-            Encounter g_(MedicationAdministration HypoglycemicMedication) => InpatientHospitalization;
-            IEnumerable<Encounter> h_ = context.Operators.Select<MedicationAdministration, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<MedicationAdministration>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
@@ -137,38 +137,37 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
         IEnumerable<MedicationAdministration> b_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> d_(MedicationAdministration MR) {
+        bool? d_(MedicationAdministration MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Opioids__All(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Opioids__All(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationAdministration l_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> m_ = context.Operators.Select<Medication, MedicationAdministration>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationAdministration> e_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, d_);
+        IEnumerable<MedicationAdministration> e_ = context.Operators.Where<MedicationAdministration>(c_, d_);
         IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(b_, e_);
 
         bool? g_(MedicationAdministration Opioids) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> x_ = Opioids?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? y_ = x_?.Value;
-            string z_ = context.Operators.Convert<string>(y_);
-            bool? aa_ = context.Operators.Equal(z_, "completed");
-            return aa_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> w_ = Opioids?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            bool? z_ = context.Operators.Equal(y_, "completed");
+            return z_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
@@ -186,56 +185,55 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounter(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientEncounter) {
+        bool? b_(Encounter InpatientEncounter) {
             IEnumerable<MedicationAdministration> d_ = this.Opioid_Administration(context);
 
             bool? e_(MedicationAdministration OpioidGiven) {
-                DataType i_ = OpioidGiven?.Effective;
-                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
-                List<Encounter.LocationComponent> o_ = InpatientEncounter?.Location;
+                DataType h_ = OpioidGiven?.Effective;
+                object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+                bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
+                List<Encounter.LocationComponent> n_ = InpatientEncounter?.Location;
 
-                bool? p_(Encounter.LocationComponent EncounterLocation) {
-                    ResourceReference u_ = EncounterLocation?.Location;
-                    Location v_ = CQMCommon_4_1_000.Instance.getLocation(context, u_);
-                    List<CodeableConcept> w_ = v_?.Type;
+                bool? o_(Encounter.LocationComponent EncounterLocation) {
+                    ResourceReference t_ = EncounterLocation?.Location;
+                    Location u_ = CQMCommon_4_1_000.Instance.getLocation(context, t_);
+                    List<CodeableConcept> v_ = u_?.Type;
 
-                    CqlConcept x_(CodeableConcept @this) {
-                        CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return aj_;
+                    CqlConcept w_(CodeableConcept @this) {
+                        CqlConcept ai_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                        return ai_;
                     }
 
-                    IEnumerable<CqlConcept> y_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)w_, x_);
-                    CqlValueSet z_ = this.Operating_Room_Suite(context);
-                    bool? aa_ = context.Operators.ConceptsInValueSet(y_, z_);
-                    DataType ab_ = OpioidGiven?.Effective;
-                    object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-                    CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
-                    CqlDateTime ae_ = context.Operators.Start(ad_);
-                    Period af_ = EncounterLocation?.Period;
-                    CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                    bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, (string)default);
-                    bool? ai_ = context.Operators.And(aa_, ah_);
-                    return ai_;
+                    IEnumerable<CqlConcept> x_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)v_, w_);
+                    CqlValueSet y_ = this.Operating_Room_Suite(context);
+                    bool? z_ = context.Operators.ConceptsInValueSet(x_, y_);
+                    DataType aa_ = OpioidGiven?.Effective;
+                    object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                    CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+                    CqlDateTime ad_ = context.Operators.Start(ac_);
+                    Period ae_ = EncounterLocation?.Period;
+                    CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
+                    bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, (string)default);
+                    bool? ah_ = context.Operators.And(z_, ag_);
+                    return ah_;
                 }
 
-                IEnumerable<Encounter.LocationComponent> q_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)o_, p_);
-                bool? r_ = context.Operators.Exists<Encounter.LocationComponent>(q_);
-                bool? s_ = context.Operators.Not(r_);
-                bool? t_ = context.Operators.And(n_, s_);
-                return t_;
+                IEnumerable<Encounter.LocationComponent> p_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)n_, o_);
+                bool? q_ = context.Operators.Exists<Encounter.LocationComponent>(p_);
+                bool? r_ = context.Operators.Not(q_);
+                bool? s_ = context.Operators.And(m_, r_);
+                return s_;
             }
 
             IEnumerable<MedicationAdministration> f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
-            Encounter g_(MedicationAdministration OpioidGiven) => InpatientEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<MedicationAdministration, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<MedicationAdministration>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -278,38 +276,37 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
         IEnumerable<MedicationAdministration> b_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> d_(MedicationAdministration MR) {
+        bool? d_(MedicationAdministration MR) {
             IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? j_(Medication M) {
-                object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
-                string q_ = context.Operators.Last<string>(p_);
-                bool? r_ = context.Operators.Equal(n_, q_);
-                CodeableConcept s_ = M?.Code;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Opioid_Antagonist(context);
-                bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
-                bool? w_ = context.Operators.And(r_, v_);
-                return w_;
+                object m_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object n_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
+                string p_ = context.Operators.Last<string>(o_);
+                bool? q_ = context.Operators.Equal(m_, p_);
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Opioid_Antagonist(context);
+                bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+                bool? v_ = context.Operators.And(q_, u_);
+                return v_;
             }
 
             IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
-            MedicationAdministration l_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> m_ = context.Operators.Select<Medication, MedicationAdministration>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Medication>(k_);
+            return l_;
         }
 
-        IEnumerable<MedicationAdministration> e_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(c_, d_);
+        IEnumerable<MedicationAdministration> e_ = context.Operators.Where<MedicationAdministration>(c_, d_);
         IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(b_, e_);
 
         bool? g_(MedicationAdministration AntagonistGiven) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> x_ = AntagonistGiven?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? y_ = x_?.Value;
-            string z_ = context.Operators.Convert<string>(y_);
-            bool? aa_ = context.Operators.Equal(z_, "completed");
-            return aa_;
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> w_ = AntagonistGiven?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            bool? z_ = context.Operators.Equal(y_, "completed");
+            return z_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
@@ -358,31 +358,30 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_Age_18_And_Older(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientHospitalization) {
+        bool? b_(Encounter InpatientHospitalization) {
             IEnumerable<Observation> d_ = this.Skin_Exams_With_Pressure_Injury(context);
 
             bool? e_(Observation SkinExam) {
-                DataType i_ = SkinExam?.Effective;
-                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlDateTime p_ = context.Operators.Start(m_);
-                CqlQuantity q_ = context.Operators.Quantity(72m, "hours");
-                CqlDateTime r_ = context.Operators.Add(p_, q_);
-                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
-                return t_;
+                DataType h_ = SkinExam?.Effective;
+                object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlDateTime o_ = context.Operators.Start(l_);
+                CqlQuantity p_ = context.Operators.Quantity(72m, "hours");
+                CqlDateTime q_ = context.Operators.Add(o_, p_);
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(m_, q_, true, true);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
+                return s_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
-            Encounter g_(Observation SkinExam) => InpatientHospitalization;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Observation, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Observation>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -434,31 +433,30 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_Age_18_And_Older(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientHospitalization) {
+        bool? b_(Encounter InpatientHospitalization) {
             IEnumerable<Observation> d_ = this.Skin_Exams_With_Pressure_Injury(context);
 
             bool? e_(Observation SkinExam) {
-                DataType i_ = SkinExam?.Effective;
-                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlDateTime p_ = context.Operators.Start(m_);
-                CqlQuantity q_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime r_ = context.Operators.Add(p_, q_);
-                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
-                return t_;
+                DataType h_ = SkinExam?.Effective;
+                object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlDateTime o_ = context.Operators.Start(l_);
+                CqlQuantity p_ = context.Operators.Quantity(24m, "hours");
+                CqlDateTime q_ = context.Operators.Add(o_, p_);
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(m_, q_, true, true);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
+                return s_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
-            Encounter g_(Observation SkinExam) => InpatientHospitalization;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Observation, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Observation>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -525,31 +523,30 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_Age_18_And_Older(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientHospitalization) {
+        bool? b_(Encounter InpatientHospitalization) {
             IEnumerable<Observation> d_ = this.Skin_Exams_With_Pressure_Injury(context);
 
             bool? e_(Observation SkinExam) {
-                DataType i_ = SkinExam?.Effective;
-                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(72m, "hours");
-                CqlDateTime p_ = context.Operators.Add(n_, o_);
-                CqlDateTime r_ = context.Operators.End(m_);
-                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
-                return t_;
+                DataType h_ = SkinExam?.Effective;
+                object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlQuantity n_ = context.Operators.Quantity(72m, "hours");
+                CqlDateTime o_ = context.Operators.Add(m_, n_);
+                CqlDateTime q_ = context.Operators.End(l_);
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
+                return s_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
-            Encounter g_(Observation SkinExam) => InpatientHospitalization;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Observation, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Observation>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -601,31 +598,30 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_Age_18_And_Older(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientHospitalization) {
+        bool? b_(Encounter InpatientHospitalization) {
             IEnumerable<Observation> d_ = this.Skin_Exams_With_Pressure_Injury(context);
 
             bool? e_(Observation SkinExam) {
-                DataType i_ = SkinExam?.Effective;
-                object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime p_ = context.Operators.Add(n_, o_);
-                CqlDateTime r_ = context.Operators.End(m_);
-                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
-                return t_;
+                DataType h_ = SkinExam?.Effective;
+                object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlQuantity n_ = context.Operators.Quantity(24m, "hours");
+                CqlDateTime o_ = context.Operators.Add(m_, n_);
+                CqlDateTime q_ = context.Operators.End(l_);
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
+                return s_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
-            Encounter g_(Observation SkinExam) => InpatientHospitalization;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Observation, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Observation>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS832FHIRHHAKI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS832FHIRHHAKI-1.0.000.g.cs
@@ -3491,72 +3491,72 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
     {
         IEnumerable<Encounter> a_ = this.Encounter_With_Creatinine_And_Without_Obstetrical_Conditions(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.High_Risk_Procedures_for_AKI(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure HighRiskProcedures) {
-                Code<EventStatus> j_ = HighRiskProcedures?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                bool? m_ = context.Operators.Equal(l_, "completed");
+                Code<EventStatus> i_ = HighRiskProcedures?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                bool? l_ = context.Operators.Equal(k_, "completed");
 
-                object n_() {
+                object m_() {
+
+                    bool s_() {
+                        DataType w_ = HighRiskProcedures?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
 
                     bool t_() {
-                        DataType x_ = HighRiskProcedures?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
+                        DataType z_ = HighRiskProcedures?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
                     }
 
 
                     bool u_() {
-                        DataType aa_ = HighRiskProcedures?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
+                        DataType ac_ = HighRiskProcedures?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
                     }
 
 
                     bool v_() {
-                        DataType ad_ = HighRiskProcedures?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
+                        DataType af_ = HighRiskProcedures?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
                     }
 
-
-                    bool w_() {
-                        DataType ag_ = HighRiskProcedures?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
+                    if (s_())
                     {
-                        DataType aj_ = HighRiskProcedures?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
+                        DataType ai_ = HighRiskProcedures?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = HighRiskProcedures?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (u_())
                     {
-                        DataType al_ = HighRiskProcedures?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
+                        DataType am_ = HighRiskProcedures?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
                     }
                     else if (v_())
                     {
-                        DataType an_ = HighRiskProcedures?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = HighRiskProcedures?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
+                        DataType ao_ = HighRiskProcedures?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -3564,21 +3564,20 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
                     };
                 }
 
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                CqlDateTime p_ = context.Operators.Start(o_);
-                CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
-                bool? s_ = context.Operators.And(m_, r_);
-                return s_;
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
+                bool? r_ = context.Operators.And(l_, q_);
+                return r_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure HighRiskProcedures) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
@@ -197,96 +197,95 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
     {
         IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> a_ = this.Encounter_with_Hospitalization_Period(context);
 
-        IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> b_((CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization) {
+        bool? b_((CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization) {
             CqlValueSet g_ = this.Diabetes(context);
             IEnumerable<Condition> h_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
             bool? i_(Condition DiabetesEncounter) {
-                Encounter t_ = Hospitalization?.encounter;
-                List<ResourceReference> u_ = t_?.ReasonReference;
-                bool? v_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)u_, DiabetesEncounter);
-                List<CodeableConcept> x_ = t_?.ReasonCode;
+                Encounter s_ = Hospitalization?.encounter;
+                List<ResourceReference> t_ = s_?.ReasonReference;
+                bool? u_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)t_, DiabetesEncounter);
+                List<CodeableConcept> w_ = s_?.ReasonCode;
 
-                CqlConcept y_(CodeableConcept @this) {
-                    CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return aj_;
+                CqlConcept x_(CodeableConcept @this) {
+                    CqlConcept ai_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ai_;
                 }
 
-                IEnumerable<CqlConcept> z_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)x_, y_);
-                CqlValueSet aa_ = this.Diabetes(context);
-                bool? ab_ = context.Operators.ConceptsInValueSet(z_, aa_);
-                bool? ac_ = context.Operators.Or(v_, ab_);
-                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesEncounter as Condition);
-                CqlDateTime ae_ = context.Operators.Start(ad_);
-                CqlInterval<CqlDateTime> af_ = Hospitalization?.hospitalizationPeriod;
-                CqlDateTime ag_ = context.Operators.End(af_);
-                bool? ah_ = context.Operators.Before(ae_, ag_, (string)default);
-                bool? ai_ = context.Operators.And(ac_, ah_);
-                return ai_;
+                IEnumerable<CqlConcept> y_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)w_, x_);
+                CqlValueSet z_ = this.Diabetes(context);
+                bool? aa_ = context.Operators.ConceptsInValueSet(y_, z_);
+                bool? ab_ = context.Operators.Or(u_, aa_);
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesEncounter as Condition);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                CqlInterval<CqlDateTime> ae_ = Hospitalization?.hospitalizationPeriod;
+                CqlDateTime af_ = context.Operators.End(ae_);
+                bool? ag_ = context.Operators.Before(ad_, af_, (string)default);
+                bool? ah_ = context.Operators.And(ab_, ag_);
+                return ah_;
             }
 
             IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
             IEnumerable<Condition> l_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? m_(Condition DiabetesProblem) {
-                CodeableConcept ak_ = DiabetesProblem?.VerificationStatus;
-                CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_);
-                bool? am_ = context.Operators.Not((bool?)(al_ is null));
-                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_);
-                CqlCode ap_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-                CqlConcept aq_ = context.Operators.ConvertCodeToConcept(ap_);
-                bool? ar_ = context.Operators.Equivalent(ao_, aq_);
-                CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_);
-                CqlCode au_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept av_ = context.Operators.ConvertCodeToConcept(au_);
-                bool? aw_ = context.Operators.Equivalent(at_, av_);
-                bool? ax_ = context.Operators.Or(ar_, aw_);
-                CqlConcept az_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_);
-                CqlCode ba_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept bb_ = context.Operators.ConvertCodeToConcept(ba_);
-                bool? bc_ = context.Operators.Equivalent(az_, bb_);
-                bool? bd_ = context.Operators.Or(ax_, bc_);
-                CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_);
-                CqlCode bg_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept bh_ = context.Operators.ConvertCodeToConcept(bg_);
-                bool? bi_ = context.Operators.Equivalent(bf_, bh_);
-                bool? bj_ = context.Operators.Or(bd_, bi_);
-                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesProblem as Condition);
-                CqlDateTime bl_ = context.Operators.Start(bk_);
-                CqlInterval<CqlDateTime> bm_ = Hospitalization?.hospitalizationPeriod;
-                CqlDateTime bn_ = context.Operators.End(bm_);
-                bool? bo_ = context.Operators.Before(bl_, bn_, (string)default);
-                bool? bp_ = context.Operators.And(bj_, bo_);
-                bool? bq_ = context.Operators.Implies(am_, bp_);
-                return bq_;
+                CodeableConcept aj_ = DiabetesProblem?.VerificationStatus;
+                CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
+                bool? al_ = context.Operators.Not((bool?)(ak_ is null));
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
+                CqlCode ao_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+                CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+                bool? aq_ = context.Operators.Equivalent(an_, ap_);
+                CqlConcept as_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
+                CqlCode at_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+                CqlConcept au_ = context.Operators.ConvertCodeToConcept(at_);
+                bool? av_ = context.Operators.Equivalent(as_, au_);
+                bool? aw_ = context.Operators.Or(aq_, av_);
+                CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
+                CqlCode az_ = QICoreCommon_4_0_000.Instance.provisional(context);
+                CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
+                bool? bb_ = context.Operators.Equivalent(ay_, ba_);
+                bool? bc_ = context.Operators.Or(aw_, bb_);
+                CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
+                CqlCode bf_ = QICoreCommon_4_0_000.Instance.differential(context);
+                CqlConcept bg_ = context.Operators.ConvertCodeToConcept(bf_);
+                bool? bh_ = context.Operators.Equivalent(be_, bg_);
+                bool? bi_ = context.Operators.Or(bc_, bh_);
+                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesProblem as Condition);
+                CqlDateTime bk_ = context.Operators.Start(bj_);
+                CqlInterval<CqlDateTime> bl_ = Hospitalization?.hospitalizationPeriod;
+                CqlDateTime bm_ = context.Operators.End(bl_);
+                bool? bn_ = context.Operators.Before(bk_, bm_, (string)default);
+                bool? bo_ = context.Operators.And(bi_, bn_);
+                bool? bp_ = context.Operators.Implies(al_, bo_);
+                return bp_;
             }
 
             IEnumerable<Condition> n_ = context.Operators.Where<Condition>(l_, m_);
             IEnumerable<Condition> o_ = context.Operators.Union<Condition>(j_ as IEnumerable<Condition>, n_ as IEnumerable<Condition>);
 
             bool? p_(Condition DiabetesCondition) {
-                ResourceReference br_ = DiabetesCondition?.Subject;
-                FhirString bs_ = br_?.ReferenceElement;
-                string bt_ = bs_?.Value;
-                Encounter bu_ = Hospitalization?.encounter;
-                ResourceReference bv_ = bu_?.Subject;
-                FhirString bw_ = bv_?.ReferenceElement;
-                string bx_ = bw_?.Value;
-                bool? by_ = context.Operators.Equal(bt_, bx_);
-                return by_;
+                ResourceReference bq_ = DiabetesCondition?.Subject;
+                FhirString br_ = bq_?.ReferenceElement;
+                string bs_ = br_?.Value;
+                Encounter bt_ = Hospitalization?.encounter;
+                ResourceReference bu_ = bt_?.Subject;
+                FhirString bv_ = bu_?.ReferenceElement;
+                string bw_ = bv_?.Value;
+                bool? bx_ = context.Operators.Equal(bs_, bw_);
+                return bx_;
             }
 
             IEnumerable<Condition> q_ = context.Operators.Where<Condition>(o_, p_);
-            (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? r_(Condition DiabetesCondition) => Hospitalization;
-            IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> s_ = context.Operators.Select<Condition, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?>(q_, r_);
-            return s_;
+            bool? r_ = context.Operators.Exists<Condition>(q_);
+            return r_;
         }
 
-        IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> c_ = context.Operators.SelectMany<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> c_ = context.Operators.Where<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?>(a_, b_);
 
         Encounter d_((CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization) {
-            Encounter bz_ = Hospitalization?.encounter;
-            return bz_;
+            Encounter by_ = Hospitalization?.encounter;
+            return by_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Select<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, Encounter>(c_, d_);
@@ -308,63 +307,62 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
         IEnumerable<MedicationAdministration> c_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
         IEnumerable<MedicationAdministration> d_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-        IEnumerable<MedicationAdministration> e_(MedicationAdministration MR) {
+        bool? e_(MedicationAdministration MR) {
             IEnumerable<Medication> p_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
             bool? q_(Medication M) {
-                object u_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object v_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> w_ = context.Operators.Split((string)v_, "/");
-                string x_ = context.Operators.Last<string>(w_);
-                bool? y_ = context.Operators.Equal(u_, x_);
-                CodeableConcept z_ = M?.Code;
-                CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-                CqlValueSet ab_ = this.Hypoglycemics_Treatment_Medications(context);
-                bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
-                bool? ad_ = context.Operators.And(y_, ac_);
-                return ad_;
+                object t_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object u_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> v_ = context.Operators.Split((string)u_, "/");
+                string w_ = context.Operators.Last<string>(v_);
+                bool? x_ = context.Operators.Equal(t_, w_);
+                CodeableConcept y_ = M?.Code;
+                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+                CqlValueSet aa_ = this.Hypoglycemics_Treatment_Medications(context);
+                bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+                bool? ac_ = context.Operators.And(x_, ab_);
+                return ac_;
             }
 
             IEnumerable<Medication> r_ = context.Operators.Where<Medication>(p_, q_);
-            MedicationAdministration s_(Medication M) => MR;
-            IEnumerable<MedicationAdministration> t_ = context.Operators.Select<Medication, MedicationAdministration>(r_, s_);
-            return t_;
+            bool? s_ = context.Operators.Exists<Medication>(r_);
+            return s_;
         }
 
-        IEnumerable<MedicationAdministration> f_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(d_, e_);
+        IEnumerable<MedicationAdministration> f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
         IEnumerable<MedicationAdministration> g_ = context.Operators.Union<MedicationAdministration>(c_, f_);
         IEnumerable<ValueTuple<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>> h_ = context.Operators.CrossJoin<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>(a_, g_);
 
         (CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)? i_(ValueTuple<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration> _valueTuple) {
-            (CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)? ae_ = (CqlTupleMetadata_BRDBXSUhdQiXBCfMGdSacWIG, _valueTuple.Item1, _valueTuple.Item2);
-            return ae_;
+            (CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)? ad_ = (CqlTupleMetadata_BRDBXSUhdQiXBCfMGdSacWIG, _valueTuple.Item1, _valueTuple.Item2);
+            return ad_;
         }
 
         IEnumerable<(CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)?> j_ = context.Operators.Select<ValueTuple<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>, (CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)?>(h_, i_);
 
         bool? k_((CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)? tuple_brdbxsuhdqixbcfmgdsacwig) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> af_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? ag_ = af_?.Value;
-            string ah_ = context.Operators.Convert<string>(ag_);
-            string[] ai_ = [
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> ae_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? af_ = ae_?.Value;
+            string ag_ = context.Operators.Convert<string>(af_);
+            string[] ah_ = [
                 "completed",
                 "in-progress",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-            CqlInterval<CqlDateTime> ak_ = tuple_brdbxsuhdqixbcfmgdsacwig?.Hospitalization?.hospitalizationPeriod;
-            DataType al_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.Effective;
-            object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
-            bool? ao_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ak_, an_, (string)default);
-            bool? ap_ = context.Operators.And(aj_, ao_);
-            return ap_;
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
+            CqlInterval<CqlDateTime> aj_ = tuple_brdbxsuhdqixbcfmgdsacwig?.Hospitalization?.hospitalizationPeriod;
+            DataType ak_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.Effective;
+            object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+            CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
+            bool? an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aj_, am_, (string)default);
+            bool? ao_ = context.Operators.And(ai_, an_);
+            return ao_;
         }
 
         IEnumerable<(CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)?> l_ = context.Operators.Where<(CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)?>(j_, k_);
 
         Encounter m_((CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)? tuple_brdbxsuhdqixbcfmgdsacwig) {
-            Encounter aq_ = tuple_brdbxsuhdqixbcfmgdsacwig?.Hospitalization?.encounter;
-            return aq_;
+            Encounter ap_ = tuple_brdbxsuhdqixbcfmgdsacwig?.Hospitalization?.encounter;
+            return ap_;
         }
 
         IEnumerable<Encounter> n_ = context.Operators.Select<(CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)?, Encounter>(l_, m_);
@@ -383,54 +381,54 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
     {
         IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> a_ = this.Encounter_with_Hospitalization_Period(context);
 
-        IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> b_((CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization) {
+        bool? b_((CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization) {
             CqlValueSet g_ = this.Glucose_Lab_Test_Mass_Per_Volume(context);
             IEnumerable<Observation> h_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
 
             bool? i_(Observation GlucoseTest) {
 
-                object m_() {
+                object l_() {
+
+                    bool aa_() {
+                        DataType ad_ = GlucoseTest?.Effective;
+                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                        bool af_ = ae_ is CqlDateTime;
+                        return af_;
+                    }
+
 
                     bool ab_() {
-                        DataType ae_ = GlucoseTest?.Effective;
-                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                        bool ag_ = af_ is CqlDateTime;
-                        return ag_;
+                        DataType ag_ = GlucoseTest?.Effective;
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        bool ai_ = ah_ is CqlInterval<CqlDateTime>;
+                        return ai_;
                     }
 
 
                     bool ac_() {
-                        DataType ah_ = GlucoseTest?.Effective;
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        bool aj_ = ai_ is CqlInterval<CqlDateTime>;
-                        return aj_;
+                        DataType aj_ = GlucoseTest?.Effective;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlDateTime;
+                        return al_;
                     }
 
-
-                    bool ad_() {
-                        DataType ak_ = GlucoseTest?.Effective;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        bool am_ = al_ is CqlDateTime;
-                        return am_;
-                    }
-
-                    if (ab_())
+                    if (aa_())
                     {
-                        DataType an_ = GlucoseTest?.Effective;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlDateTime) as object;
+                        DataType am_ = GlucoseTest?.Effective;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlDateTime) as object;
+                    }
+                    else if (ab_())
+                    {
+                        DataType ao_ = GlucoseTest?.Effective;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ac_())
                     {
-                        DataType ap_ = GlucoseTest?.Effective;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (ad_())
-                    {
-                        DataType ar_ = GlucoseTest?.Effective;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return (as_ as CqlDateTime) as object;
+                        DataType aq_ = GlucoseTest?.Effective;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        return (ar_ as CqlDateTime) as object;
                     }
                     else
                     {
@@ -438,38 +436,37 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                     };
                 }
 
-                CqlDateTime n_ = QICoreCommon_4_0_000.Instance.earliest(context, m_());
-                CqlInterval<CqlDateTime> o_ = Hospitalization?.hospitalizationPeriod;
-                bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
-                Code<ObservationStatus> q_ = GlucoseTest?.StatusElement;
-                ObservationStatus? r_ = q_?.Value;
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
+                CqlDateTime m_ = QICoreCommon_4_0_000.Instance.earliest(context, l_());
+                CqlInterval<CqlDateTime> n_ = Hospitalization?.hospitalizationPeriod;
+                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
+                Code<ObservationStatus> p_ = GlucoseTest?.StatusElement;
+                ObservationStatus? q_ = p_?.Value;
+                string r_ = context.Operators.Convert<string>(q_);
+                string[] s_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                bool? v_ = context.Operators.And(p_, u_);
-                DataType w_ = GlucoseTest?.Value;
-                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                CqlQuantity y_ = context.Operators.Quantity(200m, "mg/dL");
-                bool? z_ = context.Operators.GreaterOrEqual(x_ as CqlQuantity, y_);
-                bool? aa_ = context.Operators.And(v_, z_);
-                return aa_;
+                bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
+                bool? u_ = context.Operators.And(o_, t_);
+                DataType v_ = GlucoseTest?.Value;
+                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                CqlQuantity x_ = context.Operators.Quantity(200m, "mg/dL");
+                bool? y_ = context.Operators.GreaterOrEqual(w_ as CqlQuantity, x_);
+                bool? z_ = context.Operators.And(u_, y_);
+                return z_;
             }
 
             IEnumerable<Observation> j_ = context.Operators.Where<Observation>(h_, i_);
-            (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? k_(Observation GlucoseTest) => Hospitalization;
-            IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> l_ = context.Operators.Select<Observation, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Observation>(j_);
+            return k_;
         }
 
-        IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> c_ = context.Operators.SelectMany<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> c_ = context.Operators.Where<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?>(a_, b_);
 
         Encounter d_((CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization) {
-            Encounter at_ = Hospitalization?.encounter;
-            return at_;
+            Encounter as_ = Hospitalization?.encounter;
+            return as_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Select<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, Encounter>(c_, d_);
@@ -1349,67 +1346,67 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
     {
         IEnumerable<Encounter> a_ = this.Initial_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter InpatientHospitalization) {
+        bool? b_(Encounter InpatientHospitalization) {
             IEnumerable<object> d_ = this.Comfort_Measures_Care(context);
 
             bool? e_(object ComfortCare) {
 
-                object i_() {
+                object h_() {
+
+                    bool p_() {
+                        object t_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                        bool v_ = u_ is CqlDateTime;
+                        return v_;
+                    }
+
 
                     bool q_() {
-                        object u_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                        bool w_ = v_ is CqlDateTime;
-                        return w_;
+                        object w_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlInterval<CqlDateTime>;
+                        return y_;
                     }
 
 
                     bool r_() {
-                        object x_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlInterval<CqlDateTime>;
-                        return z_;
+                        object z_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlQuantity;
+                        return ab_;
                     }
 
 
                     bool s_() {
-                        object aa_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlQuantity;
-                        return ac_;
+                        object ac_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlQuantity>;
+                        return ae_;
                     }
 
-
-                    bool t_() {
-                        object ad_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlInterval<CqlQuantity>;
-                        return af_;
-                    }
-
-                    if (q_())
+                    if (p_())
                     {
-                        object ag_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        return (ah_ as CqlDateTime) as object;
+                        object af_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        return (ag_ as CqlDateTime) as object;
+                    }
+                    else if (q_())
+                    {
+                        object ah_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (r_())
                     {
-                        object ai_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlInterval<CqlDateTime>) as object;
+                        object aj_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlQuantity) as object;
                     }
                     else if (s_())
                     {
-                        object ak_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlQuantity) as object;
-                    }
-                    else if (t_())
-                    {
-                        object am_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlInterval<CqlQuantity>) as object;
+                        object al_ = context.Operators.LateBoundProperty<object>(ComfortCare, "performed");
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1417,23 +1414,22 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                     };
                 }
 
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
-                object k_ = context.Operators.LateBoundProperty<object>(ComfortCare, "authoredOn");
-                CqlDateTime l_ = context.Operators.LateBoundProperty<CqlDateTime>(k_, "value");
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_ as object);
-                CqlDateTime n_ = context.Operators.Start(j_ ?? m_);
-                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
-                return p_;
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_());
+                object j_ = context.Operators.LateBoundProperty<object>(ComfortCare, "authoredOn");
+                CqlDateTime k_ = context.Operators.LateBoundProperty<CqlDateTime>(j_, "value");
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_ as object);
+                CqlDateTime m_ = context.Operators.Start(i_ ?? l_);
+                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
+                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
+                return o_;
             }
 
             IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
-            Encounter g_(object ComfortCare) => InpatientHospitalization;
-            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<object>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS90FHIRFSAforHeartFailure-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS90FHIRFSAforHeartFailure-1.0.000.g.cs
@@ -328,29 +328,28 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Qualifying_Encounters(context);
 
-        IEnumerable<Encounter> b_(Encounter OfficeVisit1) {
+        bool? b_(Encounter OfficeVisit1) {
             IEnumerable<Encounter> d_ = this.Qualifying_Encounters(context);
 
             bool? e_(Encounter OfficeVisit2) {
-                Period i_ = OfficeVisit2?.Period;
-                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                Period l_ = OfficeVisit1?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.End(m_);
-                CqlQuantity o_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime p_ = context.Operators.Add(n_, o_);
-                bool? q_ = context.Operators.SameOrAfter(k_, p_, "day");
-                return q_;
+                Period h_ = OfficeVisit2?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                Period k_ = OfficeVisit1?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.End(l_);
+                CqlQuantity n_ = context.Operators.Quantity(1m, "day");
+                CqlDateTime o_ = context.Operators.Add(m_, n_);
+                bool? p_ = context.Operators.SameOrAfter(j_, o_, "day");
+                return p_;
             }
 
             IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
-            Encounter g_(Encounter OfficeVisit2) => OfficeVisit1;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
@@ -395,22 +395,21 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Measure_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             IEnumerable<CqlDateTime> d_ = this.Intervention_Hospice_Care(context);
 
             bool? e_(CqlDateTime HospiceStatusDate) {
-                CqlInterval<CqlDateTime> i_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                bool? j_ = context.Operators.In<CqlDateTime>(HospiceStatusDate, i_, "day");
-                return j_;
+                CqlInterval<CqlDateTime> h_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                bool? i_ = context.Operators.In<CqlDateTime>(HospiceStatusDate, h_, "day");
+                return i_;
             }
 
             IEnumerable<CqlDateTime> f_ = context.Operators.Where<CqlDateTime>(d_, e_);
-            Encounter g_(CqlDateTime HospiceStatusDate) => QualifyingEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<CqlDateTime, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<CqlDateTime>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -581,22 +580,21 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Measure_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             IEnumerable<CqlDateTime> d_ = this.Intervention_Dietitian_Referral(context);
 
             bool? e_(CqlDateTime DietitianReferralDate) {
-                CqlInterval<CqlDateTime> i_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                bool? j_ = context.Operators.In<CqlDateTime>(DietitianReferralDate, i_, "day");
-                return j_;
+                CqlInterval<CqlDateTime> h_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                bool? i_ = context.Operators.In<CqlDateTime>(DietitianReferralDate, h_, "day");
+                return i_;
             }
 
             IEnumerable<CqlDateTime> f_ = context.Operators.Where<CqlDateTime>(d_, e_);
-            Encounter g_(CqlDateTime DietitianReferralDate) => QualifyingEncounter;
-            IEnumerable<Encounter> h_ = context.Operators.Select<CqlDateTime, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<CqlDateTime>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -611,41 +609,40 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Measure_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Malnutrition_Risk_Screening(context);
             IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
             bool? f_(Observation MalnutritionRiskScreening) {
-                Code<ObservationStatus> j_ = MalnutritionRiskScreening?.StatusElement;
-                ObservationStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                string[] m_ = [
+                Code<ObservationStatus> i_ = MalnutritionRiskScreening?.StatusElement;
+                ObservationStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                DataType p_ = MalnutritionRiskScreening?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                bool? t_ = context.Operators.And(n_, s_);
-                DataType u_ = MalnutritionRiskScreening?.Value;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet w_ = this.Malnutrition_Screening_Finding_of_Not_At_Risk_Result(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType o_ = MalnutritionRiskScreening?.Effective;
+                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
+                bool? s_ = context.Operators.And(m_, r_);
+                DataType t_ = MalnutritionRiskScreening?.Value;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet v_ = this.Malnutrition_Screening_Finding_of_Not_At_Risk_Result(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
-            Encounter h_(Observation MalnutritionRiskScreening) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Observation>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -660,41 +657,40 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Measure_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Malnutrition_Risk_Screening(context);
             IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
             bool? f_(Observation MalnutritionRiskScreening) {
-                Code<ObservationStatus> j_ = MalnutritionRiskScreening?.StatusElement;
-                ObservationStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                string[] m_ = [
+                Code<ObservationStatus> i_ = MalnutritionRiskScreening?.StatusElement;
+                ObservationStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                DataType p_ = MalnutritionRiskScreening?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                bool? t_ = context.Operators.And(n_, s_);
-                DataType u_ = MalnutritionRiskScreening?.Value;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet w_ = this.Malnutrition_Screening_Finding_of_At_Risk_Result(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                bool? y_ = context.Operators.And(t_, x_);
-                return y_;
+                bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType o_ = MalnutritionRiskScreening?.Effective;
+                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
+                bool? s_ = context.Operators.And(m_, r_);
+                DataType t_ = MalnutritionRiskScreening?.Value;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet v_ = this.Malnutrition_Screening_Finding_of_At_Risk_Result(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
+                bool? x_ = context.Operators.And(s_, w_);
+                return x_;
             }
 
             IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
-            Encounter h_(Observation MalnutritionRiskScreening) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Observation>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -862,82 +858,82 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounters_with_Malnutrition_Risk_Screening_At_Risk_or_with_Dietitian_Referral(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Nutrition_Assessment(context);
             IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
             bool? f_(Observation NutritionAssessment) {
-                Code<ObservationStatus> j_ = NutritionAssessment?.StatusElement;
-                ObservationStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                string[] m_ = [
+                Code<ObservationStatus> i_ = NutritionAssessment?.StatusElement;
+                ObservationStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                DataType p_ = NutritionAssessment?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                bool? t_ = context.Operators.And(n_, s_);
-                DataType u_ = NutritionAssessment?.Value;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet aa_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
-                bool? ab_ = context.Operators.ConceptInValueSet(z_ as CqlConcept, aa_);
-                bool? ac_ = context.Operators.Or(x_, ab_);
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet af_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
-                bool? ag_ = context.Operators.ConceptInValueSet(ae_ as CqlConcept, af_);
-                bool? ah_ = context.Operators.Or(ac_, ag_);
-                bool? ai_ = context.Operators.And(t_, ah_);
+                bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType o_ = NutritionAssessment?.Effective;
+                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
+                bool? s_ = context.Operators.And(m_, r_);
+                DataType t_ = NutritionAssessment?.Value;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet v_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
+                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet z_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
+                bool? aa_ = context.Operators.ConceptInValueSet(y_ as CqlConcept, z_);
+                bool? ab_ = context.Operators.Or(w_, aa_);
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet ae_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_ as CqlConcept, ae_);
+                bool? ag_ = context.Operators.Or(ab_, af_);
+                bool? ah_ = context.Operators.And(s_, ag_);
 
-                object aj_() {
+                object ai_() {
+
+                    bool an_() {
+                        DataType aq_ = NutritionAssessment?.Effective;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        bool as_ = ar_ is CqlDateTime;
+                        return as_;
+                    }
+
 
                     bool ao_() {
-                        DataType ar_ = NutritionAssessment?.Effective;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlDateTime;
-                        return at_;
+                        DataType at_ = NutritionAssessment?.Effective;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        bool av_ = au_ is CqlInterval<CqlDateTime>;
+                        return av_;
                     }
 
 
                     bool ap_() {
-                        DataType au_ = NutritionAssessment?.Effective;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
-                        return aw_;
+                        DataType aw_ = NutritionAssessment?.Effective;
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        bool ay_ = ax_ is CqlDateTime;
+                        return ay_;
                     }
 
-
-                    bool aq_() {
-                        DataType ax_ = NutritionAssessment?.Effective;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        bool az_ = ay_ is CqlDateTime;
-                        return az_;
-                    }
-
-                    if (ao_())
+                    if (an_())
                     {
-                        DataType ba_ = NutritionAssessment?.Effective;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        return (bb_ as CqlDateTime) as object;
+                        DataType az_ = NutritionAssessment?.Effective;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        return (ba_ as CqlDateTime) as object;
+                    }
+                    else if (ao_())
+                    {
+                        DataType bb_ = NutritionAssessment?.Effective;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        return (bc_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ap_())
                     {
-                        DataType bc_ = NutritionAssessment?.Effective;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        return (bd_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aq_())
-                    {
-                        DataType be_ = NutritionAssessment?.Effective;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        return (bf_ as CqlDateTime) as object;
+                        DataType bd_ = NutritionAssessment?.Effective;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        return (be_ as CqlDateTime) as object;
                     }
                     else
                     {
@@ -945,20 +941,19 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     };
                 }
 
-                CqlDateTime ak_ = QICoreCommon_4_0_000.Instance.latest(context, aj_());
-                CqlDateTime al_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
-                bool? am_ = context.Operators.SameAs(ak_, al_, "day");
-                bool? an_ = context.Operators.And(ai_, am_);
-                return an_;
+                CqlDateTime aj_ = QICoreCommon_4_0_000.Instance.latest(context, ai_());
+                CqlDateTime ak_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
+                bool? al_ = context.Operators.SameAs(aj_, ak_, "day");
+                bool? am_ = context.Operators.And(ah_, al_);
+                return am_;
             }
 
             IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
-            Encounter h_(Observation NutritionAssessment) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Observation>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -973,78 +968,78 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Measure_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Nutrition_Assessment(context);
             IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
             bool? f_(Observation NutritionAssessment) {
-                Code<ObservationStatus> j_ = NutritionAssessment?.StatusElement;
-                ObservationStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                string[] m_ = [
+                Code<ObservationStatus> i_ = NutritionAssessment?.StatusElement;
+                ObservationStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                DataType p_ = NutritionAssessment?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                bool? t_ = context.Operators.And(n_, s_);
-                DataType u_ = NutritionAssessment?.Value;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet aa_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
-                bool? ab_ = context.Operators.ConceptInValueSet(z_ as CqlConcept, aa_);
-                bool? ac_ = context.Operators.Or(x_, ab_);
-                bool? ad_ = context.Operators.And(t_, ac_);
+                bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType o_ = NutritionAssessment?.Effective;
+                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
+                bool? s_ = context.Operators.And(m_, r_);
+                DataType t_ = NutritionAssessment?.Value;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet v_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
+                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet z_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
+                bool? aa_ = context.Operators.ConceptInValueSet(y_ as CqlConcept, z_);
+                bool? ab_ = context.Operators.Or(w_, aa_);
+                bool? ac_ = context.Operators.And(s_, ab_);
 
-                object ae_() {
+                object ad_() {
+
+                    bool ai_() {
+                        DataType al_ = NutritionAssessment?.Effective;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        bool an_ = am_ is CqlDateTime;
+                        return an_;
+                    }
+
 
                     bool aj_() {
-                        DataType am_ = NutritionAssessment?.Effective;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        bool ao_ = an_ is CqlDateTime;
-                        return ao_;
+                        DataType ao_ = NutritionAssessment?.Effective;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        bool aq_ = ap_ is CqlInterval<CqlDateTime>;
+                        return aq_;
                     }
 
 
                     bool ak_() {
-                        DataType ap_ = NutritionAssessment?.Effective;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        bool ar_ = aq_ is CqlInterval<CqlDateTime>;
-                        return ar_;
+                        DataType ar_ = NutritionAssessment?.Effective;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        bool at_ = as_ is CqlDateTime;
+                        return at_;
                     }
 
-
-                    bool al_() {
-                        DataType as_ = NutritionAssessment?.Effective;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        bool au_ = at_ is CqlDateTime;
-                        return au_;
-                    }
-
-                    if (aj_())
+                    if (ai_())
                     {
-                        DataType av_ = NutritionAssessment?.Effective;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        return (aw_ as CqlDateTime) as object;
+                        DataType au_ = NutritionAssessment?.Effective;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        return (av_ as CqlDateTime) as object;
+                    }
+                    else if (aj_())
+                    {
+                        DataType aw_ = NutritionAssessment?.Effective;
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        return (ax_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ak_())
                     {
-                        DataType ax_ = NutritionAssessment?.Effective;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        return (ay_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (al_())
-                    {
-                        DataType az_ = NutritionAssessment?.Effective;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        return (ba_ as CqlDateTime) as object;
+                        DataType ay_ = NutritionAssessment?.Effective;
+                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+                        return (az_ as CqlDateTime) as object;
                     }
                     else
                     {
@@ -1052,20 +1047,19 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     };
                 }
 
-                CqlDateTime af_ = QICoreCommon_4_0_000.Instance.latest(context, ae_());
-                CqlDateTime ag_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
-                bool? ah_ = context.Operators.SameAs(af_, ag_, "day");
-                bool? ai_ = context.Operators.And(ad_, ah_);
-                return ai_;
+                CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.latest(context, ad_());
+                CqlDateTime af_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
+                bool? ag_ = context.Operators.SameAs(ae_, af_, "day");
+                bool? ah_ = context.Operators.And(ac_, ag_);
+                return ah_;
             }
 
             IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
-            Encounter h_(Observation NutritionAssessment) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Observation>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1080,74 +1074,74 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Measure_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Nutrition_Assessment(context);
             IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
             bool? f_(Observation NutritionAssessment) {
-                Code<ObservationStatus> j_ = NutritionAssessment?.StatusElement;
-                ObservationStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                string[] m_ = [
+                Code<ObservationStatus> i_ = NutritionAssessment?.StatusElement;
+                ObservationStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                DataType p_ = NutritionAssessment?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                bool? t_ = context.Operators.And(n_, s_);
-                DataType u_ = NutritionAssessment?.Value;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
-                bool? x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                bool? y_ = context.Operators.And(t_, x_);
+                bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType o_ = NutritionAssessment?.Effective;
+                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
+                bool? s_ = context.Operators.And(m_, r_);
+                DataType t_ = NutritionAssessment?.Value;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlValueSet v_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
+                bool? w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
+                bool? x_ = context.Operators.And(s_, w_);
 
-                object z_() {
+                object y_() {
+
+                    bool ad_() {
+                        DataType ag_ = NutritionAssessment?.Effective;
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        bool ai_ = ah_ is CqlDateTime;
+                        return ai_;
+                    }
+
 
                     bool ae_() {
-                        DataType ah_ = NutritionAssessment?.Effective;
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        bool aj_ = ai_ is CqlDateTime;
-                        return aj_;
+                        DataType aj_ = NutritionAssessment?.Effective;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlInterval<CqlDateTime>;
+                        return al_;
                     }
 
 
                     bool af_() {
-                        DataType ak_ = NutritionAssessment?.Effective;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        bool am_ = al_ is CqlInterval<CqlDateTime>;
-                        return am_;
+                        DataType am_ = NutritionAssessment?.Effective;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        bool ao_ = an_ is CqlDateTime;
+                        return ao_;
                     }
 
-
-                    bool ag_() {
-                        DataType an_ = NutritionAssessment?.Effective;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        bool ap_ = ao_ is CqlDateTime;
-                        return ap_;
-                    }
-
-                    if (ae_())
+                    if (ad_())
                     {
-                        DataType aq_ = NutritionAssessment?.Effective;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        return (ar_ as CqlDateTime) as object;
+                        DataType ap_ = NutritionAssessment?.Effective;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        return (aq_ as CqlDateTime) as object;
+                    }
+                    else if (ae_())
+                    {
+                        DataType ar_ = NutritionAssessment?.Effective;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        return (as_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (af_())
                     {
-                        DataType as_ = NutritionAssessment?.Effective;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        return (at_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (ag_())
-                    {
-                        DataType au_ = NutritionAssessment?.Effective;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        return (av_ as CqlDateTime) as object;
+                        DataType at_ = NutritionAssessment?.Effective;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        return (au_ as CqlDateTime) as object;
                     }
                     else
                     {
@@ -1155,20 +1149,19 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     };
                 }
 
-                CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.latest(context, z_());
-                CqlDateTime ab_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
-                bool? ac_ = context.Operators.SameAs(aa_, ab_, "day");
-                bool? ad_ = context.Operators.And(y_, ac_);
-                return ad_;
+                CqlDateTime z_ = QICoreCommon_4_0_000.Instance.latest(context, y_());
+                CqlDateTime aa_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
+                bool? ab_ = context.Operators.SameAs(z_, aa_, "day");
+                bool? ac_ = context.Operators.And(x_, ab_);
+                return ac_;
             }
 
             IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
-            Encounter h_(Observation NutritionAssessment) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Observation>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1320,35 +1313,34 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Measure_Population(context);
 
-        IEnumerable<Encounter> b_(Encounter QualifyingEncounter) {
+        bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Nutrition_Care_Plan(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure NutritionCarePlan) {
-                Code<EventStatus> j_ = NutritionCarePlan?.StatusElement;
-                EventStatus? k_ = j_?.Value;
-                string l_ = context.Operators.Convert<string>(k_);
-                string[] m_ = [
+                Code<EventStatus> i_ = NutritionCarePlan?.StatusElement;
+                EventStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
                     "completed",
                     "in-progress",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-                DataType o_ = NutritionCarePlan?.Performed;
-                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                CqlDateTime q_ = QICoreCommon_4_0_000.Instance.earliest(context, p_ as object);
-                CqlInterval<CqlDateTime> r_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, (string)default);
-                bool? t_ = context.Operators.And(n_, s_);
-                return t_;
+                bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                DataType n_ = NutritionCarePlan?.Performed;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_ as object);
+                CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
+                bool? s_ = context.Operators.And(m_, r_);
+                return s_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure NutritionCarePlan) => QualifyingEncounter;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
@@ -456,52 +456,51 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwSTEMI) {
+        bool? b_(Encounter EDwSTEMI) {
             CqlValueSet d_ = this.Thrombolytic_medications(context);
             IEnumerable<AllergyIntolerance> e_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
 
             bool? f_(AllergyIntolerance ThrombolyticAllergy) {
-                CodeableConcept j_ = ThrombolyticAllergy?.ClinicalStatus;
-                CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, j_);
-                CqlCode l_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
-                CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
-                bool? n_ = context.Operators.Equivalent(k_, m_);
-                CodeableConcept o_ = ThrombolyticAllergy?.VerificationStatus;
-                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                bool? q_ = context.Operators.Not((bool?)(p_ is null));
-                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                CqlCode t_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
-                CqlConcept u_ = context.Operators.ConvertCodeToConcept(t_);
-                bool? v_ = context.Operators.Equivalent(s_, u_);
-                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                CqlCode y_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
-                CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
-                bool? aa_ = context.Operators.Equivalent(x_, z_);
-                bool? ab_ = context.Operators.Or(v_, aa_);
-                bool? ac_ = context.Operators.Implies(q_, ab_);
-                bool? ad_ = context.Operators.And(n_, ac_);
-                DataType ae_ = ThrombolyticAllergy?.Onset;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                Period ah_ = EDwSTEMI?.Period;
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                bool? aj_ = context.Operators.Overlaps(ag_, ai_, (string)default);
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                CqlDateTime ao_ = context.Operators.End(an_);
-                bool? ap_ = context.Operators.Before(al_ as CqlDateTime, ao_, (string)default);
-                bool? aq_ = context.Operators.Or(aj_, ap_);
-                bool? ar_ = context.Operators.And(ad_, aq_);
-                return ar_;
+                CodeableConcept i_ = ThrombolyticAllergy?.ClinicalStatus;
+                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, i_);
+                CqlCode k_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
+                CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+                bool? m_ = context.Operators.Equivalent(j_, l_);
+                CodeableConcept n_ = ThrombolyticAllergy?.VerificationStatus;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
+                bool? p_ = context.Operators.Not((bool?)(o_ is null));
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
+                CqlCode s_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
+                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
+                bool? u_ = context.Operators.Equivalent(r_, t_);
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
+                CqlCode x_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
+                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
+                bool? z_ = context.Operators.Equivalent(w_, y_);
+                bool? aa_ = context.Operators.Or(u_, z_);
+                bool? ab_ = context.Operators.Implies(p_, aa_);
+                bool? ac_ = context.Operators.And(m_, ab_);
+                DataType ad_ = ThrombolyticAllergy?.Onset;
+                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+                Period ag_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
+                bool? ai_ = context.Operators.Overlaps(af_, ah_, (string)default);
+                object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
+                CqlDateTime an_ = context.Operators.End(am_);
+                bool? ao_ = context.Operators.Before(ak_ as CqlDateTime, an_, (string)default);
+                bool? ap_ = context.Operators.Or(ai_, ao_);
+                bool? aq_ = context.Operators.And(ac_, ap_);
+                return aq_;
             }
 
             IEnumerable<AllergyIntolerance> g_ = context.Operators.Where<AllergyIntolerance>(e_, f_);
-            Encounter h_(AllergyIntolerance ThrombolyticAllergy) => EDwSTEMI;
-            IEnumerable<Encounter> i_ = context.Operators.Select<AllergyIntolerance, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<AllergyIntolerance>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -516,36 +515,35 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwSTEMI) {
+        bool? b_(Encounter EDwSTEMI) {
             CqlValueSet d_ = this.Thrombolytics_Adverse_Event(context);
             IEnumerable<AdverseEvent> e_ = context.Operators.Retrieve<AdverseEvent>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent"));
 
             bool? f_(AdverseEvent ThrombolyticAdverseEvent) {
-                FhirDateTime j_ = ThrombolyticAdverseEvent?.DateElement;
-                CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
-                FhirDateTime l_ = ThrombolyticAdverseEvent?.DetectedElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                FhirDateTime n_ = ThrombolyticAdverseEvent?.RecordedDateElement;
-                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
-                Period p_ = EDwSTEMI?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.End(q_);
-                bool? s_ = context.Operators.Before((k_ ?? m_) ?? o_, r_, (string)default);
-                Code<AdverseEvent.AdverseEventActuality> t_ = ThrombolyticAdverseEvent?.ActualityElement;
-                AdverseEvent.AdverseEventActuality? u_ = t_?.Value;
-                Code<AdverseEvent.AdverseEventActuality> v_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(u_);
-                bool? w_ = context.Operators.Equal(v_, "actual");
-                bool? x_ = context.Operators.And(s_, w_);
-                return x_;
+                FhirDateTime i_ = ThrombolyticAdverseEvent?.DateElement;
+                CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+                FhirDateTime k_ = ThrombolyticAdverseEvent?.DetectedElement;
+                CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+                FhirDateTime m_ = ThrombolyticAdverseEvent?.RecordedDateElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                Period o_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                bool? r_ = context.Operators.Before((j_ ?? l_) ?? n_, q_, (string)default);
+                Code<AdverseEvent.AdverseEventActuality> s_ = ThrombolyticAdverseEvent?.ActualityElement;
+                AdverseEvent.AdverseEventActuality? t_ = s_?.Value;
+                Code<AdverseEvent.AdverseEventActuality> u_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(t_);
+                bool? v_ = context.Operators.Equal(u_, "actual");
+                bool? w_ = context.Operators.And(r_, v_);
+                return w_;
             }
 
             IEnumerable<AdverseEvent> g_ = context.Operators.Where<AdverseEvent>(e_, f_);
-            Encounter h_(AdverseEvent ThrombolyticAdverseEvent) => EDwSTEMI;
-            IEnumerable<Encounter> i_ = context.Operators.Select<AdverseEvent, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<AdverseEvent>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -560,7 +558,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Active_Bleeding_or_Bleeding_Diathesis__Excluding_Menses(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             CqlValueSet f_ = this.Malignant_Intracranial_Neoplasm_Group(context);
@@ -583,20 +581,19 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             IEnumerable<Condition> w_ = Status_1_15_000.Instance.verified(context, v_);
 
             bool? x_(Condition ActiveExclusionDx) {
-                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveExclusionDx);
-                Period ac_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                bool? ae_ = context.Operators.OverlapsBefore(ab_, ad_, (string)default);
-                return ae_;
+                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveExclusionDx);
+                Period ab_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+                bool? ad_ = context.Operators.OverlapsBefore(aa_, ac_, (string)default);
+                return ad_;
             }
 
             IEnumerable<Condition> y_ = context.Operators.Where<Condition>(w_, x_);
-            Encounter z_(Condition ActiveExclusionDx) => EDwithSTEMI;
-            IEnumerable<Encounter> aa_ = context.Operators.Select<Condition, Encounter>(y_, z_);
-            return aa_;
+            bool? z_ = context.Operators.Exists<Condition>(y_);
+            return z_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -611,77 +608,75 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Oral_Anticoagulant_Medications(context);
             IEnumerable<MedicationRequest> e_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
             IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            IEnumerable<MedicationRequest> g_(MedicationRequest MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationRequest MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Oral_Anticoagulant_Medications(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Oral_Anticoagulant_Medications(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationRequest q_(Medication M) => MR;
-                IEnumerable<MedicationRequest> r_ = context.Operators.Select<Medication, MedicationRequest>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
             IEnumerable<MedicationRequest> i_ = context.Operators.Union<MedicationRequest>(e_, h_);
 
             bool? j_(MedicationRequest OralAnticoagulant) {
-                Code<MedicationRequest.MedicationrequestStatus> ac_ = OralAnticoagulant?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
+                Code<MedicationRequest.MedicationrequestStatus> aa_ = OralAnticoagulant?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                Code<MedicationRequest.MedicationRequestIntent> ah_ = OralAnticoagulant?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                string aj_ = context.Operators.Convert<string>(ai_);
-                bool? ak_ = context.Operators.Equal(aj_, "order");
-                bool? al_ = context.Operators.And(ag_, ak_);
-                FhirDateTime am_ = OralAnticoagulant?.AuthoredOnElement;
-                CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(am_);
-                Period ao_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                CqlDateTime aq_ = context.Operators.Start(ap_);
-                CqlQuantity ar_ = context.Operators.Quantity(90m, "days");
-                CqlDateTime as_ = context.Operators.Subtract(aq_, ar_);
-                CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                CqlDateTime av_ = context.Operators.Start(au_);
-                CqlInterval<CqlDateTime> aw_ = context.Operators.Interval(as_, av_, true, true);
-                bool? ax_ = context.Operators.In<CqlDateTime>(an_, aw_, (string)default);
-                CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                CqlDateTime ba_ = context.Operators.Start(az_);
-                bool? bb_ = context.Operators.Not((bool?)(ba_ is null));
-                bool? bc_ = context.Operators.And(ax_, bb_);
-                bool? bd_ = context.Operators.And(al_, bc_);
-                return bd_;
+                bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                Code<MedicationRequest.MedicationRequestIntent> af_ = OralAnticoagulant?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+                string ah_ = context.Operators.Convert<string>(ag_);
+                bool? ai_ = context.Operators.Equal(ah_, "order");
+                bool? aj_ = context.Operators.And(ae_, ai_);
+                FhirDateTime ak_ = OralAnticoagulant?.AuthoredOnElement;
+                CqlDateTime al_ = context.Operators.Convert<CqlDateTime>(ak_);
+                Period am_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
+                CqlDateTime ao_ = context.Operators.Start(an_);
+                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime aq_ = context.Operators.Subtract(ao_, ap_);
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                CqlInterval<CqlDateTime> au_ = context.Operators.Interval(aq_, at_, true, true);
+                bool? av_ = context.Operators.In<CqlDateTime>(al_, au_, (string)default);
+                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                bool? az_ = context.Operators.Not((bool?)(ay_ is null));
+                bool? ba_ = context.Operators.And(av_, az_);
+                bool? bb_ = context.Operators.And(aj_, ba_);
+                return bb_;
             }
 
             IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
-            Encounter l_(MedicationRequest OralAnticoagulant) => EDwithSTEMI;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationRequest>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -696,7 +691,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlCode d_ = this.Long_term__current__use_of_anticoagulants(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Condition> f_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
@@ -706,27 +701,26 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             IEnumerable<Condition> k_ = Status_1_15_000.Instance.verified(context, j_);
 
             bool? l_(Condition LongTermAnticoagulant) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LongTermAnticoagulant);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                Period r_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                bool? u_ = context.Operators.SameOrBefore(q_, t_, (string)default);
-                CqlDateTime w_ = context.Operators.End(p_);
-                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlDateTime z_ = context.Operators.Start(y_);
-                bool? aa_ = context.Operators.SameOrAfter(w_, z_, (string)default);
-                bool? ab_ = context.Operators.And(u_, aa_);
-                return ab_;
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LongTermAnticoagulant);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                Period q_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                bool? t_ = context.Operators.SameOrBefore(p_, s_, (string)default);
+                CqlDateTime v_ = context.Operators.End(o_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                bool? z_ = context.Operators.SameOrAfter(v_, y_, (string)default);
+                bool? aa_ = context.Operators.And(t_, z_);
+                return aa_;
             }
 
             IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
-            Encounter n_(Condition LongTermAnticoagulant) => EDwithSTEMI;
-            IEnumerable<Encounter> o_ = context.Operators.Select<Condition, Encounter>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Condition>(m_);
+            return n_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -756,7 +750,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Aortic_Dissection_or_Ruptured_Aortic_Aneurysm(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             CqlValueSet f_ = this.Neurologic_impairment(context);
@@ -790,35 +784,34 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             IEnumerable<Condition> ah_ = Status_1_15_000.Instance.verified(context, ag_);
 
             bool? ai_(Condition ExclusionDiagnosis) {
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionDiagnosis);
-                CqlDateTime an_ = context.Operators.Start(am_);
-                Period ao_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, (string)default);
-                CqlDateTime as_ = context.Operators.Start(am_);
-                CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                CqlDateTime av_ = context.Operators.Start(au_);
-                CqlQuantity aw_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime ax_ = context.Operators.Subtract(av_, aw_);
-                CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                CqlDateTime ba_ = context.Operators.Start(az_);
-                CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ax_, ba_, true, false);
-                bool? bc_ = context.Operators.In<CqlDateTime>(as_, bb_, (string)default);
-                CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                CqlDateTime bf_ = context.Operators.Start(be_);
-                bool? bg_ = context.Operators.Not((bool?)(bf_ is null));
-                bool? bh_ = context.Operators.And(bc_, bg_);
-                bool? bi_ = context.Operators.Or(aq_, bh_);
-                return bi_;
+                CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionDiagnosis);
+                CqlDateTime am_ = context.Operators.Start(al_);
+                Period an_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                bool? ap_ = context.Operators.In<CqlDateTime>(am_, ao_, (string)default);
+                CqlDateTime ar_ = context.Operators.Start(al_);
+                CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlDateTime au_ = context.Operators.Start(at_);
+                CqlQuantity av_ = context.Operators.Quantity(24m, "hours");
+                CqlDateTime aw_ = context.Operators.Subtract(au_, av_);
+                CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+                CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(aw_, az_, true, false);
+                bool? bb_ = context.Operators.In<CqlDateTime>(ar_, ba_, (string)default);
+                CqlInterval<CqlDateTime> bd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlDateTime be_ = context.Operators.Start(bd_);
+                bool? bf_ = context.Operators.Not((bool?)(be_ is null));
+                bool? bg_ = context.Operators.And(bb_, bf_);
+                bool? bh_ = context.Operators.Or(ap_, bg_);
+                return bh_;
             }
 
             IEnumerable<Condition> aj_ = context.Operators.Where<Condition>(ah_, ai_);
-            Encounter ak_(Condition ExclusionDiagnosis) => EDwithSTEMI;
-            IEnumerable<Encounter> al_ = context.Operators.Select<Condition, Encounter>(aj_, ak_);
-            return al_;
+            bool? ak_ = context.Operators.Exists<Condition>(aj_);
+            return ak_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -833,68 +826,68 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Major_Surgical_Procedure(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure MajorSurgery) {
 
-                object j_() {
+                object i_() {
+
+                    bool am_() {
+                        DataType aq_ = MajorSurgery?.Performed;
+                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                        bool as_ = ar_ is CqlDateTime;
+                        return as_;
+                    }
+
 
                     bool an_() {
-                        DataType ar_ = MajorSurgery?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlDateTime;
-                        return at_;
+                        DataType at_ = MajorSurgery?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        bool av_ = au_ is CqlInterval<CqlDateTime>;
+                        return av_;
                     }
 
 
                     bool ao_() {
-                        DataType au_ = MajorSurgery?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
-                        return aw_;
+                        DataType aw_ = MajorSurgery?.Performed;
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        bool ay_ = ax_ is CqlQuantity;
+                        return ay_;
                     }
 
 
                     bool ap_() {
-                        DataType ax_ = MajorSurgery?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        bool az_ = ay_ is CqlQuantity;
-                        return az_;
+                        DataType az_ = MajorSurgery?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        bool bb_ = ba_ is CqlInterval<CqlQuantity>;
+                        return bb_;
                     }
 
-
-                    bool aq_() {
-                        DataType ba_ = MajorSurgery?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        bool bc_ = bb_ is CqlInterval<CqlQuantity>;
-                        return bc_;
-                    }
-
-                    if (an_())
+                    if (am_())
                     {
-                        DataType bd_ = MajorSurgery?.Performed;
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        return (be_ as CqlDateTime) as object;
+                        DataType bc_ = MajorSurgery?.Performed;
+                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                        return (bd_ as CqlDateTime) as object;
+                    }
+                    else if (an_())
+                    {
+                        DataType be_ = MajorSurgery?.Performed;
+                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+                        return (bf_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ao_())
                     {
-                        DataType bf_ = MajorSurgery?.Performed;
-                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                        return (bg_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bg_ = MajorSurgery?.Performed;
+                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                        return (bh_ as CqlQuantity) as object;
                     }
                     else if (ap_())
                     {
-                        DataType bh_ = MajorSurgery?.Performed;
-                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                        return (bi_ as CqlQuantity) as object;
-                    }
-                    else if (aq_())
-                    {
-                        DataType bj_ = MajorSurgery?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        return (bk_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bi_ = MajorSurgery?.Performed;
+                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                        return (bj_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -902,78 +895,78 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     };
                 }
 
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
-                CqlDateTime l_ = context.Operators.Start(k_);
-                Period m_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlQuantity p_ = context.Operators.Quantity(21m, "days");
-                CqlDateTime q_ = context.Operators.Subtract(o_, p_);
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(q_, t_, true, false);
-                bool? v_ = context.Operators.In<CqlDateTime>(l_, u_, (string)default);
-                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                bool? z_ = context.Operators.Not((bool?)(y_ is null));
-                bool? aa_ = context.Operators.And(v_, z_);
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
+                CqlDateTime k_ = context.Operators.Start(j_);
+                Period l_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlQuantity o_ = context.Operators.Quantity(21m, "days");
+                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, false);
+                bool? u_ = context.Operators.In<CqlDateTime>(k_, t_, (string)default);
+                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                bool? y_ = context.Operators.Not((bool?)(x_ is null));
+                bool? z_ = context.Operators.And(u_, y_);
 
-                object ab_() {
+                object aa_() {
+
+                    bool bk_() {
+                        DataType bo_ = MajorSurgery?.Performed;
+                        object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                        bool bq_ = bp_ is CqlDateTime;
+                        return bq_;
+                    }
+
 
                     bool bl_() {
-                        DataType bp_ = MajorSurgery?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        bool br_ = bq_ is CqlDateTime;
-                        return br_;
+                        DataType br_ = MajorSurgery?.Performed;
+                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                        bool bt_ = bs_ is CqlInterval<CqlDateTime>;
+                        return bt_;
                     }
 
 
                     bool bm_() {
-                        DataType bs_ = MajorSurgery?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        bool bu_ = bt_ is CqlInterval<CqlDateTime>;
-                        return bu_;
+                        DataType bu_ = MajorSurgery?.Performed;
+                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                        bool bw_ = bv_ is CqlQuantity;
+                        return bw_;
                     }
 
 
                     bool bn_() {
-                        DataType bv_ = MajorSurgery?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        bool bx_ = bw_ is CqlQuantity;
-                        return bx_;
+                        DataType bx_ = MajorSurgery?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        bool bz_ = by_ is CqlInterval<CqlQuantity>;
+                        return bz_;
                     }
 
-
-                    bool bo_() {
-                        DataType by_ = MajorSurgery?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        bool ca_ = bz_ is CqlInterval<CqlQuantity>;
-                        return ca_;
-                    }
-
-                    if (bl_())
+                    if (bk_())
                     {
-                        DataType cb_ = MajorSurgery?.Performed;
-                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                        return (cc_ as CqlDateTime) as object;
+                        DataType ca_ = MajorSurgery?.Performed;
+                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                        return (cb_ as CqlDateTime) as object;
+                    }
+                    else if (bl_())
+                    {
+                        DataType cc_ = MajorSurgery?.Performed;
+                        object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
+                        return (cd_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bm_())
                     {
-                        DataType cd_ = MajorSurgery?.Performed;
-                        object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
-                        return (ce_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ce_ = MajorSurgery?.Performed;
+                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                        return (cf_ as CqlQuantity) as object;
                     }
                     else if (bn_())
                     {
-                        DataType cf_ = MajorSurgery?.Performed;
-                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                        return (cg_ as CqlQuantity) as object;
-                    }
-                    else if (bo_())
-                    {
-                        DataType ch_ = MajorSurgery?.Performed;
-                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                        return (ci_ as CqlInterval<CqlQuantity>) as object;
+                        DataType cg_ = MajorSurgery?.Performed;
+                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                        return (ch_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -981,26 +974,25 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     };
                 }
 
-                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_());
-                CqlDateTime ad_ = context.Operators.Start(ac_);
-                CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, (string)default);
-                bool? ah_ = context.Operators.Or(aa_, ag_);
-                Code<EventStatus> ai_ = MajorSurgery?.StatusElement;
-                EventStatus? aj_ = ai_?.Value;
-                string ak_ = context.Operators.Convert<string>(aj_);
-                bool? al_ = context.Operators.Equal(ak_, "completed");
-                bool? am_ = context.Operators.And(ah_, al_);
-                return am_;
+                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_());
+                CqlDateTime ac_ = context.Operators.Start(ab_);
+                CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                bool? af_ = context.Operators.In<CqlDateTime>(ac_, ae_, (string)default);
+                bool? ag_ = context.Operators.Or(z_, af_);
+                Code<EventStatus> ah_ = MajorSurgery?.StatusElement;
+                EventStatus? ai_ = ah_?.Value;
+                string aj_ = context.Operators.Convert<string>(ai_);
+                bool? ak_ = context.Operators.Equal(aj_, "completed");
+                bool? al_ = context.Operators.And(ag_, ak_);
+                return al_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure MajorSurgery) => EDwithSTEMI;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1015,7 +1007,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Endotracheal_Intubation(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
             CqlValueSet f_ = this.Mechanical_Circulatory_Assist_Device(context);
@@ -1024,62 +1016,62 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
 
             bool? i_(Procedure AirwayProcedure) {
 
-                object m_() {
+                object l_() {
+
+                    bool ap_() {
+                        DataType at_ = AirwayProcedure?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        bool av_ = au_ is CqlDateTime;
+                        return av_;
+                    }
+
 
                     bool aq_() {
-                        DataType au_ = AirwayProcedure?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlDateTime;
-                        return aw_;
+                        DataType aw_ = AirwayProcedure?.Performed;
+                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                        bool ay_ = ax_ is CqlInterval<CqlDateTime>;
+                        return ay_;
                     }
 
 
                     bool ar_() {
-                        DataType ax_ = AirwayProcedure?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        bool az_ = ay_ is CqlInterval<CqlDateTime>;
-                        return az_;
+                        DataType az_ = AirwayProcedure?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        bool bb_ = ba_ is CqlQuantity;
+                        return bb_;
                     }
 
 
                     bool as_() {
-                        DataType ba_ = AirwayProcedure?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        bool bc_ = bb_ is CqlQuantity;
-                        return bc_;
+                        DataType bc_ = AirwayProcedure?.Performed;
+                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                        bool be_ = bd_ is CqlInterval<CqlQuantity>;
+                        return be_;
                     }
 
-
-                    bool at_() {
-                        DataType bd_ = AirwayProcedure?.Performed;
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        bool bf_ = be_ is CqlInterval<CqlQuantity>;
-                        return bf_;
-                    }
-
-                    if (aq_())
+                    if (ap_())
                     {
-                        DataType bg_ = AirwayProcedure?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        return (bh_ as CqlDateTime) as object;
+                        DataType bf_ = AirwayProcedure?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        return (bg_ as CqlDateTime) as object;
+                    }
+                    else if (aq_())
+                    {
+                        DataType bh_ = AirwayProcedure?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        return (bi_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ar_())
                     {
-                        DataType bi_ = AirwayProcedure?.Performed;
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        return (bj_ as CqlInterval<CqlDateTime>) as object;
+                        DataType bj_ = AirwayProcedure?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        return (bk_ as CqlQuantity) as object;
                     }
                     else if (as_())
                     {
-                        DataType bk_ = AirwayProcedure?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        return (bl_ as CqlQuantity) as object;
-                    }
-                    else if (at_())
-                    {
-                        DataType bm_ = AirwayProcedure?.Performed;
-                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                        return (bn_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bl_ = AirwayProcedure?.Performed;
+                        object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+                        return (bm_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1087,68 +1079,68 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     };
                 }
 
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
-                CqlDateTime o_ = context.Operators.Start(n_);
-                Period p_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, (string)default);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
+                CqlDateTime n_ = context.Operators.Start(m_);
+                Period o_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, (string)default);
 
-                object s_() {
+                object r_() {
+
+                    bool bn_() {
+                        DataType br_ = AirwayProcedure?.Performed;
+                        object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                        bool bt_ = bs_ is CqlDateTime;
+                        return bt_;
+                    }
+
 
                     bool bo_() {
-                        DataType bs_ = AirwayProcedure?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        bool bu_ = bt_ is CqlDateTime;
-                        return bu_;
+                        DataType bu_ = AirwayProcedure?.Performed;
+                        object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                        bool bw_ = bv_ is CqlInterval<CqlDateTime>;
+                        return bw_;
                     }
 
 
                     bool bp_() {
-                        DataType bv_ = AirwayProcedure?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        bool bx_ = bw_ is CqlInterval<CqlDateTime>;
-                        return bx_;
+                        DataType bx_ = AirwayProcedure?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        bool bz_ = by_ is CqlQuantity;
+                        return bz_;
                     }
 
 
                     bool bq_() {
-                        DataType by_ = AirwayProcedure?.Performed;
-                        object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
-                        bool ca_ = bz_ is CqlQuantity;
-                        return ca_;
+                        DataType ca_ = AirwayProcedure?.Performed;
+                        object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                        bool cc_ = cb_ is CqlInterval<CqlQuantity>;
+                        return cc_;
                     }
 
-
-                    bool br_() {
-                        DataType cb_ = AirwayProcedure?.Performed;
-                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                        bool cd_ = cc_ is CqlInterval<CqlQuantity>;
-                        return cd_;
-                    }
-
-                    if (bo_())
+                    if (bn_())
                     {
-                        DataType ce_ = AirwayProcedure?.Performed;
-                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
-                        return (cf_ as CqlDateTime) as object;
+                        DataType cd_ = AirwayProcedure?.Performed;
+                        object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                        return (ce_ as CqlDateTime) as object;
+                    }
+                    else if (bo_())
+                    {
+                        DataType cf_ = AirwayProcedure?.Performed;
+                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                        return (cg_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (bp_())
                     {
-                        DataType cg_ = AirwayProcedure?.Performed;
-                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
-                        return (ch_ as CqlInterval<CqlDateTime>) as object;
+                        DataType ch_ = AirwayProcedure?.Performed;
+                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                        return (ci_ as CqlQuantity) as object;
                     }
                     else if (bq_())
                     {
-                        DataType ci_ = AirwayProcedure?.Performed;
-                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                        return (cj_ as CqlQuantity) as object;
-                    }
-                    else if (br_())
-                    {
-                        DataType ck_ = AirwayProcedure?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        return (cl_ as CqlInterval<CqlQuantity>) as object;
+                        DataType cj_ = AirwayProcedure?.Performed;
+                        object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                        return (ck_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1156,36 +1148,35 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     };
                 }
 
-                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_());
-                CqlDateTime u_ = context.Operators.Start(t_);
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                CqlQuantity y_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime ac_ = context.Operators.Start(ab_);
-                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(z_, ac_, true, false);
-                bool? ae_ = context.Operators.In<CqlDateTime>(u_, ad_, (string)default);
-                CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime ah_ = context.Operators.Start(ag_);
-                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
-                bool? aj_ = context.Operators.And(ae_, ai_);
-                bool? ak_ = context.Operators.Or(r_, aj_);
-                Code<EventStatus> al_ = AirwayProcedure?.StatusElement;
-                EventStatus? am_ = al_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                bool? ao_ = context.Operators.Equal(an_, "completed");
-                bool? ap_ = context.Operators.And(ak_, ao_);
-                return ap_;
+                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlQuantity x_ = context.Operators.Quantity(24m, "hours");
+                CqlDateTime y_ = context.Operators.Subtract(w_, x_);
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, false);
+                bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
+                CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime ag_ = context.Operators.Start(af_);
+                bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+                bool? ai_ = context.Operators.And(ad_, ah_);
+                bool? aj_ = context.Operators.Or(q_, ai_);
+                Code<EventStatus> ak_ = AirwayProcedure?.StatusElement;
+                EventStatus? al_ = ak_?.Value;
+                string am_ = context.Operators.Convert<string>(al_);
+                bool? an_ = context.Operators.Equal(am_, "completed");
+                bool? ao_ = context.Operators.And(aj_, an_);
+                return ao_;
             }
 
             IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
-            Encounter k_(Procedure AirwayProcedure) => EDwithSTEMI;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Procedure, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Procedure>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1200,7 +1191,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwSTEMI) {
+        bool? b_(Encounter EDwSTEMI) {
             CqlValueSet d_ = this.Ischemic_Stroke(context);
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             CqlValueSet f_ = this.Closed_Head_and_Facial_Trauma(context);
@@ -1214,27 +1205,26 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             IEnumerable<Condition> n_ = Status_1_15_000.Instance.verified(context, m_);
 
             bool? o_(Condition ExclusionCondition) {
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionCondition);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                Period u_ = EDwSTEMI?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(90m, "days");
-                CqlDateTime y_ = context.Operators.Subtract(w_, x_);
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, true);
-                bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
-                return ad_;
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionCondition);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                Period t_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlQuantity w_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime x_ = context.Operators.Subtract(v_, w_);
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(x_, aa_, true, true);
+                bool? ac_ = context.Operators.In<CqlDateTime>(s_, ab_, (string)default);
+                return ac_;
             }
 
             IEnumerable<Condition> p_ = context.Operators.Where<Condition>(n_, o_);
-            Encounter q_(Condition ExclusionCondition) => EDwSTEMI;
-            IEnumerable<Encounter> r_ = context.Operators.Select<Condition, Encounter>(p_, q_);
-            return r_;
+            bool? q_ = context.Operators.Exists<Condition>(p_);
+            return q_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1249,68 +1239,68 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Intracranial_or_Intraspinal_surgery(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure CranialorSpinalSurgery) {
 
-                object j_() {
+                object i_() {
+
+                    bool af_() {
+                        DataType aj_ = CranialorSpinalSurgery?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlDateTime;
+                        return al_;
+                    }
+
 
                     bool ag_() {
-                        DataType ak_ = CranialorSpinalSurgery?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        bool am_ = al_ is CqlDateTime;
-                        return am_;
+                        DataType am_ = CranialorSpinalSurgery?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        bool ao_ = an_ is CqlInterval<CqlDateTime>;
+                        return ao_;
                     }
 
 
                     bool ah_() {
-                        DataType an_ = CranialorSpinalSurgery?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        bool ap_ = ao_ is CqlInterval<CqlDateTime>;
-                        return ap_;
+                        DataType ap_ = CranialorSpinalSurgery?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        bool ar_ = aq_ is CqlQuantity;
+                        return ar_;
                     }
 
 
                     bool ai_() {
-                        DataType aq_ = CranialorSpinalSurgery?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        bool as_ = ar_ is CqlQuantity;
-                        return as_;
+                        DataType as_ = CranialorSpinalSurgery?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        bool au_ = at_ is CqlInterval<CqlQuantity>;
+                        return au_;
                     }
 
-
-                    bool aj_() {
-                        DataType at_ = CranialorSpinalSurgery?.Performed;
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        bool av_ = au_ is CqlInterval<CqlQuantity>;
-                        return av_;
-                    }
-
-                    if (ag_())
+                    if (af_())
                     {
-                        DataType aw_ = CranialorSpinalSurgery?.Performed;
-                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                        return (ax_ as CqlDateTime) as object;
+                        DataType av_ = CranialorSpinalSurgery?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        return (aw_ as CqlDateTime) as object;
+                    }
+                    else if (ag_())
+                    {
+                        DataType ax_ = CranialorSpinalSurgery?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        return (ay_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ah_())
                     {
-                        DataType ay_ = CranialorSpinalSurgery?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        return (az_ as CqlInterval<CqlDateTime>) as object;
+                        DataType az_ = CranialorSpinalSurgery?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        return (ba_ as CqlQuantity) as object;
                     }
                     else if (ai_())
                     {
-                        DataType ba_ = CranialorSpinalSurgery?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        return (bb_ as CqlQuantity) as object;
-                    }
-                    else if (aj_())
-                    {
-                        DataType bc_ = CranialorSpinalSurgery?.Performed;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        return (bd_ as CqlInterval<CqlQuantity>) as object;
+                        DataType bb_ = CranialorSpinalSurgery?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        return (bc_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -1318,36 +1308,35 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     };
                 }
 
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
-                CqlDateTime l_ = context.Operators.Start(k_);
-                Period m_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlQuantity p_ = context.Operators.Quantity(90m, "days");
-                CqlDateTime q_ = context.Operators.Subtract(o_, p_);
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(q_, t_, true, false);
-                bool? v_ = context.Operators.In<CqlDateTime>(l_, u_, (string)default);
-                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                bool? z_ = context.Operators.Not((bool?)(y_ is null));
-                bool? aa_ = context.Operators.And(v_, z_);
-                Code<EventStatus> ab_ = CranialorSpinalSurgery?.StatusElement;
-                EventStatus? ac_ = ab_?.Value;
-                string ad_ = context.Operators.Convert<string>(ac_);
-                bool? ae_ = context.Operators.Equal(ad_, "completed");
-                bool? af_ = context.Operators.And(aa_, ae_);
-                return af_;
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
+                CqlDateTime k_ = context.Operators.Start(j_);
+                Period l_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlQuantity o_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, false);
+                bool? u_ = context.Operators.In<CqlDateTime>(k_, t_, (string)default);
+                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                bool? y_ = context.Operators.Not((bool?)(x_ is null));
+                bool? z_ = context.Operators.And(u_, y_);
+                Code<EventStatus> aa_ = CranialorSpinalSurgery?.StatusElement;
+                EventStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                bool? ad_ = context.Operators.Equal(ac_, "completed");
+                bool? ae_ = context.Operators.And(z_, ad_);
+                return ae_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure CranialorSpinalSurgery) => EDwithSTEMI;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1733,35 +1722,34 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwSTEMI) {
+        bool? b_(Encounter EDwSTEMI) {
             IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancystatus"));
 
             bool? e_(Observation PregStatus) {
-                Code<ObservationStatus> i_ = PregStatus?.StatusElement;
-                ObservationStatus? j_ = i_?.Value;
-                Code<ObservationStatus> k_ = context.Operators.Convert<Code<ObservationStatus>>(j_);
-                bool? l_ = context.Operators.Equal(k_, "final");
-                DataType m_ = PregStatus?.Value;
-                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_ as CodeableConcept);
-                CqlValueSet o_ = this.Pregnant_State(context);
-                bool? p_ = context.Operators.ConceptInValueSet(n_, o_);
-                bool? q_ = context.Operators.And(l_, p_);
-                DataType r_ = PregStatus?.Effective;
-                CqlDateTime s_ = context.Operators.LateBoundProperty<CqlDateTime>(r_, "value");
-                Period t_ = EDwSTEMI?.Period;
-                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, (string)default);
-                bool? w_ = context.Operators.And(q_, v_);
-                return w_;
+                Code<ObservationStatus> h_ = PregStatus?.StatusElement;
+                ObservationStatus? i_ = h_?.Value;
+                Code<ObservationStatus> j_ = context.Operators.Convert<Code<ObservationStatus>>(i_);
+                bool? k_ = context.Operators.Equal(j_, "final");
+                DataType l_ = PregStatus?.Value;
+                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_ as CodeableConcept);
+                CqlValueSet n_ = this.Pregnant_State(context);
+                bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+                bool? p_ = context.Operators.And(k_, o_);
+                DataType q_ = PregStatus?.Effective;
+                CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+                Period s_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
+                bool? u_ = context.Operators.In<CqlDateTime>(r_, t_, (string)default);
+                bool? v_ = context.Operators.And(p_, u_);
+                return v_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
-            Encounter g_(Observation PregStatus) => EDwSTEMI;
-            IEnumerable<Encounter> h_ = context.Operators.Select<Observation, Encounter>(f_, g_);
-            return h_;
+            bool? g_ = context.Operators.Exists<Observation>(f_);
+            return g_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1813,7 +1801,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlCode d_ = this.Status_post_administration_of_tPA__rtPA__in_a_different_facility_within_the_last_24_hours_prior_to_admission_to_current_facility(context);
             IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
             IEnumerable<Condition> f_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
@@ -1823,21 +1811,20 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             IEnumerable<Condition> k_ = Status_1_15_000.Instance.verified(context, j_);
 
             bool? l_(Condition TPA) {
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, TPA);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                Period r_ = EDwithSTEMI?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, (string)default);
-                return t_;
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, TPA);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                Period q_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+                bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, (string)default);
+                return s_;
             }
 
             IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
-            Encounter n_(Condition TPA) => EDwithSTEMI;
-            IEnumerable<Encounter> o_ = context.Operators.Select<Condition, Encounter>(m_, n_);
-            return o_;
+            bool? n_ = context.Operators.Exists<Condition>(m_);
+            return n_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1852,56 +1839,55 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwSTEMI) {
+        bool? b_(Encounter EDwSTEMI) {
             CqlValueSet d_ = this.Percutaneous_Coronary_Intervention(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone"));
             IEnumerable<Procedure> g_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone"));
             IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 
             bool? i_(Procedure PCINotDone) {
-                CodeableConcept m_ = PCINotDone?.StatusReason;
-                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-                CqlValueSet o_ = this.Patient_Refusal(context);
-                bool? p_ = context.Operators.ConceptInValueSet(n_, o_);
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-                CqlValueSet s_ = this.Procedure_Not_Indicated_Contraindicated(context);
-                bool? t_ = context.Operators.ConceptInValueSet(r_, s_);
-                bool? u_ = context.Operators.Or(p_, t_);
+                CodeableConcept l_ = PCINotDone?.StatusReason;
+                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
+                CqlValueSet n_ = this.Patient_Refusal(context);
+                bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
+                CqlValueSet r_ = this.Procedure_Not_Indicated_Contraindicated(context);
+                bool? s_ = context.Operators.ConceptInValueSet(q_, r_);
+                bool? t_ = context.Operators.Or(o_, s_);
 
-                bool? v_(Extension @this) {
-                    FhirUri ag_ = @this?.UrlElement;
-                    string ah_ = FHIRHelpers_4_4_000.Instance.ToString(context, ag_);
-                    bool? ai_ = context.Operators.Equal(ah_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                bool? u_(Extension @this) {
+                    FhirUri af_ = @this?.UrlElement;
+                    string ag_ = FHIRHelpers_4_4_000.Instance.ToString(context, af_);
+                    bool? ah_ = context.Operators.Equal(ag_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return ah_;
+                }
+
+                IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(PCINotDone is DomainResource
+                    ? (PCINotDone as DomainResource).Extension
+                    : default), u_);
+
+                DataType w_(Extension @this) {
+                    DataType ai_ = @this?.Value;
                     return ai_;
                 }
 
-                IEnumerable<Extension> w_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(PCINotDone is DomainResource
-                    ? (PCINotDone as DomainResource).Extension
-                    : default), v_);
-
-                DataType x_(Extension @this) {
-                    DataType aj_ = @this?.Value;
-                    return aj_;
-                }
-
-                IEnumerable<DataType> y_ = context.Operators.Select<Extension, DataType>(w_, x_);
-                DataType z_ = context.Operators.SingletonFrom<DataType>(y_);
-                FhirDateTime aa_ = context.Operators.Convert<FhirDateTime>(z_);
-                CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-                Period ac_ = EDwSTEMI?.Period;
-                CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                bool? ae_ = context.Operators.In<CqlDateTime>(ab_, ad_, (string)default);
-                bool? af_ = context.Operators.And(u_, ae_);
-                return af_;
+                IEnumerable<DataType> x_ = context.Operators.Select<Extension, DataType>(v_, w_);
+                DataType y_ = context.Operators.SingletonFrom<DataType>(x_);
+                FhirDateTime z_ = context.Operators.Convert<FhirDateTime>(y_);
+                CqlDateTime aa_ = context.Operators.Convert<CqlDateTime>(z_);
+                Period ab_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+                bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, (string)default);
+                bool? ae_ = context.Operators.And(t_, ad_);
+                return ae_;
             }
 
             IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
-            Encounter k_(Procedure PCINotDone) => EDwSTEMI;
-            IEnumerable<Encounter> l_ = context.Operators.Select<Procedure, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<Procedure>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -1916,68 +1902,67 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwSTEMI) {
+        bool? b_(Encounter EDwSTEMI) {
             CqlValueSet d_ = this.Fibrinolytic_Therapy(context);
             IEnumerable<MedicationAdministration> e_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministrationnotdone"));
             IEnumerable<MedicationAdministration> g_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministrationnotdone"));
             IEnumerable<MedicationAdministration> h_ = context.Operators.Union<MedicationAdministration>(e_, g_);
 
             bool? i_(MedicationAdministration FibrinolyticNoMed) {
-                List<CodeableConcept> m_ = FibrinolyticNoMed?.StatusReason;
+                List<CodeableConcept> l_ = FibrinolyticNoMed?.StatusReason;
 
-                CqlConcept n_(CodeableConcept @this) {
+                CqlConcept m_(CodeableConcept @this) {
+                    CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ah_;
+                }
+
+                IEnumerable<CqlConcept> n_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)l_, m_);
+                CqlValueSet o_ = this.Patient_Refusal(context);
+                bool? p_ = context.Operators.ConceptsInValueSet(n_, o_);
+
+                CqlConcept r_(CodeableConcept @this) {
                     CqlConcept ai_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                     return ai_;
                 }
 
-                IEnumerable<CqlConcept> o_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)m_, n_);
-                CqlValueSet p_ = this.Patient_Refusal(context);
-                bool? q_ = context.Operators.ConceptsInValueSet(o_, p_);
+                IEnumerable<CqlConcept> s_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)l_, r_);
+                CqlValueSet t_ = this.Drug_Intervention_Not_Indicated_Contraindicated(context);
+                bool? u_ = context.Operators.ConceptsInValueSet(s_, t_);
+                bool? v_ = context.Operators.Or(p_, u_);
 
-                CqlConcept s_(CodeableConcept @this) {
-                    CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return aj_;
+                bool? w_(Extension @this) {
+                    FhirUri aj_ = @this?.UrlElement;
+                    string ak_ = FHIRHelpers_4_4_000.Instance.ToString(context, aj_);
+                    bool? al_ = context.Operators.Equal(ak_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return al_;
                 }
 
-                IEnumerable<CqlConcept> t_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)m_, s_);
-                CqlValueSet u_ = this.Drug_Intervention_Not_Indicated_Contraindicated(context);
-                bool? v_ = context.Operators.ConceptsInValueSet(t_, u_);
-                bool? w_ = context.Operators.Or(q_, v_);
+                IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(FibrinolyticNoMed is DomainResource
+                    ? (FibrinolyticNoMed as DomainResource).Extension
+                    : default), w_);
 
-                bool? x_(Extension @this) {
-                    FhirUri ak_ = @this?.UrlElement;
-                    string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
-                    bool? am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                DataType y_(Extension @this) {
+                    DataType am_ = @this?.Value;
                     return am_;
                 }
 
-                IEnumerable<Extension> y_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(FibrinolyticNoMed is DomainResource
-                    ? (FibrinolyticNoMed as DomainResource).Extension
-                    : default), x_);
-
-                DataType z_(Extension @this) {
-                    DataType an_ = @this?.Value;
-                    return an_;
-                }
-
-                IEnumerable<DataType> aa_ = context.Operators.Select<Extension, DataType>(y_, z_);
-                DataType ab_ = context.Operators.SingletonFrom<DataType>(aa_);
-                FhirDateTime ac_ = context.Operators.Convert<FhirDateTime>(ab_);
-                CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(ac_);
-                Period ae_ = EDwSTEMI?.Period;
-                CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
-                bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, (string)default);
-                bool? ah_ = context.Operators.And(w_, ag_);
-                return ah_;
+                IEnumerable<DataType> z_ = context.Operators.Select<Extension, DataType>(x_, y_);
+                DataType aa_ = context.Operators.SingletonFrom<DataType>(z_);
+                FhirDateTime ab_ = context.Operators.Convert<FhirDateTime>(aa_);
+                CqlDateTime ac_ = context.Operators.Convert<CqlDateTime>(ab_);
+                Period ad_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
+                bool? af_ = context.Operators.In<CqlDateTime>(ac_, ae_, (string)default);
+                bool? ag_ = context.Operators.And(v_, af_);
+                return ag_;
             }
 
             IEnumerable<MedicationAdministration> j_ = context.Operators.Where<MedicationAdministration>(h_, i_);
-            Encounter k_(MedicationAdministration FibrinolyticNoMed) => EDwSTEMI;
-            IEnumerable<Encounter> l_ = context.Operators.Select<MedicationAdministration, Encounter>(j_, k_);
-            return l_;
+            bool? k_ = context.Operators.Exists<MedicationAdministration>(j_);
+            return k_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -2067,64 +2052,62 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Fibrinolytic_Therapy(context);
             IEnumerable<MedicationAdministration> e_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
             IEnumerable<MedicationAdministration> f_ = context.Operators.Retrieve<MedicationAdministration>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration"));
 
-            IEnumerable<MedicationAdministration> g_(MedicationAdministration MR) {
-                IEnumerable<Medication> n_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? g_(MedicationAdministration MR) {
+                IEnumerable<Medication> m_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? o_(Medication M) {
-                    object s_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object t_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
-                    string v_ = context.Operators.Last<string>(u_);
-                    bool? w_ = context.Operators.Equal(s_, v_);
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Fibrinolytic_Therapy(context);
-                    bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    bool? ab_ = context.Operators.And(w_, aa_);
-                    return ab_;
+                bool? n_(Medication M) {
+                    object q_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object r_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
+                    string t_ = context.Operators.Last<string>(s_);
+                    bool? u_ = context.Operators.Equal(q_, t_);
+                    CodeableConcept v_ = M?.Code;
+                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                    CqlValueSet x_ = this.Fibrinolytic_Therapy(context);
+                    bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
                 }
 
-                IEnumerable<Medication> p_ = context.Operators.Where<Medication>(n_, o_);
-                MedicationAdministration q_(Medication M) => MR;
-                IEnumerable<MedicationAdministration> r_ = context.Operators.Select<Medication, MedicationAdministration>(p_, q_);
-                return r_;
+                IEnumerable<Medication> o_ = context.Operators.Where<Medication>(m_, n_);
+                bool? p_ = context.Operators.Exists<Medication>(o_);
+                return p_;
             }
 
-            IEnumerable<MedicationAdministration> h_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(f_, g_);
+            IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
             IEnumerable<MedicationAdministration> i_ = context.Operators.Union<MedicationAdministration>(e_, h_);
 
             bool? j_(MedicationAdministration Fibrinolytic) {
-                Code<MedicationAdministration.MedicationAdministrationStatusCodes> ac_ = Fibrinolytic?.StatusElement;
-                MedicationAdministration.MedicationAdministrationStatusCodes? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                bool? af_ = context.Operators.Equal(ae_, "completed");
-                DataType ag_ = Fibrinolytic?.Effective;
-                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.Start(ai_);
-                CqlDateTime ak_ = this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI);
-                CqlQuantity am_ = context.Operators.Quantity(30m, "minutes");
-                CqlDateTime an_ = context.Operators.Add(ak_, am_);
-                CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ak_, an_, false, true);
-                bool? ap_ = context.Operators.In<CqlDateTime>(aj_, ao_, (string)default);
-                bool? ar_ = context.Operators.Not((bool?)(ak_ is null));
-                bool? as_ = context.Operators.And(ap_, ar_);
-                bool? at_ = context.Operators.And(af_, as_);
-                return at_;
+                Code<MedicationAdministration.MedicationAdministrationStatusCodes> aa_ = Fibrinolytic?.StatusElement;
+                MedicationAdministration.MedicationAdministrationStatusCodes? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                bool? ad_ = context.Operators.Equal(ac_, "completed");
+                DataType ae_ = Fibrinolytic?.Effective;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
+                CqlDateTime ah_ = context.Operators.Start(ag_);
+                CqlDateTime ai_ = this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI);
+                CqlQuantity ak_ = context.Operators.Quantity(30m, "minutes");
+                CqlDateTime al_ = context.Operators.Add(ai_, ak_);
+                CqlInterval<CqlDateTime> am_ = context.Operators.Interval(ai_, al_, false, true);
+                bool? an_ = context.Operators.In<CqlDateTime>(ah_, am_, (string)default);
+                bool? ap_ = context.Operators.Not((bool?)(ai_ is null));
+                bool? aq_ = context.Operators.And(an_, ap_);
+                bool? ar_ = context.Operators.And(ad_, aq_);
+                return ar_;
             }
 
             IEnumerable<MedicationAdministration> k_ = context.Operators.Where<MedicationAdministration>(i_, j_);
-            Encounter l_(MedicationAdministration Fibrinolytic) => EDwithSTEMI;
-            IEnumerable<Encounter> m_ = context.Operators.Select<MedicationAdministration, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<MedicationAdministration>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 
@@ -2139,68 +2122,68 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
     {
         IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis(context);
 
-        IEnumerable<Encounter> b_(Encounter EDwithSTEMI) {
+        bool? b_(Encounter EDwithSTEMI) {
             CqlValueSet d_ = this.Percutaneous_Coronary_Intervention(context);
             IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
             bool? f_(Procedure PCI) {
 
-                object j_() {
+                object i_() {
+
+                    bool z_() {
+                        DataType ad_ = PCI?.Performed;
+                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                        bool af_ = ae_ is CqlDateTime;
+                        return af_;
+                    }
+
 
                     bool aa_() {
-                        DataType ae_ = PCI?.Performed;
-                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                        bool ag_ = af_ is CqlDateTime;
-                        return ag_;
+                        DataType ag_ = PCI?.Performed;
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                        bool ai_ = ah_ is CqlInterval<CqlDateTime>;
+                        return ai_;
                     }
 
 
                     bool ab_() {
-                        DataType ah_ = PCI?.Performed;
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        bool aj_ = ai_ is CqlInterval<CqlDateTime>;
-                        return aj_;
+                        DataType aj_ = PCI?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlQuantity;
+                        return al_;
                     }
 
 
                     bool ac_() {
-                        DataType ak_ = PCI?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        bool am_ = al_ is CqlQuantity;
-                        return am_;
+                        DataType am_ = PCI?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        bool ao_ = an_ is CqlInterval<CqlQuantity>;
+                        return ao_;
                     }
 
-
-                    bool ad_() {
-                        DataType an_ = PCI?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        bool ap_ = ao_ is CqlInterval<CqlQuantity>;
-                        return ap_;
-                    }
-
-                    if (aa_())
+                    if (z_())
                     {
-                        DataType aq_ = PCI?.Performed;
-                        object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                        return (ar_ as CqlDateTime) as object;
+                        DataType ap_ = PCI?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        return (aq_ as CqlDateTime) as object;
+                    }
+                    else if (aa_())
+                    {
+                        DataType ar_ = PCI?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        return (as_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ab_())
                     {
-                        DataType as_ = PCI?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        return (at_ as CqlInterval<CqlDateTime>) as object;
+                        DataType at_ = PCI?.Performed;
+                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                        return (au_ as CqlQuantity) as object;
                     }
                     else if (ac_())
                     {
-                        DataType au_ = PCI?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        return (av_ as CqlQuantity) as object;
-                    }
-                    else if (ad_())
-                    {
-                        DataType aw_ = PCI?.Performed;
-                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                        return (ax_ as CqlInterval<CqlQuantity>) as object;
+                        DataType av_ = PCI?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        return (aw_ as CqlInterval<CqlQuantity>) as object;
                     }
                     else
                     {
@@ -2208,30 +2191,29 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     };
                 }
 
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlDateTime m_ = this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI);
-                CqlQuantity o_ = context.Operators.Quantity(90m, "minutes");
-                CqlDateTime p_ = context.Operators.Add(m_, o_);
-                CqlInterval<CqlDateTime> q_ = context.Operators.Interval(m_, p_, false, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, (string)default);
-                bool? t_ = context.Operators.Not((bool?)(m_ is null));
-                bool? u_ = context.Operators.And(r_, t_);
-                Code<EventStatus> v_ = PCI?.StatusElement;
-                EventStatus? w_ = v_?.Value;
-                string x_ = context.Operators.Convert<string>(w_);
-                bool? y_ = context.Operators.Equal(x_, "completed");
-                bool? z_ = context.Operators.And(u_, y_);
-                return z_;
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_());
+                CqlDateTime k_ = context.Operators.Start(j_);
+                CqlDateTime l_ = this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI);
+                CqlQuantity n_ = context.Operators.Quantity(90m, "minutes");
+                CqlDateTime o_ = context.Operators.Add(l_, n_);
+                CqlInterval<CqlDateTime> p_ = context.Operators.Interval(l_, o_, false, true);
+                bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, (string)default);
+                bool? s_ = context.Operators.Not((bool?)(l_ is null));
+                bool? t_ = context.Operators.And(q_, s_);
+                Code<EventStatus> u_ = PCI?.StatusElement;
+                EventStatus? v_ = u_?.Value;
+                string w_ = context.Operators.Convert<string>(v_);
+                bool? x_ = context.Operators.Equal(w_, "completed");
+                bool? y_ = context.Operators.And(t_, x_);
+                return y_;
             }
 
             IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
-            Encounter h_(Procedure PCI) => EDwithSTEMI;
-            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
-            return i_;
+            bool? h_ = context.Operators.Exists<Procedure>(g_);
+            return h_;
         }
 
-        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
         return c_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
@@ -137,7 +137,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
         CqlValueSet a_ = this.Encounter_Inpatient(context);
         IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        IEnumerable<Encounter> c_(Encounter InpatientEncounter) {
+        bool? c_(Encounter InpatientEncounter) {
             CqlValueSet e_ = this.Medicare_FFS_payer(context);
             IEnumerable<Coverage> f_ = context.Operators.Retrieve<Coverage>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage"));
             CqlValueSet g_ = this.Medicare_Advantage_payer(context);
@@ -145,40 +145,39 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
             IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 
             bool? j_(Coverage MedicarePayer) {
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, InpatientEncounter);
-                int? o_ = CQMCommon_4_1_000.Instance.lengthInDays(context, n_);
-                bool? p_ = context.Operators.Less(o_, 365);
-                Code<Encounter.EncounterStatus> q_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? r_ = q_?.Value;
-                Code<Encounter.EncounterStatus> s_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(r_);
-                bool? t_ = context.Operators.Equal(s_, "finished");
-                bool? u_ = context.Operators.And(p_, t_);
-                Patient v_ = this.Patient(context);
-                Date w_ = v_?.BirthDateElement;
-                string x_ = w_?.Value;
-                CqlDate y_ = context.Operators.ConvertStringToDate(x_);
-                Period z_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlDate ac_ = context.Operators.DateFrom(ab_);
-                int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
-                bool? ae_ = context.Operators.GreaterOrEqual(ad_, 65);
-                bool? af_ = context.Operators.And(u_, ae_);
-                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlDateTime ai_ = context.Operators.End(ah_);
-                CqlInterval<CqlDateTime> aj_ = this.Measurement_Period(context);
-                bool? ak_ = context.Operators.In<CqlDateTime>(ai_, aj_, "day");
-                bool? al_ = context.Operators.And(af_, ak_);
-                return al_;
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, InpatientEncounter);
+                int? n_ = CQMCommon_4_1_000.Instance.lengthInDays(context, m_);
+                bool? o_ = context.Operators.Less(n_, 365);
+                Code<Encounter.EncounterStatus> p_ = InpatientEncounter?.StatusElement;
+                Encounter.EncounterStatus? q_ = p_?.Value;
+                Code<Encounter.EncounterStatus> r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
+                bool? s_ = context.Operators.Equal(r_, "finished");
+                bool? t_ = context.Operators.And(o_, s_);
+                Patient u_ = this.Patient(context);
+                Date v_ = u_?.BirthDateElement;
+                string w_ = v_?.Value;
+                CqlDate x_ = context.Operators.ConvertStringToDate(w_);
+                Period y_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlDate ab_ = context.Operators.DateFrom(aa_);
+                int? ac_ = context.Operators.CalculateAgeAt(x_, ab_, "year");
+                bool? ad_ = context.Operators.GreaterOrEqual(ac_, 65);
+                bool? ae_ = context.Operators.And(t_, ad_);
+                CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlDateTime ah_ = context.Operators.End(ag_);
+                CqlInterval<CqlDateTime> ai_ = this.Measurement_Period(context);
+                bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, "day");
+                bool? ak_ = context.Operators.And(ae_, aj_);
+                return ak_;
             }
 
             IEnumerable<Coverage> k_ = context.Operators.Where<Coverage>(i_, j_);
-            Encounter l_(Coverage MedicarePayer) => InpatientEncounter;
-            IEnumerable<Encounter> m_ = context.Operators.Select<Coverage, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Coverage>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+        IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
         return d_;
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
@@ -137,7 +137,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
         CqlValueSet a_ = this.Encounter_Inpatient(context);
         IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        IEnumerable<Encounter> c_(Encounter EncounterInpatient) {
+        bool? c_(Encounter EncounterInpatient) {
             CqlValueSet e_ = this.Medicare_FFS_payer(context);
             IEnumerable<Coverage> f_ = context.Operators.Retrieve<Coverage>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage"));
             CqlValueSet g_ = this.Medicare_Advantage_payer(context);
@@ -145,41 +145,40 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
             IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 
             bool? j_(Coverage MedicarePayer) {
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                int? o_ = CQMCommon_4_1_000.Instance.lengthInDays(context, n_);
-                bool? p_ = context.Operators.Less(o_, 365);
-                Code<Encounter.EncounterStatus> q_ = EncounterInpatient?.StatusElement;
-                Encounter.EncounterStatus? r_ = q_?.Value;
-                Code<Encounter.EncounterStatus> s_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(r_);
-                bool? t_ = context.Operators.Equal(s_, "finished");
-                bool? u_ = context.Operators.And(p_, t_);
-                Patient v_ = this.Patient(context);
-                Date w_ = v_?.BirthDateElement;
-                string x_ = w_?.Value;
-                CqlDate y_ = context.Operators.ConvertStringToDate(x_);
-                Period z_ = EncounterInpatient?.Period;
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlDate ac_ = context.Operators.DateFrom(ab_);
-                int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
-                CqlInterval<int?> ae_ = context.Operators.Interval(65, 94, true, true);
-                bool? af_ = context.Operators.In<int?>(ad_, ae_, (string)default);
-                bool? ag_ = context.Operators.And(u_, af_);
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlDateTime aj_ = context.Operators.End(ai_);
-                CqlInterval<CqlDateTime> ak_ = this.Measurement_Period(context);
-                bool? al_ = context.Operators.In<CqlDateTime>(aj_, ak_, "day");
-                bool? am_ = context.Operators.And(ag_, al_);
-                return am_;
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
+                int? n_ = CQMCommon_4_1_000.Instance.lengthInDays(context, m_);
+                bool? o_ = context.Operators.Less(n_, 365);
+                Code<Encounter.EncounterStatus> p_ = EncounterInpatient?.StatusElement;
+                Encounter.EncounterStatus? q_ = p_?.Value;
+                Code<Encounter.EncounterStatus> r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
+                bool? s_ = context.Operators.Equal(r_, "finished");
+                bool? t_ = context.Operators.And(o_, s_);
+                Patient u_ = this.Patient(context);
+                Date v_ = u_?.BirthDateElement;
+                string w_ = v_?.Value;
+                CqlDate x_ = context.Operators.ConvertStringToDate(w_);
+                Period y_ = EncounterInpatient?.Period;
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlDate ab_ = context.Operators.DateFrom(aa_);
+                int? ac_ = context.Operators.CalculateAgeAt(x_, ab_, "year");
+                CqlInterval<int?> ad_ = context.Operators.Interval(65, 94, true, true);
+                bool? ae_ = context.Operators.In<int?>(ac_, ad_, (string)default);
+                bool? af_ = context.Operators.And(t_, ae_);
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlDateTime ai_ = context.Operators.End(ah_);
+                CqlInterval<CqlDateTime> aj_ = this.Measurement_Period(context);
+                bool? ak_ = context.Operators.In<CqlDateTime>(ai_, aj_, "day");
+                bool? al_ = context.Operators.And(af_, ak_);
+                return al_;
             }
 
             IEnumerable<Coverage> k_ = context.Operators.Where<Coverage>(i_, j_);
-            Encounter l_(Coverage MedicarePayer) => EncounterInpatient;
-            IEnumerable<Encounter> m_ = context.Operators.Select<Coverage, Encounter>(k_, l_);
-            return m_;
+            bool? l_ = context.Operators.Exists<Coverage>(k_);
+            return l_;
         }
 
-        IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+        IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
         return d_;
     }
 

--- a/LibrarySets/dqm-content-qicore-2025/Extracted/CSharp/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
+++ b/LibrarySets/dqm-content-qicore-2025/Extracted/CSharp/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
@@ -564,20 +564,784 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
 
-        IEnumerable<Procedure> b_(Procedure THAProcedure) {
+        bool? b_(Procedure THAProcedure) {
             CqlValueSet e_ = this.Lower_Body_Fractures_Excluding_Ankle_and_Foot(context);
             IEnumerable<Condition> f_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
             IEnumerable<Condition> h_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
             IEnumerable<Condition> i_ = context.Operators.Union<Condition>(f_ as IEnumerable<Condition>, h_ as IEnumerable<Condition>);
 
             bool? j_(Condition LowerBodyFracture) {
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LowerBodyFracture);
-                CqlDateTime o_ = context.Operators.Start(n_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LowerBodyFracture);
+                CqlDateTime n_ = context.Operators.Start(m_);
 
-                object p_() {
+                object o_() {
+
+                    bool af_() {
+                        DataType aj_ = THAProcedure?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        bool al_ = ak_ is CqlDateTime;
+                        return al_;
+                    }
+
 
                     bool ag_() {
+                        DataType am_ = THAProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        bool ao_ = an_ is CqlInterval<CqlDateTime>;
+                        return ao_;
+                    }
+
+
+                    bool ah_() {
+                        DataType ap_ = THAProcedure?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                        bool ar_ = aq_ is CqlQuantity;
+                        return ar_;
+                    }
+
+
+                    bool ai_() {
+                        DataType as_ = THAProcedure?.Performed;
+                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                        bool au_ = at_ is CqlInterval<CqlQuantity>;
+                        return au_;
+                    }
+
+                    if (af_())
+                    {
+                        DataType av_ = THAProcedure?.Performed;
+                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                        return (aw_ as CqlDateTime) as object;
+                    }
+                    else if (ag_())
+                    {
+                        DataType ax_ = THAProcedure?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        return (ay_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (ah_())
+                    {
+                        DataType az_ = THAProcedure?.Performed;
+                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                        return (ba_ as CqlQuantity) as object;
+                    }
+                    else if (ai_())
+                    {
+                        DataType bb_ = THAProcedure?.Performed;
+                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                        return (bc_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlQuantity r_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+
+                object t_() {
+
+                    bool bd_() {
+                        DataType bh_ = THAProcedure?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        bool bj_ = bi_ is CqlDateTime;
+                        return bj_;
+                    }
+
+
+                    bool be_() {
+                        DataType bk_ = THAProcedure?.Performed;
+                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                        bool bm_ = bl_ is CqlInterval<CqlDateTime>;
+                        return bm_;
+                    }
+
+
+                    bool bf_() {
+                        DataType bn_ = THAProcedure?.Performed;
+                        object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                        bool bp_ = bo_ is CqlQuantity;
+                        return bp_;
+                    }
+
+
+                    bool bg_() {
+                        DataType bq_ = THAProcedure?.Performed;
+                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                        bool bs_ = br_ is CqlInterval<CqlQuantity>;
+                        return bs_;
+                    }
+
+                    if (bd_())
+                    {
+                        DataType bt_ = THAProcedure?.Performed;
+                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                        return (bu_ as CqlDateTime) as object;
+                    }
+                    else if (be_())
+                    {
+                        DataType bv_ = THAProcedure?.Performed;
+                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                        return (bw_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (bf_())
+                    {
+                        DataType bx_ = THAProcedure?.Performed;
+                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                        return (by_ as CqlQuantity) as object;
+                    }
+                    else if (bg_())
+                    {
+                        DataType bz_ = THAProcedure?.Performed;
+                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                        return (ca_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+                bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, (string)default);
+
+                object y_() {
+
+                    bool cb_() {
+                        DataType cf_ = THAProcedure?.Performed;
+                        object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                        bool ch_ = cg_ is CqlDateTime;
+                        return ch_;
+                    }
+
+
+                    bool cc_() {
+                        DataType ci_ = THAProcedure?.Performed;
+                        object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                        bool ck_ = cj_ is CqlInterval<CqlDateTime>;
+                        return ck_;
+                    }
+
+
+                    bool cd_() {
+                        DataType cl_ = THAProcedure?.Performed;
+                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                        bool cn_ = cm_ is CqlQuantity;
+                        return cn_;
+                    }
+
+
+                    bool ce_() {
+                        DataType co_ = THAProcedure?.Performed;
+                        object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+                        bool cq_ = cp_ is CqlInterval<CqlQuantity>;
+                        return cq_;
+                    }
+
+                    if (cb_())
+                    {
+                        DataType cr_ = THAProcedure?.Performed;
+                        object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+                        return (cs_ as CqlDateTime) as object;
+                    }
+                    else if (cc_())
+                    {
+                        DataType ct_ = THAProcedure?.Performed;
+                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                        return (cu_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (cd_())
+                    {
+                        DataType cv_ = THAProcedure?.Performed;
+                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                        return (cw_ as CqlQuantity) as object;
+                    }
+                    else if (ce_())
+                    {
+                        DataType cx_ = THAProcedure?.Performed;
+                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
+                        return (cy_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+                bool? ac_ = context.Operators.And(x_, ab_);
+                bool? ad_ = this.isVerified(context, LowerBodyFracture);
+                bool? ae_ = context.Operators.And(ac_, ad_);
+                return ae_;
+            }
+
+            IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
+            bool? l_ = context.Operators.Exists<Condition>(k_);
+            return l_;
+        }
+
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
+        bool? d_ = context.Operators.Exists<Procedure>(c_);
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Partial Hip Arthroplasty Procedure")]
+    public bool? Has_Partial_Hip_Arthroplasty_Procedure(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure, Has_Partial_Hip_Arthroplasty_Procedure_Compute);
+
+    private const long _cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure = 5573278062808731434L;
+
+    private bool? Has_Partial_Hip_Arthroplasty_Procedure_Compute(CqlContext context)
+    {
+        CqlValueSet a_ = this.Partial_Arthroplasty_of_Hip(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> c_ = Status_1_15_000.Instance.isProcedurePerformed(context, b_);
+
+        bool? d_(Procedure PartialTHAProcedure) {
+            IEnumerable<Procedure> g_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+            bool? h_(Procedure THAProcedure) {
+
+                object k_() {
+
+                    bool p_() {
+                        DataType t_ = THAProcedure?.Performed;
+                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                        bool v_ = u_ is CqlDateTime;
+                        return v_;
+                    }
+
+
+                    bool q_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlInterval<CqlDateTime>;
+                        return y_;
+                    }
+
+
+                    bool r_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlQuantity;
+                        return ab_;
+                    }
+
+
+                    bool s_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlQuantity>;
+                        return ae_;
+                    }
+
+                    if (p_())
+                    {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        return (ag_ as CqlDateTime) as object;
+                    }
+                    else if (q_())
+                    {
+                        DataType ah_ = THAProcedure?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (r_())
+                    {
+                        DataType aj_ = THAProcedure?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlQuantity) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType al_ = THAProcedure?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
+
+                object m_() {
+
+                    bool an_() {
+                        DataType ar_ = PartialTHAProcedure?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        bool at_ = as_ is CqlDateTime;
+                        return at_;
+                    }
+
+
+                    bool ao_() {
+                        DataType au_ = PartialTHAProcedure?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
+                        return aw_;
+                    }
+
+
+                    bool ap_() {
+                        DataType ax_ = PartialTHAProcedure?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlQuantity;
+                        return az_;
+                    }
+
+
+                    bool aq_() {
+                        DataType ba_ = PartialTHAProcedure?.Performed;
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlInterval<CqlQuantity>;
+                        return bc_;
+                    }
+
+                    if (an_())
+                    {
+                        DataType bd_ = PartialTHAProcedure?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        return (be_ as CqlDateTime) as object;
+                    }
+                    else if (ao_())
+                    {
+                        DataType bf_ = PartialTHAProcedure?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        return (bg_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (ap_())
+                    {
+                        DataType bh_ = PartialTHAProcedure?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        return (bi_ as CqlQuantity) as object;
+                    }
+                    else if (aq_())
+                    {
+                        DataType bj_ = PartialTHAProcedure?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        return (bk_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, "day");
+                return o_;
+            }
+
+            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
+            bool? j_ = context.Operators.Exists<Procedure>(i_);
+            return j_;
+        }
+
+        IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+        bool? f_ = context.Operators.Exists<Procedure>(e_);
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Has Revision Hip Arthroplasty Procedure or Implanted Device or Prosthesis Removal Procedure")]
+    public bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure, Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute);
+
+    private const long _cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure = 5889930654885795887L;
+
+    private bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute(CqlContext context)
+    {
+        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+        bool? b_(Procedure THAProcedure) {
+            CqlValueSet e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine(context);
+            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
+
+            bool? h_(Procedure RevisionTHAProcedure) {
+
+                object k_() {
+
+                    bool p_() {
+                        DataType t_ = THAProcedure?.Performed;
+                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                        bool v_ = u_ is CqlDateTime;
+                        return v_;
+                    }
+
+
+                    bool q_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlInterval<CqlDateTime>;
+                        return y_;
+                    }
+
+
+                    bool r_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlQuantity;
+                        return ab_;
+                    }
+
+
+                    bool s_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlQuantity>;
+                        return ae_;
+                    }
+
+                    if (p_())
+                    {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        return (ag_ as CqlDateTime) as object;
+                    }
+                    else if (q_())
+                    {
+                        DataType ah_ = THAProcedure?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                        return (ai_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (r_())
+                    {
+                        DataType aj_ = THAProcedure?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                        return (ak_ as CqlQuantity) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType al_ = THAProcedure?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                        return (am_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
+
+                object m_() {
+
+                    bool an_() {
+                        DataType ar_ = RevisionTHAProcedure?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                        bool at_ = as_ is CqlDateTime;
+                        return at_;
+                    }
+
+
+                    bool ao_() {
+                        DataType au_ = RevisionTHAProcedure?.Performed;
+                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                        bool aw_ = av_ is CqlInterval<CqlDateTime>;
+                        return aw_;
+                    }
+
+
+                    bool ap_() {
+                        DataType ax_ = RevisionTHAProcedure?.Performed;
+                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                        bool az_ = ay_ is CqlQuantity;
+                        return az_;
+                    }
+
+
+                    bool aq_() {
+                        DataType ba_ = RevisionTHAProcedure?.Performed;
+                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                        bool bc_ = bb_ is CqlInterval<CqlQuantity>;
+                        return bc_;
+                    }
+
+                    if (an_())
+                    {
+                        DataType bd_ = RevisionTHAProcedure?.Performed;
+                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                        return (be_ as CqlDateTime) as object;
+                    }
+                    else if (ao_())
+                    {
+                        DataType bf_ = RevisionTHAProcedure?.Performed;
+                        object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                        return (bg_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (ap_())
+                    {
+                        DataType bh_ = RevisionTHAProcedure?.Performed;
+                        object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                        return (bi_ as CqlQuantity) as object;
+                    }
+                    else if (aq_())
+                    {
+                        DataType bj_ = RevisionTHAProcedure?.Performed;
+                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                        return (bk_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+                bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, "day");
+                return o_;
+            }
+
+            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
+            bool? j_ = context.Operators.Exists<Procedure>(i_);
+            return j_;
+        }
+
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
+        bool? d_ = context.Operators.Exists<Procedure>(c_);
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Malignant Neoplasm of Lower and Unspecified Limbs")]
+    public bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs, Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute);
+
+    private const long _cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs = -2389632056529416502L;
+
+    private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute(CqlContext context)
+    {
+        CqlValueSet a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
+
+        bool? f_(Condition MalignantNeoplasm) {
+            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+            bool? j_(Procedure THAProcedure) {
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MalignantNeoplasm);
+
+                object n_() {
+
+                    bool s_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
+
+                    bool t_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
+                    }
+
+
+                    bool u_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
+                    }
+
+
+                    bool v_() {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
+                    }
+
+                    if (s_())
+                    {
+                        DataType ai_ = THAProcedure?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
                         DataType ak_ = THAProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (u_())
+                    {
+                        DataType am_ = THAProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
+                    }
+                    else if (v_())
+                    {
+                        DataType ao_ = THAProcedure?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
+                bool? p_ = context.Operators.Overlaps(m_, o_, "day");
+                bool? q_ = this.isVerified(context, MalignantNeoplasm);
+                bool? r_ = context.Operators.And(p_, q_);
+                return r_;
+            }
+
+            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
+            bool? l_ = context.Operators.Exists<Procedure>(k_);
+            return l_;
+        }
+
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Mechanical Complication")]
+    public bool? Has_Mechanical_Complication(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_Mechanical_Complication, Has_Mechanical_Complication_Compute);
+
+    private const long _cacheIndex_Has_Mechanical_Complication = 7139202238750288841L;
+
+    private bool? Has_Mechanical_Complication_Compute(CqlContext context)
+    {
+        CqlValueSet a_ = this.Mechanical_Complications_Excluding_Upper_Body(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
+
+        bool? f_(Condition MechanicalComplications) {
+            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+            bool? j_(Procedure THAProcedure) {
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MechanicalComplications);
+
+                object n_() {
+
+                    bool s_() {
+                        DataType w_ = THAProcedure?.Performed;
+                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                        bool y_ = x_ is CqlDateTime;
+                        return y_;
+                    }
+
+
+                    bool t_() {
+                        DataType z_ = THAProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlInterval<CqlDateTime>;
+                        return ab_;
+                    }
+
+
+                    bool u_() {
+                        DataType ac_ = THAProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlQuantity;
+                        return ae_;
+                    }
+
+
+                    bool v_() {
+                        DataType af_ = THAProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlInterval<CqlQuantity>;
+                        return ah_;
+                    }
+
+                    if (s_())
+                    {
+                        DataType ai_ = THAProcedure?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        return (aj_ as CqlDateTime) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType ak_ = THAProcedure?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                        return (al_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (u_())
+                    {
+                        DataType am_ = THAProcedure?.Performed;
+                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                        return (an_ as CqlQuantity) as object;
+                    }
+                    else if (v_())
+                    {
+                        DataType ao_ = THAProcedure?.Performed;
+                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                        return (ap_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    };
+                }
+
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
+                bool? p_ = context.Operators.Overlaps(m_, o_, "day");
+                bool? q_ = this.isVerified(context, MechanicalComplications);
+                bool? r_ = context.Operators.And(p_, q_);
+                return r_;
+            }
+
+            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
+            bool? l_ = context.Operators.Exists<Procedure>(k_);
+            return l_;
+        }
+
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has More Than One Elective Primary Total Hip Arthroplasty Performed")]
+    public bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed, Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute);
+
+    private const long _cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed = -923175309866963357L;
+
+    private bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute(CqlContext context)
+    {
+        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
+
+        bool? b_(Procedure THAProcedure) {
+            CqlValueSet e_ = this.Primary_THA_Procedure(context);
+            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
+
+            bool? h_(Procedure ElectiveTHAProcedure) {
+                Id k_ = THAProcedure?.IdElement;
+                string l_ = k_?.Value;
+                Id m_ = ElectiveTHAProcedure?.IdElement;
+                string n_ = m_?.Value;
+                bool? o_ = context.Operators.Equivalent(l_, n_);
+                bool? p_ = context.Operators.Not(o_);
+
+                object q_() {
+
+                    bool ag_() {
+                        DataType ak_ = ElectiveTHAProcedure?.Performed;
                         object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
                         bool am_ = al_ is CqlDateTime;
                         return am_;
@@ -585,7 +1349,7 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
 
                     bool ah_() {
-                        DataType an_ = THAProcedure?.Performed;
+                        DataType an_ = ElectiveTHAProcedure?.Performed;
                         object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
                         bool ap_ = ao_ is CqlInterval<CqlDateTime>;
                         return ap_;
@@ -593,7 +1357,7 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
 
                     bool ai_() {
-                        DataType aq_ = THAProcedure?.Performed;
+                        DataType aq_ = ElectiveTHAProcedure?.Performed;
                         object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                         bool as_ = ar_ is CqlQuantity;
                         return as_;
@@ -601,7 +1365,7 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
 
                     bool aj_() {
-                        DataType at_ = THAProcedure?.Performed;
+                        DataType at_ = ElectiveTHAProcedure?.Performed;
                         object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
                         bool av_ = au_ is CqlInterval<CqlQuantity>;
                         return av_;
@@ -609,25 +1373,25 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
 
                     if (ag_())
                     {
-                        DataType aw_ = THAProcedure?.Performed;
+                        DataType aw_ = ElectiveTHAProcedure?.Performed;
                         object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
                         return (ax_ as CqlDateTime) as object;
                     }
                     else if (ah_())
                     {
-                        DataType ay_ = THAProcedure?.Performed;
+                        DataType ay_ = ElectiveTHAProcedure?.Performed;
                         object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
                         return (az_ as CqlInterval<CqlDateTime>) as object;
                     }
                     else if (ai_())
                     {
-                        DataType ba_ = THAProcedure?.Performed;
+                        DataType ba_ = ElectiveTHAProcedure?.Performed;
                         object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
                         return (bb_ as CqlQuantity) as object;
                     }
                     else if (aj_())
                     {
-                        DataType bc_ = THAProcedure?.Performed;
+                        DataType bc_ = ElectiveTHAProcedure?.Performed;
                         object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
                         return (bd_ as CqlInterval<CqlQuantity>) as object;
                     }
@@ -637,12 +1401,10 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_());
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
+                CqlDateTime s_ = context.Operators.Start(r_);
 
-                object u_() {
+                object t_() {
 
                     bool be_() {
                         DataType bi_ = THAProcedure?.Performed;
@@ -705,12 +1467,12 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
-                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, (string)default);
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_());
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlQuantity w_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime x_ = context.Operators.Subtract(v_, w_);
 
-                object z_() {
+                object y_() {
 
                     bool cc_() {
                         DataType cg_ = THAProcedure?.Performed;
@@ -773,789 +1535,21 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                     };
                 }
 
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
-                bool? ad_ = context.Operators.And(y_, ac_);
-                bool? ae_ = this.isVerified(context, LowerBodyFracture);
-                bool? af_ = context.Operators.And(ad_, ae_);
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
+                CqlDateTime aa_ = context.Operators.Start(z_);
+                CqlDateTime ac_ = context.Operators.Add(aa_, w_);
+                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
+                bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, "day");
+                bool? af_ = context.Operators.And(p_, ae_);
                 return af_;
             }
 
-            IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
-            Procedure l_(Condition LowerBodyFracture) => THAProcedure;
-            IEnumerable<Procedure> m_ = context.Operators.Select<Condition, Procedure>(k_, l_);
-            return m_;
-        }
-
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
-        bool? d_ = context.Operators.Exists<Procedure>(c_);
-        return d_;
-    }
-
-
-    [CqlExpressionDefinition("Has Partial Hip Arthroplasty Procedure")]
-    public bool? Has_Partial_Hip_Arthroplasty_Procedure(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure, Has_Partial_Hip_Arthroplasty_Procedure_Compute);
-
-    private const long _cacheIndex_Has_Partial_Hip_Arthroplasty_Procedure = 5573278062808731434L;
-
-    private bool? Has_Partial_Hip_Arthroplasty_Procedure_Compute(CqlContext context)
-    {
-        CqlValueSet a_ = this.Partial_Arthroplasty_of_Hip(context);
-        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-        IEnumerable<Procedure> c_ = Status_1_15_000.Instance.isProcedurePerformed(context, b_);
-
-        IEnumerable<Procedure> d_(Procedure PartialTHAProcedure) {
-            IEnumerable<Procedure> g_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-            bool? h_(Procedure THAProcedure) {
-
-                object l_() {
-
-                    bool q_() {
-                        DataType u_ = THAProcedure?.Performed;
-                        object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                        bool w_ = v_ is CqlDateTime;
-                        return w_;
-                    }
-
-
-                    bool r_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlInterval<CqlDateTime>;
-                        return z_;
-                    }
-
-
-                    bool s_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlQuantity;
-                        return ac_;
-                    }
-
-
-                    bool t_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlInterval<CqlQuantity>;
-                        return af_;
-                    }
-
-                    if (q_())
-                    {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        return (ah_ as CqlDateTime) as object;
-                    }
-                    else if (r_())
-                    {
-                        DataType ai_ = THAProcedure?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (s_())
-                    {
-                        DataType ak_ = THAProcedure?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlQuantity) as object;
-                    }
-                    else if (t_())
-                    {
-                        DataType am_ = THAProcedure?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
-
-                object n_() {
-
-                    bool ao_() {
-                        DataType as_ = PartialTHAProcedure?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        bool au_ = at_ is CqlDateTime;
-                        return au_;
-                    }
-
-
-                    bool ap_() {
-                        DataType av_ = PartialTHAProcedure?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlInterval<CqlDateTime>;
-                        return ax_;
-                    }
-
-
-                    bool aq_() {
-                        DataType ay_ = PartialTHAProcedure?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlQuantity;
-                        return ba_;
-                    }
-
-
-                    bool ar_() {
-                        DataType bb_ = PartialTHAProcedure?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlInterval<CqlQuantity>;
-                        return bd_;
-                    }
-
-                    if (ao_())
-                    {
-                        DataType be_ = PartialTHAProcedure?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        return (bf_ as CqlDateTime) as object;
-                    }
-                    else if (ap_())
-                    {
-                        DataType bg_ = PartialTHAProcedure?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        return (bh_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aq_())
-                    {
-                        DataType bi_ = PartialTHAProcedure?.Performed;
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        return (bj_ as CqlQuantity) as object;
-                    }
-                    else if (ar_())
-                    {
-                        DataType bk_ = PartialTHAProcedure?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        return (bl_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
-                return p_;
-            }
-
             IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
-            Procedure j_(Procedure THAProcedure) => PartialTHAProcedure;
-            IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
-            return k_;
+            bool? j_ = context.Operators.Exists<Procedure>(i_);
+            return j_;
         }
 
-        IEnumerable<Procedure> e_ = context.Operators.SelectMany<Procedure, Procedure>(c_, d_);
-        bool? f_ = context.Operators.Exists<Procedure>(e_);
-        return f_;
-    }
-
-
-    [CqlExpressionDefinition("Has Revision Hip Arthroplasty Procedure or Implanted Device or Prosthesis Removal Procedure")]
-    public bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure, Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute);
-
-    private const long _cacheIndex_Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure = 5889930654885795887L;
-
-    private bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Compute(CqlContext context)
-    {
-        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-        IEnumerable<Procedure> b_(Procedure THAProcedure) {
-            CqlValueSet e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine(context);
-            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
-
-            bool? h_(Procedure RevisionTHAProcedure) {
-
-                object l_() {
-
-                    bool q_() {
-                        DataType u_ = THAProcedure?.Performed;
-                        object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                        bool w_ = v_ is CqlDateTime;
-                        return w_;
-                    }
-
-
-                    bool r_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlInterval<CqlDateTime>;
-                        return z_;
-                    }
-
-
-                    bool s_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlQuantity;
-                        return ac_;
-                    }
-
-
-                    bool t_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlInterval<CqlQuantity>;
-                        return af_;
-                    }
-
-                    if (q_())
-                    {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        return (ah_ as CqlDateTime) as object;
-                    }
-                    else if (r_())
-                    {
-                        DataType ai_ = THAProcedure?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        return (aj_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (s_())
-                    {
-                        DataType ak_ = THAProcedure?.Performed;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        return (al_ as CqlQuantity) as object;
-                    }
-                    else if (t_())
-                    {
-                        DataType am_ = THAProcedure?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        return (an_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
-
-                object n_() {
-
-                    bool ao_() {
-                        DataType as_ = RevisionTHAProcedure?.Performed;
-                        object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                        bool au_ = at_ is CqlDateTime;
-                        return au_;
-                    }
-
-
-                    bool ap_() {
-                        DataType av_ = RevisionTHAProcedure?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlInterval<CqlDateTime>;
-                        return ax_;
-                    }
-
-
-                    bool aq_() {
-                        DataType ay_ = RevisionTHAProcedure?.Performed;
-                        object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                        bool ba_ = az_ is CqlQuantity;
-                        return ba_;
-                    }
-
-
-                    bool ar_() {
-                        DataType bb_ = RevisionTHAProcedure?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        bool bd_ = bc_ is CqlInterval<CqlQuantity>;
-                        return bd_;
-                    }
-
-                    if (ao_())
-                    {
-                        DataType be_ = RevisionTHAProcedure?.Performed;
-                        object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                        return (bf_ as CqlDateTime) as object;
-                    }
-                    else if (ap_())
-                    {
-                        DataType bg_ = RevisionTHAProcedure?.Performed;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        return (bh_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aq_())
-                    {
-                        DataType bi_ = RevisionTHAProcedure?.Performed;
-                        object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                        return (bj_ as CqlQuantity) as object;
-                    }
-                    else if (ar_())
-                    {
-                        DataType bk_ = RevisionTHAProcedure?.Performed;
-                        object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                        return (bl_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
-                bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
-                return p_;
-            }
-
-            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
-            Procedure j_(Procedure RevisionTHAProcedure) => THAProcedure;
-            IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
-            return k_;
-        }
-
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
-        bool? d_ = context.Operators.Exists<Procedure>(c_);
-        return d_;
-    }
-
-
-    [CqlExpressionDefinition("Has Malignant Neoplasm of Lower and Unspecified Limbs")]
-    public bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs, Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute);
-
-    private const long _cacheIndex_Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs = -2389632056529416502L;
-
-    private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Compute(CqlContext context)
-    {
-        CqlValueSet a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs(context);
-        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
-
-        IEnumerable<Condition> f_(Condition MalignantNeoplasm) {
-            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-            bool? j_(Procedure THAProcedure) {
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MalignantNeoplasm);
-
-                object o_() {
-
-                    bool t_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
-                    }
-
-
-                    bool u_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
-                    }
-
-
-                    bool v_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
-                    }
-
-
-                    bool w_() {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
-                    {
-                        DataType aj_ = THAProcedure?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
-                    }
-                    else if (u_())
-                    {
-                        DataType al_ = THAProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (v_())
-                    {
-                        DataType an_ = THAProcedure?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = THAProcedure?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
-                bool? q_ = context.Operators.Overlaps(n_, p_, "day");
-                bool? r_ = this.isVerified(context, MalignantNeoplasm);
-                bool? s_ = context.Operators.And(q_, r_);
-                return s_;
-            }
-
-            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
-            Condition l_(Procedure THAProcedure) => MalignantNeoplasm;
-            IEnumerable<Condition> m_ = context.Operators.Select<Procedure, Condition>(k_, l_);
-            return m_;
-        }
-
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
-        bool? h_ = context.Operators.Exists<Condition>(g_);
-        return h_;
-    }
-
-
-    [CqlExpressionDefinition("Has Mechanical Complication")]
-    public bool? Has_Mechanical_Complication(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_Mechanical_Complication, Has_Mechanical_Complication_Compute);
-
-    private const long _cacheIndex_Has_Mechanical_Complication = 7139202238750288841L;
-
-    private bool? Has_Mechanical_Complication_Compute(CqlContext context)
-    {
-        CqlValueSet a_ = this.Mechanical_Complications_Excluding_Upper_Body(context);
-        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, d_ as IEnumerable<Condition>);
-
-        IEnumerable<Condition> f_(Condition MechanicalComplications) {
-            IEnumerable<Procedure> i_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-            bool? j_(Procedure THAProcedure) {
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MechanicalComplications);
-
-                object o_() {
-
-                    bool t_() {
-                        DataType x_ = THAProcedure?.Performed;
-                        object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                        bool z_ = y_ is CqlDateTime;
-                        return z_;
-                    }
-
-
-                    bool u_() {
-                        DataType aa_ = THAProcedure?.Performed;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        bool ac_ = ab_ is CqlInterval<CqlDateTime>;
-                        return ac_;
-                    }
-
-
-                    bool v_() {
-                        DataType ad_ = THAProcedure?.Performed;
-                        object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                        bool af_ = ae_ is CqlQuantity;
-                        return af_;
-                    }
-
-
-                    bool w_() {
-                        DataType ag_ = THAProcedure?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlInterval<CqlQuantity>;
-                        return ai_;
-                    }
-
-                    if (t_())
-                    {
-                        DataType aj_ = THAProcedure?.Performed;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        return (ak_ as CqlDateTime) as object;
-                    }
-                    else if (u_())
-                    {
-                        DataType al_ = THAProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        return (am_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (v_())
-                    {
-                        DataType an_ = THAProcedure?.Performed;
-                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                        return (ao_ as CqlQuantity) as object;
-                    }
-                    else if (w_())
-                    {
-                        DataType ap_ = THAProcedure?.Performed;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return (aq_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_());
-                bool? q_ = context.Operators.Overlaps(n_, p_, "day");
-                bool? r_ = this.isVerified(context, MechanicalComplications);
-                bool? s_ = context.Operators.And(q_, r_);
-                return s_;
-            }
-
-            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
-            Condition l_(Procedure THAProcedure) => MechanicalComplications;
-            IEnumerable<Condition> m_ = context.Operators.Select<Procedure, Condition>(k_, l_);
-            return m_;
-        }
-
-        IEnumerable<Condition> g_ = context.Operators.SelectMany<Condition, Condition>(e_, f_);
-        bool? h_ = context.Operators.Exists<Condition>(g_);
-        return h_;
-    }
-
-
-    [CqlExpressionDefinition("Has More Than One Elective Primary Total Hip Arthroplasty Performed")]
-    public bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed(CqlContext context) =>
-        context.GetOrCompute(_cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed, Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute);
-
-    private const long _cacheIndex_Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed = -923175309866963357L;
-
-    private bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Compute(CqlContext context)
-    {
-        IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure(context);
-
-        IEnumerable<Procedure> b_(Procedure THAProcedure) {
-            CqlValueSet e_ = this.Primary_THA_Procedure(context);
-            IEnumerable<Procedure> f_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-            IEnumerable<Procedure> g_ = Status_1_15_000.Instance.isProcedurePerformed(context, f_);
-
-            bool? h_(Procedure ElectiveTHAProcedure) {
-                Id l_ = THAProcedure?.IdElement;
-                string m_ = l_?.Value;
-                Id n_ = ElectiveTHAProcedure?.IdElement;
-                string o_ = n_?.Value;
-                bool? p_ = context.Operators.Equivalent(m_, o_);
-                bool? q_ = context.Operators.Not(p_);
-
-                object r_() {
-
-                    bool ah_() {
-                        DataType al_ = ElectiveTHAProcedure?.Performed;
-                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                        bool an_ = am_ is CqlDateTime;
-                        return an_;
-                    }
-
-
-                    bool ai_() {
-                        DataType ao_ = ElectiveTHAProcedure?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        bool aq_ = ap_ is CqlInterval<CqlDateTime>;
-                        return aq_;
-                    }
-
-
-                    bool aj_() {
-                        DataType ar_ = ElectiveTHAProcedure?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlQuantity;
-                        return at_;
-                    }
-
-
-                    bool ak_() {
-                        DataType au_ = ElectiveTHAProcedure?.Performed;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        bool aw_ = av_ is CqlInterval<CqlQuantity>;
-                        return aw_;
-                    }
-
-                    if (ah_())
-                    {
-                        DataType ax_ = ElectiveTHAProcedure?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        return (ay_ as CqlDateTime) as object;
-                    }
-                    else if (ai_())
-                    {
-                        DataType az_ = ElectiveTHAProcedure?.Performed;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        return (ba_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (aj_())
-                    {
-                        DataType bb_ = ElectiveTHAProcedure?.Performed;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        return (bc_ as CqlQuantity) as object;
-                    }
-                    else if (ak_())
-                    {
-                        DataType bd_ = ElectiveTHAProcedure?.Performed;
-                        object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                        return (be_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
-                CqlDateTime t_ = context.Operators.Start(s_);
-
-                object u_() {
-
-                    bool bf_() {
-                        DataType bj_ = THAProcedure?.Performed;
-                        object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                        bool bl_ = bk_ is CqlDateTime;
-                        return bl_;
-                    }
-
-
-                    bool bg_() {
-                        DataType bm_ = THAProcedure?.Performed;
-                        object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                        bool bo_ = bn_ is CqlInterval<CqlDateTime>;
-                        return bo_;
-                    }
-
-
-                    bool bh_() {
-                        DataType bp_ = THAProcedure?.Performed;
-                        object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                        bool br_ = bq_ is CqlQuantity;
-                        return br_;
-                    }
-
-
-                    bool bi_() {
-                        DataType bs_ = THAProcedure?.Performed;
-                        object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                        bool bu_ = bt_ is CqlInterval<CqlQuantity>;
-                        return bu_;
-                    }
-
-                    if (bf_())
-                    {
-                        DataType bv_ = THAProcedure?.Performed;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        return (bw_ as CqlDateTime) as object;
-                    }
-                    else if (bg_())
-                    {
-                        DataType bx_ = THAProcedure?.Performed;
-                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                        return (by_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (bh_())
-                    {
-                        DataType bz_ = THAProcedure?.Performed;
-                        object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                        return (ca_ as CqlQuantity) as object;
-                    }
-                    else if (bi_())
-                    {
-                        DataType cb_ = THAProcedure?.Performed;
-                        object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                        return (cc_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(1m, "year");
-                CqlDateTime y_ = context.Operators.Subtract(w_, x_);
-
-                object z_() {
-
-                    bool cd_() {
-                        DataType ch_ = THAProcedure?.Performed;
-                        object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                        bool cj_ = ci_ is CqlDateTime;
-                        return cj_;
-                    }
-
-
-                    bool ce_() {
-                        DataType ck_ = THAProcedure?.Performed;
-                        object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                        bool cm_ = cl_ is CqlInterval<CqlDateTime>;
-                        return cm_;
-                    }
-
-
-                    bool cf_() {
-                        DataType cn_ = THAProcedure?.Performed;
-                        object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                        bool cp_ = co_ is CqlQuantity;
-                        return cp_;
-                    }
-
-
-                    bool cg_() {
-                        DataType cq_ = THAProcedure?.Performed;
-                        object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                        bool cs_ = cr_ is CqlInterval<CqlQuantity>;
-                        return cs_;
-                    }
-
-                    if (cd_())
-                    {
-                        DataType ct_ = THAProcedure?.Performed;
-                        object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                        return (cu_ as CqlDateTime) as object;
-                    }
-                    else if (ce_())
-                    {
-                        DataType cv_ = THAProcedure?.Performed;
-                        object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                        return (cw_ as CqlInterval<CqlDateTime>) as object;
-                    }
-                    else if (cf_())
-                    {
-                        DataType cx_ = THAProcedure?.Performed;
-                        object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
-                        return (cy_ as CqlQuantity) as object;
-                    }
-                    else if (cg_())
-                    {
-                        DataType cz_ = THAProcedure?.Performed;
-                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
-                        return (da_ as CqlInterval<CqlQuantity>) as object;
-                    }
-                    else
-                    {
-                        return null;
-                    };
-                }
-
-                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
-                CqlDateTime ab_ = context.Operators.Start(aa_);
-                CqlDateTime ad_ = context.Operators.Add(ab_, x_);
-                CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(y_, ad_, true, true);
-                bool? af_ = context.Operators.In<CqlDateTime>(t_, ae_, "day");
-                bool? ag_ = context.Operators.And(q_, af_);
-                return ag_;
-            }
-
-            IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
-            Procedure j_(Procedure ElectiveTHAProcedure) => THAProcedure;
-            IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
-            return k_;
-        }
-
-        IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+        IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
         bool? d_ = context.Operators.Exists<Procedure>(c_);
         return d_;
     }
@@ -1984,66 +1978,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_HOOS_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentHOOS) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentHOOS, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentHOOS, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentHOOS, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentHOOS, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentHOOS, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentHOOS, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentHOOS, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentHOOS, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentHOOS, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentHOOS, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentHOOS) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_HOOS_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_HOOS_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentHOOS) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentHOOS);
+            bool? bl_(CqlDate FollowUpHipAssessmentHOOS) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentHOOS);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentHOOS) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2168,66 +2160,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_HOOSJr_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessment) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessment, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessment, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessment, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessment, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessment, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessment, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessment, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessment, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessment, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessment, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessment) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_HOOSJr_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_HOOSJr_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessment) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessment);
+            bool? bl_(CqlDate FollowUpHipAssessment) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessment);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessment) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2390,66 +2380,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_PROMIS10_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentPROMIS10) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentPROMIS10, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentPROMIS10) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_PROMIS10_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_PROMIS10_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentPROMIS10) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentPROMIS10);
+            bool? bl_(CqlDate FollowUpHipAssessmentPROMIS10) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentPROMIS10);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentPROMIS10) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2612,66 +2600,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_VR12_Oblique_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentOblique) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentOblique, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentOblique, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentOblique, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentOblique, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentOblique, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentOblique, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentOblique, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentOblique, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentOblique, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentOblique, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentOblique) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_VR12_Oblique_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_VR12_Oblique_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentOblique) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOblique);
+            bool? bl_(CqlDate FollowUpHipAssessmentOblique) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOblique);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentOblique) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }
@@ -2834,66 +2820,64 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
         IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
         IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(c_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> e_(CqlInterval<CqlDateTime> TotalHip) {
+        bool? e_(CqlInterval<CqlDateTime> TotalHip) {
             IEnumerable<CqlDate> aj_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed(context);
 
             bool? ak_(CqlDate InitialHipAssessmentOrthogonal) {
-                CqlDateTime ao_ = context.Operators.Start(TotalHip);
-                CqlQuantity ap_ = context.Operators.Quantity(90m, "days");
-                CqlDate aq_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> ar_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, aq_, true, true);
-                CqlDate as_ = ar_?.low;
-                CqlDateTime at_ = context.Operators.ConvertDateToDateTime(as_);
-                CqlDate av_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, av_, true, true);
-                CqlDate ax_ = aw_?.high;
-                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
-                CqlDate ba_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> bb_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ba_, true, true);
-                bool? bc_ = bb_?.lowClosed;
-                CqlDate be_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ap_);
-                CqlInterval<CqlDate> bf_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, be_, true, true);
-                bool? bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(at_, ay_, bc_, bg_);
-                bool? bi_ = context.Operators.In<CqlDateTime>(ao_, bh_, "day");
-                bool? bj_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
-                bool? bk_ = context.Operators.And(bi_, bj_);
-                return bk_;
+                CqlDateTime an_ = context.Operators.Start(TotalHip);
+                CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
+                CqlDate ap_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ap_, true, true);
+                CqlDate ar_ = aq_?.low;
+                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
+                CqlDate au_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> av_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, au_, true, true);
+                CqlDate aw_ = av_?.high;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate az_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> ba_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, az_, true, true);
+                bool? bb_ = ba_?.lowClosed;
+                CqlDate bd_ = context.Operators.Add(InitialHipAssessmentOrthogonal, ao_);
+                CqlInterval<CqlDate> be_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, bd_, true, true);
+                bool? bf_ = be_?.highClosed;
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(as_, ax_, bb_, bf_);
+                bool? bh_ = context.Operators.In<CqlDateTime>(an_, bg_, "day");
+                bool? bi_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
+                bool? bj_ = context.Operators.And(bh_, bi_);
+                return bj_;
             }
 
             IEnumerable<CqlDate> al_ = context.Operators.Where<CqlDate>(aj_, ak_);
-            CqlInterval<CqlDateTime> am_(CqlDate InitialHipAssessmentOrthogonal) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> an_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(al_, am_);
-            return an_;
+            bool? am_ = context.Operators.Exists<CqlDate>(al_);
+            return am_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(d_, e_);
+        IEnumerable<CqlInterval<CqlDateTime>> f_ = context.Operators.Where<CqlInterval<CqlDateTime>>(d_, e_);
 
-        IEnumerable<CqlInterval<CqlDateTime>> g_(CqlInterval<CqlDateTime> TotalHip) {
-            IEnumerable<CqlDate> bl_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed(context);
+        bool? g_(CqlInterval<CqlDateTime> TotalHip) {
+            IEnumerable<CqlDate> bk_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed(context);
 
-            bool? bm_(CqlDate FollowUpHipAssessmentOrthogonal) {
-                CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOrthogonal);
+            bool? bl_(CqlDate FollowUpHipAssessmentOrthogonal) {
+                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOrthogonal);
+                CqlDate bp_ = context.Operators.DateFrom(bo_);
+                CqlDateTime bq_ = context.Operators.End(TotalHip);
                 CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlDateTime bs_ = context.Operators.End(TotalHip);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                CqlQuantity bu_ = context.Operators.Quantity(300m, "days");
-                CqlDate bv_ = context.Operators.Add(bt_, bu_);
-                CqlDate bx_ = context.Operators.DateFrom(bs_);
-                CqlQuantity by_ = context.Operators.Quantity(425m, "days");
-                CqlDate bz_ = context.Operators.Add(bx_, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(bv_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDate>(br_, ca_, "day");
-                return cb_;
+                CqlQuantity bs_ = context.Operators.Quantity(300m, "days");
+                CqlDate bt_ = context.Operators.Add(br_, bs_);
+                CqlDate bv_ = context.Operators.DateFrom(bq_);
+                CqlQuantity bw_ = context.Operators.Quantity(425m, "days");
+                CqlDate bx_ = context.Operators.Add(bv_, bw_);
+                CqlInterval<CqlDate> by_ = context.Operators.Interval(bt_, bx_, true, true);
+                bool? bz_ = context.Operators.In<CqlDate>(bp_, by_, "day");
+                return bz_;
             }
 
-            IEnumerable<CqlDate> bn_ = context.Operators.Where<CqlDate>(bl_, bm_);
-            CqlInterval<CqlDateTime> bo_(CqlDate FollowUpHipAssessmentOrthogonal) => TotalHip;
-            IEnumerable<CqlInterval<CqlDateTime>> bp_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(bn_, bo_);
-            return bp_;
+            IEnumerable<CqlDate> bm_ = context.Operators.Where<CqlDate>(bk_, bl_);
+            bool? bn_ = context.Operators.Exists<CqlDate>(bm_);
+            return bn_;
         }
 
-        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(f_, g_);
+        IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(f_, g_);
         bool? i_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(h_);
         return i_;
     }

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -5,3 +5,5 @@
 ## Features
 
 ## Fixes
+
+- CQL `with`/`without` relationship clauses now compile as an existence filter (semi-join/anti-semi-join) instead of `SelectMany`/`Except`, so a source element with multiple matching related elements is emitted exactly once instead of duplicated (or spuriously deduplicated by `Except` set semantics for `without`) (#1366).


### PR DESCRIPTION
## Description
A CQL `with` relationship clause is a semi-join (existence filter): each source element must be emitted at most once, no matter how many related elements satisfy the `such that` condition. The compiler previously emitted `SelectMany(source, s => related.Where(suchThat).Select(r => s))`, which emits a source element once per matching related element — over-counting whenever an element has two or more matches.

`without` had related defects: it was compiled as `Except(source, <the multiplied matches>)`, whose set semantics also deduplicated the surviving source elements.

Both clauses now compile to an existence filter over the source, exactly as proposed in the issue:

```csharp
// with
Where(source, s => Exists(Where(related, r => suchThat)))
// without
Where(source, s => Not(Exists(Where(related, r => suchThat))))
```

Changes:
- `Cql/Cql.Compiler/ExpressionBuilderContext.cs`: `WithToSelectManyBody` replaced by `WithToExistenceCheck`; the `Query` relationship handling now applies a single `Where` per relationship clause for both `with` and `without`.
- `LibrarySets/dqm-content-qicore-2025/Extracted/CSharp/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs`: golden file regenerated (the RR23 golden corpus contains no relationship clauses and regenerates byte-identical).
- `Demo/Measures.dqm-content-qicore-2025/CSharp/*.g.cs`: demo measure corpus (used by the integration runner) regenerated with PackagerCLI from the checked-in ELM; 61 of 89 libraries contain relationship clauses and change, the rest regenerate byte-identical.
- Submodule `submodules/Firely.Cql.Sdk.Integration.Runner` bumped to [`82d7eac79`](https://github.com/FirelyTeam/Firely.Cql.Sdk.Integration.Runner/commits/claude/with-clause-semijoin-passes) (branch `claude/with-clause-semijoin-passes`, see FirelyTeam/Firely.Cql.Sdk.Integration.Runner#102), which refreshes `passed.jsonl` with 81 additional passing cases (see Testing).

Regenerating `PCMaternal` (the library quoted in the issue) produces the expected shape for `Delivery_Encounter_With_Age_Range_Compute`: a `Where` over the source encounters whose predicate is `Exists` over the matching procedures.

## Related issues
Fixes #1366.

## Testing
- New `Cql/CoreTests/RelationshipClauseTests.cs`: end-to-end tests (CQL → ELM → C# → execution) covering the issue's semantics table — 0 matches drops the element, 1 match emits once, N ≥ 2 matches emits once — plus `without`, duplicate-preservation for both clauses, and chained `with` clauses. Three of the five tests fail against the previous implementation.
- Full `CoreTests` suite (including the C# generation golden tests): 742 passed on net10.0; key tests also verified on net8.0. `CqlToElmTests`: 2427 passed.
- **Integration suite** (all 3857 cases, `Write` mode, run twice): the fixed SDK passes 2447 cases with zero regressions against the previous `passed.jsonl` (2366 entries). A baseline run against develop *without* this fix passes the identical 2447 cases — so the fix flips no integration outcome, and the 81 newly listed cases (13 measures, e.g. CMS71/CMS104/CMS190) come from SDK fixes already on develop that predate the last `passed.jsonl` refresh. The refreshed list was re-validated in `ReadAndOnlyRunPreviousPasses` mode: 2447/2447 pass.
- `Cql-Sdk.slnf` and the demo measure projects build cleanly. (`Test.Measures.Demo` has one pre-existing, unrelated failure caused by FHIR Library resources that are not checked into the repo.)

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDy7nDXVN5AYZMPa7X3eB9
