### PR TITLE
Fix FHIR stratifier invariant violation in generated measures

### DIFF
--- a/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
+++ b/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
@@ -10,6 +10,7 @@
 
 using Hl7.Cql.Elm;
 using Hl7.Cql.Packaging;
+using Hl7.FhirPath;
 using ElmAnnotation = Hl7.Cql.Elm.Annotation;
 using ElmLibrary = Hl7.Cql.Elm.Library;
 using FhirLibrary = Hl7.Fhir.Model.Library;
@@ -269,11 +270,17 @@ public class FhirMeasureExtensionsTests
             "the definition should also contribute a stratifier component");
     }
 
+    /// <summary>
+    /// The FHIR R4 invariant mea-1 on Measure ("Stratifier SHALL be either a single
+    /// criteria or a set of criteria components"), evaluated as the literal FhirPath
+    /// expression rather than a hand-rolled C# translation of it.
+    /// </summary>
+    private const string StratifierInvariant =
+        "group.stratifier.all((code | description | criteria).exists() xor component.exists())";
+
     [TestMethod]
     public void GeneratedStratifiers_SatisfyFhirStratifierInvariant()
     {
-        // FHIR invariant on Measure.group.stratifier:
-        // (code | description | criteria).exists() xor component.exists()
         var measure = CreateMeasure(BaseStatements(
             Def("Region Stratifier",
                 CreateTag("group", "RateA"),
@@ -284,15 +291,21 @@ public class FhirMeasureExtensionsTests
                 CreateTag("stratifier", "AgeBand"),
                 CreateTag("description", "Stratifies by age band"))));
 
+        new FhirPathCompiler().Compile(StratifierInvariant)
+            .Predicate(measure, new EvaluationContext())
+            .Should().BeTrue("generated measures must satisfy invariant mea-1: {0}", StratifierInvariant);
+
+        // Targeted halves of the invariant, so a failure identifies which side broke:
+        // the container carries no own content, while every component is fully populated.
         var stratifiers = measure.Group.SelectMany(g => g.Stratifier).ToList();
         stratifiers.Should().NotBeEmpty();
-        foreach (var stratifier in stratifiers)
-        {
-            var hasOwnContent = stratifier.Code != null || stratifier.Description != null || stratifier.Criteria != null;
-            var hasComponents = stratifier.Component.Count > 0;
-            (hasOwnContent ^ hasComponents).Should().BeTrue(
-                "stratifier {0} must have either code/description/criteria or components, never both", stratifier.ElementId);
-        }
+        stratifiers.Should().OnlyContain(s => s.Code == null && s.Description == null && s.Criteria == null,
+            "container stratifiers must not carry code/description/criteria");
+        stratifiers.Should().OnlyContain(s => s.Component.Count > 0,
+            "a container with no components would satisfy neither side of the invariant's xor");
+        stratifiers.SelectMany(s => s.Component).Should().OnlyContain(
+            c => c.Code != null && c.Description != null && c.Criteria != null,
+            "the stratification's meaning lives on the components");
     }
 
     [TestMethod]

--- a/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
+++ b/Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs
@@ -81,8 +81,8 @@ public class FhirMeasureExtensionsTests
         var group = measure.Group.Single(g => g.ElementId == "RateA");
         var container = group.Stratifier.Should().ContainSingle().Subject;
         container.ElementId.Should().Be("RateA-Stratifier");
-        container.Code!.Text.Should().Be("RateA-Stratifier");
-        container.Description.Should().Be("RateA-Stratifier");
+        container.Code.Should().BeNull("a stratifier with components must not also have a code (FHIR stratifier invariant)");
+        container.Description.Should().BeNull("a stratifier with components must not also have a description (FHIR stratifier invariant)");
         container.Criteria.Should().BeNull("the container stratifier only holds components");
 
         var component = container.Component.Should().ContainSingle().Subject;
@@ -267,6 +267,32 @@ public class FhirMeasureExtensionsTests
         var component = group.Stratifier.Single().Component.Single();
         component.Criteria.Expression_.Should().Be("Denominator Stratifier",
             "the definition should also contribute a stratifier component");
