### PR TITLE
Fix interval Intersect with null boundaries

### DIFF
--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3390,14 +3390,108 @@ namespace CoreTests
             var result = ops.IntervalIncludesInterval(lhs, rhs, null);
             Assert.IsNull(result);
         }
+        // Interval[1, 10] intersect Interval[5, null) returns Interval[5, null):
+        // the start is certain, the end is unknown (spec 05, Interval Operators).
         [TestMethod]
-        public void TestIntersectNull()
+        public void TestIntersectOpenNullHighBoundary()
         {
             var lhs = new CqlInterval<int?>(1, 10, true, true);
             var rhs = new CqlInterval<int?>(5, null, true, false);
             var ops = GetNewContext().Operators;
             var result = ops.Intersect(lhs, rhs);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(5, result.low);
+            Assert.IsTrue(result.lowClosed ?? false);
+            Assert.IsNull(result.high);
+            Assert.IsFalse(result.highClosed ?? false);
+        }
+
+        // Interval[1, 10] intersect Interval[5, null] returns Interval[5, 10]:
+        // a null closed boundary is the maximum value of the point type.
+        [TestMethod]
+        public void TestIntersectClosedNullHighBoundary()
+        {
+            var lhs = new CqlInterval<int?>(1, 10, true, true);
+            var rhs = new CqlInterval<int?>(5, null, true, true);
+            var ops = GetNewContext().Operators;
+            var result = ops.Intersect(lhs, rhs);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(5, result.low);
+            Assert.IsTrue(result.lowClosed ?? false);
+            Assert.AreEqual(10, result.high);
+            Assert.IsTrue(result.highClosed ?? false);
+        }
+
+        // Interval(null, 10] intersect Interval[5, 20] returns Interval(null, 10]:
+        // the end is certain, the start is unknown.
+        [TestMethod]
+        public void TestIntersectOpenNullLowBoundary()
+        {
+            var lhs = new CqlInterval<int?>(null, 10, false, true);
+            var rhs = new CqlInterval<int?>(5, 20, true, true);
+            var ops = GetNewContext().Operators;
+            var result = ops.Intersect(lhs, rhs);
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.low);
+            Assert.IsFalse(result.lowClosed ?? false);
+            Assert.AreEqual(10, result.high);
+            Assert.IsTrue(result.highClosed ?? false);
+        }
+
+        // Interval[null, 10] intersect Interval[5, 20] returns Interval[5, 10]:
+        // a null closed boundary is the minimum value of the point type.
+        [TestMethod]
+        public void TestIntersectClosedNullLowBoundary()
+        {
+            var lhs = new CqlInterval<int?>(null, 10, true, true);
+            var rhs = new CqlInterval<int?>(5, 20, true, true);
+            var ops = GetNewContext().Operators;
+            var result = ops.Intersect(lhs, rhs);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(5, result.low);
+            Assert.IsTrue(result.lowClosed ?? false);
+            Assert.AreEqual(10, result.high);
+            Assert.IsTrue(result.highClosed ?? false);
+        }
+
+        // Interval[1, null) intersect Interval[5, 10] returns null: whether the
+        // intervals overlap at all depends on the unknown boundary.
+        [TestMethod]
+        public void TestIntersectIndeterminateOverlapIsNull()
+        {
+            var lhs = new CqlInterval<int?>(1, null, true, false);
+            var rhs = new CqlInterval<int?>(5, 10, true, true);
+            var ops = GetNewContext().Operators;
+            var result = ops.Intersect(lhs, rhs);
             Assert.IsNull(result);
+        }
+
+        // Interval[1, 3] intersect Interval[5, null) returns null: the intervals are
+        // disjoint regardless of the unknown boundary.
+        [TestMethod]
+        public void TestIntersectDisjointWithUnknownBoundaryIsNull()
+        {
+            var lhs = new CqlInterval<int?>(1, 3, true, true);
+            var rhs = new CqlInterval<int?>(5, null, true, false);
+            var ops = GetNewContext().Operators;
+            var result = ops.Intersect(lhs, rhs);
+            Assert.IsNull(result);
+        }
+
+        // Interval[1, null) intersect Interval[1, 10] returns Interval[1, null):
+        // the shared start makes the overlap certain even though the end is unknown.
+        [TestMethod]
+        public void TestIntersectCertainOverlapWithUnknownHighBoundary()
+        {
+            var lhs = new CqlInterval<int?>(1, null, true, false);
+            var rhs = new CqlInterval<int?>(1, 10, true, true);
+            var ops = GetNewContext().Operators;
+            var result = ops.Intersect(lhs, rhs);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.low);
+            Assert.IsTrue(result.lowClosed ?? false);
+            Assert.IsNull(result.high);
+            Assert.IsFalse(result.highClosed ?? false);
         }
 
         // { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes @T15:59:59

