### PR TITLE
Fix AssemblyCompiler intermittently dropping cross-library references

### DIFF
--- a/Cql/CodeGeneration.NET/AssemblyCompiler.cs
+++ b/Cql/CodeGeneration.NET/AssemblyCompiler.cs
@@ -92,15 +92,46 @@ namespace Hl7.Cql.CodeGeneration.NET
         {
             Dictionary<string, AssemblyBinaryWithSourceCode> results = new();
             Assembly[] assemblyReferences = _referencesLazy.Value;
+
+            // Looked up by identifier so a dependency can be compiled on demand regardless of
+            // where it falls in librariesWithCSharp's own enumeration order (see
+            // firely-cql-sdk#1373: relying on that order alone to already guarantee
+            // "dependencies come before dependents" turned out not to hold reliably --
+            // ElmToolkit builds this sequence from an ImmutableDictionary.Values enumeration,
+            // whose order is hash-bucket-driven and varies per process, not insertion-stable).
+            var sourceByIdentifier = librariesWithCSharp.ToDictionary(t => t.library.VersionedLibraryIdentifier, t => t);
+            var currentlyCompiling = new HashSet<CqlVersionedLibraryIdentifier>();
+
+            AssemblyBinaryWithSourceCode CompileWithDependenciesFirst(CqlVersionedLibraryIdentifier identifier)
+            {
+                if (results.TryGetValue(identifier, out var existing))
+                    return existing;
+
+                if (!currentlyCompiling.Add(identifier))
+                    throw new InvalidOperationException($"Circular dependency detected involving library '{identifier}'.");
+
+                try
+                {
+                    if (!sourceByIdentifier.TryGetValue(identifier, out var self))
+                        throw new InvalidOperationException(
+                            $"No C# source was generated for library '{identifier}', but it's a declared dependency of another library.");
+
+                    foreach (var dependency in librarySet.GetLibraryDependencies(identifier))
+                        CompileWithDependenciesFirst(dependency.VersionedLibraryIdentifier);
+
+                    var compiled = CompileNode(self.csharp, results, librarySet, self.library, assemblyReferences, debugSymbolsFormat);
+                    results[identifier] = compiled;
+                    return compiled;
+                }
+                finally
+                {
+                    currentlyCompiling.Remove(identifier);
+                }
+            }
+
             return librariesWithCSharp
                 .TrySelect(
-                    t =>
-                    {
-                        var (library, cSharp) = t;
-                        var assemblyBinaryWithSourceCode = CompileNode(cSharp, results, librarySet, library, assemblyReferences, debugSymbolsFormat);
-                        results.Add(library.VersionedLibraryIdentifier, assemblyBinaryWithSourceCode);
-                        return (library, assemblyBinaryWithSourceCode);
-                    },
+                    t => (t.library, assemblyBinaryWithSourceCode: CompileWithDependenciesFirst(t.library.VersionedLibraryIdentifier)),
                     buildExceptionHandlingStrategy,
                     allowInvalidCSharp ? YieldWithoutAssemblyBinary : null);
 
@@ -158,16 +189,14 @@ namespace Hl7.Cql.CodeGeneration.NET
                 }
                 else
                 {
-                    // TEMP DIAGNOSTIC -- firely-cql-sdk#1373
-                    var dep = libraryDependency.VersionedLibraryIdentifier;
-                    var depKeys = string.Join(", ", assemblies.Keys);
-                    var exactKeyMatch = assemblies.Keys.Any(k => (string)k == (string)dep);
-                    var caseInsensitiveMatch = assemblies.Keys.Any(k => string.Equals((string)k, (string)dep, StringComparison.OrdinalIgnoreCase));
-                    Console.Error.WriteLine(
-                        $"[DIAG-1373] MISSING while compiling {libraryVersionedIdentifier}: " +
-                        $"dependency='{dep}' (hash={dep.GetHashCode()}) not found in assemblies dict " +
-                        $"(count={assemblies.Count}). ExactStringMatchExistsButTryGetValueFailed={exactKeyMatch} " +
-                        $"CaseInsensitiveMatchExists={caseInsensitiveMatch}. Keys so far: {depKeys}");
+                    // Should be structurally unreachable: CompileEachLibraryToAssemblies compiles
+                    // dependencies before dependents via recursive memoization (CompileWithDependenciesFirst),
+                    // not by trusting a pre-computed enumeration order. Fail loudly rather than silently
+                    // drop the reference (which used to surface later as a confusing unrelated CS0103 --
+                    // see firely-cql-sdk#1373).
+                    throw new InvalidOperationException(
+                        $"Library '{libraryVersionedIdentifier}' depends on '{libraryDependency.VersionedLibraryIdentifier}', " +
+                        "which has not been compiled yet.");
                 }
             }
 