+    }
+
+    [TestMethod]
+    public void GeneratedStratifiers_SatisfyFhirStratifierInvariant()
+    {
+        // FHIR invariant on Measure.group.stratifier:
+        // (code | description | criteria).exists() xor component.exists()
+        var measure = CreateMeasure(BaseStatements(
+            Def("Region Stratifier",
+                CreateTag("group", "RateA"),
+                CreateTag("group", "RateB"),
+                CreateTag("stratifier", "Region")),
+            Def("Age Band Stratifier",
+                CreateTag("group", "RateA"),
+                CreateTag("stratifier", "AgeBand"),
+                CreateTag("description", "Stratifies by age band"))));
+
+        var stratifiers = measure.Group.SelectMany(g => g.Stratifier).ToList();
+        stratifiers.Should().NotBeEmpty();
+        foreach (var stratifier in stratifiers)
+        {
+            var hasOwnContent = stratifier.Code != null || stratifier.Description != null || stratifier.Criteria != null;
+            var hasComponents = stratifier.Component.Count > 0;
+            (hasOwnContent ^ hasComponents).Should().BeTrue(
+                "stratifier {0} must have either code/description/criteria or components, never both", stratifier.ElementId);
+        }
     }
 
     [TestMethod]

--- a/Cql/Cql.Packaging/FhirMeasureExtensions.cs
+++ b/Cql/Cql.Packaging/FhirMeasureExtensions.cs
@@ -231,11 +231,12 @@ internal static partial class FhirMeasureExtensions
         if (existing != null)
             return existing;
 
+        // Only the element id is set: the FHIR invariant on Measure.group.stratifier
+        // ((code | description | criteria).exists() xor component.exists()) forbids
+        // code/description/criteria on a stratifier that holds components.
         var container = new FhirMeasure.StratifierComponent
         {
             ElementId = id,
-            Code = new CodeableConcept { Text = id },
-            Description = id,
         };
         group.Stratifier.Add(container);
         return container;

--- a/Cql/Cql.Packaging/FhirMeasureExtensions.cs
+++ b/Cql/Cql.Packaging/FhirMeasureExtensions.cs
@@ -224,22 +224,27 @@ internal static partial class FhirMeasureExtensions
         }
     }
 
-    private static FhirMeasure.StratifierComponent GetOrCreateStratifier(FhirMeasure.GroupComponent group)
+    private static void AddStratifierComponent(FhirMeasure.GroupComponent group, FhirMeasure.ComponentComponent component)
     {
         var id = $"{group.ElementId}-Stratifier";
-        var existing = group.Stratifier.FirstOrDefault(s => s.ElementId == id);
-        if (existing != null)
-            return existing;
+        var container = group.Stratifier.FirstOrDefault(s => s.ElementId == id);
+        if (container?.Component.Any(c => c.ElementId == component.ElementId) == true)
+            throw new InvalidOperationException($"Stratifier component {component.ElementId} is defined twice for this measure.");
 
-        // Only the element id is set: the FHIR invariant on Measure.group.stratifier
-        // ((code | description | criteria).exists() xor component.exists()) forbids
-        // code/description/criteria on a stratifier that holds components.
-        var container = new FhirMeasure.StratifierComponent
+        if (container == null)
         {
-            ElementId = id,
-        };
-        group.Stratifier.Add(container);
-        return container;
+            // Only the element id is set: the FHIR invariant on Measure.group.stratifier
+            // ((code | description | criteria).exists() xor component.exists()) forbids
+            // code/description/criteria on a stratifier that holds components — and a
+            // container with no components satisfies neither side of the xor, so the
+            // container is only ever created together with its first component.
+            container = new FhirMeasure.StratifierComponent
+            {
+                ElementId = id,
+            };
+            group.Stratifier.Add(container);
+        }
+        container.Component.Add(component);
     }
 
     private static void AnnotateMeasureStratifiers(FhirMeasure fhirMeasure, ElmLibrary library, string? measureGroupCodeSystem)
