### PR TITLE
Add MeasureGroupCodeSystem option to emit Measure.group.code

### DIFF
--- a/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
+++ b/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
@@ -316,4 +316,49 @@ public class FhirMeasureExtensionsTests
 
         measure.Group.Should().OnlyContain(g => g.Code == null);
     }
+
+    [TestMethod]
+    [DataRow("Rate\tA", DisplayName = "tab")]
+    [DataRow("Rate  A", DisplayName = "double space")]
+    [DataRow(" RateA", DisplayName = "leading space")]
+    [DataRow("RateA ", DisplayName = "trailing space")]
+    public void MeasureGroupCodeSystem_GroupIdViolatingFhirCodeConstraints_Throws(string groupId)
+    {
+        const string system = "https://example.org/fhir/CodeSystem/measure-group";
+
+        var act = () => CreateMeasure(system, BaseStatements(
+            Def("Region Stratifier",
+                CreateTag("group", groupId),
+                CreateTag("stratifier", "Region"))));
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage($"*'{groupId}'*FHIR code*");
+    }
+
+    [TestMethod]
+    public void MeasureGroupCodeSystem_GroupIdWithSingleInternalSpaces_IsAccepted()
+    {
+        const string system = "https://example.org/fhir/CodeSystem/measure-group";
+
+        var measure = CreateMeasure(system, BaseStatements(
+            Def("Region Stratifier",
+                CreateTag("group", "Rate C"),
+                CreateTag("stratifier", "Region"))));
+
+        var group = measure.Group.Single(g => g.ElementId == "Rate C");
+        group.Code!.Coding.Single().Code.Should().Be("Rate C");
+    }
+
+    [TestMethod]
+    public void NoMeasureGroupCodeSystem_GroupIdViolatingFhirCodeConstraints_IsNotValidated()
+    {
+        // Without a code system the group id is never emitted as a FHIR code,
+        // so the code datatype constraints don't apply.
+        var measure = CreateMeasure(BaseStatements(
+            Def("Region Stratifier",
+                CreateTag("group", "Rate\tC"),
+                CreateTag("stratifier", "Region"))));
+
+        measure.Group.Single(g => g.ElementId == "Rate\tC").Code.Should().BeNull();
+    }
 }