--- a/Cql/CodeGeneration.NET/AssemblyCompiler.cs
+++ b/Cql/CodeGeneration.NET/AssemblyCompiler.cs
@@ -151,8 +151,25 @@ namespace Hl7.Cql.CodeGeneration.NET
                 metadataReferences.Add(GetOrCreateMetadataReference(asm.Location));
 
             foreach (var libraryDependency in librarySet.GetLibraryDependencies(libraryVersionedIdentifier!))
+            {
                 if (assemblies.TryGetValue(libraryDependency.VersionedLibraryIdentifier, out var referencedDll))
+                {
                     metadataReferences.Add(MetadataReference.CreateFromImage(referencedDll.AssemblyBytes!));
+                }
+                else
+                {
+                    // TEMP DIAGNOSTIC -- firely-cql-sdk#1373
+                    var dep = libraryDependency.VersionedLibraryIdentifier;
+                    var depKeys = string.Join(", ", assemblies.Keys);
+                    var exactKeyMatch = assemblies.Keys.Any(k => (string)k == (string)dep);
+                    var caseInsensitiveMatch = assemblies.Keys.Any(k => string.Equals((string)k, (string)dep, StringComparison.OrdinalIgnoreCase));
+                    Console.Error.WriteLine(
+                        $"[DIAG-1373] MISSING while compiling {libraryVersionedIdentifier}: " +
+                        $"dependency='{dep}' (hash={dep.GetHashCode()}) not found in assemblies dict " +
+                        $"(count={assemblies.Count}). ExactStringMatchExistsButTryGetValueFailed={exactKeyMatch} " +
+                        $"CaseInsensitiveMatchExists={caseInsensitiveMatch}. Keys so far: {depKeys}");
+                }
+            }
 
             var assemblyInfoSourceString = CreateAssemblyInfoSourceString(library);
             var assemblyInfoSourcePath = "AssemblyInfo.cs";

--- a/Cql/CodeGeneration.NET/AssemblyCompiler.cs
+++ b/Cql/CodeGeneration.NET/AssemblyCompiler.cs
@@ -93,13 +93,18 @@ namespace Hl7.Cql.CodeGeneration.NET
             Dictionary<string, AssemblyBinaryWithSourceCode> results = new();
             Assembly[] assemblyReferences = _referencesLazy.Value;
 
+            // Materialized once: librariesWithCSharp is a lazy, side-effecting iterator in the
+            // real ElmToolkit pipeline (it generates each library's C# and logs on every
+            // enumeration), so it must not be enumerated more than once here.
+            var materialized = librariesWithCSharp.ToList();
+
             // Looked up by identifier so a dependency can be compiled on demand regardless of
-            // where it falls in librariesWithCSharp's own enumeration order (see
-            // firely-cql-sdk#1373: relying on that order alone to already guarantee
-            // "dependencies come before dependents" turned out not to hold reliably --
-            // ElmToolkit builds this sequence from an ImmutableDictionary.Values enumeration,
-            // whose order is hash-bucket-driven and varies per process, not insertion-stable).
-            var sourceByIdentifier = librariesWithCSharp.ToDictionary(t => t.library.VersionedLibraryIdentifier, t => t);
+            // where it falls in the original enumeration order (see firely-cql-sdk#1373:
+            // relying on that order alone to already guarantee "dependencies come before
+            // dependents" turned out not to hold reliably -- ElmToolkit builds this sequence
+            // from an ImmutableDictionary.Values enumeration, whose order is hash-bucket-driven
+            // and varies per process, not insertion-stable).
+            var sourceByIdentifier = materialized.ToDictionary(t => t.library.VersionedLibraryIdentifier, t => t);
             var currentlyCompiling = new HashSet<CqlVersionedLibraryIdentifier>();
 
             AssemblyBinaryWithSourceCode CompileWithDependenciesFirst(CqlVersionedLibraryIdentifier identifier)
@@ -129,7 +134,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 }
             }
 