@@ -276,13 +281,9 @@ internal static partial class FhirMeasureExtensions
             foreach (var tuple in tuples)
             {
                 var group = GetOrCreateGroup(fhirMeasure, tuple.Group, measureGroupCodeSystem);
-                var container = GetOrCreateStratifier(group);
 
                 var componentId = $"{tuple.Group}-StratifierComponent-{tuple.Stratifier}";
-                if (container.Component.Any(c => c.ElementId == componentId))
-                    throw new InvalidOperationException($"Stratifier component {componentId} is defined twice for this measure.");
-
-                container.Component.Add(new FhirMeasure.ComponentComponent
+                AddStratifierComponent(group, new FhirMeasure.ComponentComponent
                 {
                     ElementId = componentId,
                     Code = new CodeableConcept { Text = tuple.Stratifier },

--- a/Demo/Cql/Build/CqlTooling.Targets.xml
+++ b/Demo/Cql/Build/CqlTooling.Targets.xml
@@ -189,7 +189,10 @@ static string PrettyPrintJson(string json)
 		<JavaCommand>java</JavaCommand>
 		<!-- <JavaCommand>java -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persistence.jaxb.XMLBindingContextFactory</JavaCommand> -->
 
-		<ClassPath>-classpath $(TargetDependencies)/* org.cqframework.cql.cql2elm.cli.Main</ClassPath>
+		<!-- The classpath wildcard must be quoted so Unix shells pass it through for java
+		     to expand itself; unquoted, sh expands it and the first extra jar path is
+		     misread as the main class. Quotes are harmless on Windows. -->
+		<ClassPath>-classpath "$(TargetDependencies)/*" org.cqframework.cql.cql2elm.cli.Main</ClassPath>
 		<JavaOutputFile>$(MSBuildProjectDirectory)/elm-build.log</JavaOutputFile>
 		<JavaArgs>-input $(CqlDirectory) -f JSON -output $(ElmDirectory) -locators true -result-types true -signatures All</JavaArgs>
 		<JavaCLI>"$(JavaCommand)" $(ClassPath) $(JavaArgs)</JavaCLI>

--- a/Demo/Measures.Demo/CSharp/MeasureExample-0.0.1.g.cs
+++ b/Demo/Measures.Demo/CSharp/MeasureExample-0.0.1.g.cs
@@ -12,11 +12,11 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.2.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.7.0")]
 [CqlLibrary("MeasureExample", "0.0.1")]
 public partial class MeasureExample_0_0_1 : ILibrary, ISingleton<MeasureExample_0_0_1>
 {
-    #region Functions and Expressions (6)
+    #region Functions and Expressions (7)
 
     [CqlExpressionDefinition("Patient")]
     public Patient Patient(CqlContext context) =>
@@ -103,6 +103,25 @@ public partial class MeasureExample_0_0_1 : ILibrary, ISingleton<MeasureExample_
 
     private bool? Numerator_2_Compute(CqlContext context) =>
     false;
+
+
+    [CqlExpressionDefinition("Gender Stratifier")]
+    [CqlTag("group", "1")]
+    [CqlTag("stratifier", "Gender")]
+    [CqlTag("description", "Stratifies by the patient's administrative gender")]
+    public string Gender_Stratifier(CqlContext context) =>
+        context.GetOrCompute(_cacheIndex_Gender_Stratifier, Gender_Stratifier_Compute);
+
+    private const long _cacheIndex_Gender_Stratifier = -8144273202348602151L;
+
+    private string Gender_Stratifier_Compute(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Code<AdministrativeGender> b_ = a_?.GenderElement;
+        AdministrativeGender? c_ = b_?.Value;
+        string d_ = context.Operators.Convert<string>(c_);
+        return d_;
+    }
 
 
     #endregion Functions and Expressions

--- a/LibrarySets/Demo/Cql/MeasureExample.cql
+++ b/LibrarySets/Demo/Cql/MeasureExample.cql
@@ -49,3 +49,11 @@ define "Numerator 1":
 */
 define "Numerator 2":
 	false
+
+/*
+* @group: 1
+* @stratifier: Gender
+* @description: Stratifies by the patient's administrative gender
+*/
+define "Gender Stratifier":
+	Patient.gender.value

--- a/LibrarySets/Demo/Elm/MeasureExample.json
+++ b/LibrarySets/Demo/Elm/MeasureExample.json
@@ -228,6 +228,46 @@
                "value" : "false",
                "annotation" : [ ]
             }
+         }, {
+            "locator" : "58:1-59:21",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+            "name" : "Gender Stratifier",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "t" : [ {
+                  "name" : "group",
+                  "value" : "1"
+               }, {
+                  "name" : "stratifier",
+                  "value" : "Gender"
+               }, {
+                  "name" : "description",
+                  "value" : "Stratifies by the patient's administrative gender"
+               } ]
+            } ],
+            "expression" : {
+               "type" : "Property",
+               "locator" : "59:2-59:21",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+               "path" : "value",
+               "annotation" : [ ],
+               "source" : {
+                  "type" : "Property",
+                  "locator" : "59:2-59:15",
+                  "resultTypeName" : "{http://hl7.org/fhir}AdministrativeGender",
+                  "path" : "gender",
+                  "annotation" : [ ],
+                  "source" : {
+                     "type" : "ExpressionRef",
+                     "locator" : "59:2-59:8",
+                     "resultTypeName" : "{http://hl7.org/fhir}Patient",
+                     "name" : "Patient",
+                     "annotation" : [ ]
+                  }
+               }
+            }
          } ]
       }
    }