--- a/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
+++ b/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
@@ -280,7 +280,7 @@ public class FhirMeasureExtensionsTests
     [TestMethod]
     public void MeasureGroupCodeSystem_SetsGroupCodeWithGroupIdAsCode()
     {
-        const string system = "https://ncqa.org/fhir/CodeSystem/measure-group";
+        const string system = "https://example.org/fhir/CodeSystem/measure-group";
 
         var measure = CreateMeasure(system, BaseStatements());
 
@@ -296,7 +296,7 @@ public class FhirMeasureExtensionsTests
     [TestMethod]
     public void MeasureGroupCodeSystem_AlsoAppliesToGroupsCreatedByStratifiers()
     {
-        const string system = "https://ncqa.org/fhir/CodeSystem/measure-group";
+        const string system = "https://example.org/fhir/CodeSystem/measure-group";
 
         var measure = CreateMeasure(system, BaseStatements(
             Def("Region Stratifier",

--- a/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
+++ b/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
@@ -54,7 +54,10 @@ public class FhirMeasureExtensionsTests
         .. extra,
     ];
 
-    private static FhirMeasure CreateMeasure(params ExpressionDef[] statements)
+    private static FhirMeasure CreateMeasure(params ExpressionDef[] statements) =>
+        CreateMeasure(measureGroupCodeSystem: null, statements);
+
+    private static FhirMeasure CreateMeasure(string? measureGroupCodeSystem, params ExpressionDef[] statements)
     {
         var elmLibrary = new ElmLibrary
         {
@@ -62,7 +65,7 @@ public class FhirMeasureExtensionsTests
             statements = statements,
         };
         var fhirLibrary = new FhirLibrary { Id = "StratifierExample-1.0.0", Name = "StratifierExample" };
-        var created = fhirLibrary.TryCreateMeasure(elmLibrary, out var fhirMeasure, CanonicalBuilder, TestDate);
+        var created = fhirLibrary.TryCreateMeasure(elmLibrary, out var fhirMeasure, CanonicalBuilder, TestDate, measureGroupCodeSystem);
         created.Should().BeTrue();
         return fhirMeasure!;
     }
@@ -272,5 +275,45 @@ public class FhirMeasureExtensionsTests
         var measure = CreateMeasure(BaseStatements());
 
         measure.Group.Should().OnlyContain(g => g.Stratifier.Count == 0);
+    }
+
+    [TestMethod]
+    public void MeasureGroupCodeSystem_SetsGroupCodeWithGroupIdAsCode()
+    {
+        const string system = "https://ncqa.org/fhir/CodeSystem/measure-group";
+
+        var measure = CreateMeasure(system, BaseStatements());
+
+        foreach (var rate in new[] { "RateA", "RateB" })
+        {
+            var group = measure.Group.Single(g => g.ElementId == rate);
+            var coding = group.Code!.Coding.Should().ContainSingle().Subject;
+            coding.System.Should().Be(system);
+            coding.Code.Should().Be(rate);
+        }
+    }
+
+    [TestMethod]
+    public void MeasureGroupCodeSystem_AlsoAppliesToGroupsCreatedByStratifiers()
+    {
+        const string system = "https://ncqa.org/fhir/CodeSystem/measure-group";
+
+        var measure = CreateMeasure(system, BaseStatements(
+            Def("Region Stratifier",
+                CreateTag("group", "RateC"),
+                CreateTag("stratifier", "Region"))));
+
+        var group = measure.Group.Single(g => g.ElementId == "RateC");
+        var coding = group.Code!.Coding.Should().ContainSingle().Subject;
+        coding.System.Should().Be(system);
+        coding.Code.Should().Be("RateC");
+    }
+
+    [TestMethod]
+    public void NoMeasureGroupCodeSystem_LeavesGroupCodeUnset()
+    {
+        var measure = CreateMeasure(BaseStatements());
+
+        measure.Group.Should().OnlyContain(g => g.Code == null);
     }
 }

--- a/Cql/Cql.Packaging/FhirMeasureExtensions.cs
+++ b/Cql/Cql.Packaging/FhirMeasureExtensions.cs
@@ -4,7 +4,7 @@ using Hl7.Fhir.Model;
 
 namespace Hl7.Cql.Packaging;
 
-internal static class FhirMeasureExtensions
+internal static partial class FhirMeasureExtensions
 {
     private static readonly Dictionary<string, string> Populations = new()
     {
@@ -128,6 +128,10 @@ internal static class FhirMeasureExtensions
         };
         if (!string.IsNullOrWhiteSpace(measureGroupCodeSystem))
         {
+            if (!FhirCodeConstraint().IsMatch(groupId))
+                throw new InvalidOperationException(
+                    $"Group id '{groupId}' cannot be used as the code of Measure.group.code: a FHIR code must be non-empty, without leading or trailing whitespace, and with no whitespace other than single spaces. Fix the @group annotation value or unset the measure group code system.");
+
             group.Code = new CodeableConcept
             {
                 Coding =
@@ -135,7 +139,7 @@ internal static class FhirMeasureExtensions
                     new Coding
                     {
                         System = measureGroupCodeSystem,
-                        Code = groupId.Trim(),
+                        Code = groupId,
                     }
                 ]
             };
@@ -143,6 +147,11 @@ internal static class FhirMeasureExtensions
         fhirMeasure.Group!.Add(group);
         return group;
     }
+
+    // The FHIR `code` datatype constraint (https://hl7.org/fhir/R4/datatypes.html#code):
+    // at least one character, no leading/trailing whitespace, internal whitespace only single spaces.
+    [GeneratedRegex(@"^[^\s]+( [^\s]+)*$")]
+    private static partial Regex FhirCodeConstraint();
 
     private static void AnnotateMeasurePopulations(FhirMeasure fhirMeasure, ElmLibrary library, string? measureGroupCodeSystem)
     {

--- a/Cql/Cql.Packaging/FhirMeasureExtensions.cs
+++ b/Cql/Cql.Packaging/FhirMeasureExtensions.cs
@@ -38,7 +38,8 @@ internal static class FhirMeasureExtensions
             Tag measureAnnotation,
             int measureYear,
             ResourceCanonicalBuilder resourceCanonicalBuilder,
-            SysDateTime overrideDate)
+            SysDateTime overrideDate,
+            string? measureGroupCodeSystem = null)
         {
             var measure = new FhirMeasure();
             var libName = fhirLibrary.Name ?? throw new ArgumentException("Library must have a name", nameof(fhirLibrary));
@@ -59,8 +60,8 @@ internal static class FhirMeasureExtensions
             };
             measure.Group = [];
 
-            FhirMeasureExtensions.AnnotateMeasurePopulations(measure, elmLibrary);
-            FhirMeasureExtensions.AnnotateMeasureStratifiers(measure, elmLibrary);
+            FhirMeasureExtensions.AnnotateMeasurePopulations(measure, elmLibrary, measureGroupCodeSystem);
+            FhirMeasureExtensions.AnnotateMeasureStratifiers(measure, elmLibrary, measureGroupCodeSystem);
             string[] library = [resourceCanonicalBuilder("Library", libName, libVer)];
             measure.Library = library;
             return measure;
@@ -73,7 +74,8 @@ internal static class FhirMeasureExtensions
             ElmLibrary elmLibrary,
             [NotNullWhen(true)] out FhirMeasure? fhirMeasure,
             ResourceCanonicalBuilder resourceCanonicalBuilder,
-            SysDateTime overrideDate)
+            SysDateTime overrideDate,
+            string? measureGroupCodeSystem = null)
         {
             var tags = elmLibrary.statements?
                                  .SelectMany(GetAnnotationTags)
@@ -91,7 +93,8 @@ internal static class FhirMeasureExtensions
                     fhirLibrary,
                     elmLibrary,
                     measureAnnotation,
-                    measureYear, resourceCanonicalBuilder, overrideDate);
+                    measureYear, resourceCanonicalBuilder, overrideDate,
+                    measureGroupCodeSystem);
                 return true;
             }
 