-            return librariesWithCSharp
+            return materialized
                 .TrySelect(
                     t => (t.library, assemblyBinaryWithSourceCode: CompileWithDependenciesFirst(t.library.VersionedLibraryIdentifier)),
                     buildExceptionHandlingStrategy,

--- a/Demo/Cql/Build/CqlTooling.Targets.xml
+++ b/Demo/Cql/Build/CqlTooling.Targets.xml
@@ -25,7 +25,7 @@
 
 	<Target
 		Name="Download CQL to ELM CLI"
-		Condition="'$(TargetFramework)' == 'net10.0' Or '$(TargetFramework)' == ''"
+		Condition="'$(CqlToolingEnabled)'=='true' And ('$(TargetFramework)' == 'net10.0' Or '$(TargetFramework)' == '')"
 		BeforeTargets="PreBuildEvent">
 		<Exec Command="$(DownloadJavaDependenciesScript)" ContinueOnError="false" />
 	</Target>

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -254,6 +254,8 @@ stages:
     jobs:
       - job: TestNet8
         displayName: "Test on .NET 8"
+        # TEMP: skipped while iterating on firely-cql-sdk#1373 -- not needed for this diagnostic branch.
+        condition: false
         pool:
           vmImage: "windows-latest"
         steps:
@@ -290,6 +292,8 @@ stages:
 
       - job: TestNet10
         displayName: "Test on .NET 10"
+        # TEMP: skipped while iterating on firely-cql-sdk#1373 -- not needed for this diagnostic branch.
+        condition: false
         pool:
           vmImage: "windows-latest"
         steps:

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -260,8 +260,6 @@ stages:
     jobs:
       - job: TestNet8
         displayName: "Test on .NET 8"
-        # TEMP: skipped while iterating on firely-cql-sdk#1373 -- not needed for this diagnostic branch.
-        condition: false
         pool:
           vmImage: "windows-latest"
         steps:
@@ -298,8 +296,6 @@ stages:
 
       - job: TestNet10
         displayName: "Test on .NET 10"
-        # TEMP: skipped while iterating on firely-cql-sdk#1373 -- not needed for this diagnostic branch.
-        condition: false
         pool:
           vmImage: "windows-latest"
         steps:

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -111,6 +111,12 @@ stages:
             inputs:
               nuGetServiceConnections: "${{ parameters.nuGetServiceConnections }}"
 
+          # Ensure the cache path exists even when CqlToolingEnabled is false (the default)
+          # and the Java dependency download never runs -- Cache@2's post-job tar step
+          # fails outright if the directory it's asked to cache doesn't exist at all.
+          - pwsh: New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)/Demo/Cql/Build/target/dependency" | Out-Null
+            displayName: "Ensure Java dependency cache path exists"
+
           # Cache Java dependencies to avoid re-downloading on each build
           - task: Cache@2
             displayName: "Cache Java Dependencies"


### PR DESCRIPTION
Fixes #1373.
Fixes #1377.

## The bug

`AssemblyCompiler.CompileEachLibraryToAssemblies` (`Cql/CodeGeneration.NET/AssemblyCompiler.cs`) compiles each ELM library into its own separate Roslyn assembly, resolving cross-library references by looking up an already-compiled dependency in a dictionary built up incrementally as it iterates `librariesWithCSharp` — trusting that this sequence's enumeration order already guarantees every dependency is compiled before its dependents need it:

```csharp
// before
foreach (var libraryDependency in librarySet.GetLibraryDependencies(libraryVersionedIdentifier!))
    if (assemblies.TryGetValue(libraryDependency.VersionedLibraryIdentifier, out var referencedDll))
        metadataReferences.Add(MetadataReference.CreateFromImage(referencedDll.AssemblyBytes!));
    // else: silently dropped, no error here
```

If a dependency wasn't compiled yet at that point, its reference was **silently dropped** — no error at that moment — surfacing later as a confusing Roslyn `CS0103: name does not exist in the current context` on what looks like an unrelated library.

That "already guaranteed" assumption didn't reliably hold. `ElmToolkit.CompileToAssemblies` (`Toolkit/ElmToolkit.cs`) builds this sequence from `_artifactsById.Values` on an `ImmutableDictionary<CqlVersionedLibraryIdentifier, _>` — and that enumeration order is hash-bucket-driven, not insertion-order-stable, varying per process under .NET's randomized string hashing. Confirmed empirically: identical insertion order into an `ImmutableDictionary` produced different `.Values` enumeration order across separate process runs on this machine.

## How it was found