--- a/docs/cql-packager.md
+++ b/docs/cql-packager.md
@@ -216,7 +216,10 @@ ELM `annotation` element. See `LibrarySets/Demo/Cql/MeasureExample.cql` for a co
 
 All stratifier-tagged definitions of a group collapse into a single container stratifier
 (`<group>-Stratifier`) whose dimensions are `stratifier.component` entries — including when a group
-has only one dimension. Each component gets id `<group>-StratifierComponent-<value>`, a text-only
+has only one dimension. The container carries only its element id — no `code`, `description`, or
+`criteria` — because the FHIR invariant on `Measure.group.stratifier`
+(`(code | description | criteria).exists() xor component.exists()`) forbids combining them with
+components. Each component gets id `<group>-StratifierComponent-<value>`, a text-only
 code with the `@stratifier` value, and a `text/cql-identifier` criteria referencing the definition.
 The definition's return value is the stratum value for the subject; any CQL type is allowed.
 

--- a/docs/cql-packager.md
+++ b/docs/cql-packager.md
@@ -219,9 +219,20 @@ All stratifier-tagged definitions of a group collapse into a single container st
 has only one dimension. The container carries only its element id — no `code`, `description`, or
 `criteria` — because the FHIR invariant on `Measure.group.stratifier`
 (`(code | description | criteria).exists() xor component.exists()`) forbids combining them with
-components. Each component gets id `<group>-StratifierComponent-<value>`, a text-only
-code with the `@stratifier` value, and a `text/cql-identifier` criteria referencing the definition.
+components. The human-readable labels therefore live on the components: each component gets id
+`<group>-StratifierComponent-<value>`, a text-only code with the `@stratifier` value (and the
+`@description` value as its description), and a `text/cql-identifier` criteria referencing the
+definition — display or key on `stratifier.component.code`/`.description`, not on the container.
 The definition's return value is the stratum value for the subject; any CQL type is allowed.