@@ -108,7 +111,7 @@ internal static class FhirMeasureExtensions
         .Where(t => t is not null)
         .ToArray();
 
-    private static FhirMeasure.GroupComponent GetOrCreateGroup(FhirMeasure fhirMeasure, string groupId)
+    private static FhirMeasure.GroupComponent GetOrCreateGroup(FhirMeasure fhirMeasure, string groupId, string? measureGroupCodeSystem)
     {
         var groupsForId = fhirMeasure.Group?
                                      .Where(g => g.ElementId == groupId)
@@ -121,14 +124,27 @@ internal static class FhirMeasureExtensions
         var group = new FhirMeasure.GroupComponent
         {
             ElementId = groupId,
-            //Code = new CodeableConcept(groupId, MeasureGroupCodeSystem),
             Description = $"Group {groupId}",
         };
+        if (!string.IsNullOrWhiteSpace(measureGroupCodeSystem))
+        {
+            group.Code = new CodeableConcept
+            {
+                Coding =
+                [
+                    new Coding
+                    {
+                        System = measureGroupCodeSystem,
+                        Code = groupId,
+                    }
+                ]
+            };
+        }
         fhirMeasure.Group!.Add(group);
         return group;
     }
 
-    private static void AnnotateMeasurePopulations(FhirMeasure fhirMeasure, ElmLibrary library)
+    private static void AnnotateMeasurePopulations(FhirMeasure fhirMeasure, ElmLibrary library, string? measureGroupCodeSystem)
     {
         var defs = library.statements ?? Enumerable.Empty<Hl7.Cql.Elm.ExpressionDef>();
         foreach (var def in defs)
@@ -155,7 +171,7 @@ internal static class FhirMeasureExtensions
                             $"Definition {def.name} has a @population annotation whose value is {tuple.Population}.  @population must be one of: {string.Join(", ", Populations.Keys)}");
 
                     var rate = $"{tuple.Group}";
