### PR TITLE
Introduce docs/releases/vnext/ fragment files to avoid release-notes conflicts

### DIFF
--- a/.claude/skills/cut-release-notes/SKILL.md
+++ b/.claude/skills/cut-release-notes/SKILL.md
@@ -8,23 +8,28 @@ description: Prepare a versioned release notes document for the Firely CQL SDK, 
 Full process (authoritative source): [Creating Tags and Releases](https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases) wiki page. This skill covers everything up to and including the version-bump PR — creating the git tag, the GitHub Release, and approving the NuGet/GitHub Packages deploy are separate, permission-gated steps for a release manager, not something to do as part of this skill.
 
 1. Use [docs/releases/release-notes-template.md](../../../docs/releases/release-notes-template.md) as the structure and guidance — follow its `tl;dr` format, product-area grouping, and "Common Items To Check" list.
-2. Base the notes on every commit since the previous release tag, and incorporate all relevant content already drafted in [docs/releases/vnext-release-notes.md](../../../docs/releases/vnext-release-notes.md).
+2. Base the notes on every commit since the previous release tag, and incorporate all relevant content already drafted as fragment files under [docs/releases/vnext/](../../../docs/releases/vnext/README.md), plus (transitionally, see [#1432](https://github.com/FirelyTeam/firely-cql-sdk/issues/1432)) any content still directly in [docs/releases/vnext-release-notes.md](../../../docs/releases/vnext-release-notes.md) from PRs that predate the fragment convention.
 3. Call out exact public type/member/property/method names for API changes. For dependency version bumps, name the version property (e.g. `FirelyNetVersion`) and the old/new value.
 4. Save the new document as `docs/releases/release-notes-<version>.md`.
 5. Bump `VersionPrefix` (and `VersionSuffix` for a pre-release) in **every** `*.props` file that declares it — currently `cql-sdk.props` and `Demo/cql-demo.props`. Also update the `## Release Notes` section of `README.md` — it has a line like "This is release version X.Y.Z of the engine." that must stay in sync.
 6. **Confirm `FirelyNetVersion`** (in `cql-base.props`/`Demo/cql-demo.props`) still matches `FhirNetApiVersion` in [Vonk's `Directory.Packages.props` on `develop`](https://github.com/FirelyTeam/Vonk/blob/develop/Directory.Packages.props) — if you have a local Vonk clone, check the FirelyTeam `develop` branch specifically (e.g. `git show upstream/develop:Directory.Packages.props` if `upstream` points at `FirelyTeam/Vonk`, or `git show origin/develop:Directory.Packages.props` if `origin` does), not whatever branch happens to be checked out locally. Bump `FirelyNetVersion` to match if they've drifted.
 7. **Promote every `PublicAPI.Unshipped.txt` entry to that project's `PublicAPI.Shipped.txt`**, for every project that has pending entries (check all of them — e.g. `find . -path ./submodules -prune -o -name PublicAPI.Unshipped.txt -print`).
-8. After the new release notes document is written, **move** all content out of `docs/releases/vnext-release-notes.md` into it — that file's content is pre-drafted material for exactly this purpose and must not be left behind.
-9. Reset `docs/releases/vnext-release-notes.md` back to the empty template, ready for the next cycle:
+8. After the new release notes document is written, consolidate all pending content into it — none of it may be left behind:
+   - Glob `docs/releases/vnext/*.md` (excluding `README.md`). Fold each fragment's `## Breaking Changes`/`## Features`/`## Fixes` bullets into the matching section of the new document, then delete the fragment file.
+   - Also fold in any bullets still sitting directly in `docs/releases/vnext-release-notes.md` below its section headers — transitional content from PRs that predate the fragment convention (see [#1432](https://github.com/FirelyTeam/firely-cql-sdk/issues/1432)).
+9. Reset for the next cycle:
+   - Delete every fragment file under `docs/releases/vnext/` (except `README.md`).
+   - **If** `vnext-release-notes.md` had no directly-authored content left to fold in this time (the transitional file has fully drained), the transition is complete: replace `vnext-release-notes.md` with a short pointer doc — "Pending release notes are tracked as individual files under `docs/releases/vnext/`, one per PR. See that folder for everything accumulated since the last release." — instead of resetting it to the template, and remove the "transitional exception" wording from `CLAUDE.md` and copilot-instructions §4.5.1 (bump the copilot-instructions changelog for that removal, same as any other rule change there).
+   - **Otherwise** (there was still transitional content to fold in this cut), just reset `vnext-release-notes.md` back to the empty template below, ready for the next cycle:
 
-```md
-# vNext Release Notes
+     ```md
+     # vNext Release Notes
 
-## Breaking Changes
+     ## Breaking Changes
 
-## Features
+     ## Features
 
-## Fixes
-```
+     ## Fixes
+     ```
 
-Note: breaking changes should already be landing in `vnext-release-notes.md` as part of the PRs that introduce them (see root [CLAUDE.md](../../../CLAUDE.md)) — this skill is about turning that accumulated content into a versioned release, not about discovering breaking changes from scratch.
+Note: breaking changes should already be landing as `docs/releases/vnext/` fragments as part of the PRs that introduce them (see root [CLAUDE.md](../../../CLAUDE.md)) — this skill is about turning that accumulated content into a versioned release, not about discovering breaking changes from scratch.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # 1. Copilot Instructions for Firely CQL SDK
 
-**Version:** 3.9.0
+**Version:** 3.10.0
 
 This file is the decision-tree entry point. Route tasks here first, then open the focused sub-document before choosing tools.
 
@@ -97,6 +97,8 @@ This file is the decision-tree entry point. Route tasks here first, then open th
 
 ## 6.0. Appendix: Version History
 
+- 3.10.0
+  - Updated 4.5.1: release-note entries now go in a new fragment file under `docs/releases/vnext/` (one per PR) instead of directly editing the shared `vnext-release-notes.md`, which caused recurring merge conflicts between parallel PRs. Transitional exception noted for PRs that already added a direct entry before this convention existed. See `docs/releases/vnext/README.md` for the naming/format convention and [#1432](https://github.com/FirelyTeam/firely-cql-sdk/issues/1432) for the full rationale; mirrored into `CLAUDE.md`.
 - 3.9.0
   - Added a new rule (4.4.11) requiring Mermaid diagrams to be pre-rendered to `.svg` and embedded as an image rather than left as a raw fenced code block, since GitHub's inline renderer doesn't reliably support `classDiagram` `namespace`/`style`/`<<stereotype>>` syntax used in this repo's diagrams; mechanics live in the new `generate-svg-from-mermaid` skill (also mirrored into `CLAUDE.md`).
 - 3.8.1

--- a/.github/copilot-instructions/04-development-guidelines.md
+++ b/.github/copilot-instructions/04-development-guidelines.md
@@ -179,6 +179,6 @@ Parent document: [../copilot-instructions.md](../copilot-instructions.md)
 
 ## 4.5. Release Notes
 
-4.5.1 **Any breaking change** (public API, generated C# output, Packager CLI behavior, build/tooling behavior) must be recorded in [docs/releases/vnext-release-notes.md](../../docs/releases/vnext-release-notes.md) in the same PR that introduces it — not deferred to release time.
+4.5.1 **Any breaking change** (public API, generated C# output, Packager CLI behavior, build/tooling behavior) must be recorded in the same PR that introduces it — not deferred to release time. Add a new fragment file under [docs/releases/vnext/](../../docs/releases/vnext/README.md) (one file per PR — see that folder's README for the naming/format convention) rather than editing the shared `vnext-release-notes.md` directly, which causes merge conflicts between parallel PRs ([#1432](https://github.com/FirelyTeam/firely-cql-sdk/issues/1432)). **Transitional exception:** a PR that already added its entry directly to `vnext-release-notes.md` before this convention existed doesn't need to move it — only write new entries as fragments.
 
-4.5.2 For the full procedure to turn that accumulated content into a versioned release note (template, README version sync, resetting vnext-release-notes.md), follow [cut-release-notes](../../.claude/skills/cut-release-notes/SKILL.md).
+4.5.2 For the full procedure to turn that accumulated content into a versioned release note (template, README version sync, consolidating and clearing `docs/releases/vnext/` fragments), follow [cut-release-notes](../../.claude/skills/cut-release-notes/SKILL.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Any change that alters the C# emitted for CQL libraries requires bumping `Librar
 
 ## Release notes
 
-Any breaking change (public API, generated C# output, Packager CLI behavior, build/tooling behavior) must be recorded in [docs/releases/vnext-release-notes.md](docs/releases/vnext-release-notes.md) in the same PR that introduces it — not deferred to release time. See the `cut-release-notes` skill for the full release-cutting procedure.
+Any breaking change (public API, generated C# output, Packager CLI behavior, build/tooling behavior) must be recorded in the same PR that introduces it — not deferred to release time. Add a new fragment file under [docs/releases/vnext/](docs/releases/vnext/README.md) (one file per PR, see that folder's README for the naming/format convention) rather than editing the shared `vnext-release-notes.md` directly, which causes merge conflicts between parallel PRs (see [#1432](https://github.com/FirelyTeam/firely-cql-sdk/issues/1432)). **Transitional exception:** a PR that already added its entry directly to `vnext-release-notes.md` before this convention existed doesn't need to move it — only write new entries as fragments. See the `cut-release-notes` skill for the full release-cutting procedure, including how fragments get consolidated.
 
 ## Skills
 

--- a/docs/releases/vnext/README.md
+++ b/docs/releases/vnext/README.md
@@ -1,0 +1,46 @@
+# vNext release note fragments
+
+This folder holds one release-note fragment file per pull request, instead of everyone editing the
+single shared [`docs/releases/vnext-release-notes.md`](../vnext-release-notes.md) and hitting merge
+conflicts (see [#1432](https://github.com/FirelyTeam/firely-cql-sdk/issues/1432)).
+
+## When to add one
+
+Same trigger as before: any breaking change, feature, or fix worth calling out in the release notes
+must be recorded in the same PR that introduces it — not deferred to release time. See the root
+[CLAUDE.md](../../../CLAUDE.md) / [copilot-instructions](../../../.github/copilot-instructions/04-development-guidelines.md)
+for the exact rule.
+
+> **Transitional note** (see [#1432](https://github.com/FirelyTeam/firely-cql-sdk/issues/1432)): a PR
+> that already added its entry directly to `vnext-release-notes.md` before this folder existed does
+> not need to move it here. Only entries not yet written should use this folder.
+
+## Naming
+
+`<issue-number>-<short-slug>.md`, e.g. `1413-expand-overshoot.md` — use the tracking **issue** number
+(known as soon as the branch is created, per this repo's issue-number-prefixed branch naming
+convention), not the PR number (not assigned until the PR is opened). If a PR has no tracking issue,
+use a slug-only name unlikely to collide, e.g. `add-benchmark-skill.md`.
+
+`README.md` is reserved and is never treated as a fragment.
+
+## Format
+
+Exactly the same structure as `vnext-release-notes.md` itself, scoped to only the section(s) this PR
+needs:
+
+```md
+## Fixes
+
+- `Expand` no longer emits a trailing interval that overshoots the upper
+  boundary when `per` does not divide the interval width. ... (#1413)
+```
+
+A PR with both a breaking change and a fix writes both `##` sections in its one fragment file. No
+frontmatter or other metadata — the category comes from the `##` heading, same as today.
+
+## Consolidation
+
+Handled by the [`cut-release-notes`](../../../.claude/skills/cut-release-notes/SKILL.md) skill when a
+release is cut: every fragment here gets folded into the versioned release notes document, then
+deleted.


### PR DESCRIPTION
## Primary Work

Implements Phase 1 of #1432: introduces `docs/releases/vnext/` as a per-PR fragment directory for release notes, so parallel/stacked PRs stop conflicting on the single shared `docs/releases/vnext-release-notes.md` file (we hit this twice in one review session this week — PR #1421 vs. `develop`, and again against its own stacked base #1414).

- **New `docs/releases/vnext/README.md`** documents the convention: one fragment file per PR, named `<issue-number>-<short-slug>.md` (issue number chosen over PR number since it's known as soon as the branch is created, per this repo's branch-naming convention), same `##` section format as the shared file today (no new metadata format to invent).
- **`CLAUDE.md`** and **`.github/copilot-instructions/04-development-guidelines.md`** §4.5.1 updated in lockstep: new entries go in a fragment file; PRs that already added their entry directly to `vnext-release-notes.md` before this landed are grandfathered and don't need to change (dividing line is the entry, not the PR/branch age).
- **`.claude/skills/cut-release-notes/SKILL.md`** updated to consolidate from both sources during the transition (fragments + whatever's still directly in the shared file), and to self-detect when the transition is complete (the shared file has fully drained) — at that point a future release cut replaces it with a static pointer doc instead of resetting it to the template, and removes the transitional wording. No separate follow-up ticket needed for that; it's baked into the skill's own steps.
- **`docs/releases/vnext-release-notes.md` is deliberately left untouched** — per the phased plan, it stays live and directly editable until it naturally drains, so none of the ~12 currently open PRs need to redo their release-note entries.
- Copilot-instructions version bumped 3.9.0 → 3.10.0 with a changelog entry, per that document's own convention.

## Related issues

Refs #1432 (Phase 1 only — Phase 2, replacing `vnext-release-notes.md` with the pointer doc, happens at a future release cut once the transition has fully drained).

---

## Auxiliary Work

None.