--- a/Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs
@@ -1071,27 +1071,62 @@ namespace Hl7.Cql.Operators
 
         public CqlInterval<T>? Intersect<T>(CqlInterval<T>? left, CqlInterval<T>? right)
         {
-            if (left == null
-               || right == null
-               || left.low == null
-               || left.high == null
-               || right.low == null
-               || right.high == null)
+            if (left == null || right == null)
                 return null;
 
-            var leftLow = left.low ?? MinValue<T>();
-            var leftHigh = left.high ?? MaxValue<T>();
-            var rightLow = right.low ?? MinValue<T>();
-            var rightHigh = right.high ?? MaxValue<T>();
-            if (Comparer.Compare(leftLow!, rightHigh!, null) > 0 || Comparer.Compare(rightLow!, leftHigh!, null) > 0) return null;
+            // A null closed boundary is the minimum/maximum value of the point type; a null
+            // open boundary is unknown and only nulls out comparisons that depend on it.
+            var leftLowUnknown = IsUnknownBoundary(left.low, left.lowClosed);
+            var leftHighUnknown = IsUnknownBoundary(left.high, left.highClosed);
+            var rightLowUnknown = IsUnknownBoundary(right.low, right.lowClosed);
+            var rightHighUnknown = IsUnknownBoundary(right.high, right.highClosed);
+
+            // Null when the arguments do not overlap, or when an unknown boundary makes it
+            // impossible to establish that they do.
+            bool? leftStartsAfterRightEnds = leftLowUnknown || rightHighUnknown
+                ? RangeGreaterThan(LowBoundaryRange(left), HighBoundaryRange(right), null)
+                : Comparer.Compare(left.low ?? MinValue<T>()!, right.high ?? MaxValue<T>()!, null) > 0;
+            bool? rightStartsAfterLeftEnds = rightLowUnknown || leftHighUnknown
+                ? RangeGreaterThan(LowBoundaryRange(right), HighBoundaryRange(left), null)
+                : Comparer.Compare(right.low ?? MinValue<T>()!, left.high ?? MaxValue<T>()!, null) > 0;
+            if (leftStartsAfterRightEnds != false || rightStartsAfterLeftEnds != false)
+                return null;
+
+            T? LowValue;
+            bool LowValueClosed;
+            T? HighValue;
+            bool HighValueClosed;
+
+            // The result low is the larger of the lows. When an unknown boundary is involved
+            // and the comparison is indeterminate, the result low is itself unknown.
+            if (leftLowUnknown || rightLowUnknown)
+            {
+                var leftLowGreaterOrEqual = RangeGreaterOrEqual(LowBoundaryRange(left), LowBoundaryRange(right), null);
+                var rightLowGreaterOrEqual = RangeGreaterOrEqual(LowBoundaryRange(right), LowBoundaryRange(left), null);
+                if (leftLowGreaterOrEqual == true && rightLowGreaterOrEqual == true)
+                {
+                    LowValue = left.low;
+                    LowValueClosed = (left.lowClosed ?? false) && (right.lowClosed ?? false);
+                }
+                else if (leftLowGreaterOrEqual == true)
+                {
+                    LowValue = left.low;
+                    LowValueClosed = left.lowClosed ?? false;
+                }
+                else if (rightLowGreaterOrEqual == true)
+                {
+                    LowValue = right.low;
+                    LowValueClosed = right.lowClosed ?? false;
+                }
+                else
+                {
+                    LowValue = default;
+                    LowValueClosed = false;
+                }
+            }
             else
             {
-                T LowValue;
-                bool LowValueClosed;
-                T HighValue;
-                bool HighValueClosed;
-
-                var leftCompare = Comparer.Compare(leftLow!, rightLow!, null);
+                var leftCompare = Comparer.Compare(left.low ?? MinValue<T>()!, right.low ?? MinValue<T>()!, null);
                 if (leftCompare > 0)
                 {
                     LowValue = left.low;
@@ -1107,8 +1142,37 @@ namespace Hl7.Cql.Operators
                     LowValue = right.low;
                     LowValueClosed = right.lowClosed ?? false;
                 }
+            }
 
-                var rightCompare = Comparer.Compare(leftHigh!, rightHigh!, null);
+            // The result high is the smaller of the highs, with the same unknown handling.
+            if (leftHighUnknown || rightHighUnknown)
+            {
+                var leftHighLessOrEqual = RangeLessOrEqual(HighBoundaryRange(left), HighBoundaryRange(right), null);
+                var rightHighLessOrEqual = RangeLessOrEqual(HighBoundaryRange(right), HighBoundaryRange(left), null);
+                if (leftHighLessOrEqual == true && rightHighLessOrEqual == true)
+                {
+                    HighValue = left.high;
+                    HighValueClosed = (left.highClosed ?? false) && (right.highClosed ?? false);
+                }
+                else if (leftHighLessOrEqual == true)
+                {
+                    HighValue = left.high;
+                    HighValueClosed = left.highClosed ?? false;
+                }
+                else if (rightHighLessOrEqual == true)
+                {
+                    HighValue = right.high;
+                    HighValueClosed = right.highClosed ?? false;
+                }
+                else
+                {
+                    HighValue = default;
+                    HighValueClosed = false;
+                }
+            }
+            else
+            {
+                var rightCompare = Comparer.Compare(left.high ?? MaxValue<T>()!, right.high ?? MaxValue<T>()!, null);
                 if (rightCompare < 0)
                 {
                     HighValue = left.high;
@@ -1124,9 +1188,9 @@ namespace Hl7.Cql.Operators
                     HighValue = right.high;
                     HighValueClosed = right.highClosed ?? false;
                 }
-
-                return new CqlInterval<T>(LowValue, HighValue, LowValueClosed, HighValueClosed);
             }
+
+            return new CqlInterval<T>(LowValue, HighValue, LowValueClosed, HighValueClosed);
         }
 
         #endregion