-                    var group = GetOrCreateGroup(fhirMeasure, rate);
+                    var group = GetOrCreateGroup(fhirMeasure, rate, measureGroupCodeSystem);
 
                     var populationSuffix = productLine != null ? $"{tuple.Population}-{productLine.value}" : tuple.Population;
                     var pop = $"{rate}-{populationSuffix}";
@@ -216,7 +232,7 @@ internal static class FhirMeasureExtensions
         return container;
     }
 
-    private static void AnnotateMeasureStratifiers(FhirMeasure fhirMeasure, ElmLibrary library)
+    private static void AnnotateMeasureStratifiers(FhirMeasure fhirMeasure, ElmLibrary library, string? measureGroupCodeSystem)
     {
         var defs = library.statements ?? Enumerable.Empty<Hl7.Cql.Elm.ExpressionDef>();
         foreach (var def in defs)
@@ -249,7 +265,7 @@ internal static class FhirMeasureExtensions
                          select new { Group = g.value, Stratifier = s.value };
             foreach (var tuple in tuples)
             {
-                var group = GetOrCreateGroup(fhirMeasure, tuple.Group);
+                var group = GetOrCreateGroup(fhirMeasure, tuple.Group, measureGroupCodeSystem);
                 var container = GetOrCreateStratifier(group);
 
                 var componentId = $"{tuple.Group}-StratifierComponent-{tuple.Stratifier}";

--- a/Cql/Cql.Packaging/FhirMeasureExtensions.cs
+++ b/Cql/Cql.Packaging/FhirMeasureExtensions.cs
@@ -135,7 +135,7 @@ internal static class FhirMeasureExtensions
                     new Coding
                     {
                         System = measureGroupCodeSystem,
-                        Code = groupId,
+                        Code = groupId.Trim(),
                     }
                 ]
             };

--- a/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Hl7.Cql.Packaging.Toolkit.PackagingToolkitConfig.MeasureGroupCodeSystem.get -> string?
+Hl7.Cql.Packaging.Toolkit.PackagingToolkitConfig.MeasureGroupCodeSystem.init -> void

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -30,7 +30,8 @@ internal class ResourcePackager(
         Func<string, InputArtifacts> inputsById,
         SysDateTime? overrideDate = null,
         BatchProcessExceptionHandlingStrategyBuilder<ElmLibrary>? buildExceptionHandlingStrategy = null,
-        Action<ElmLibrary>? onNextLibrary = null)
+        Action<ElmLibrary>? onNextLibrary = null,
+        string? measureGroupCodeSystem = null)
     {
         return librarySet.TrySelect(PackageResource, buildExceptionHandlingStrategy);
 
@@ -62,7 +63,8 @@ internal class ResourcePackager(
 
             fhirLibrary.TryCreateMeasure(elmLibrary,
                           out var fhirMeasure,
-                          resourceCanonicalBuilder, localOverrideDate);
+                          resourceCanonicalBuilder, localOverrideDate,
+                          measureGroupCodeSystem);
             return (versionedIdentifier, fhirLibrary, fhirMeasure);
         }
     }

--- a/Cql/Cql.Packaging/Toolkit/PackagingToolkit.cs
+++ b/Cql/Cql.Packaging/Toolkit/PackagingToolkit.cs
@@ -166,7 +166,8 @@ public sealed class PackagingToolkit : IToolkit<PackagingToolkit>
                          librarySet: librarySet,
                          inputsById: id => inputArtifactsById[id],
                          overrideDate: Config.OverrideDate,
-                         errorStrategy => errorStrategy
+                         measureGroupCodeSystem: Config.MeasureGroupCodeSystem,
+                         buildExceptionHandlingStrategy: errorStrategy => errorStrategy
                              .SetContinuation(BatchProcessExceptionContinuation)
                              .AddLoggerExceptionHandler(logger, (library, logMessage) => logMessage("Could not package FHIR resources for library {lib}", library.VersionedLibraryIdentifier)),
                          onNextLibrary: library => logger.LogInformation("Packaging FHIR resources for library: {lib}", library.VersionedLibraryIdentifier))