Discovered via `Hedis2025.GoldenTests`' `HEDIS_2025_OldPipeline_CompilesToAssemblies`, which compiles the full 382-library NCQA HEDIS 2025 golden-parity corpus (#1363 / #1371) — large and interconnected enough to expose this, unlike the existing smaller golden corpora (RR23, dqm-content-qicore-2025). It failed intermittently in CI (roughly 1 in 4 runs observed), always on a *different* library within the same densely-interconnected cluster (`FHIRHelpers`, `FHIR_Common`, `HEDIS_Concepts`, etc. — some included by 250+ of the 382 libraries) — but **never reproduced locally** across 30+ attempts spanning:
- Debug and Release configurations
- 22 different input orderings fed directly into `LibrarySet`'s topological sort (natural, reversed, 20 random shuffles)
- `DOTNET_PROCESSOR_COUNT=2`-constrained runs to approximate CI's actual agent resources, run in heavy parallel (to induce real CPU contention my normally-sequential local runs never hit)

Ruled out along the way: a genuine cycle in the HEDIS dependency graph (independently rebuilt the full 382-node graph from raw ELM `includes` and ran proper cycle detection — none found, clean layered DAG); the topological sort itself being order-sensitive (it's a standard DFS post-order sort, structurally correct for any DAG and any input/tie-break order); hidden parallelism anywhere in the pipeline (traced every stage back to the same sequential `TrySelect` iterator, no `Parallel`/`Task.Run` anywhere). Full investigation log: #1373.

## The fix

Rather than continue chasing the exact non-deterministic trigger (a valid compile order was always *computable* — the sort is correct and the graph is acyclic — it just wasn't reliably the one *used*), this closes the entire bug class structurally. `CompileEachLibraryToAssemblies` now compiles each library's dependencies first via explicit recursion with memoization:

```csharp
AssemblyBinaryWithSourceCode CompileWithDependenciesFirst(CqlVersionedLibraryIdentifier identifier)
{
    if (results.TryGetValue(identifier, out var existing))
        return existing;
    // ... cycle guard ...
    foreach (var dependency in librarySet.GetLibraryDependencies(identifier))
        CompileWithDependenciesFirst(dependency.VersionedLibraryIdentifier);
    var compiled = CompileNode(...);
    results[identifier] = compiled;
    return compiled;
}
```

A library's dependencies are always compiled — and available in `results` — before it's compiled itself, by construction, independent of whatever order `librariesWithCSharp` happens to enumerate in. Each library compiles at most once (memoized). Includes a defensive cycle guard (throws a clear error instead of a stack overflow — no cycle exists in any current corpus, this is just future-proofing) and turns the previous silent-drop in `CompileNode` into a permanent, clear `InvalidOperationException` should this ever somehow still be reached.

## Also in this PR

- **`Demo/Cql/Build/CqlTooling.Targets.xml`**: gates the Java/Maven dependency download on `CqlToolingEnabled` (matching its only consumer, `GenerateElmFiles`, which was already gated) — the download ran unconditionally on every CI build even though `CqlToolingEnabled` defaults to `false` and nothing downstream ever used it. Found because rapid repeated CI builds while iterating on this fix hit a download-lock timeout that then hung the *entire* build silently for the full 60-minute job timeout instead of failing fast. Filed and fixed as #1377.
- **`build/build-test-sign.yml`**: the "Cache Java Dependencies" step's post-job tar unconditionally expects `Demo/Cql/Build/target/dependency` to exist — which it no longer does by default now that the download above is properly skipped. Ensures the directory exists (empty is fine) before caching.

## Test plan

- [x] Existing golden tests unaffected: `Regenerated_RR23_CSharp_Matches_CheckedInFiles`, `Regenerated_DqmQiCore2025_CMS56_CSharp_Matches_CheckedInFiles` both pass, byte-identical output.
- [x] Full `CoreTests` suite: 746 passed / 9 skipped / 0 failed.
- [x] 10+ parallel *local* runs of the real HEDIS 2025 corpus (Debug+Release, `DOTNET_PROCESSOR_COUNT=2`) against the fix, invoking `Hedis2025.GoldenTests.csproj` directly: all passed.
- [x] CI green on this branch (Build/Sign/Package, Test on .NET 8, Test on .NET 10, Integration Tests on .NET 10, Compare Test Results, Check for skippable changes).

**Note on CI coverage**: this branch doesn't wire `Hedis2025.GoldenTests` into `build/variables.yml`/`Cql-Sdk-All.sln` — that's #1371's scope (it depends on this fix and picks it up via a `develop` merge once this lands), and adding it here would conflict with that PR. So CI's "Integration Tests" job on *this* PR only runs `IntegrationRunner.csproj`, not the HEDIS corpus — the HEDIS-specific verification above is local-only. #1371 is where this fix gets its real CI-level confirmation against the actual bug-triggering corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)