--- a/docs/releases/vnext/1459-interval-intersect-null-boundaries.md
+++ b/docs/releases/vnext/1459-interval-intersect-null-boundaries.md
@@ -1,0 +1,9 @@
+## Fixes
+
+- The interval `intersect` operator no longer returns `null` whenever one of the operands has a
+  `null` boundary. Null closed boundaries are now interpreted as the minimum/maximum value of the
+  point type, and null open boundaries as unknown boundaries, per the CQL specification:
+  `Interval[1, 10] intersect Interval[5, null)` now returns `Interval[5, null)` instead of `null`,
+  and `Interval[1, 10] intersect Interval[5, null]` now returns `Interval[5, 10]`. The result is
+  still `null` when the operands do not overlap or when an unknown boundary makes the overlap
+  undeterminable. (#1457)


### PR DESCRIPTION
## Description
`Intersect<T>` for intervals short-circuited to `null` whenever **any** of the four boundary values was `null`, ignoring the open/closed flag. Per the CQL spec, a null closed boundary is the minimum/maximum of the point type, and a null open boundary is an *uncertainty* that only nulls out comparisons that depend on it (spec 05, "Interval Operators" — which uses `Interval[1, 10] intersect Interval[5, null)` as its worked example).

`Intersect` now reuses the existing `IsUnknownBoundary`/boundary-range helpers already used by `IntervalIncludesInterval` and `OverlapsHelper`:

- The overlap pre-check compares uncertainty ranges when an unknown boundary is involved; the result is `null` when the intervals are disjoint **or** when the overlap cannot be established because of an unknown boundary.
- The max-of-lows/min-of-highs boundary selection likewise compares ranges; an indeterminate comparison emits a null **open** result boundary (unknown), while determinate comparisons pick the known boundary and its closed flag as before.
- Null **closed** boundaries flow through the pre-existing `?? MinValue<T>()`/`?? MaxValue<T>()` normalization (previously dead code behind the removed guard).

Behavior for intervals with all-known boundaries is unchanged, and there is no `ICqlOperators` signature change (no `GeneratorToolVersion` bump needed).

Examples:

| Expression | Before | After |
|---|---|---|
| `Interval[1, 10] intersect Interval[5, null)` | `null` | `Interval[5, null)` |
| `Interval[1, 10] intersect Interval[5, null]` | `null` | `Interval[5, 10]` |
| `Interval(null, 10] intersect Interval[5, 20]` | `null` | `Interval(null, 10]` |
| `Interval[1, null) intersect Interval[5, 10]` | `null` | `null` (overlap unknowable) |

## Related issues
Fixes #1457.

## Testing
- Replaced `TestIntersectNull` (which asserted the buggy null result for the spec's worked example) with seven tests in `CoreTests/PrimitiveTests.cs` covering: open-null high (spec example), closed-null high, open-null low, closed-null low, indeterminate overlap → null, disjoint with unknown boundary → null, and certain overlap with unknown high.
- Full `CoreTests` suite: 1061 passed, 0 failed (net10.0).
- Full integration test suite (`Firely.Cql.Sdk.Integration.Runner`, CMS/HEDIS corpus, 3857 cases): **no regressions** — every case in the committed `passed.jsonl` baseline (2851) still passes with this branch. The run showed 3 additional passes vs. that baseline (all `CMS156FHIRHighRiskMedsElderly`), but an A/B run against `develop` without this fix produces the identical pass set, so those flips come from changes already on `develop` since the baseline was last regenerated (2026-07-29), not from this PR.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jcpygZCSctt5u8CffsYxd