--- a/Cql/Cql.Packaging/Toolkit/PackagingToolkitConfig.cs
+++ b/Cql/Cql.Packaging/Toolkit/PackagingToolkitConfig.cs
@@ -31,7 +31,8 @@ public record PackagingToolkitConfig(
     /// <summary>
     /// The code system URL used for <c>Measure.group.code</c>. When set, each measure group's id is
     /// also emitted as a coding with this system and the group id as its code. When <see langword="null"/>
-    /// or empty/whitespace (the default), no <c>Measure.group.code</c> is emitted.
+    /// (the default), no <c>Measure.group.code</c> is emitted; an empty or whitespace-only value is
+    /// treated the same as <see langword="null"/>.
     /// </summary>
     public string? MeasureGroupCodeSystem { get; init; }
 

--- a/Cql/Cql.Packaging/Toolkit/PackagingToolkitConfig.cs
+++ b/Cql/Cql.Packaging/Toolkit/PackagingToolkitConfig.cs
@@ -28,6 +28,13 @@ public record PackagingToolkitConfig(
     public IReadOnlyDictionary<CqlLibraryIdentifier, string> FixedLibraryCanonicals { get; init; }
         = FixedLibraryCanonicals ?? CreateDefaultFixedLibraryCanonicals();
 
+    /// <summary>
+    /// The code system URL used for <c>Measure.group.code</c>. When set, each measure group's id is
+    /// also emitted as a coding with this system and the group id as its code. When <see langword="null"/>
+    /// (the default), no <c>Measure.group.code</c> is emitted.
+    /// </summary>
+    public string? MeasureGroupCodeSystem { get; init; }
+
     private static ReadOnlyDictionary<CqlLibraryIdentifier, string> CreateDefaultFixedLibraryCanonicals() =>
         new Dictionary<CqlLibraryIdentifier, string> { { (CqlLibraryIdentifier)"FHIRHelpers", "http://hl7.org/fhir/uv/cql/Library/FHIRHelpers" } }
             .AsReadOnly();

--- a/Cql/Cql.Packaging/Toolkit/PackagingToolkitConfig.cs
+++ b/Cql/Cql.Packaging/Toolkit/PackagingToolkitConfig.cs
@@ -31,7 +31,7 @@ public record PackagingToolkitConfig(
     /// <summary>
     /// The code system URL used for <c>Measure.group.code</c>. When set, each measure group's id is
     /// also emitted as a coding with this system and the group id as its code. When <see langword="null"/>
-    /// (the default), no <c>Measure.group.code</c> is emitted.
+    /// or empty/whitespace (the default), no <c>Measure.group.code</c> is emitted.
     /// </summary>
     public string? MeasureGroupCodeSystem { get; init; }
 

--- a/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirCommand.cs
+++ b/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirCommand.cs
@@ -25,6 +25,7 @@ public record CqlToFhirCommand
     DirectoryInfo? Measures,
     DateTimeOffset? OverrideUtcDateTime,
     string? CanonicalRootUrl,
+    string? MeasureGroupCodeSystem,
     string? CSharpNamespace,
     bool? JsonPretty,
     bool? ExitOnError,
@@ -122,6 +123,14 @@ public record CqlToFhirCommand
             (Used with --fhir)
             """),
 
+        Option<string>(
+            "--measure-group-code-system",
+            """
+            The code system url used for the group codes in FHIR measures.
+            When set, each measure group's id is also output as a coding on Measure.group.code with this system and the group id as its code.
+            (Used with --fhir or --measures)
+            """),
+
         Option<DateTimeOffset>(
             "--override-utc-date-time",
             """
@@ -174,6 +183,7 @@ public record CqlToFhirCommand
         (DebugSymbols, [ElmOptions.ConfigSection, nameof(ElmOptions.DebugSymbolsFormat)]),
         (CSharpNamespace, [ElmOptions.ConfigSection, nameof(ElmOptions.CSharpNamespace)]),
         (CanonicalRootUrl, [PackagingOptions.ConfigSection, nameof(PackagingOptions.CanonicalRootUrl)]),
+        (MeasureGroupCodeSystem, [PackagingOptions.ConfigSection, nameof(PackagingOptions.MeasureGroupCodeSystem)]),
         (OverrideUtcDateTime, [PackagingOptions.ConfigSection, nameof(PackagingOptions.OverrideDate)]),
         (ExitOnError, [PackagingOptions.ConfigSection, nameof(PackagingOptions.ExitOnError)]),
         (JsonPretty, [PackagingOptions.ConfigSection, nameof(PackagingOptions.JsonPretty)]),

--- a/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirCommand.cs
+++ b/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirCommand.cs
@@ -25,6 +25,7 @@ internal record ElmToFhirCommand
     DirectoryInfo? Measures,
     DateTimeOffset? OverrideUtcDateTime,
     string? CanonicalRootUrl,
+    string? MeasureGroupCodeSystem,
     string? CSharpNamespace,
     bool? JsonPretty,
     bool? ExitOnError,
@@ -120,6 +121,14 @@ internal record ElmToFhirCommand
             (Used with --fhir)
             """),
 
+        Option<string>(
+            "--measure-group-code-system",
+            """
+            The code system url used for the group codes in FHIR measures.
+            When set, each measure group's id is also output as a coding on Measure.group.code with this system and the group id as its code.
+            (Used with --fhir or --measures)
+            """),
+
         Option<DateTimeOffset>(
             "--override-utc-date-time",
             """
@@ -177,6 +186,7 @@ internal record ElmToFhirCommand
         (DebugSymbols, [ElmOptions.ConfigSection, nameof(ElmOptions.DebugSymbolsFormat)]),
         (CSharpNamespace, [ElmOptions.ConfigSection, nameof(ElmOptions.CSharpNamespace)]),
         (CanonicalRootUrl, [PackagingOptions.ConfigSection, nameof(PackagingOptions.CanonicalRootUrl)]),
+        (MeasureGroupCodeSystem, [PackagingOptions.ConfigSection, nameof(PackagingOptions.MeasureGroupCodeSystem)]),
         (OverrideUtcDateTime, [PackagingOptions.ConfigSection, nameof(PackagingOptions.OverrideDate)]),
         (ExitOnError, [PackagingOptions.ConfigSection, nameof(PackagingOptions.ExitOnError)]),
         (JsonPretty, [PackagingOptions.ConfigSection, nameof(PackagingOptions.JsonPretty)]),

--- a/docs/cql-packager.md
+++ b/docs/cql-packager.md
@@ -75,6 +75,7 @@ Reads pre-built ELM JSON files and converts them to one or more outputs.
 | `--libraries <dir>` | | FHIR Libraries-only output (use with `--measures`; mutually exclusive with `--fhir`) |
 | `--measures <dir>` | | FHIR Measures-only output (use with `--libraries`; mutually exclusive with `--fhir`) |
 | `--canonical-root-url <url>` | | Root canonical URL embedded in generated FHIR resources |
+| `--measure-group-code-system <url>` | | Code system URL for `Measure.group.code`; when set, each group's id is also emitted as a coding with this system and the group id as its code |
 | `--override-utc-date-time <dt>` | | Override the timestamp written into FHIR resources (e.g. `1970-01-01T00:00:00Z` for reproducible builds) |
 | `--json-pretty` | | Emit pretty-printed JSON for FHIR output |
 | `--cs-namespace <ns>` | | C# namespace for generated code (e.g. `MyCompany.MyCqlLibraries`) |
@@ -113,6 +114,7 @@ Reads CQL source files, compiles them to ELM in-process, then continues the same
 | `--libraries <dir>` | | FHIR Libraries-only output (use with `--measures`; mutually exclusive with `--fhir`) |
 | `--measures <dir>` | | FHIR Measures-only output (use with `--libraries`; mutually exclusive with `--fhir`) |
 | `--canonical-root-url <url>` | | Root canonical URL embedded in generated FHIR resources |
+| `--measure-group-code-system <url>` | | Code system URL for `Measure.group.code`; when set, each group's id is also emitted as a coding with this system and the group id as its code |
 | `--override-utc-date-time <dt>` | | Override the timestamp in generated FHIR resources |
 | `--json-pretty` | | Emit pretty-printed JSON for FHIR and ELM output |
 | `--cs-namespace <ns>` | | C# namespace for generated code |

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -9,6 +9,13 @@
 
 ## Features
 
+- The Measure packaging step can now emit `Measure.group.code`: the new
+  `PackagingToolkitConfig.MeasureGroupCodeSystem` setting (also available as the
+  `--measure-group-code-system` PackagerCLI option and the `Packaging:MeasureGroupCodeSystem`
+  appsettings key) takes a code system URL, and when set, each measure group's id is also emitted
+  as a coding with that system and the group id as its code. Unset (the default), the output is
+  unchanged.
+
 ## Fixes
 
 - Fixed a CQL `union` of two structurally compatible tuple lists with differing element types

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -13,8 +13,10 @@
   `PackagingToolkitConfig.MeasureGroupCodeSystem` setting (also available as the
   `--measure-group-code-system` PackagerCLI option and the `Packaging:MeasureGroupCodeSystem`
   appsettings key) takes a code system URL, and when set, each measure group's id is also emitted
-  as a coding with that system and the group id as its code. Unset (the default), the output is
-  unchanged.
+  as a coding with that system and the group id as its code. When the setting is enabled, group ids
+  are validated against the FHIR `code` datatype constraints (non-empty, no leading/trailing
+  whitespace, internal whitespace limited to single spaces) and packaging fails with a clear error
+  for a `@group` annotation value that violates them. Unset (the default), the output is unchanged.
 
 ## Fixes
 


### PR DESCRIPTION
## Summary

Adds support for emitting `Measure.group.code` during measure packaging. A new optional `MeasureGroupCodeSystem` configuration setting allows users to specify a code system URL; when set, each measure group's id is also emitted as a coding with that system and the group id as its code.

## Changes

- **Core packaging logic** (`FhirMeasureExtensions.cs`):
  - Added `measureGroupCodeSystem` parameter to `CreateMeasureResource()`, `TryCreateMeasure()`, `AnnotateMeasurePopulations()`, and `AnnotateMeasureStratifiers()`
  - Updated `GetOrCreateGroup()` to accept and apply the code system, setting `Measure.group.code` with a `Coding` containing the system and group id when the parameter is non-null
  - Removed commented-out code that was a placeholder for this feature

- **Configuration** (`PackagingToolkitConfig.cs`):
  - Added `MeasureGroupCodeSystem` property with documentation explaining its behavior

- **CLI commands** (`CqlToFhirCommand.cs`, `ElmToFhirCommand.cs`):
  - Added `--measure-group-code-system` option to both commands with help text
  - Wired the option to `PackagingOptions.MeasureGroupCodeSystem` config section

- **Packaging orchestration** (`PackagingToolkit.cs`, `ResourcePackager.cs`):
  - Threaded `measureGroupCodeSystem` parameter through the packaging pipeline from config to resource creation

- **Tests** (`FhirMeasureExtensionsTests.cs`):
  - Refactored `CreateMeasure()` helper to accept optional `measureGroupCodeSystem` parameter
  - Added three new test cases:
    - `MeasureGroupCodeSystem_SetsGroupCodeWithGroupIdAsCode`: verifies groups get the code system and group id as code
    - `MeasureGroupCodeSystem_AlsoAppliesToGroupsCreatedByStratifiers`: verifies the code system applies to groups created by stratifiers
    - `NoMeasureGroupCodeSystem_LeavesGroupCodeUnset`: verifies default behavior (null) leaves code unset

- **Documentation**:
  - Updated release notes with feature description
  - Updated CLI documentation with the new option

## Implementation Details

- The feature is opt-in: when `measureGroupCodeSystem` is null (the default), no `Measure.group.code` is emitted, preserving backward compatibility
- The code system is applied consistently to all groups, whether created directly from populations or indirectly from stratifiers
- The group id itself becomes the `code` value in the coding, with the provided system URL

https://claude.ai/code/session_01QqhsgX24cc7zwWo6jhPhYr