### PR TITLE
Require commit SHA and detail when resolving review comments

### DIFF
--- a/.claude/skills/resolve-pr-review-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-review-comments/SKILL.md
@@ -14,7 +14,7 @@ description: Address code review comments (e.g. from Copilot's automated PR revi
    - the **test** that pins it, if one was added or changed,
    - and how the fix was **verified**, when that's not obvious (e.g. "confirmed the test fails with the fix reverted").
 
-   `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies -f body="Fixed in <sha> — ..."`
+   `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies -X POST -f body="Fixed in <sha> — ..."`
 
    **If a comment was refuted rather than fixed** (per step 2), there is no SHA to cite, so give the concrete evidence in its place: the build result, an existing in-repo precedent, or the passing test that disproves the claim. Say plainly that you're leaving the code as-is and why. Never resolve a refuted thread with a bare "this is incorrect".
 5. **Mark the conversation resolved** — this does not happen automatically just by pushing a fix or replying. Look up the review thread's node ID (not the comment ID) via GraphQL, since only GraphQL can resolve threads:

--- a/.claude/skills/resolve-pr-review-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-review-comments/SKILL.md
@@ -7,8 +7,16 @@ description: Address code review comments (e.g. from Copilot's automated PR revi
 
 1. Fetch the inline review comments: `gh api repos/<owner>/<repo>/pulls/<n>/comments -q '.[] | {id, path, line, body}'`.
 2. **Verify each comment before acting on it** — a review comment (bot or human) can itself be wrong. Check the claim against the real repo state (read the file, run the check) rather than applying it blindly.
-3. Fix what's genuinely wrong, commit, and push to the PR's branch.
-4. Reply to each comment thread confirming what changed, referencing the commit: `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies -f body="Fixed in <sha> — ..."`.
+3. Fix what's genuinely wrong, commit, and push to the PR's branch. Prefer one commit per comment, so each thread maps to a reviewable change.
+4. Reply to each comment thread before resolving it. **Every reply must make the thread self-contained** — someone reading the resolved thread should see which commit to look at and what it did, without cross-referencing the commit list. Include:
+   - the **commit SHA** (short form is fine),
+   - **what actually changed**, in a sentence or two — not just "fixed",
+   - the **test** that pins it, if one was added or changed,
+   - and how the fix was **verified**, when that's not obvious (e.g. "confirmed the test fails with the fix reverted").
+
+   `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies -f body="Fixed in <sha> — ..."`
+
+   **If a comment was refuted rather than fixed** (per step 2), there is no SHA to cite, so give the concrete evidence in its place: the build result, an existing in-repo precedent, or the passing test that disproves the claim. Say plainly that you're leaving the code as-is and why. Never resolve a refuted thread with a bare "this is incorrect".
 5. **Mark the conversation resolved** — this does not happen automatically just by pushing a fix or replying. Look up the review thread's node ID (not the comment ID) via GraphQL, since only GraphQL can resolve threads:
 
 ```graphql

--- a/.claude/skills/sync-acceptance-criteria/SKILL.md
+++ b/.claude/skills/sync-acceptance-criteria/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: sync-acceptance-criteria
-description: Tick off completed acceptance-criteria checkboxes in a linked issue/ticket or PR body after finishing and pushing the corresponding work. Use right after pushing commits to a PR, before reporting the task as done.
+description: Tick off completed acceptance-criteria checkboxes in a linked issue/ticket or PR body. Use after pushing commits to a PR, after a follow-up commit that addresses review comments, and when reviewing a PR — before reporting the review or the task as done.
 ---
 
 # Sync acceptance criteria
 
-After pushing work to a PR, check whether the linked issue and/or the PR body has an "Acceptance Criteria" (or similar) checklist, and update it to reflect what's actually true on the pushed branch:
+## When to run this
+
+Run it at **every** point where the truth of a checklist may have changed — not only when first pushing a feature:
+
+- **After pushing work to a PR**, before reporting the task done.
+- **After a follow-up commit**, e.g. one that addresses review comments. A fix for a review comment often satisfies a criterion that was previously unmet, and the checklist is otherwise left stale by exactly the commits most likely to complete it.
+- **When reviewing a PR**, including someone else's. If the PR demonstrably satisfies criteria in its linked ticket, tick them off as part of the review rather than leaving it to the author — the review is the point at which someone has actually verified them.
+
+In all three cases this applies to the checklist in the **linked issue** as well as the PR body. Find the linked issue with `gh api graphql` on `pullRequest.closingIssuesReferences` — a PR body using `Refs #N` instead of `Fixes #N` has no closing reference, so fall back to reading the ticket number out of the body.
+
+## Procedure
+
+Check whether the linked issue and/or the PR body has an "Acceptance Criteria" (or similar) checklist, and update it to reflect what's actually true on the pushed branch:
 
 1. Fetch the **current** body first (`gh issue view <n> --json body -q '.body'` / `gh pr view <n> --json body -q '.body'`) — never edit from a stale copy, since someone (or an earlier step in the same session) may have changed it since you last read it.
 2. For each unchecked item, verify honestly against the real repo/branch state (read the file, run the check, `grep` for the thing) before checking it off. **Never check off a criterion you haven't actually verified** — a false positive here is worse than leaving it unchecked for a human to confirm.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # 1. Copilot Instructions for Firely CQL SDK
 
-**Version:** 3.12.0
+**Version:** 3.13.0
 
 This file is the decision-tree entry point. Route tasks here first, then open the focused sub-document before choosing tools.
 
@@ -97,6 +97,9 @@ This file is the decision-tree entry point. Route tasks here first, then open th
 
 ## 6.0. Appendix: Version History
 
+- 3.13.0
+  - Broadened 1.8.1 (acceptance-criteria tracking): criteria are now ticked off automatically at every point where a checklist's truth may have changed — after pushing work, after a follow-up commit addressing review comments, and when reviewing a PR (including someone else's) — not only when first pushing. The `sync-acceptance-criteria` skill gains a "When to run this" section covering the three triggers plus how to resolve the linked issue when a PR uses `Refs` rather than `Fixes`. Mirrored into `CLAUDE.md`.
+  - Expanded the `resolve-pr-review-comments` skill (referenced from 1.9.1): step 4 now states what a reply must contain before a thread is resolved (commit SHA, what changed, the test that pins it, how it was verified), asks for one commit per comment, and adds guidance for a comment that turns out to be wrong — give the concrete evidence in place of a SHA rather than resolving with a bare "this is incorrect" ([#1463](https://github.com/FirelyTeam/firely-cql-sdk/issues/1463)).
 - 3.12.0
   - Completed Phase 2 of the fragment-file convention ([#1445](https://github.com/FirelyTeam/firely-cql-sdk/issues/1445)): replaced `docs/releases/vnext-release-notes.md` with a static pointer doc; dropped the "Transitional exception" sentence from §4.5.1 and the dual-source description from §4.5.2; updated the `cut-release-notes` skill to remove the transitional callout and the `vnext-release-notes.md` sweep step; fragment files under `docs/releases/vnext/` are now the sole pending-content source. Mirrored into `CLAUDE.md`.
 - 3.11.0

--- a/.github/copilot-instructions/01-user-workflow-preferences.md
+++ b/.github/copilot-instructions/01-user-workflow-preferences.md
@@ -96,7 +96,7 @@ Parent document: [../copilot-instructions.md](../copilot-instructions.md)
 
 ## 1.8. Acceptance Criteria Tracking
 
-1.8.1 After pushing work that completes one or more acceptance-criteria checkboxes in a linked issue or the PR body, tick them off before reporting the task done — follow the shared procedure in [sync-acceptance-criteria](../../.claude/skills/sync-acceptance-criteria/SKILL.md).
+1.8.1 Tick off acceptance-criteria checkboxes in a PR's linked issue (and the PR body) automatically, whenever their truth may have changed: after pushing work, after a follow-up commit that addresses review comments, and when reviewing a PR — including someone else's. Do it before reporting the review or the task done — follow the shared procedure in [sync-acceptance-criteria](../../.claude/skills/sync-acceptance-criteria/SKILL.md).
 
 ## 1.9. PR Review Comment Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ If the user gives a memory-style instruction ("remember...", "never...", "always
 - When asked for ideas, suggestions, or "what's the best way to..." — discuss 2-3 options with trade-offs and wait for the user to pick one before implementing. Don't jump straight to code for exploratory questions.
 - When running PowerShell via a terminal tool, always use non-interactive mode (`-NonInteractive`) — interactive PowerShell/`dotnet repl` sessions will hang waiting for input. Don't open an interactive shell unless explicitly asked.
 - Prefer the GitHub CLI (`gh`) over raw HTTP/browser steps for issue/PR lookup and edits. If it's missing, install and authenticate it first.
-- After pushing work that completes one or more acceptance-criteria checkboxes in a linked issue or the PR body, tick them off before reporting the task done — see the `sync-acceptance-criteria` skill.
+- Tick off acceptance-criteria checkboxes in a PR's linked issue (and the PR body) automatically, whenever their truth may have changed: after pushing work, after a follow-up commit that addresses review comments, and when reviewing a PR — including someone else's. Do it before reporting the review or the task done — see the `sync-acceptance-criteria` skill.
 - After fixing a review comment and pushing the fix, mark that conversation resolved (it doesn't happen automatically) — see the `resolve-pr-review-comments` skill.
 
 ## Code conventions (non-obvious ones)


### PR DESCRIPTION
## Primary Work

Tightens step 4 of the [`resolve-pr-review-comments`](.claude/skills/resolve-pr-review-comments/SKILL.md) skill.

The step already said to reference the commit, but didn't say what a good reply actually contains, and said nothing about the case where a review comment turns out to be **wrong**. A resolved thread should be self-contained — someone reading it later should see which commit to look at and what that commit did, without cross-referencing the commit list.

Changes:

- Spells out the four things a reply needs before resolving: the **commit SHA**, **what actually changed** (not just "fixed"), the **test** that pins it, and how the fix was **verified** where that isn't obvious.
- Asks for **one commit per comment**, so each thread maps to a reviewable change.
- Adds guidance for **refuted** comments: there's no SHA to cite, so give the concrete evidence in its place (build result, existing in-repo precedent, or the passing test that disproves the claim), state plainly that the code is staying as-is and why, and never resolve with a bare "this is incorrect".

Prompted by the Copilot review on #1461, where one of three comments was factually incorrect (it claimed a legal C# record-property redeclaration wouldn't compile) and the skill offered no guidance on how to close that out.

### Also: acceptance-criteria tracking triggers

Same class of problem in [`sync-acceptance-criteria`](.claude/skills/sync-acceptance-criteria/SKILL.md) — a correct procedure with too narrow a trigger. It fired only "after pushing work to a PR", leaving a checklist stale at the two moments most likely to complete it: a **follow-up commit** addressing review comments, and the **review itself**, which is when someone has actually verified the criteria (and should tick them off even on someone else's PR).

Adds a "When to run this" section naming all three triggers, and notes how to find the linked issue when a PR uses `Refs #N` rather than `Fixes #N`, since `closingIssuesReferences` comes back empty in that case.

Folded into this PR rather than opened separately: same directory, same theme (PR-review closeout hygiene), and reviewable in one pass.

## Auxiliary Work

- Mirrored the acceptance-criteria trigger change into `CLAUDE.md` and `.github/copilot-instructions/01-user-workflow-preferences.md` §1.8.1. Unlike §1.9.1 (which only links), §1.8.1 **restates** the trigger wording, so the sync rule in `CLAUDE.md` requires updating it.
- Bumped `.github/copilot-instructions.md` to **3.13.0** with changelog entries for both changes in this PR.

Note this touches only `.claude/`, `.github/` and `CLAUDE.md`, all of which are in `ignorePatterns` in `build/azure-pipelines.yml`, so CI will skip the full build.

Fixes #1463