+
+Because the dimensions are modelled as components of one stratifier, they form a single
+**composite** stratification: a `MeasureReport` stratum is the combination of all the group's
+dimension values (one `stratum.component` per dimension), not one independent stratification per
+`@stratifier` tag. This is how FHIR defines multi-component stratifiers ("Stratifiers are defined
+either as a single criteria, or as a set of component criteria") — see the
+[Measure resource definitions](https://hl7.org/fhir/R4/measure-definitions.html) and the
+[CQF Measures IG measure conformance page](https://hl7.org/fhir/us/cqfmeasures/measure-conformance.html)
+(both mirrored under [/spec/fhir/condensed/](../spec/fhir/README.md)).
 
 ```cql
 /*

--- a/docs/releases/vnext/1499-measure-stratifier-invariant.md
+++ b/docs/releases/vnext/1499-measure-stratifier-invariant.md
@@ -6,4 +6,4 @@
   `Measure.group.stratifier`
   (`(code | description | criteria).exists() xor component.exists()`), so the previous
   output failed validation. The container now carries only its element id
-  (`<group>-Stratifier`); the components are unchanged.
+  (`<group>-Stratifier`); the components are unchanged. (#1499)

--- a/docs/releases/vnext/1499-measure-stratifier-invariant.md
+++ b/docs/releases/vnext/1499-measure-stratifier-invariant.md
@@ -1,3 +1,12 @@
+## Breaking Changes
+
+- The Packager's generated `Measure` JSON changed shape: `Measure.group.stratifier` entries no
+  longer carry `code` or `description`. Both previously duplicated the container's element id
+  (`<group>-Stratifier`) and made the resource invalid (see the fix below). Anyone diffing or
+  asserting on generated `Measure` resources from re-packaged libraries will see this difference;
+  the human-readable labels remain on `stratifier.component.code`/`.description`, which is where
+  consumers should read them. (#1499)
+
 ## Fixes
 
 - Generated `Measure` resources no longer set `code` and `description` on the container
@@ -6,4 +15,9 @@
   `Measure.group.stratifier`
   (`(code | description | criteria).exists() xor component.exists()`), so the previous
   output failed validation. The container now carries only its element id
-  (`<group>-Stratifier`); the components are unchanged. (#1499)
+  (`<group>-Stratifier`); the components are unchanged. A container also can no longer be
+  emitted without at least one component (which would equally violate the invariant). (#1499)
+- CQL-to-ELM generation (`CqlToolingEnabled`) now works on Linux/macOS: the Java classpath
+  wildcard in `Demo/Cql/Build/CqlTooling.Targets.xml` is quoted so Unix shells no longer
+  expand it before `java` sees it, which misread the first dependency jar as the main
+  class. (#1499)

--- a/docs/releases/vnext/measure-stratifier-invariant.md
+++ b/docs/releases/vnext/measure-stratifier-invariant.md
@@ -1,0 +1,9 @@
+## Fixes
+
+- Generated `Measure` resources no longer set `code` and `description` on the container
+  stratifier that holds `@stratifier` components. A stratifier with components must not
+  also carry `code`, `description`, or `criteria`, per the FHIR invariant on
+  `Measure.group.stratifier`
+  (`(code | description | criteria).exists() xor component.exists()`), so the previous
+  output failed validation. The container now carries only its element id
+  (`<group>-Stratifier`); the components are unchanged.


### PR DESCRIPTION
Fixes #1500

## Primary Work

Generated `Measure` resources violated the FHIR R4 invariant `mea-1` on `Measure.group.stratifier`:

```
group.stratifier.all((code | description | criteria).exists() xor component.exists())
```

The Packager set `Code` and `Description` on the per-group container stratifier (`<group>-Stratifier`) while also adding the `@stratifier` dimensions as `component` entries under it — so every generated Measure with stratifiers had `code`, `description`, and `component` simultaneously and failed validation.

Changes (`Cql/Cql.Packaging/FhirMeasureExtensions.cs`):

- The container stratifier now carries only its element id; `Code` and `Description` are no longer set. The components are unchanged: they keep their id (`<group>-StratifierComponent-<value>`), text-only code, description, and `text/cql-identifier` criteria — the "set of criteria components" side of the invariant's XOR.
- The container also cannot be emitted **without** components (which would satisfy neither side of the XOR): `GetOrCreateStratifier` was replaced by `AddStratifierComponent`, which runs the duplicate-component check first and only then creates the container together with its first component, so no code path can leave a componentless container behind.

Tests (`Cql/CoreTests/Packaging/FhirMeasureExtensionsTests.cs`):

- `GeneratedStratifiers_SatisfyFhirStratifierInvariant` evaluates the **literal FhirPath invariant expression** against the generated Measure via `FhirPathCompiler` (no hand-rolled C# translation), plus targeted per-half assertions so a failure identifies which side broke — including that every container has ≥ 1 component.
- `SingleStratifierDefinition_CreatesContainerWithOneComponent` asserts the container's `Code`/`Description` are null.
- All 22 tests in the class pass.

End-to-end coverage:

- `LibrarySets/Demo/Cql/MeasureExample.cql` gained a `@stratifier`-tagged definition (`Gender Stratifier`), with its ELM (`LibrarySets/Demo/Elm/MeasureExample.json`) and generated C# (`Demo/Measures.Demo/CSharp/MeasureExample-0.0.1.g.cs`) regenerated — so a packaged artifact now exercises the stratifier path, and the packaged `Measure-MeasureExample-0.0.1.json` was verified to satisfy the invariant. Only files with real content changes are committed; header-only `GeneratedCodeAttribute` churn was reverted per repo convention.

---

## Auxiliary Work

- **`docs/cql-packager.md`** — documents that the container is id-only and why; that the human-readable labels live on `stratifier.component.code`/`.description`; and that the components form a single composite stratification (a `MeasureReport` stratum combines all the group's dimension values), with links to the R4 definitions and CQF Measures IG.
- **`docs/releases/vnext/1499-measure-stratifier-invariant.md`** — release-note fragment with a `## Breaking Changes` section (generated `Measure` JSON shape change) and `## Fixes`.
- **`Demo/Cql/Build/CqlTooling.Targets.xml`** — fixed CQL-to-ELM generation on Linux/macOS: the Java classpath wildcard is now quoted so Unix shells don't expand it (previously the first dependency jar was misread as the main class).

Review by @baseTwo (5 required findings) is fully addressed in d22a467; threads answered and resolved. Copilot's #1501 was opened for the same findings and is redundant.

https://claude.ai/code/session_01TKXe5yP5wzM1PkxPcaLEWd