### PR TITLE
Evaluate non-inlinable short-circuit operands eagerly instead of in a local function

### DIFF
--- a/Cql/CodeGeneration.NET/CSharpEmitter.Scope.cs
+++ b/Cql/CodeGeneration.NET/CSharpEmitter.Scope.cs
@@ -195,7 +195,7 @@ internal partial class CSharpEmitter
                 // cases must not depend on their position in the switch.
                 case CodeBinary shortCircuit when CodeBinary.ShortCircuits(shortCircuit.Op)
                                                  && !PrintsInlineAsShortCircuitOperand(shortCircuit.Right):
-                    return LinearizeShortCircuitCallingRightOperand(shortCircuit);
+                    return LinearizeShortCircuitEvaluatingRightOperandEagerly(shortCircuit);
 
                 // Pass-through composites: printed inline over their (spine-linearized)
                 // children instead of being hoisted into a local. This mirrors the old
@@ -478,30 +478,38 @@ internal partial class CSharpEmitter
         /// a zero-argument local function and the operand position becomes a CALL to it, so
         /// evaluation still happens only when the operator does not skip.
         /// </summary>
-        private Atom LinearizeShortCircuitCallingRightOperand(CodeBinary node)
+        private Atom LinearizeShortCircuitEvaluatingRightOperandEagerly(CodeBinary node)
         {
             // The left operand is always evaluated, so hoisting it is free and desirable.
             var left = Linearize(node.Left)!;
 
-            // The function is DECLARED to return CqlBoolean while its body stays the plain bool?
-            // expression, so the conversion happens implicitly at the `return` and nothing needs a
-            // cast: neither the body (`return t_;`) nor the call site (`f_()`). Returning bool?
-            // instead would produce `return (bool?)((CqlBoolean)t_);` in the body AND
-            // `(CqlBoolean)f_()` at the call site — three conversions to move one value through
-            // unchanged.
+            // Eagerly, into THIS scope, rather than into a zero-argument local function.
             //
-            // CqlBoolean, NOT CqlBoolean?: && is not lifted over nullable types, so a nullable
-            // return would leave the call site unable to short-circuit at all — which is the whole
-            // reason this type exists. CqlBoolean already carries its own null.
-            var body = UnwrapCqlBooleanConversion(node.Right);
-            var function = HoistLocalFunction(new CodeLambda([], body), declaredReturnType: typeof(CqlBoolean));
-            var right = $"{function.Code}()";
+            // The skip is given up for these operands, deliberately. A local function gives the operand
+            // its own scope and therefore its own dedup table, so every subexpression the enclosing
+            // scope had already computed gets emitted a second time inside it — including retrieves, and
+            // including calls to other CQL functions that two sibling operands both need. Measured
+            // across the integration corpus that cost +22.7% runtime retrieves and ~7,000 generated
+            // lines, while the skip itself fired for roughly 2% of evaluations and produced no
+            // measurable wall-clock gain. One scope means one dedup table, which is what keeps the
+            // output non-redundant.
+            //
+            // Operands that print INLINE keep their skip and cost nothing, because they never leave this
+            // scope — see PrintsInlineAsShortCircuitOperand, which is what selects between the two.
+            var right = Linearize(node.Right)!;
+
+            // Force anything that is not already a plain reference into a local, so the operand position
+            // is a simple name rather than an expression that would be re-printed, and so the operator
+            // still reads as one flat chain.
+            if (right.Node is not (CodeLocal or CodeConstant or CodeContextParameter))
+                right = Hoist(right.Code, right.KeyCode, node.Right);
 
             return new Atom(
-                _emitter.FormatShortCircuit(node.Op, node.Left, left.Code, right, node.OriginTag),
-                _emitter.FormatShortCircuit(node.Op, node.Left, left.KeyCode, right, originTag: null),
+                _emitter.FormatShortCircuit(node.Op, node.Left, left.Code, right.Code, node.OriginTag),
+                _emitter.FormatShortCircuit(node.Op, node.Left, left.KeyCode, right.KeyCode, originTag: null),
                 node);
         }
+
 
         /// <summary>
         /// Binds the let's value to its local exactly once, then linearizes the body. The

--- a/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
+++ b/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
@@ -26,5 +26,5 @@ internal partial class LibrarySetCSharpCodeGenerator
     /// Also, it is important to ensure the library invoker toolkit is updated to support the new version,
     /// for this you need to update the LibraryInvoker.SupportsVersion method, or create a new version of the LibraryInvoker.
     /// </remarks>
-    internal const string GeneratorToolVersion = "5.3.7.0";
+    internal const string GeneratorToolVersion = "5.3.8.0";
 }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("AHAOverall", "4.1.000")]
 public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_000>
 {
@@ -159,51 +159,27 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (166:54-167:66) */ || i_()
-                /* CQL 'or' (166:54-168:66) */ || j_()
-                /* CQL 'or' (166:52-170:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (166:54-167:66) */ || i_
+            /* CQL 'or' (166:54-168:66) */ || m_
+            /* CQL 'or' (166:52-170:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (166:3-170:3) */ || c_();
+            /* CQL 'implies' (166:3-170:3) */ || r_;
     }
 
 
@@ -213,29 +189,17 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
     {
         CodeableConcept a_ = AllergyIntolerance?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = AllergyIntolerance?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept j_ = AllergyIntolerance?.VerificationStatus;
-                CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, j_);
-                CqlCode l_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
-                CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
-                CqlBoolean n_ = context.Operators.Equivalent(k_, m_);
-                return n_;
-            }
-
-            return h_
-                /* CQL 'or' (249:61-251:3) */ || i_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlBoolean j_ = e_
+            /* CQL 'or' (249:61-251:3) */ || i_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (249:3-251:3) */ || c_();
+            /* CQL 'implies' (249:3-251:3) */ || j_;
     }
 
 
@@ -314,22 +278,18 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
             object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
             CqlQuantity v_ = context.Operators.Quantity(40m, "%");
             CqlBoolean w_ = context.Operators.LessOrEqual(u_ as CqlQuantity, v_);
-
-            CqlBoolean x_() {
-                Code<ObservationStatus> y_ = EjectionFraction?.StatusElement;
-                ObservationStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
-            }
-
+            Code<ObservationStatus> x_ = EjectionFraction?.StatusElement;
+            ObservationStatus? y_ = x_?.Value;
+            string z_ = context.Operators.Convert<string>(y_);
+            string[] aa_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
+            CqlBoolean ac_ = ab_;
             return w_
-                /* CQL 'and' (134:7-135:74) */ && x_();
+                /* CQL 'and' (134:7-135:74) */ && ac_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -714,40 +674,32 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 18);
+        IEnumerable<Encounter> j_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period(context);
 
-        CqlBoolean j_() {
-            IEnumerable<Encounter> l_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period(context);
+        bool? k_(Encounter Encounter1) {
+            IEnumerable<Encounter> q_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period(context);
 
-            bool? m_(Encounter Encounter1) {
-                IEnumerable<Encounter> o_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period(context);
-
-                bool? p_(Encounter Encounter2) {
-                    Id r_ = Encounter2?.IdElement;
-                    string s_ = r_?.Value;
-                    Id t_ = Encounter1?.IdElement;
-                    string u_ = t_?.Value;
-                    CqlBoolean v_ = context.Operators.Equivalent(s_, u_);
-                    return !v_;
-                }
-
-                CqlBoolean q_ = context.Operators.WhereAny<Encounter>(o_, p_);
-                return q_;
+            bool? r_(Encounter Encounter2) {
+                Id t_ = Encounter2?.IdElement;
+                string u_ = t_?.Value;
+                Id v_ = Encounter1?.IdElement;
+                string w_ = v_?.Value;
+                CqlBoolean x_ = context.Operators.Equivalent(u_, w_);
+                return !x_;
             }
 
-            CqlBoolean n_ = context.Operators.WhereAny<Encounter>(l_, m_);
-            return n_;
+            CqlBoolean s_ = context.Operators.WhereAny<Encounter>(q_, r_);
+            return s_;
         }
 
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> w_ = this.Heart_Failure_Outpatient_Encounter(context);
-            CqlBoolean x_ = context.Operators.Exists<Encounter>(w_);
-            return x_;
-        }
-
+        CqlBoolean l_ = context.Operators.WhereAny<Encounter>(j_, k_);
+        CqlBoolean m_ = l_;
+        IEnumerable<Encounter> n_ = this.Heart_Failure_Outpatient_Encounter(context);
+        CqlBoolean o_ = context.Operators.Exists<Encounter>(n_);
+        CqlBoolean p_ = o_;
         return i_
-            /* CQL 'and' (154:3-158:5) */ && j_()
-            /* CQL 'and' (154:3-159:51) */ && k_();
+            /* CQL 'and' (154:3-158:5) */ && m_
+            /* CQL 'and' (154:3-159:51) */ && p_;
     }
 
 
@@ -763,64 +715,48 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
             Period f_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.In<CqlDateTime>(e_, g_, "day");
+            Code<MedicationRequest.MedicationrequestStatus> i_ = MedicationRequest?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? j_ = i_?.Value;
+            string k_ = context.Operators.Convert<string>(j_);
+            string[] l_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+            CqlBoolean n_ = m_;
+            Code<MedicationRequest.MedicationRequestIntent> o_ = MedicationRequest?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            string[] r_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            CqlBoolean t_ = s_;
+            IEnumerable<Task> u_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            CqlBoolean i_() {
-                Code<MedicationRequest.MedicationrequestStatus> l_ = MedicationRequest?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? m_ = l_?.Value;
-                string n_ = context.Operators.Convert<string>(m_);
-                string[] o_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
-                return p_;
+            bool? v_(Task TaskReject) {
+                ResourceReference y_ = TaskReject?.Focus;
+                CqlBoolean z_ = QICoreCommon_4_0_000.Instance.references(context, y_, MedicationRequest);
+                CodeableConcept aa_ = TaskReject?.Code;
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
+                CqlCode ac_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
+                CqlBoolean ae_ = context.Operators.Equivalent(ab_, ad_);
+                CqlBoolean af_ = ae_;
+                return z_
+                    /* CQL 'and' (187:13-188:58) */ && af_;
             }
 
-
-            CqlBoolean j_() {
-                Code<MedicationRequest.MedicationRequestIntent> q_ = MedicationRequest?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? r_ = q_?.Value;
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                IEnumerable<Task> v_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
-
-                bool? w_(Task TaskReject) {
-                    ResourceReference y_ = TaskReject?.Focus;
-                    CqlBoolean z_ = QICoreCommon_4_0_000.Instance.references(context, y_, MedicationRequest);
-
-                    CqlBoolean aa_() {
-                        CodeableConcept ab_ = TaskReject?.Code;
-                        CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
-                        CqlCode ad_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                        CqlConcept ae_ = context.Operators.ConvertCodeToConcept(ad_);
-                        CqlBoolean af_ = context.Operators.Equivalent(ac_, ae_);
-                        return af_;
-                    }
-
-                    return z_
-                        /* CQL 'and' (187:13-188:58) */ && aa_();
-                }
-
-                CqlBoolean x_ = context.Operators.WhereAny<Task>(v_, w_);
-                return !x_;
-            }
-
+            CqlBoolean w_ = context.Operators.WhereAny<Task>(u_, v_);
+            CqlBoolean x_ = (CqlBoolean)!w_;
             return h_
-                /* CQL 'and' (183:13-184:65) */ && i_()
-                /* CQL 'and' (183:13-185:119) */ && j_()
-                /* CQL 'and' (183:7-189:9) */ && k_();
+                /* CQL 'and' (183:13-184:65) */ && n_
+                /* CQL 'and' (183:13-185:119) */ && t_
+                /* CQL 'and' (183:7-189:9) */ && x_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Encounter>(a_, b_);
@@ -840,64 +776,48 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
             Period f_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.In<CqlDateTime>(e_, g_, "day");
+            Code<MedicationRequest.MedicationrequestStatus> i_ = MedicationRequest?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? j_ = i_?.Value;
+            string k_ = context.Operators.Convert<string>(j_);
+            string[] l_ = [
+                "completed",
+                "active",
+            ];
+            CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+            CqlBoolean n_ = m_;
+            Code<MedicationRequest.MedicationRequestIntent> o_ = MedicationRequest?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            string[] r_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            CqlBoolean t_ = s_;
+            IEnumerable<Task> u_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            CqlBoolean i_() {
-                Code<MedicationRequest.MedicationrequestStatus> l_ = MedicationRequest?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? m_ = l_?.Value;
-                string n_ = context.Operators.Convert<string>(m_);
-                string[] o_ = [
-                    "completed",
-                    "active",
-                ];
-                CqlBoolean p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
-                return p_;
+            bool? v_(Task TaskReject) {
+                ResourceReference y_ = TaskReject?.Focus;
+                CqlBoolean z_ = QICoreCommon_4_0_000.Instance.references(context, y_, MedicationRequest);
+                CodeableConcept aa_ = TaskReject?.Code;
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
+                CqlCode ac_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
+                CqlBoolean ae_ = context.Operators.Equivalent(ab_, ad_);
+                CqlBoolean af_ = ae_;
+                return z_
+                    /* CQL 'and' (201:13-202:58) */ && af_;
             }
 
-
-            CqlBoolean j_() {
-                Code<MedicationRequest.MedicationRequestIntent> q_ = MedicationRequest?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? r_ = q_?.Value;
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                IEnumerable<Task> v_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
-
-                bool? w_(Task TaskReject) {
-                    ResourceReference y_ = TaskReject?.Focus;
-                    CqlBoolean z_ = QICoreCommon_4_0_000.Instance.references(context, y_, MedicationRequest);
-
-                    CqlBoolean aa_() {
-                        CodeableConcept ab_ = TaskReject?.Code;
-                        CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
-                        CqlCode ad_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                        CqlConcept ae_ = context.Operators.ConvertCodeToConcept(ad_);
-                        CqlBoolean af_ = context.Operators.Equivalent(ac_, ae_);
-                        return af_;
-                    }
-
-                    return z_
-                        /* CQL 'and' (201:13-202:58) */ && aa_();
-                }
-
-                CqlBoolean x_ = context.Operators.WhereAny<Task>(v_, w_);
-                return !x_;
-            }
-
+            CqlBoolean w_ = context.Operators.WhereAny<Task>(u_, v_);
+            CqlBoolean x_ = (CqlBoolean)!w_;
             return h_
-                /* CQL 'and' (197:13-198:65) */ && i_()
-                /* CQL 'and' (197:13-199:119) */ && j_()
-                /* CQL 'and' (197:7-203:9) */ && k_();
+                /* CQL 'and' (197:13-198:65) */ && n_
+                /* CQL 'and' (197:13-199:119) */ && t_
+                /* CQL 'and' (197:7-203:9) */ && x_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Encounter>(a_, b_);
@@ -955,33 +875,33 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
 
         bool? b_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
             object d_;
-            DataType j_ = Procedure?.Performed;
-            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-            bool l_ = k_ is CqlDateTime;
-            if (l_)
+            DataType n_ = Procedure?.Performed;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            bool p_ = o_ is CqlDateTime;
+            if (p_)
             {
-                d_ = k_ as CqlDateTime;
+                d_ = o_ as CqlDateTime;
             }
             else
             {
-                bool m_ = k_ is CqlQuantity;
-                if (m_)
+                bool q_ = o_ is CqlQuantity;
+                if (q_)
                 {
-                    d_ = k_ as CqlQuantity;
+                    d_ = o_ as CqlQuantity;
                 }
                 else
                 {
-                    bool n_ = k_ is CqlInterval<CqlDateTime>;
-                    if (n_)
+                    bool r_ = o_ is CqlInterval<CqlDateTime>;
+                    if (r_)
                     {
-                        d_ = k_ as CqlInterval<CqlDateTime>;
+                        d_ = o_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool o_ = k_ is CqlInterval<CqlQuantity>;
-                        if (o_)
+                        bool s_ = o_ is CqlInterval<CqlQuantity>;
+                        if (s_)
                         {
-                            d_ = k_ as CqlInterval<CqlQuantity>;
+                            d_ = o_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
@@ -994,17 +914,13 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
             Period f_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.OverlapsAfter(e_, g_, "day");
-
-            CqlBoolean i_() {
-                Code<EventStatus> p_ = Procedure?.StatusElement;
-                EventStatus? q_ = p_?.Value;
-                string r_ = context.Operators.Convert<string>(q_);
-                CqlBoolean s_ = context.Operators.Equal(r_, "completed");
-                return s_;
-            }
-
+            Code<EventStatus> i_ = Procedure?.StatusElement;
+            EventStatus? j_ = i_?.Value;
+            string k_ = context.Operators.Convert<string>(j_);
+            CqlBoolean l_ = context.Operators.Equal(k_, "completed");
+            CqlBoolean m_ = l_;
             return h_
-                /* CQL 'and' (231:7-232:42) */ && i_();
+                /* CQL 'and' (231:7-232:42) */ && m_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Encounter>(a_, b_);
@@ -1050,59 +966,59 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
             List<Dosage> d_ = MedicationRequest?.DosageInstruction;
 
             bool? e_(Dosage @this) {
-                Timing z_ = @this?.Timing;
-                return z_ is not null;
+                Timing am_ = @this?.Timing;
+                return am_ is not null;
             }
 
 
             Timing f_(Dosage @this) {
-                Timing aa_ = @this?.Timing;
-                return aa_;
+                Timing an_ = @this?.Timing;
+                return an_;
             }
 
             IEnumerable<Timing> g_ = context.Operators.WhereSelect<Dosage, Timing>((IEnumerable<Dosage>)d_, e_, f_);
 
             bool? h_(Timing @this) {
-                Timing.RepeatComponent ab_ = @this?.Repeat;
-                return ab_ is not null;
+                Timing.RepeatComponent ao_ = @this?.Repeat;
+                return ao_ is not null;
             }
 
 
             Timing.RepeatComponent i_(Timing @this) {
-                Timing.RepeatComponent ac_ = @this?.Repeat;
-                return ac_;
+                Timing.RepeatComponent ap_ = @this?.Repeat;
+                return ap_;
             }
 
             IEnumerable<Timing.RepeatComponent> j_ = context.Operators.WhereSelect<Timing, Timing.RepeatComponent>(g_, h_, i_);
 
             bool? k_(Timing.RepeatComponent @this) {
-                DataType ad_ = @this?.Bounds;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                return ae_ is not null;
+                DataType aq_ = @this?.Bounds;
+                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                return ar_ is not null;
             }
 
 
             object l_(Timing.RepeatComponent @this) {
-                DataType af_ = @this?.Bounds;
-                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                return ag_;
+                DataType as_ = @this?.Bounds;
+                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                return at_;
             }
 
             IEnumerable<object> m_ = context.Operators.WhereSelect<Timing.RepeatComponent, object>(j_, k_, l_);
 
             CqlInterval<CqlDateTime> n_(object DoseTime) {
-                FhirDateTime ah_ = MedicationRequest?.AuthoredOnElement;
-                CqlDateTime ai_ = context.Operators.Convert<CqlDateTime>(ah_);
-                CqlInterval<CqlDateTime> aj_ = this.TimingBoundToInterval(context, ai_, DoseTime);
-                return aj_;
+                FhirDateTime au_ = MedicationRequest?.AuthoredOnElement;
+                CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(au_);
+                CqlInterval<CqlDateTime> aw_ = this.TimingBoundToInterval(context, av_, DoseTime);
+                return aw_;
             }
 
             IEnumerable<CqlInterval<CqlDateTime>> o_ = context.Operators.SelectDistinct<object, CqlInterval<CqlDateTime>>(m_, n_);
             IEnumerable<CqlInterval<CqlDateTime>> p_ = context.Operators.Collapse(o_, (string)default);
 
             object q_(CqlInterval<CqlDateTime> @this) {
-                CqlDateTime ak_ = context.Operators.Start(@this);
-                return ak_;
+                CqlDateTime ax_ = context.Operators.Start(@this);
+                return ax_;
             }
 
             IEnumerable<CqlInterval<CqlDateTime>> r_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(p_, q_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1110,64 +1026,48 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
             Period t_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
             CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
             CqlBoolean v_ = context.Operators.OverlapsAfter(s_, u_, "day");
+            Code<MedicationRequest.MedicationrequestStatus> w_ = MedicationRequest?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
+            Code<MedicationRequest.MedicationRequestIntent> ac_ = MedicationRequest?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+            string ae_ = context.Operators.Convert<string>(ad_);
+            string[] af_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+            CqlBoolean ah_ = ag_;
+            IEnumerable<Task> ai_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            CqlBoolean w_() {
-                Code<MedicationRequest.MedicationrequestStatus> al_ = MedicationRequest?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? am_ = al_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                string[] ao_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
-                return ap_;
+            bool? aj_(Task TaskReject) {
+                ResourceReference ay_ = TaskReject?.Focus;
+                CqlBoolean az_ = QICoreCommon_4_0_000.Instance.references(context, ay_, MedicationRequest);
+                CodeableConcept ba_ = TaskReject?.Code;
+                CqlConcept bb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ba_);
+                CqlCode bc_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept bd_ = context.Operators.ConvertCodeToConcept(bc_);
+                CqlBoolean be_ = context.Operators.Equivalent(bb_, bd_);
+                CqlBoolean bf_ = be_;
+                return az_
+                    /* CQL 'and' (267:13-268:58) */ && bf_;
             }
 
-
-            CqlBoolean x_() {
-                Code<MedicationRequest.MedicationRequestIntent> aq_ = MedicationRequest?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ar_ = aq_?.Value;
-                string as_ = context.Operators.Convert<string>(ar_);
-                string[] at_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
-                return au_;
-            }
-
-
-            CqlBoolean y_() {
-                IEnumerable<Task> av_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
-
-                bool? aw_(Task TaskReject) {
-                    ResourceReference ay_ = TaskReject?.Focus;
-                    CqlBoolean az_ = QICoreCommon_4_0_000.Instance.references(context, ay_, MedicationRequest);
-
-                    CqlBoolean ba_() {
-                        CodeableConcept bb_ = TaskReject?.Code;
-                        CqlConcept bc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bb_);
-                        CqlCode bd_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                        CqlConcept be_ = context.Operators.ConvertCodeToConcept(bd_);
-                        CqlBoolean bf_ = context.Operators.Equivalent(bc_, be_);
-                        return bf_;
-                    }
-
-                    return az_
-                        /* CQL 'and' (267:13-268:58) */ && ba_();
-                }
-
-                CqlBoolean ax_ = context.Operators.WhereAny<Task>(av_, aw_);
-                return !ax_;
-            }
-
+            CqlBoolean ak_ = context.Operators.WhereAny<Task>(ai_, aj_);
+            CqlBoolean al_ = (CqlBoolean)!ak_;
             return v_
-                /* CQL 'and' (259:13-264:65) */ && w_()
-                /* CQL 'and' (259:13-265:119) */ && x_()
-                /* CQL 'and' (259:7-269:9) */ && y_();
+                /* CQL 'and' (259:13-264:65) */ && ab_
+                /* CQL 'and' (259:13-265:119) */ && ah_
+                /* CQL 'and' (259:7-269:9) */ && al_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Encounter>(a_, b_);
@@ -1189,22 +1089,18 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
             Period g_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
             CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, g_);
             CqlBoolean i_ = context.Operators.OverlapsAfter(f_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<ObservationStatus> k_ = HeartRateObservation?.StatusElement;
-                ObservationStatus? l_ = k_?.Value;
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                return o_;
-            }
-
+            Code<ObservationStatus> j_ = HeartRateObservation?.StatusElement;
+            ObservationStatus? k_ = j_?.Value;
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
             return i_
-                /* CQL 'and' (278:7-279:78) */ && j_();
+                /* CQL 'and' (278:7-279:78) */ && o_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Encounter>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AdultOutpatientEncounters-4.19.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AdultOutpatientEncounters-4.19.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("AdultOutpatientEncounters", "4.19.000")]
 public partial class AdultOutpatientEncounters_4_19_000 : ILibrary, ISingleton<AdultOutpatientEncounters_4_19_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("AdvancedIllnessandFrailty", "1.27.000")]
 public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<AdvancedIllnessandFrailty_1_27_000>
 {
@@ -124,107 +124,87 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
         IEnumerable<DeviceRequest> d_ = Status_1_15_000.Instance.isDeviceOrderPersonalUseDevices(context, c_);
 
         bool? e_(DeviceRequest FrailtyDeviceOrder) {
-            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
-            FhirDateTime l_ = FrailtyDeviceOrder?.AuthoredOnElement;
-            CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-            CqlBoolean o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, "day");
-            return o_;
+            CqlInterval<CqlDateTime> ah_ = this.Measurement_Period(context);
+            FhirDateTime ai_ = FrailtyDeviceOrder?.AuthoredOnElement;
+            CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
+            CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
+            CqlBoolean al_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ah_, ak_, "day");
+            return al_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<DeviceRequest>(d_, e_);
+        CqlCode g_ = this.Medical_equipment_used(context);
+        IEnumerable<CqlCode> h_ = context.Operators.ToList<CqlCode>(g_);
+        IEnumerable<Observation> i_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, h_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> j_ = Status_1_15_000.Instance.isAssessmentPerformed(context, i_);
 
-        CqlBoolean g_() {
-            CqlCode p_ = this.Medical_equipment_used(context);
-            IEnumerable<CqlCode> q_ = context.Operators.ToList<CqlCode>(p_);
-            IEnumerable<Observation> r_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, q_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
-            IEnumerable<Observation> s_ = Status_1_15_000.Instance.isAssessmentPerformed(context, r_);
-
-            bool? t_(Observation EquipmentUsed) {
-                DataType v_ = EquipmentUsed?.Value;
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                CqlValueSet x_ = this.Frailty_Device(context);
-                CqlBoolean y_ = context.Operators.ConceptInValueSet(w_ as CqlConcept, x_);
-
-                CqlBoolean z_() {
-                    DataType aa_ = EquipmentUsed?.Effective;
-                    object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                    CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
-                    CqlDateTime ad_ = context.Operators.End(ac_);
-                    CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
-                    CqlBoolean af_ = context.Operators.In<CqlDateTime>(ad_, ae_, "day");
-                    return af_;
-                }
-
-                return y_
-                    /* CQL 'and' (51:9-52:88) */ && z_();
-            }
-
-            CqlBoolean u_ = context.Operators.WhereAny<Observation>(s_, t_);
-            return u_;
+        bool? k_(Observation EquipmentUsed) {
+            DataType am_ = EquipmentUsed?.Value;
+            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            CqlValueSet ao_ = this.Frailty_Device(context);
+            CqlBoolean ap_ = context.Operators.ConceptInValueSet(an_ as CqlConcept, ao_);
+            DataType aq_ = EquipmentUsed?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.End(as_);
+            CqlInterval<CqlDateTime> au_ = this.Measurement_Period(context);
+            CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, "day");
+            CqlBoolean aw_ = av_;
+            return ap_
+                /* CQL 'and' (51:9-52:88) */ && aw_;
         }
 
+        CqlBoolean l_ = context.Operators.WhereAny<Observation>(j_, k_);
+        CqlBoolean m_ = l_;
+        CqlValueSet n_ = this.Frailty_Diagnosis(context);
+        IEnumerable<Condition> o_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> p_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> q_ = context.Operators.Union<Condition>(o_ as IEnumerable<Condition>, p_ as IEnumerable<Condition>);
+        IEnumerable<Condition> r_ = Status_1_15_000.Instance.verified(context, q_);
 
-        CqlBoolean h_() {
-            CqlValueSet ag_ = this.Frailty_Diagnosis(context);
-            IEnumerable<Condition> ah_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ag_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> ai_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ag_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> aj_ = context.Operators.Union<Condition>(ah_ as IEnumerable<Condition>, ai_ as IEnumerable<Condition>);
-            IEnumerable<Condition> ak_ = Status_1_15_000.Instance.verified(context, aj_);
-
-            bool? al_(Condition FrailtyDiagnosis) {
-                CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, FrailtyDiagnosis);
-                CqlInterval<CqlDateTime> ao_ = this.Measurement_Period(context);
-                CqlBoolean ap_ = context.Operators.Overlaps(an_, ao_, "day");
-                return ap_;
-            }
-
-            CqlBoolean am_ = context.Operators.WhereAny<Condition>(ak_, al_);
-            return am_;
+        bool? s_(Condition FrailtyDiagnosis) {
+            CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, FrailtyDiagnosis);
+            CqlInterval<CqlDateTime> ay_ = this.Measurement_Period(context);
+            CqlBoolean az_ = context.Operators.Overlaps(ax_, ay_, "day");
+            return az_;
         }
 
+        CqlBoolean t_ = context.Operators.WhereAny<Condition>(r_, s_);
+        CqlBoolean u_ = t_;
+        CqlValueSet v_ = this.Frailty_Encounter(context);
+        IEnumerable<Encounter> w_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, v_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> x_ = Status_1_15_000.Instance.isEncounterPerformed(context, w_);
 
-        CqlBoolean i_() {
-            CqlValueSet aq_ = this.Frailty_Encounter(context);
-            IEnumerable<Encounter> ar_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-            IEnumerable<Encounter> as_ = Status_1_15_000.Instance.isEncounterPerformed(context, ar_);
-
-            bool? at_(Encounter FrailtyEncounter) {
-                Period av_ = FrailtyEncounter?.Period;
-                CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
-                CqlInterval<CqlDateTime> ax_ = this.Measurement_Period(context);
-                CqlBoolean ay_ = context.Operators.Overlaps(aw_, ax_, "day");
-                return ay_;
-            }
-
-            CqlBoolean au_ = context.Operators.WhereAny<Encounter>(as_, at_);
-            return au_;
-        }
-
-
-        CqlBoolean j_() {
-            CqlValueSet az_ = this.Frailty_Symptom(context);
-            IEnumerable<Observation> ba_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, az_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
-            IEnumerable<Observation> bb_ = Status_1_15_000.Instance.isSymptom(context, ba_);
-
-            bool? bc_(Observation FrailtySymptom) {
-                DataType be_ = FrailtySymptom?.Effective;
-                object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                CqlInterval<CqlDateTime> bg_ = QICoreCommon_4_0_000.Instance.toInterval(context, bf_);
-                CqlInterval<CqlDateTime> bh_ = this.Measurement_Period(context);
-                CqlBoolean bi_ = context.Operators.Overlaps(bg_, bh_, "day");
-                return bi_;
-            }
-
-            CqlBoolean bd_ = context.Operators.WhereAny<Observation>(bb_, bc_);
+        bool? y_(Encounter FrailtyEncounter) {
+            Period ba_ = FrailtyEncounter?.Period;
+            CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
+            CqlInterval<CqlDateTime> bc_ = this.Measurement_Period(context);
+            CqlBoolean bd_ = context.Operators.Overlaps(bb_, bc_, "day");
             return bd_;
         }
 
+        CqlBoolean z_ = context.Operators.WhereAny<Encounter>(x_, y_);
+        CqlBoolean aa_ = z_;
+        CqlValueSet ab_ = this.Frailty_Symptom(context);
+        IEnumerable<Observation> ac_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, ab_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
+        IEnumerable<Observation> ad_ = Status_1_15_000.Instance.isSymptom(context, ac_);
+
+        bool? ae_(Observation FrailtySymptom) {
+            DataType be_ = FrailtySymptom?.Effective;
+            object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+            CqlInterval<CqlDateTime> bg_ = QICoreCommon_4_0_000.Instance.toInterval(context, bf_);
+            CqlInterval<CqlDateTime> bh_ = this.Measurement_Period(context);
+            CqlBoolean bi_ = context.Operators.Overlaps(bg_, bh_, "day");
+            return bi_;
+        }
+
+        CqlBoolean af_ = context.Operators.WhereAny<Observation>(ad_, ae_);
+        CqlBoolean ag_ = af_;
         return f_
-            /* CQL 'or' (47:3-53:5) */ || g_()
-            /* CQL 'or' (47:3-57:5) */ || h_()
-            /* CQL 'or' (47:3-60:5) */ || i_()
-            /* CQL 'or' (47:3-63:5) */ || j_();
+            /* CQL 'or' (47:3-53:5) */ || m_
+            /* CQL 'or' (47:3-57:5) */ || u_
+            /* CQL 'or' (47:3-60:5) */ || aa_
+            /* CQL 'or' (47:3-63:5) */ || ag_;
     }
 
 
@@ -279,17 +259,13 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
                 IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
                 string p_ = context.Operators.Last<string>(o_);
                 CqlBoolean q_ = context.Operators.Equal(m_, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = M?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlValueSet u_ = this.Dementia_Medications(context);
-                    CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                    return v_;
-                }
-
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Dementia_Medications(context);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' */ && r_();
+                    /* CQL 'and' */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Medication>(j_, k_);
@@ -343,16 +319,12 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 66);
-
-        CqlBoolean j_() {
-            CqlBoolean k_ = this.Has_Advanced_Illness_in_Year_Before_or_During_Measurement_Period(context);
-            return k_
-                /* CQL 'or' (31:9-33:5) */ || this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period(context);
-        }
-
+        CqlBoolean j_ = this.Has_Advanced_Illness_in_Year_Before_or_During_Measurement_Period(context);
+        CqlBoolean k_ = j_
+            /* CQL 'or' (31:9-33:5) */ || this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period(context);
         return i_
             /* CQL 'and' (29:4-30:41) */ && this.Has_Criteria_Indicating_Frailty(context)
-            /* CQL 'and' (29:4-33:5) */ && j_();
+            /* CQL 'and' (29:4-33:5) */ && k_;
     }
 
 
@@ -374,32 +346,16 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            CqlBoolean m_ = this.Has_Advanced_Illness_in_Year_Before_or_During_Measurement_Period(context);
-            return m_
-                /* CQL 'or' (38:11-40:7) */ || this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period(context);
-        }
-
-
-        CqlBoolean l_() {
-            Patient n_ = this.Patient(context);
-            Date o_ = n_?.BirthDateElement;
-            string p_ = o_?.Value;
-            CqlDate q_ = context.Operators.ConvertStringToDate(p_);
-            CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
-            CqlDateTime s_ = context.Operators.End(r_);
-            CqlDate t_ = context.Operators.DateFrom(s_);
-            int? u_ = context.Operators.CalculateAgeAt(q_, t_, "year");
-            CqlBoolean v_ = context.Operators.GreaterOrEqual(u_, 81);
-            return v_
-                /* CQL 'and' (42:8-44:5) */ && this.Has_Criteria_Indicating_Frailty(context);
-        }
-
+        CqlBoolean k_ = this.Has_Advanced_Illness_in_Year_Before_or_During_Measurement_Period(context);
+        CqlBoolean l_ = k_
+            /* CQL 'or' (38:11-40:7) */ || this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period(context);
+        CqlBoolean m_ = context.Operators.GreaterOrEqual(h_, 81);
+        CqlBoolean n_ = m_
+            /* CQL 'and' (42:8-44:5) */ && this.Has_Criteria_Indicating_Frailty(context);
         return (j_
             /* CQL 'and' (36:5-37:43) */ && this.Has_Criteria_Indicating_Frailty(context)
-            /* CQL 'and' (36:3-41:3) */ && k_())
-            /* CQL 'or' (36:3-44:5) */ || l_();
+            /* CQL 'and' (36:3-41:3) */ && l_)
+            /* CQL 'or' (36:3-44:5) */ || n_;
     }
 
 
@@ -420,56 +376,52 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 66);
+        CqlCode j_ = this.Housing_status(context);
+        IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
+        IEnumerable<Observation> l_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, k_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> m_ = Status_1_15_000.Instance.isAssessmentPerformed(context, l_);
 
-        CqlBoolean j_() {
-            CqlCode k_ = this.Housing_status(context);
-            IEnumerable<CqlCode> l_ = context.Operators.ToList<CqlCode>(k_);
-            IEnumerable<Observation> m_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, l_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
-            IEnumerable<Observation> n_ = Status_1_15_000.Instance.isAssessmentPerformed(context, m_);
-
-            bool? o_(Observation HousingStatus) {
-                DataType x_ = HousingStatus?.Effective;
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.End(z_);
-                CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
-                CqlDateTime ac_ = context.Operators.End(ab_);
-                CqlBoolean ad_ = context.Operators.SameOrBefore(aa_, ac_, "day");
-                return ad_;
-            }
-
-            IEnumerable<Observation> p_ = context.Operators.Where<Observation>(n_, o_);
-
-            object q_(Observation @this) {
-                DataType ae_ = @this?.Effective;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                CqlDateTime ah_ = context.Operators.End(ag_);
-                return ah_;
-            }
-
-            IEnumerable<Observation> r_ = context.Operators.SortBy<Observation>(p_, q_, System.ComponentModel.ListSortDirection.Ascending);
-            Observation s_ = context.Operators.Last<Observation>(r_);
-            Observation[] t_ = [
-                s_,
-            ];
-
-            bool? u_(Observation LastHousingStatus) {
-                DataType ai_ = LastHousingStatus?.Value;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlCode ak_ = this.Lives_in_nursing_home__finding_(context);
-                CqlConcept al_ = context.Operators.ConvertCodeToConcept(ak_);
-                CqlBoolean am_ = context.Operators.Equivalent(aj_ as CqlConcept, al_);
-                return am_;
-            }
-
-            IEnumerable<Observation> v_ = context.Operators.Where<Observation>((IEnumerable<Observation>)t_, u_);
-            Observation w_ = context.Operators.SingletonFrom<Observation>(v_);
-            return w_ is not null;
+        bool? n_(Observation HousingStatus) {
+            DataType x_ = HousingStatus?.Effective;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+            CqlDateTime aa_ = context.Operators.End(z_);
+            CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
+            CqlDateTime ac_ = context.Operators.End(ab_);
+            CqlBoolean ad_ = context.Operators.SameOrBefore(aa_, ac_, "day");
+            return ad_;
         }
 
+        IEnumerable<Observation> o_ = context.Operators.Where<Observation>(m_, n_);
+
+        object p_(Observation @this) {
+            DataType ae_ = @this?.Effective;
+            object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+            CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
+            CqlDateTime ah_ = context.Operators.End(ag_);
+            return ah_;
+        }
+
+        IEnumerable<Observation> q_ = context.Operators.SortBy<Observation>(o_, p_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation r_ = context.Operators.Last<Observation>(q_);
+        Observation[] s_ = [
+            r_,
+        ];
+
+        bool? t_(Observation LastHousingStatus) {
+            DataType ai_ = LastHousingStatus?.Value;
+            object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+            CqlCode ak_ = this.Lives_in_nursing_home__finding_(context);
+            CqlConcept al_ = context.Operators.ConvertCodeToConcept(ak_);
+            CqlBoolean am_ = context.Operators.Equivalent(aj_ as CqlConcept, al_);
+            return am_;
+        }
+
+        IEnumerable<Observation> u_ = context.Operators.Where<Observation>((IEnumerable<Observation>)s_, t_);
+        Observation v_ = context.Operators.SingletonFrom<Observation>(u_);
+        CqlBoolean w_ = (CqlBoolean)(v_ is not null);
         return i_
-            /* CQL 'and' (77:3-87:17) */ && j_();
+            /* CQL 'and' (77:3-87:17) */ && w_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AlaraCommonFunctions-1.10.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AlaraCommonFunctions-1.10.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("AlaraCommonFunctions", "1.10.000")]
 public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraCommonFunctions_1_10_000>
 {
@@ -152,177 +152,96 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
         decimal? b_ = context.Operators.ConvertIntegerToDecimal(64);
         decimal? c_ = context.Operators.ConvertIntegerToDecimal(598);
         CqlBoolean d_ = this.qualifies(context, Result, a_, b_, c_);
-
-        CqlBoolean e_() {
-            CqlCode v_ = this.Abdomen_and_Pelvis_Routine_Dose(context);
-            decimal? w_ = context.Operators.ConvertIntegerToDecimal(29);
-            decimal? x_ = context.Operators.ConvertIntegerToDecimal(644);
-            CqlBoolean y_ = this.qualifies(context, Result, v_, w_, x_);
-            return y_;
-        }
-
-
-        CqlBoolean f_() {
-            CqlCode z_ = this.Abdomen_and_Pelvis_High_Dose(context);
-            decimal? aa_ = context.Operators.ConvertIntegerToDecimal(29);
-            decimal? ab_ = context.Operators.ConvertIntegerToDecimal(1260);
-            CqlBoolean ac_ = this.qualifies(context, Result, z_, aa_, ab_);
-            return ac_;
-        }
-
-
-        CqlBoolean g_() {
-            CqlCode ad_ = this.Cardiac_Low_Dose(context);
-            decimal? ae_ = context.Operators.ConvertIntegerToDecimal(55);
-            decimal? af_ = context.Operators.ConvertIntegerToDecimal(93);
-            CqlBoolean ag_ = this.qualifies(context, Result, ad_, ae_, af_);
-            return ag_;
-        }
-
-
-        CqlBoolean h_() {
-            CqlCode ah_ = this.Cardiac_Routine_Dose(context);
-            decimal? ai_ = context.Operators.ConvertIntegerToDecimal(32);
-            decimal? aj_ = context.Operators.ConvertIntegerToDecimal(576);
-            CqlBoolean ak_ = this.qualifies(context, Result, ah_, ai_, aj_);
-            return ak_;
-        }
-
-
-        CqlBoolean i_() {
-            CqlCode al_ = this.Chest_Low_Dose(context);
-            decimal? am_ = context.Operators.ConvertIntegerToDecimal(55);
-            decimal? an_ = context.Operators.ConvertIntegerToDecimal(377);
-            CqlBoolean ao_ = this.qualifies(context, Result, al_, am_, an_);
-            return ao_;
-        }
-
-
-        CqlBoolean j_() {
-            CqlCode ap_ = this.Chest_Routine_Dose(context);
-            decimal? aq_ = context.Operators.ConvertIntegerToDecimal(49);
-            decimal? ar_ = context.Operators.ConvertIntegerToDecimal(377);
-            CqlBoolean as_ = this.qualifies(context, Result, ap_, aq_, ar_);
-            return as_;
-        }
-
-
-        CqlBoolean k_() {
-            CqlCode at_ = this.Cardiac_High_Dose_or_Chest_High_Dose(context);
-            decimal? au_ = context.Operators.ConvertIntegerToDecimal(49);
-            decimal? av_ = context.Operators.ConvertIntegerToDecimal(1282);
-            CqlBoolean aw_ = this.qualifies(context, Result, at_, au_, av_);
-            return aw_;
-        }
-
-
-        CqlBoolean l_() {
-            CqlCode ax_ = this.Head_Low_Dose(context);
-            decimal? ay_ = context.Operators.ConvertIntegerToDecimal(115);
-            decimal? az_ = context.Operators.ConvertIntegerToDecimal(582);
-            CqlBoolean ba_ = this.qualifies(context, Result, ax_, ay_, az_);
-            return ba_;
-        }
-
-
-        CqlBoolean m_() {
-            CqlCode bb_ = this.Head_Routine_Dose(context);
-            decimal? bc_ = context.Operators.ConvertIntegerToDecimal(115);
-            decimal? bd_ = context.Operators.ConvertIntegerToDecimal(1025);
-            CqlBoolean be_ = this.qualifies(context, Result, bb_, bc_, bd_);
-            return be_;
-        }
-
-
-        CqlBoolean n_() {
-            CqlCode bf_ = this.Head_High_Dose(context);
-            decimal? bg_ = context.Operators.ConvertIntegerToDecimal(115);
-            decimal? bh_ = context.Operators.ConvertIntegerToDecimal(1832);
-            CqlBoolean bi_ = this.qualifies(context, Result, bf_, bg_, bh_);
-            return bi_;
-        }
-
-
-        CqlBoolean o_() {
-            CqlCode bj_ = this.Extremity(context);
-            decimal? bk_ = context.Operators.ConvertIntegerToDecimal(73);
-            decimal? bl_ = context.Operators.ConvertIntegerToDecimal(320);
-            CqlBoolean bm_ = this.qualifies(context, Result, bj_, bk_, bl_);
-            return bm_;
-        }
-
-
-        CqlBoolean p_() {
-            CqlCode bn_ = this.Neck_or_Cervical_Spine(context);
-            decimal? bo_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? bp_ = context.Operators.ConvertIntegerToDecimal(1260);
-            CqlBoolean bq_ = this.qualifies(context, Result, bn_, bo_, bp_);
-            return bq_;
-        }
-
-
-        CqlBoolean q_() {
-            CqlCode br_ = this.Thoracic_or_Lumbar_Spine(context);
-            decimal? bs_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? bt_ = context.Operators.ConvertIntegerToDecimal(1260);
-            CqlBoolean bu_ = this.qualifies(context, Result, br_, bs_, bt_);
-            return bu_;
-        }
-
-
-        CqlBoolean r_() {
-            CqlCode bv_ = this.Simultaneous_Chest_and_Abdomen_and_Pelvis(context);
-            decimal? bw_ = context.Operators.ConvertIntegerToDecimal(29);
-            decimal? bx_ = context.Operators.ConvertIntegerToDecimal(1637);
-            CqlBoolean by_ = this.qualifies(context, Result, bv_, bw_, bx_);
-            return by_;
-        }
-
-
-        CqlBoolean s_() {
-            CqlCode bz_ = this.Simultaneous_Thoracic_and_Lumbar_Spine(context);
-            decimal? ca_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? cb_ = context.Operators.ConvertIntegerToDecimal(2520);
-            CqlBoolean cc_ = this.qualifies(context, Result, bz_, ca_, cb_);
-            return cc_;
-        }
-
-
-        CqlBoolean t_() {
-            CqlCode cd_ = this.Simultaneous_Head_and_Neck_Routine_Dose(context);
-            decimal? ce_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? cf_ = context.Operators.ConvertIntegerToDecimal(2285);
-            CqlBoolean cg_ = this.qualifies(context, Result, cd_, ce_, cf_);
-            return cg_;
-        }
-
-
-        CqlBoolean u_() {
-            CqlCode ch_ = this.Simultaneous_Head_and_Neck_High_Dose(context);
-            decimal? ci_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? cj_ = context.Operators.ConvertIntegerToDecimal(3092);
-            CqlBoolean ck_ = this.qualifies(context, Result, ch_, ci_, cj_);
-            return ck_;
-        }
-
+        CqlCode e_ = this.Abdomen_and_Pelvis_Routine_Dose(context);
+        decimal? f_ = context.Operators.ConvertIntegerToDecimal(29);
+        decimal? g_ = context.Operators.ConvertIntegerToDecimal(644);
+        CqlBoolean h_ = this.qualifies(context, Result, e_, f_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = this.Abdomen_and_Pelvis_High_Dose(context);
+        decimal? k_ = context.Operators.ConvertIntegerToDecimal(1260);
+        CqlBoolean l_ = this.qualifies(context, Result, j_, f_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = this.Cardiac_Low_Dose(context);
+        decimal? o_ = context.Operators.ConvertIntegerToDecimal(55);
+        decimal? p_ = context.Operators.ConvertIntegerToDecimal(93);
+        CqlBoolean q_ = this.qualifies(context, Result, n_, o_, p_);
+        CqlBoolean r_ = q_;
+        CqlCode s_ = this.Cardiac_Routine_Dose(context);
+        decimal? t_ = context.Operators.ConvertIntegerToDecimal(32);
+        decimal? u_ = context.Operators.ConvertIntegerToDecimal(576);
+        CqlBoolean v_ = this.qualifies(context, Result, s_, t_, u_);
+        CqlBoolean w_ = v_;
+        CqlCode x_ = this.Chest_Low_Dose(context);
+        decimal? y_ = context.Operators.ConvertIntegerToDecimal(377);
+        CqlBoolean z_ = this.qualifies(context, Result, x_, o_, y_);
+        CqlBoolean aa_ = z_;
+        CqlCode ab_ = this.Chest_Routine_Dose(context);
+        decimal? ac_ = context.Operators.ConvertIntegerToDecimal(49);
+        CqlBoolean ad_ = this.qualifies(context, Result, ab_, ac_, y_);
+        CqlBoolean ae_ = ad_;
+        CqlCode af_ = this.Cardiac_High_Dose_or_Chest_High_Dose(context);
+        decimal? ag_ = context.Operators.ConvertIntegerToDecimal(1282);
+        CqlBoolean ah_ = this.qualifies(context, Result, af_, ac_, ag_);
+        CqlBoolean ai_ = ah_;
+        CqlCode aj_ = this.Head_Low_Dose(context);
+        decimal? ak_ = context.Operators.ConvertIntegerToDecimal(115);
+        decimal? al_ = context.Operators.ConvertIntegerToDecimal(582);
+        CqlBoolean am_ = this.qualifies(context, Result, aj_, ak_, al_);
+        CqlBoolean an_ = am_;
+        CqlCode ao_ = this.Head_Routine_Dose(context);
+        decimal? ap_ = context.Operators.ConvertIntegerToDecimal(1025);
+        CqlBoolean aq_ = this.qualifies(context, Result, ao_, ak_, ap_);
+        CqlBoolean ar_ = aq_;
+        CqlCode as_ = this.Head_High_Dose(context);
+        decimal? at_ = context.Operators.ConvertIntegerToDecimal(1832);
+        CqlBoolean au_ = this.qualifies(context, Result, as_, ak_, at_);
+        CqlBoolean av_ = au_;
+        CqlCode aw_ = this.Extremity(context);
+        decimal? ax_ = context.Operators.ConvertIntegerToDecimal(73);
+        decimal? ay_ = context.Operators.ConvertIntegerToDecimal(320);
+        CqlBoolean az_ = this.qualifies(context, Result, aw_, ax_, ay_);
+        CqlBoolean ba_ = az_;
+        CqlCode bb_ = this.Neck_or_Cervical_Spine(context);
+        decimal? bc_ = context.Operators.ConvertIntegerToDecimal(25);
+        CqlBoolean bd_ = this.qualifies(context, Result, bb_, bc_, k_);
+        CqlBoolean be_ = bd_;
+        CqlCode bf_ = this.Thoracic_or_Lumbar_Spine(context);
+        CqlBoolean bg_ = this.qualifies(context, Result, bf_, bc_, k_);
+        CqlBoolean bh_ = bg_;
+        CqlCode bi_ = this.Simultaneous_Chest_and_Abdomen_and_Pelvis(context);
+        decimal? bj_ = context.Operators.ConvertIntegerToDecimal(1637);
+        CqlBoolean bk_ = this.qualifies(context, Result, bi_, f_, bj_);
+        CqlBoolean bl_ = bk_;
+        CqlCode bm_ = this.Simultaneous_Thoracic_and_Lumbar_Spine(context);
+        decimal? bn_ = context.Operators.ConvertIntegerToDecimal(2520);
+        CqlBoolean bo_ = this.qualifies(context, Result, bm_, bc_, bn_);
+        CqlBoolean bp_ = bo_;
+        CqlCode bq_ = this.Simultaneous_Head_and_Neck_Routine_Dose(context);
+        decimal? br_ = context.Operators.ConvertIntegerToDecimal(2285);
+        CqlBoolean bs_ = this.qualifies(context, Result, bq_, bc_, br_);
+        CqlBoolean bt_ = bs_;
+        CqlCode bu_ = this.Simultaneous_Head_and_Neck_High_Dose(context);
+        decimal? bv_ = context.Operators.ConvertIntegerToDecimal(3092);
+        CqlBoolean bw_ = this.qualifies(context, Result, bu_, bc_, bv_);
+        CqlBoolean bx_ = bw_;
         return d_
-            /* CQL 'or' (33:3-34:67) */ || e_()
-            /* CQL 'or' (33:3-35:65) */ || f_()
-            /* CQL 'or' (33:3-36:51) */ || g_()
-            /* CQL 'or' (33:3-37:56) */ || h_()
-            /* CQL 'or' (33:3-38:50) */ || i_()
-            /* CQL 'or' (33:3-39:54) */ || j_()
-            /* CQL 'or' (33:3-40:73) */ || k_()
-            /* CQL 'or' (33:3-41:50) */ || l_()
-            /* CQL 'or' (33:3-42:55) */ || m_()
-            /* CQL 'or' (33:3-43:52) */ || n_()
-            /* CQL 'or' (33:3-44:45) */ || o_()
-            /* CQL 'or' (33:3-45:59) */ || p_()
-            /* CQL 'or' (33:3-46:61) */ || q_()
-            /* CQL 'or' (33:3-47:78) */ || r_()
-            /* CQL 'or' (33:3-48:75) */ || s_()
-            /* CQL 'or' (33:3-49:76) */ || t_()
-            /* CQL 'or' (33:3-50:73) */ || u_();
+            /* CQL 'or' (33:3-34:67) */ || i_
+            /* CQL 'or' (33:3-35:65) */ || m_
+            /* CQL 'or' (33:3-36:51) */ || r_
+            /* CQL 'or' (33:3-37:56) */ || w_
+            /* CQL 'or' (33:3-38:50) */ || aa_
+            /* CQL 'or' (33:3-39:54) */ || ae_
+            /* CQL 'or' (33:3-40:73) */ || ai_
+            /* CQL 'or' (33:3-41:50) */ || an_
+            /* CQL 'or' (33:3-42:55) */ || ar_
+            /* CQL 'or' (33:3-43:52) */ || av_
+            /* CQL 'or' (33:3-44:45) */ || ba_
+            /* CQL 'or' (33:3-45:59) */ || be_
+            /* CQL 'or' (33:3-46:61) */ || bh_
+            /* CQL 'or' (33:3-47:78) */ || bl_
+            /* CQL 'or' (33:3-48:75) */ || bp_
+            /* CQL 'or' (33:3-49:76) */ || bt_
+            /* CQL 'or' (33:3-50:73) */ || bx_;
     }
 
 
@@ -333,23 +252,15 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
         object b_ = FHIRHelpers_4_4_000.Instance.ToValue(context, a_);
         CqlConcept c_ = context.Operators.ConvertCodeToConcept(code);
         CqlBoolean d_ = context.Operators.Equivalent(b_ as CqlConcept, c_);
-
-        CqlBoolean e_() {
-            decimal? f_ = this.globalNoiseValue(context, Result);
-            CqlBoolean g_ = context.Operators.GreaterOrEqual(f_, noiseThreshold);
-
-            CqlBoolean h_() {
-                decimal? i_ = this.sizeAdjustedValue(context, Result);
-                CqlBoolean j_ = context.Operators.GreaterOrEqual(i_, sizeDoseThreshold);
-                return j_;
-            }
-
-            return g_
-                /* CQL 'or' (80:9-82:5) */ || h_();
-        }
-
+        decimal? e_ = this.globalNoiseValue(context, Result);
+        CqlBoolean f_ = context.Operators.GreaterOrEqual(e_, noiseThreshold);
+        decimal? g_ = this.sizeAdjustedValue(context, Result);
+        CqlBoolean h_ = context.Operators.GreaterOrEqual(g_, sizeDoseThreshold);
+        CqlBoolean i_ = h_;
+        CqlBoolean j_ = f_
+            /* CQL 'or' (80:9-82:5) */ || i_;
         return d_
-            /* CQL 'and' (79:3-82:5) */ && e_();
+            /* CQL 'and' (79:3-82:5) */ && j_;
     }
 
 
@@ -368,28 +279,20 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "corrected",
             ];
             CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
-
-            CqlBoolean l_() {
-                CodeableConcept n_ = C?.Code;
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlCode p_ = this.Calculated_CT_global_noise(context);
-                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-                return r_;
-            }
-
-
-            CqlBoolean m_() {
-                DataType s_ = C?.Value;
-                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                string u_ = (t_ as CqlQuantity)?.unit;
-                CqlBoolean v_ = context.Operators.Equal(u_, "[hnsf'U]");
-                return v_;
-            }
-
+            CodeableConcept l_ = C?.Code;
+            CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
+            CqlCode n_ = this.Calculated_CT_global_noise(context);
+            CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+            CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
+            CqlBoolean q_ = p_;
+            DataType r_ = C?.Value;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            string t_ = (s_ as CqlQuantity)?.unit;
+            CqlBoolean u_ = context.Operators.Equal(t_, "[hnsf'U]");
+            CqlBoolean v_ = u_;
             return k_
-                /* CQL 'and' (96:13-97:49) */ && l_()
-                /* CQL 'and' (96:7-98:54) */ && m_();
+                /* CQL 'and' (96:13-97:49) */ && q_
+                /* CQL 'and' (96:7-98:54) */ && v_;
         }
 
 
@@ -422,28 +325,20 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "corrected",
             ];
             CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
-
-            CqlBoolean l_() {
-                CodeableConcept n_ = C?.Code;
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlCode p_ = this.Calculated_CT_size_adjusted_dose(context);
-                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-                return r_;
-            }
-
-
-            CqlBoolean m_() {
-                DataType s_ = C?.Value;
-                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                string u_ = (t_ as CqlQuantity)?.unit;
-                CqlBoolean v_ = context.Operators.Equal(u_, "mGy.cm");
-                return v_;
-            }
-
+            CodeableConcept l_ = C?.Code;
+            CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
+            CqlCode n_ = this.Calculated_CT_size_adjusted_dose(context);
+            CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+            CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
+            CqlBoolean q_ = p_;
+            DataType r_ = C?.Value;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            string t_ = (s_ as CqlQuantity)?.unit;
+            CqlBoolean u_ = context.Operators.Equal(t_, "mGy.cm");
+            CqlBoolean v_ = u_;
             return k_
-                /* CQL 'and' (112:13-113:55) */ && l_()
-                /* CQL 'and' (112:7-114:51) */ && m_();
+                /* CQL 'and' (112:13-113:55) */ && q_
+                /* CQL 'and' (112:7-114:51) */ && v_;
         }
 
 
@@ -468,177 +363,96 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
         decimal? b_ = context.Operators.ConvertIntegerToDecimal(64);
         decimal? c_ = context.Operators.ConvertIntegerToDecimal(598);
         CqlBoolean d_ = this.qualifies(context, Result, a_, b_, c_);
-
-        CqlBoolean e_() {
-            CqlCode v_ = this.Abdomen_and_Pelvis_Routine_Dose(context);
-            decimal? w_ = context.Operators.ConvertIntegerToDecimal(29);
-            decimal? x_ = context.Operators.ConvertIntegerToDecimal(644);
-            CqlBoolean y_ = this.qualifies(context, Result, v_, w_, x_);
-            return y_;
-        }
-
-
-        CqlBoolean f_() {
-            CqlCode z_ = this.Abdomen_and_Pelvis_High_Dose(context);
-            decimal? aa_ = context.Operators.ConvertIntegerToDecimal(29);
-            decimal? ab_ = context.Operators.ConvertIntegerToDecimal(1260);
-            CqlBoolean ac_ = this.qualifies(context, Result, z_, aa_, ab_);
-            return ac_;
-        }
-
-
-        CqlBoolean g_() {
-            CqlCode ad_ = this.Cardiac_Low_Dose(context);
-            decimal? ae_ = context.Operators.ConvertIntegerToDecimal(55);
-            decimal? af_ = context.Operators.ConvertIntegerToDecimal(93);
-            CqlBoolean ag_ = this.qualifies(context, Result, ad_, ae_, af_);
-            return ag_;
-        }
-
-
-        CqlBoolean h_() {
-            CqlCode ah_ = this.Cardiac_Routine_Dose(context);
-            decimal? ai_ = context.Operators.ConvertIntegerToDecimal(32);
-            decimal? aj_ = context.Operators.ConvertIntegerToDecimal(576);
-            CqlBoolean ak_ = this.qualifies(context, Result, ah_, ai_, aj_);
-            return ak_;
-        }
-
-
-        CqlBoolean i_() {
-            CqlCode al_ = this.Chest_Low_Dose(context);
-            decimal? am_ = context.Operators.ConvertIntegerToDecimal(55);
-            decimal? an_ = context.Operators.ConvertIntegerToDecimal(377);
-            CqlBoolean ao_ = this.qualifies(context, Result, al_, am_, an_);
-            return ao_;
-        }
-
-
-        CqlBoolean j_() {
-            CqlCode ap_ = this.Chest_Routine_Dose(context);
-            decimal? aq_ = context.Operators.ConvertIntegerToDecimal(49);
-            decimal? ar_ = context.Operators.ConvertIntegerToDecimal(377);
-            CqlBoolean as_ = this.qualifies(context, Result, ap_, aq_, ar_);
-            return as_;
-        }
-
-
-        CqlBoolean k_() {
-            CqlCode at_ = this.Cardiac_High_Dose_or_Chest_High_Dose(context);
-            decimal? au_ = context.Operators.ConvertIntegerToDecimal(49);
-            decimal? av_ = context.Operators.ConvertIntegerToDecimal(1282);
-            CqlBoolean aw_ = this.qualifies(context, Result, at_, au_, av_);
-            return aw_;
-        }
-
-
-        CqlBoolean l_() {
-            CqlCode ax_ = this.Head_Low_Dose(context);
-            decimal? ay_ = context.Operators.ConvertIntegerToDecimal(115);
-            decimal? az_ = context.Operators.ConvertIntegerToDecimal(582);
-            CqlBoolean ba_ = this.qualifies(context, Result, ax_, ay_, az_);
-            return ba_;
-        }
-
-
-        CqlBoolean m_() {
-            CqlCode bb_ = this.Head_Routine_Dose(context);
-            decimal? bc_ = context.Operators.ConvertIntegerToDecimal(115);
-            decimal? bd_ = context.Operators.ConvertIntegerToDecimal(1025);
-            CqlBoolean be_ = this.qualifies(context, Result, bb_, bc_, bd_);
-            return be_;
-        }
-
-
-        CqlBoolean n_() {
-            CqlCode bf_ = this.Head_High_Dose(context);
-            decimal? bg_ = context.Operators.ConvertIntegerToDecimal(115);
-            decimal? bh_ = context.Operators.ConvertIntegerToDecimal(1832);
-            CqlBoolean bi_ = this.qualifies(context, Result, bf_, bg_, bh_);
-            return bi_;
-        }
-
-
-        CqlBoolean o_() {
-            CqlCode bj_ = this.Extremity(context);
-            decimal? bk_ = context.Operators.ConvertIntegerToDecimal(73);
-            decimal? bl_ = context.Operators.ConvertIntegerToDecimal(320);
-            CqlBoolean bm_ = this.qualifies(context, Result, bj_, bk_, bl_);
-            return bm_;
-        }
-
-
-        CqlBoolean p_() {
-            CqlCode bn_ = this.Neck_or_Cervical_Spine(context);
-            decimal? bo_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? bp_ = context.Operators.ConvertIntegerToDecimal(1260);
-            CqlBoolean bq_ = this.qualifies(context, Result, bn_, bo_, bp_);
-            return bq_;
-        }
-
-
-        CqlBoolean q_() {
-            CqlCode br_ = this.Thoracic_or_Lumbar_Spine(context);
-            decimal? bs_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? bt_ = context.Operators.ConvertIntegerToDecimal(1260);
-            CqlBoolean bu_ = this.qualifies(context, Result, br_, bs_, bt_);
-            return bu_;
-        }
-
-
-        CqlBoolean r_() {
-            CqlCode bv_ = this.Simultaneous_Chest_and_Abdomen_and_Pelvis(context);
-            decimal? bw_ = context.Operators.ConvertIntegerToDecimal(29);
-            decimal? bx_ = context.Operators.ConvertIntegerToDecimal(1637);
-            CqlBoolean by_ = this.qualifies(context, Result, bv_, bw_, bx_);
-            return by_;
-        }
-
-
-        CqlBoolean s_() {
-            CqlCode bz_ = this.Simultaneous_Thoracic_and_Lumbar_Spine(context);
-            decimal? ca_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? cb_ = context.Operators.ConvertIntegerToDecimal(2520);
-            CqlBoolean cc_ = this.qualifies(context, Result, bz_, ca_, cb_);
-            return cc_;
-        }
-
-
-        CqlBoolean t_() {
-            CqlCode cd_ = this.Simultaneous_Head_and_Neck_Routine_Dose(context);
-            decimal? ce_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? cf_ = context.Operators.ConvertIntegerToDecimal(2285);
-            CqlBoolean cg_ = this.qualifies(context, Result, cd_, ce_, cf_);
-            return cg_;
-        }
-
-
-        CqlBoolean u_() {
-            CqlCode ch_ = this.Simultaneous_Head_and_Neck_High_Dose(context);
-            decimal? ci_ = context.Operators.ConvertIntegerToDecimal(25);
-            decimal? cj_ = context.Operators.ConvertIntegerToDecimal(3092);
-            CqlBoolean ck_ = this.qualifies(context, Result, ch_, ci_, cj_);
-            return ck_;
-        }
-
+        CqlCode e_ = this.Abdomen_and_Pelvis_Routine_Dose(context);
+        decimal? f_ = context.Operators.ConvertIntegerToDecimal(29);
+        decimal? g_ = context.Operators.ConvertIntegerToDecimal(644);
+        CqlBoolean h_ = this.qualifies(context, Result, e_, f_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = this.Abdomen_and_Pelvis_High_Dose(context);
+        decimal? k_ = context.Operators.ConvertIntegerToDecimal(1260);
+        CqlBoolean l_ = this.qualifies(context, Result, j_, f_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = this.Cardiac_Low_Dose(context);
+        decimal? o_ = context.Operators.ConvertIntegerToDecimal(55);
+        decimal? p_ = context.Operators.ConvertIntegerToDecimal(93);
+        CqlBoolean q_ = this.qualifies(context, Result, n_, o_, p_);
+        CqlBoolean r_ = q_;
+        CqlCode s_ = this.Cardiac_Routine_Dose(context);
+        decimal? t_ = context.Operators.ConvertIntegerToDecimal(32);
+        decimal? u_ = context.Operators.ConvertIntegerToDecimal(576);
+        CqlBoolean v_ = this.qualifies(context, Result, s_, t_, u_);
+        CqlBoolean w_ = v_;
+        CqlCode x_ = this.Chest_Low_Dose(context);
+        decimal? y_ = context.Operators.ConvertIntegerToDecimal(377);
+        CqlBoolean z_ = this.qualifies(context, Result, x_, o_, y_);
+        CqlBoolean aa_ = z_;
+        CqlCode ab_ = this.Chest_Routine_Dose(context);
+        decimal? ac_ = context.Operators.ConvertIntegerToDecimal(49);
+        CqlBoolean ad_ = this.qualifies(context, Result, ab_, ac_, y_);
+        CqlBoolean ae_ = ad_;
+        CqlCode af_ = this.Cardiac_High_Dose_or_Chest_High_Dose(context);
+        decimal? ag_ = context.Operators.ConvertIntegerToDecimal(1282);
+        CqlBoolean ah_ = this.qualifies(context, Result, af_, ac_, ag_);
+        CqlBoolean ai_ = ah_;
+        CqlCode aj_ = this.Head_Low_Dose(context);
+        decimal? ak_ = context.Operators.ConvertIntegerToDecimal(115);
+        decimal? al_ = context.Operators.ConvertIntegerToDecimal(582);
+        CqlBoolean am_ = this.qualifies(context, Result, aj_, ak_, al_);
+        CqlBoolean an_ = am_;
+        CqlCode ao_ = this.Head_Routine_Dose(context);
+        decimal? ap_ = context.Operators.ConvertIntegerToDecimal(1025);
+        CqlBoolean aq_ = this.qualifies(context, Result, ao_, ak_, ap_);
+        CqlBoolean ar_ = aq_;
+        CqlCode as_ = this.Head_High_Dose(context);
+        decimal? at_ = context.Operators.ConvertIntegerToDecimal(1832);
+        CqlBoolean au_ = this.qualifies(context, Result, as_, ak_, at_);
+        CqlBoolean av_ = au_;
+        CqlCode aw_ = this.Extremity(context);
+        decimal? ax_ = context.Operators.ConvertIntegerToDecimal(73);
+        decimal? ay_ = context.Operators.ConvertIntegerToDecimal(320);
+        CqlBoolean az_ = this.qualifies(context, Result, aw_, ax_, ay_);
+        CqlBoolean ba_ = az_;
+        CqlCode bb_ = this.Neck_or_Cervical_Spine(context);
+        decimal? bc_ = context.Operators.ConvertIntegerToDecimal(25);
+        CqlBoolean bd_ = this.qualifies(context, Result, bb_, bc_, k_);
+        CqlBoolean be_ = bd_;
+        CqlCode bf_ = this.Thoracic_or_Lumbar_Spine(context);
+        CqlBoolean bg_ = this.qualifies(context, Result, bf_, bc_, k_);
+        CqlBoolean bh_ = bg_;
+        CqlCode bi_ = this.Simultaneous_Chest_and_Abdomen_and_Pelvis(context);
+        decimal? bj_ = context.Operators.ConvertIntegerToDecimal(1637);
+        CqlBoolean bk_ = this.qualifies(context, Result, bi_, f_, bj_);
+        CqlBoolean bl_ = bk_;
+        CqlCode bm_ = this.Simultaneous_Thoracic_and_Lumbar_Spine(context);
+        decimal? bn_ = context.Operators.ConvertIntegerToDecimal(2520);
+        CqlBoolean bo_ = this.qualifies(context, Result, bm_, bc_, bn_);
+        CqlBoolean bp_ = bo_;
+        CqlCode bq_ = this.Simultaneous_Head_and_Neck_Routine_Dose(context);
+        decimal? br_ = context.Operators.ConvertIntegerToDecimal(2285);
+        CqlBoolean bs_ = this.qualifies(context, Result, bq_, bc_, br_);
+        CqlBoolean bt_ = bs_;
+        CqlCode bu_ = this.Simultaneous_Head_and_Neck_High_Dose(context);
+        decimal? bv_ = context.Operators.ConvertIntegerToDecimal(3092);
+        CqlBoolean bw_ = this.qualifies(context, Result, bu_, bc_, bv_);
+        CqlBoolean bx_ = bw_;
         return d_
-            /* CQL 'or' (53:3-54:67) */ || e_()
-            /* CQL 'or' (53:3-55:65) */ || f_()
-            /* CQL 'or' (53:3-56:51) */ || g_()
-            /* CQL 'or' (53:3-57:56) */ || h_()
-            /* CQL 'or' (53:3-58:50) */ || i_()
-            /* CQL 'or' (53:3-59:54) */ || j_()
-            /* CQL 'or' (53:3-60:73) */ || k_()
-            /* CQL 'or' (53:3-61:50) */ || l_()
-            /* CQL 'or' (53:3-62:55) */ || m_()
-            /* CQL 'or' (53:3-63:52) */ || n_()
-            /* CQL 'or' (53:3-64:45) */ || o_()
-            /* CQL 'or' (53:3-65:59) */ || p_()
-            /* CQL 'or' (53:3-66:61) */ || q_()
-            /* CQL 'or' (53:3-67:78) */ || r_()
-            /* CQL 'or' (53:3-68:75) */ || s_()
-            /* CQL 'or' (53:3-69:76) */ || t_()
-            /* CQL 'or' (53:3-70:73) */ || u_();
+            /* CQL 'or' (53:3-54:67) */ || i_
+            /* CQL 'or' (53:3-55:65) */ || m_
+            /* CQL 'or' (53:3-56:51) */ || r_
+            /* CQL 'or' (53:3-57:56) */ || w_
+            /* CQL 'or' (53:3-58:50) */ || aa_
+            /* CQL 'or' (53:3-59:54) */ || ae_
+            /* CQL 'or' (53:3-60:73) */ || ai_
+            /* CQL 'or' (53:3-61:50) */ || an_
+            /* CQL 'or' (53:3-62:55) */ || ar_
+            /* CQL 'or' (53:3-63:52) */ || av_
+            /* CQL 'or' (53:3-64:45) */ || ba_
+            /* CQL 'or' (53:3-65:59) */ || be_
+            /* CQL 'or' (53:3-66:61) */ || bh_
+            /* CQL 'or' (53:3-67:78) */ || bl_
+            /* CQL 'or' (53:3-68:75) */ || bp_
+            /* CQL 'or' (53:3-69:76) */ || bt_
+            /* CQL 'or' (53:3-70:73) */ || bx_;
     }
 
 
@@ -649,23 +463,15 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
         object b_ = FHIRHelpers_4_4_000.Instance.ToValue(context, a_);
         CqlConcept c_ = context.Operators.ConvertCodeToConcept(code);
         CqlBoolean d_ = context.Operators.Equivalent(b_ as CqlConcept, c_);
-
-        CqlBoolean e_() {
-            decimal? f_ = this.Global_Noise_Value(context, Result);
-            CqlBoolean g_ = context.Operators.GreaterOrEqual(f_, noiseThreshold);
-
-            CqlBoolean h_() {
-                decimal? i_ = this.Size_Adjusted_Value(context, Result);
-                CqlBoolean j_ = context.Operators.GreaterOrEqual(i_, sizeDoseThreshold);
-                return j_;
-            }
-
-            return g_
-                /* CQL 'or' (74:9-76:5) */ || h_();
-        }
-
+        decimal? e_ = this.Global_Noise_Value(context, Result);
+        CqlBoolean f_ = context.Operators.GreaterOrEqual(e_, noiseThreshold);
+        decimal? g_ = this.Size_Adjusted_Value(context, Result);
+        CqlBoolean h_ = context.Operators.GreaterOrEqual(g_, sizeDoseThreshold);
+        CqlBoolean i_ = h_;
+        CqlBoolean j_ = f_
+            /* CQL 'or' (74:9-76:5) */ || i_;
         return d_
-            /* CQL 'and' (73:3-76:5) */ && e_();
+            /* CQL 'and' (73:3-76:5) */ && j_;
     }
 
 
@@ -684,28 +490,20 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "corrected",
             ];
             CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
-
-            CqlBoolean l_() {
-                CodeableConcept n_ = C?.Code;
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlCode p_ = this.Calculated_CT_global_noise(context);
-                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-                return r_;
-            }
-
-
-            CqlBoolean m_() {
-                DataType s_ = C?.Value;
-                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                string u_ = (t_ as CqlQuantity)?.unit;
-                CqlBoolean v_ = context.Operators.Equal(u_, "[hnsf'U]");
-                return v_;
-            }
-
+            CodeableConcept l_ = C?.Code;
+            CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
+            CqlCode n_ = this.Calculated_CT_global_noise(context);
+            CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+            CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
+            CqlBoolean q_ = p_;
+            DataType r_ = C?.Value;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            string t_ = (s_ as CqlQuantity)?.unit;
+            CqlBoolean u_ = context.Operators.Equal(t_, "[hnsf'U]");
+            CqlBoolean v_ = u_;
             return k_
-                /* CQL 'and' (87:13-88:49) */ && l_()
-                /* CQL 'and' (87:7-89:54) */ && m_();
+                /* CQL 'and' (87:13-88:49) */ && q_
+                /* CQL 'and' (87:7-89:54) */ && v_;
         }
 
 
@@ -738,28 +536,20 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "corrected",
             ];
             CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
-
-            CqlBoolean l_() {
-                CodeableConcept n_ = C?.Code;
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlCode p_ = this.Calculated_CT_size_adjusted_dose(context);
-                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-                return r_;
-            }
-
-
-            CqlBoolean m_() {
-                DataType s_ = C?.Value;
-                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                string u_ = (t_ as CqlQuantity)?.unit;
-                CqlBoolean v_ = context.Operators.Equal(u_, "mGy.cm");
-                return v_;
-            }
-
+            CodeableConcept l_ = C?.Code;
+            CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
+            CqlCode n_ = this.Calculated_CT_size_adjusted_dose(context);
+            CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+            CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
+            CqlBoolean q_ = p_;
+            DataType r_ = C?.Value;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            string t_ = (s_ as CqlQuantity)?.unit;
+            CqlBoolean u_ = context.Operators.Equal(t_, "mGy.cm");
+            CqlBoolean v_ = u_;
             return k_
-                /* CQL 'and' (104:13-105:55) */ && l_()
-                /* CQL 'and' (104:7-106:51) */ && m_();
+                /* CQL 'and' (104:13-105:55) */ && q_
+                /* CQL 'and' (104:7-106:51) */ && v_;
         }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("Antibiotic", "1.11.000")]
 public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_000>
 {
@@ -97,16 +97,9 @@ public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_
                 CqlDateTime m_ = context.Operators.Add(k_, l_);
                 CqlInterval<CqlDateTime> n_ = context.Operators.Interval(k_, m_, true, true);
                 CqlBoolean o_ = context.Operators.In<CqlDateTime>(h_, n_, "day");
-
-                CqlBoolean p_() {
-                    Period q_ = episode?.Period;
-                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                    CqlDateTime s_ = context.Operators.Start(r_);
-                    return s_ is not null;
-                }
-
+                CqlBoolean p_ = (CqlBoolean)(k_ is not null);
                 return o_
-                    /* CQL 'and' (22:19-22:119) */ && p_();
+                    /* CQL 'and' (22:19-22:119) */ && p_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Condition>(competingConditions, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CumulativeMedicationDuration", "6.0.000")]
 public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton<CumulativeMedicationDuration_6_0_000>
 {
@@ -1080,143 +1080,95 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
             CqlDateTime s_ = context.Operators.Start(r_);
             CqlDate t_ = context.Operators.DateFrom(s_);
+            Duration u_ = p_?.ExpectedSupplyDuration;
+            CqlQuantity v_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, u_);
+            CqlQuantity w_ = context.Operators.ConvertQuantity(v_, "d");
+            decimal? x_ = w_?.value;
+            Quantity y_ = p_?.Quantity;
+            CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_);
+            decimal? aa_ = z_?.value;
+            List<Dosage.DoseAndRateComponent> ab_ = f_?.DoseAndRate;
+            Dosage.DoseAndRateComponent ac_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)ab_);
+            DataType ad_ = ac_?.Dose;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlQuantity af_ = context.Operators.End(ae_ as CqlInterval<CqlQuantity>);
+            decimal? ag_ = (af_ ?? ae_ as CqlQuantity)?.value;
+            PositiveInt ah_ = h_?.FrequencyMaxElement;
+            int? ai_ = ah_?.Value;
+            PositiveInt aj_ = h_?.FrequencyElement;
+            int? ak_ = aj_?.Value;
+            FhirDecimal al_ = h_?.PeriodElement;
+            decimal? am_ = al_?.Value;
+            Code<Timing.UnitsOfTime> an_ = h_?.PeriodUnitElement;
+            Timing.UnitsOfTime? ao_ = an_?.Value;
+            string ap_ = context.Operators.Convert<string>(ao_);
+            CqlQuantity aq_ = this.Quantity(context, am_, ap_);
+            decimal? ar_ = this.ToDaily(context, ai_ ?? ak_, aq_);
+            List<Time> as_ = h_?.TimeOfDayElement;
 
-            CqlBoolean u_() {
-                MedicationRequest.DispenseRequestComponent v_ = R?.DispenseRequest;
-                Duration w_ = v_?.ExpectedSupplyDuration;
-                CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_);
-                CqlQuantity y_ = context.Operators.ConvertQuantity(x_, "d");
-                decimal? z_ = y_?.value;
-                Quantity aa_ = v_?.Quantity;
-                CqlQuantity ab_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aa_);
-                decimal? ac_ = ab_?.value;
-                List<Dosage> ad_ = R?.DosageInstruction;
-                Dosage ae_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)ad_);
-                List<Dosage.DoseAndRateComponent> af_ = ae_?.DoseAndRate;
-                Dosage.DoseAndRateComponent ag_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)af_);
-                DataType ah_ = ag_?.Dose;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlQuantity aj_ = context.Operators.End(ai_ as CqlInterval<CqlQuantity>);
-                decimal? ak_ = (aj_ ?? ai_ as CqlQuantity)?.value;
-                Timing al_ = ae_?.Timing;
-                Timing.RepeatComponent am_ = al_?.Repeat;
-                PositiveInt an_ = am_?.FrequencyMaxElement;
-                int? ao_ = an_?.Value;
-                PositiveInt ap_ = am_?.FrequencyElement;
-                int? aq_ = ap_?.Value;
-                FhirDecimal ar_ = am_?.PeriodElement;
-                decimal? as_ = ar_?.Value;
-                Code<Timing.UnitsOfTime> at_ = am_?.PeriodUnitElement;
-                Timing.UnitsOfTime? au_ = at_?.Value;
-                string av_ = context.Operators.Convert<string>(au_);
-                CqlQuantity aw_ = this.Quantity(context, as_, av_);
-                decimal? ax_ = this.ToDaily(context, ao_ ?? aq_, aw_);
-                List<Time> ay_ = am_?.TimeOfDayElement;
-
-                string az_(Time @this) {
-                    string bm_ = @this?.Value;
-                    return bm_;
-                }
-
-                IEnumerable<string> ba_ = context.Operators.Select<Time, string>((IEnumerable<Time>)ay_, az_);
-
-                CqlTime bb_(string @string) {
-                    CqlTime bn_ = context.Operators.ConvertStringToTime(@string);
-                    return bn_;
-                }
-
-                IEnumerable<CqlTime> bc_ = context.Operators.Select<string, CqlTime>(ba_, bb_);
-                int? bd_ = context.Operators.Count<CqlTime>(bc_);
-                decimal? be_ = context.Operators.ConvertIntegerToDecimal(bd_);
-                decimal? bf_ = context.Operators.Multiply(ak_, (ax_ ?? be_) ?? 1.0m);
-                decimal? bg_ = context.Operators.Divide(ac_, bf_);
-                UnsignedInt bh_ = v_?.NumberOfRepeatsAllowedElement;
-                int? bi_ = bh_?.Value;
-                int? bj_ = context.Operators.Add(1, bi_ ?? 0);
-                decimal? bk_ = context.Operators.ConvertIntegerToDecimal(bj_);
-                decimal? bl_ = context.Operators.Multiply(z_ ?? bg_, bk_);
-                return bl_ is not null;
+            string at_(Time @this) {
+                string bh_ = @this?.Value;
+                return bh_;
             }
 
+            IEnumerable<string> au_ = context.Operators.Select<Time, string>((IEnumerable<Time>)as_, at_);
+
+            CqlTime av_(string @string) {
+                CqlTime bi_ = context.Operators.ConvertStringToTime(@string);
+                return bi_;
+            }
+
+            IEnumerable<CqlTime> aw_ = context.Operators.Select<string, CqlTime>(au_, av_);
+            int? ax_ = context.Operators.Count<CqlTime>(aw_);
+            decimal? ay_ = context.Operators.ConvertIntegerToDecimal(ax_);
+            decimal? az_ = context.Operators.Multiply(ag_, (ar_ ?? ay_) ?? 1.0m);
+            decimal? ba_ = context.Operators.Divide(aa_, az_);
+            UnsignedInt bb_ = p_?.NumberOfRepeatsAllowedElement;
+            int? bc_ = bb_?.Value;
+            int? bd_ = context.Operators.Add(1, bc_ ?? 0);
+            decimal? be_ = context.Operators.ConvertIntegerToDecimal(bd_);
+            decimal? bf_ = context.Operators.Multiply(x_ ?? ba_, be_);
+            CqlBoolean bg_ = (CqlBoolean)(bf_ is not null);
             if ((CqlBoolean)(((l_ ?? o_) ?? t_) is not null)
-                /* CQL 'and' (260:10-260:64) */ && u_())
+                /* CQL 'and' (260:10-260:64) */ && bg_)
             {
-                Duration bo_ = p_?.ExpectedSupplyDuration;
-                CqlQuantity bp_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bo_);
-                CqlQuantity bq_ = context.Operators.ConvertQuantity(bp_, "d");
-                decimal? br_ = bq_?.value;
-                Quantity bs_ = p_?.Quantity;
-                CqlQuantity bt_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bs_);
-                decimal? bu_ = bt_?.value;
-                List<Dosage.DoseAndRateComponent> bv_ = f_?.DoseAndRate;
-                Dosage.DoseAndRateComponent bw_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)bv_);
-                DataType bx_ = bw_?.Dose;
-                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                CqlQuantity bz_ = context.Operators.End(by_ as CqlInterval<CqlQuantity>);
-                decimal? ca_ = (bz_ ?? by_ as CqlQuantity)?.value;
-                PositiveInt cb_ = h_?.FrequencyMaxElement;
-                int? cc_ = cb_?.Value;
-                PositiveInt cd_ = h_?.FrequencyElement;
-                int? ce_ = cd_?.Value;
-                FhirDecimal cf_ = h_?.PeriodElement;
-                decimal? cg_ = cf_?.Value;
-                Code<Timing.UnitsOfTime> ch_ = h_?.PeriodUnitElement;
-                Timing.UnitsOfTime? ci_ = ch_?.Value;
-                string cj_ = context.Operators.Convert<string>(ci_);
-                CqlQuantity ck_ = this.Quantity(context, cg_, cj_);
-                decimal? cl_ = this.ToDaily(context, cc_ ?? ce_, ck_);
-                List<Time> cm_ = h_?.TimeOfDayElement;
 
-                string cn_(Time @this) {
-                    string df_ = @this?.Value;
-                    return df_;
+                string bj_(Time @this) {
+                    string bx_ = @this?.Value;
+                    return bx_;
                 }
 
-                IEnumerable<string> co_ = context.Operators.Select<Time, string>((IEnumerable<Time>)cm_, cn_);
+                IEnumerable<string> bk_ = context.Operators.Select<Time, string>((IEnumerable<Time>)as_, bj_);
 
-                CqlTime cp_(string @string) {
-                    CqlTime dg_ = context.Operators.ConvertStringToTime(@string);
-                    return dg_;
+                CqlTime bl_(string @string) {
+                    CqlTime by_ = context.Operators.ConvertStringToTime(@string);
+                    return by_;
                 }
 
-                IEnumerable<CqlTime> cq_ = context.Operators.Select<string, CqlTime>(co_, cp_);
-                int? cr_ = context.Operators.Count<CqlTime>(cq_);
-                decimal? cs_ = context.Operators.ConvertIntegerToDecimal(cr_);
-                decimal? ct_ = context.Operators.Multiply(ca_, (cl_ ?? cs_) ?? 1.0m);
-                decimal? cu_ = context.Operators.Divide(bu_, ct_);
-                UnsignedInt cv_ = p_?.NumberOfRepeatsAllowedElement;
-                int? cw_ = cv_?.Value;
-                int? cx_ = context.Operators.Add(1, cw_ ?? 0);
-                decimal? cy_ = context.Operators.ConvertIntegerToDecimal(cx_);
-                decimal? cz_ = context.Operators.Multiply(br_ ?? cu_, cy_);
-                decimal? da_ = context.Operators.ConvertIntegerToDecimal(1);
-                decimal? db_ = context.Operators.Subtract(cz_, da_);
-                CqlQuantity dc_ = this.Quantity(context, db_, "day");
-                CqlDate dd_ = context.Operators.Add((l_ ?? o_) ?? t_, dc_);
-                CqlInterval<CqlDate> de_ = context.Operators.Interval((l_ ?? o_) ?? t_, dd_, true, true);
-                return de_;
+                IEnumerable<CqlTime> bm_ = context.Operators.Select<string, CqlTime>(bk_, bl_);
+                int? bn_ = context.Operators.Count<CqlTime>(bm_);
+                decimal? bo_ = context.Operators.ConvertIntegerToDecimal(bn_);
+                decimal? bp_ = context.Operators.Multiply(ag_, (ar_ ?? bo_) ?? 1.0m);
+                decimal? bq_ = context.Operators.Divide(aa_, bp_);
+                decimal? br_ = context.Operators.Multiply(x_ ?? bq_, be_);
+                decimal? bs_ = context.Operators.ConvertIntegerToDecimal(1);
+                decimal? bt_ = context.Operators.Subtract(br_, bs_);
+                CqlQuantity bu_ = this.Quantity(context, bt_, "day");
+                CqlDate bv_ = context.Operators.Add((l_ ?? o_) ?? t_, bu_);
+                CqlInterval<CqlDate> bw_ = context.Operators.Interval((l_ ?? o_) ?? t_, bv_, true, true);
+                return bw_;
             }
             else
             {
-
-                CqlBoolean dh_() {
-                    List<Dosage> di_ = R?.DosageInstruction;
-                    Dosage dj_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)di_);
-                    Timing dk_ = dj_?.Timing;
-                    Timing.RepeatComponent dl_ = dk_?.Repeat;
-                    DataType dm_ = dl_?.Bounds;
-                    object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
-                    CqlDateTime do_ = (dn_ as CqlInterval<CqlDateTime>)?.high;
-                    return do_ is not null;
-                }
-
+                CqlDateTime bz_ = (j_ as CqlInterval<CqlDateTime>)?.high;
+                CqlBoolean ca_ = (CqlBoolean)(bz_ is not null);
                 if ((CqlBoolean)(((l_ ?? o_) ?? t_) is not null)
-                    /* CQL 'and' (262:15-262:71) */ && dh_())
+                    /* CQL 'and' (262:15-262:71) */ && ca_)
                 {
-                    CqlDateTime dp_ = context.Operators.End(j_ as CqlInterval<CqlDateTime>);
-                    CqlDate dq_ = context.Operators.DateFrom(dp_);
-                    CqlInterval<CqlDate> dr_ = context.Operators.Interval((l_ ?? o_) ?? t_, dq_, true, true);
-                    return dr_;
+                    CqlDateTime cb_ = context.Operators.End(j_ as CqlInterval<CqlDateTime>);
+                    CqlDate cc_ = context.Operators.DateFrom(cb_);
+                    CqlInterval<CqlDate> cd_ = context.Operators.Interval((l_ ?? o_) ?? t_, cc_, true, true);
+                    return cd_;
                 }
                 else
                 {
@@ -1262,143 +1214,95 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
             CqlDateTime s_ = context.Operators.Start(r_);
             CqlDate t_ = context.Operators.DateFrom(s_);
+            Duration u_ = p_?.ExpectedSupplyDuration;
+            CqlQuantity v_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, u_);
+            CqlQuantity w_ = context.Operators.ConvertQuantity(v_, "d");
+            decimal? x_ = w_?.value;
+            Quantity y_ = p_?.Quantity;
+            CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_);
+            decimal? aa_ = z_?.value;
+            List<Dosage.DoseAndRateComponent> ab_ = f_?.DoseAndRate;
+            Dosage.DoseAndRateComponent ac_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)ab_);
+            DataType ad_ = ac_?.Dose;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlQuantity af_ = context.Operators.End(ae_ as CqlInterval<CqlQuantity>);
+            decimal? ag_ = (af_ ?? ae_ as CqlQuantity)?.value;
+            PositiveInt ah_ = h_?.FrequencyMaxElement;
+            int? ai_ = ah_?.Value;
+            PositiveInt aj_ = h_?.FrequencyElement;
+            int? ak_ = aj_?.Value;
+            FhirDecimal al_ = h_?.PeriodElement;
+            decimal? am_ = al_?.Value;
+            Code<Timing.UnitsOfTime> an_ = h_?.PeriodUnitElement;
+            Timing.UnitsOfTime? ao_ = an_?.Value;
+            string ap_ = context.Operators.Convert<string>(ao_);
+            CqlQuantity aq_ = this.Quantity(context, am_, ap_);
+            decimal? ar_ = this.ToDaily(context, ai_ ?? ak_, aq_);
+            List<Time> as_ = h_?.TimeOfDayElement;
 
-            CqlBoolean u_() {
-                MedicationRequest.DispenseRequestComponent v_ = R?.DispenseRequest;
-                Duration w_ = v_?.ExpectedSupplyDuration;
-                CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_);
-                CqlQuantity y_ = context.Operators.ConvertQuantity(x_, "d");
-                decimal? z_ = y_?.value;
-                Quantity aa_ = v_?.Quantity;
-                CqlQuantity ab_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aa_);
-                decimal? ac_ = ab_?.value;
-                List<Dosage> ad_ = R?.DosageInstruction;
-                Dosage ae_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)ad_);
-                List<Dosage.DoseAndRateComponent> af_ = ae_?.DoseAndRate;
-                Dosage.DoseAndRateComponent ag_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)af_);
-                DataType ah_ = ag_?.Dose;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlQuantity aj_ = context.Operators.End(ai_ as CqlInterval<CqlQuantity>);
-                decimal? ak_ = (aj_ ?? ai_ as CqlQuantity)?.value;
-                Timing al_ = ae_?.Timing;
-                Timing.RepeatComponent am_ = al_?.Repeat;
-                PositiveInt an_ = am_?.FrequencyMaxElement;
-                int? ao_ = an_?.Value;
-                PositiveInt ap_ = am_?.FrequencyElement;
-                int? aq_ = ap_?.Value;
-                FhirDecimal ar_ = am_?.PeriodElement;
-                decimal? as_ = ar_?.Value;
-                Code<Timing.UnitsOfTime> at_ = am_?.PeriodUnitElement;
-                Timing.UnitsOfTime? au_ = at_?.Value;
-                string av_ = context.Operators.Convert<string>(au_);
-                CqlQuantity aw_ = this.Quantity(context, as_, av_);
-                decimal? ax_ = this.ToDaily(context, ao_ ?? aq_, aw_);
-                List<Time> ay_ = am_?.TimeOfDayElement;
-
-                string az_(Time @this) {
-                    string bm_ = @this?.Value;
-                    return bm_;
-                }
-
-                IEnumerable<string> ba_ = context.Operators.Select<Time, string>((IEnumerable<Time>)ay_, az_);
-
-                CqlTime bb_(string @string) {
-                    CqlTime bn_ = context.Operators.ConvertStringToTime(@string);
-                    return bn_;
-                }
-
-                IEnumerable<CqlTime> bc_ = context.Operators.Select<string, CqlTime>(ba_, bb_);
-                int? bd_ = context.Operators.Count<CqlTime>(bc_);
-                decimal? be_ = context.Operators.ConvertIntegerToDecimal(bd_);
-                decimal? bf_ = context.Operators.Multiply(ak_, (ax_ ?? be_) ?? 1.0m);
-                decimal? bg_ = context.Operators.Divide(ac_, bf_);
-                UnsignedInt bh_ = v_?.NumberOfRepeatsAllowedElement;
-                int? bi_ = bh_?.Value;
-                int? bj_ = context.Operators.Add(1, bi_ ?? 0);
-                decimal? bk_ = context.Operators.ConvertIntegerToDecimal(bj_);
-                decimal? bl_ = context.Operators.Multiply(z_ ?? bg_, bk_);
-                return bl_ is not null;
+            string at_(Time @this) {
+                string bh_ = @this?.Value;
+                return bh_;
             }
 
+            IEnumerable<string> au_ = context.Operators.Select<Time, string>((IEnumerable<Time>)as_, at_);
+
+            CqlTime av_(string @string) {
+                CqlTime bi_ = context.Operators.ConvertStringToTime(@string);
+                return bi_;
+            }
+
+            IEnumerable<CqlTime> aw_ = context.Operators.Select<string, CqlTime>(au_, av_);
+            int? ax_ = context.Operators.Count<CqlTime>(aw_);
+            decimal? ay_ = context.Operators.ConvertIntegerToDecimal(ax_);
+            decimal? az_ = context.Operators.Multiply(ag_, (ar_ ?? ay_) ?? 1.0m);
+            decimal? ba_ = context.Operators.Divide(aa_, az_);
+            UnsignedInt bb_ = p_?.NumberOfRepeatsAllowedElement;
+            int? bc_ = bb_?.Value;
+            int? bd_ = context.Operators.Add(1, bc_ ?? 0);
+            decimal? be_ = context.Operators.ConvertIntegerToDecimal(bd_);
+            decimal? bf_ = context.Operators.Multiply(x_ ?? ba_, be_);
+            CqlBoolean bg_ = (CqlBoolean)(bf_ is not null);
             if ((CqlBoolean)(((l_ ?? o_) ?? t_) is not null)
-                /* CQL 'and' (291:10-291:64) */ && u_())
+                /* CQL 'and' (291:10-291:64) */ && bg_)
             {
-                Duration bo_ = p_?.ExpectedSupplyDuration;
-                CqlQuantity bp_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bo_);
-                CqlQuantity bq_ = context.Operators.ConvertQuantity(bp_, "d");
-                decimal? br_ = bq_?.value;
-                Quantity bs_ = p_?.Quantity;
-                CqlQuantity bt_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bs_);
-                decimal? bu_ = bt_?.value;
-                List<Dosage.DoseAndRateComponent> bv_ = f_?.DoseAndRate;
-                Dosage.DoseAndRateComponent bw_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)bv_);
-                DataType bx_ = bw_?.Dose;
-                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                CqlQuantity bz_ = context.Operators.End(by_ as CqlInterval<CqlQuantity>);
-                decimal? ca_ = (bz_ ?? by_ as CqlQuantity)?.value;
-                PositiveInt cb_ = h_?.FrequencyMaxElement;
-                int? cc_ = cb_?.Value;
-                PositiveInt cd_ = h_?.FrequencyElement;
-                int? ce_ = cd_?.Value;
-                FhirDecimal cf_ = h_?.PeriodElement;
-                decimal? cg_ = cf_?.Value;
-                Code<Timing.UnitsOfTime> ch_ = h_?.PeriodUnitElement;
-                Timing.UnitsOfTime? ci_ = ch_?.Value;
-                string cj_ = context.Operators.Convert<string>(ci_);
-                CqlQuantity ck_ = this.Quantity(context, cg_, cj_);
-                decimal? cl_ = this.ToDaily(context, cc_ ?? ce_, ck_);
-                List<Time> cm_ = h_?.TimeOfDayElement;
 
-                string cn_(Time @this) {
-                    string df_ = @this?.Value;
-                    return df_;
+                string bj_(Time @this) {
+                    string bx_ = @this?.Value;
+                    return bx_;
                 }
 
-                IEnumerable<string> co_ = context.Operators.Select<Time, string>((IEnumerable<Time>)cm_, cn_);
+                IEnumerable<string> bk_ = context.Operators.Select<Time, string>((IEnumerable<Time>)as_, bj_);
 
-                CqlTime cp_(string @string) {
-                    CqlTime dg_ = context.Operators.ConvertStringToTime(@string);
-                    return dg_;
+                CqlTime bl_(string @string) {
+                    CqlTime by_ = context.Operators.ConvertStringToTime(@string);
+                    return by_;
                 }
 
-                IEnumerable<CqlTime> cq_ = context.Operators.Select<string, CqlTime>(co_, cp_);
-                int? cr_ = context.Operators.Count<CqlTime>(cq_);
-                decimal? cs_ = context.Operators.ConvertIntegerToDecimal(cr_);
-                decimal? ct_ = context.Operators.Multiply(ca_, (cl_ ?? cs_) ?? 1.0m);
-                decimal? cu_ = context.Operators.Divide(bu_, ct_);
-                UnsignedInt cv_ = p_?.NumberOfRepeatsAllowedElement;
-                int? cw_ = cv_?.Value;
-                int? cx_ = context.Operators.Add(1, cw_ ?? 0);
-                decimal? cy_ = context.Operators.ConvertIntegerToDecimal(cx_);
-                decimal? cz_ = context.Operators.Multiply(br_ ?? cu_, cy_);
-                decimal? da_ = context.Operators.ConvertIntegerToDecimal(1);
-                decimal? db_ = context.Operators.Subtract(cz_, da_);
-                CqlQuantity dc_ = this.Quantity(context, db_, "day");
-                CqlDate dd_ = context.Operators.Add((l_ ?? o_) ?? t_, dc_);
-                CqlInterval<CqlDate> de_ = context.Operators.Interval((l_ ?? o_) ?? t_, dd_, true, true);
-                return de_;
+                IEnumerable<CqlTime> bm_ = context.Operators.Select<string, CqlTime>(bk_, bl_);
+                int? bn_ = context.Operators.Count<CqlTime>(bm_);
+                decimal? bo_ = context.Operators.ConvertIntegerToDecimal(bn_);
+                decimal? bp_ = context.Operators.Multiply(ag_, (ar_ ?? bo_) ?? 1.0m);
+                decimal? bq_ = context.Operators.Divide(aa_, bp_);
+                decimal? br_ = context.Operators.Multiply(x_ ?? bq_, be_);
+                decimal? bs_ = context.Operators.ConvertIntegerToDecimal(1);
+                decimal? bt_ = context.Operators.Subtract(br_, bs_);
+                CqlQuantity bu_ = this.Quantity(context, bt_, "day");
+                CqlDate bv_ = context.Operators.Add((l_ ?? o_) ?? t_, bu_);
+                CqlInterval<CqlDate> bw_ = context.Operators.Interval((l_ ?? o_) ?? t_, bv_, true, true);
+                return bw_;
             }
             else
             {
-
-                CqlBoolean dh_() {
-                    List<Dosage> di_ = R?.DosageInstruction;
-                    Dosage dj_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)di_);
-                    Timing dk_ = dj_?.Timing;
-                    Timing.RepeatComponent dl_ = dk_?.Repeat;
-                    DataType dm_ = dl_?.Bounds;
-                    object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
-                    CqlDateTime do_ = (dn_ as CqlInterval<CqlDateTime>)?.high;
-                    return do_ is not null;
-                }
-
+                CqlDateTime bz_ = (j_ as CqlInterval<CqlDateTime>)?.high;
+                CqlBoolean ca_ = (CqlBoolean)(bz_ is not null);
                 if ((CqlBoolean)(((l_ ?? o_) ?? t_) is not null)
-                    /* CQL 'and' (293:15-293:71) */ && dh_())
+                    /* CQL 'and' (293:15-293:71) */ && ca_)
                 {
-                    CqlDateTime dp_ = context.Operators.End(j_ as CqlInterval<CqlDateTime>);
-                    CqlDate dq_ = context.Operators.DateFrom(dp_);
-                    CqlInterval<CqlDate> dr_ = context.Operators.Interval((l_ ?? o_) ?? t_, dq_, true, true);
-                    return dr_;
+                    CqlDateTime cb_ = context.Operators.End(j_ as CqlInterval<CqlDateTime>);
+                    CqlDate cc_ = context.Operators.DateFrom(cb_);
+                    CqlInterval<CqlDate> cd_ = context.Operators.Interval((l_ ?? o_) ?? t_, cc_, true, true);
+                    return cd_;
                 }
                 else
                 {
@@ -1427,114 +1331,81 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             FhirDateTime h_ = D?.WhenPreparedElement;
             CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
             CqlDate j_ = context.Operators.DateFrom(i_);
+            Quantity k_ = D?.DaysSupply;
+            CqlQuantity l_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, k_);
+            CqlQuantity m_ = context.Operators.ConvertQuantity(l_, "d");
+            decimal? n_ = m_?.value;
+            Quantity o_ = D?.Quantity;
+            CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_);
+            decimal? q_ = p_?.value;
+            List<Dosage> r_ = D?.DosageInstruction;
+            Dosage s_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)r_);
+            List<Dosage.DoseAndRateComponent> t_ = s_?.DoseAndRate;
+            Dosage.DoseAndRateComponent u_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)t_);
+            DataType v_ = u_?.Dose;
+            object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+            CqlQuantity x_ = context.Operators.End(w_ as CqlInterval<CqlQuantity>);
+            decimal? y_ = (x_ ?? w_ as CqlQuantity)?.value;
+            Timing z_ = s_?.Timing;
+            Timing.RepeatComponent aa_ = z_?.Repeat;
+            PositiveInt ab_ = aa_?.FrequencyMaxElement;
+            int? ac_ = ab_?.Value;
+            PositiveInt ad_ = aa_?.FrequencyElement;
+            int? ae_ = ad_?.Value;
+            FhirDecimal af_ = aa_?.PeriodElement;
+            decimal? ag_ = af_?.Value;
+            Code<Timing.UnitsOfTime> ah_ = aa_?.PeriodUnitElement;
+            Timing.UnitsOfTime? ai_ = ah_?.Value;
+            string aj_ = context.Operators.Convert<string>(ai_);
+            CqlQuantity ak_ = this.Quantity(context, ag_, aj_);
+            decimal? al_ = this.ToDaily(context, ac_ ?? ae_, ak_);
+            List<Time> am_ = aa_?.TimeOfDayElement;
 
-            CqlBoolean k_() {
-                Quantity l_ = D?.DaysSupply;
-                CqlQuantity m_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, l_);
-                CqlQuantity n_ = context.Operators.ConvertQuantity(m_, "d");
-                decimal? o_ = n_?.value;
-                Quantity p_ = D?.Quantity;
-                CqlQuantity q_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, p_);
-                decimal? r_ = q_?.value;
-                List<Dosage> s_ = D?.DosageInstruction;
-                Dosage t_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)s_);
-                List<Dosage.DoseAndRateComponent> u_ = t_?.DoseAndRate;
-                Dosage.DoseAndRateComponent v_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)u_);
-                DataType w_ = v_?.Dose;
-                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                CqlQuantity y_ = context.Operators.End(x_ as CqlInterval<CqlQuantity>);
-                decimal? z_ = (y_ ?? x_ as CqlQuantity)?.value;
-                Timing aa_ = t_?.Timing;
-                Timing.RepeatComponent ab_ = aa_?.Repeat;
-                PositiveInt ac_ = ab_?.FrequencyMaxElement;
-                int? ad_ = ac_?.Value;
-                PositiveInt ae_ = ab_?.FrequencyElement;
-                int? af_ = ae_?.Value;
-                FhirDecimal ag_ = ab_?.PeriodElement;
-                decimal? ah_ = ag_?.Value;
-                Code<Timing.UnitsOfTime> ai_ = ab_?.PeriodUnitElement;
-                Timing.UnitsOfTime? aj_ = ai_?.Value;
-                string ak_ = context.Operators.Convert<string>(aj_);
-                CqlQuantity al_ = this.Quantity(context, ah_, ak_);
-                decimal? am_ = this.ToDaily(context, ad_ ?? af_, al_);
-                List<Time> an_ = ab_?.TimeOfDayElement;
-
-                string ao_(Time @this) {
-                    string aw_ = @this?.Value;
-                    return aw_;
-                }
-
-                IEnumerable<string> ap_ = context.Operators.Select<Time, string>((IEnumerable<Time>)an_, ao_);
-
-                CqlTime aq_(string @string) {
-                    CqlTime ax_ = context.Operators.ConvertStringToTime(@string);
-                    return ax_;
-                }
-
-                IEnumerable<CqlTime> ar_ = context.Operators.Select<string, CqlTime>(ap_, aq_);
-                int? as_ = context.Operators.Count<CqlTime>(ar_);
-                decimal? at_ = context.Operators.ConvertIntegerToDecimal(as_);
-                decimal? au_ = context.Operators.Multiply(z_, (am_ ?? at_) ?? 1.0m);
-                decimal? av_ = context.Operators.Divide(r_, au_);
-                return (o_ ?? av_) is not null;
+            string an_(Time @this) {
+                string aw_ = @this?.Value;
+                return aw_;
             }
 
+            IEnumerable<string> ao_ = context.Operators.Select<Time, string>((IEnumerable<Time>)am_, an_);
+
+            CqlTime ap_(string @string) {
+                CqlTime ax_ = context.Operators.ConvertStringToTime(@string);
+                return ax_;
+            }
+
+            IEnumerable<CqlTime> aq_ = context.Operators.Select<string, CqlTime>(ao_, ap_);
+            int? ar_ = context.Operators.Count<CqlTime>(aq_);
+            decimal? as_ = context.Operators.ConvertIntegerToDecimal(ar_);
+            decimal? at_ = context.Operators.Multiply(y_, (al_ ?? as_) ?? 1.0m);
+            decimal? au_ = context.Operators.Divide(q_, at_);
+            CqlBoolean av_ = (CqlBoolean)((n_ ?? au_) is not null);
             if ((CqlBoolean)((g_ ?? j_) is not null)
-                /* CQL 'and' (387:10-387:64) */ && k_())
+                /* CQL 'and' (387:10-387:64) */ && av_)
             {
-                Quantity ay_ = D?.DaysSupply;
-                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_);
-                CqlQuantity ba_ = context.Operators.ConvertQuantity(az_, "d");
-                decimal? bb_ = ba_?.value;
-                Quantity bc_ = D?.Quantity;
-                CqlQuantity bd_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bc_);
-                decimal? be_ = bd_?.value;
-                List<Dosage> bf_ = D?.DosageInstruction;
-                Dosage bg_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)bf_);
-                List<Dosage.DoseAndRateComponent> bh_ = bg_?.DoseAndRate;
-                Dosage.DoseAndRateComponent bi_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)bh_);
-                DataType bj_ = bi_?.Dose;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                CqlQuantity bl_ = context.Operators.End(bk_ as CqlInterval<CqlQuantity>);
-                decimal? bm_ = (bl_ ?? bk_ as CqlQuantity)?.value;
-                Timing bn_ = bg_?.Timing;
-                Timing.RepeatComponent bo_ = bn_?.Repeat;
-                PositiveInt bp_ = bo_?.FrequencyMaxElement;
-                int? bq_ = bp_?.Value;
-                PositiveInt br_ = bo_?.FrequencyElement;
-                int? bs_ = br_?.Value;
-                FhirDecimal bt_ = bo_?.PeriodElement;
-                decimal? bu_ = bt_?.Value;
-                Code<Timing.UnitsOfTime> bv_ = bo_?.PeriodUnitElement;
-                Timing.UnitsOfTime? bw_ = bv_?.Value;
-                string bx_ = context.Operators.Convert<string>(bw_);
-                CqlQuantity by_ = this.Quantity(context, bu_, bx_);
-                decimal? bz_ = this.ToDaily(context, bq_ ?? bs_, by_);
-                List<Time> ca_ = bo_?.TimeOfDayElement;
 
-                string cb_(Time @this) {
-                    string co_ = @this?.Value;
-                    return co_;
+                string ay_(Time @this) {
+                    string bl_ = @this?.Value;
+                    return bl_;
                 }
 
-                IEnumerable<string> cc_ = context.Operators.Select<Time, string>((IEnumerable<Time>)ca_, cb_);
+                IEnumerable<string> az_ = context.Operators.Select<Time, string>((IEnumerable<Time>)am_, ay_);
 
-                CqlTime cd_(string @string) {
-                    CqlTime cp_ = context.Operators.ConvertStringToTime(@string);
-                    return cp_;
+                CqlTime ba_(string @string) {
+                    CqlTime bm_ = context.Operators.ConvertStringToTime(@string);
+                    return bm_;
                 }
 
-                IEnumerable<CqlTime> ce_ = context.Operators.Select<string, CqlTime>(cc_, cd_);
-                int? cf_ = context.Operators.Count<CqlTime>(ce_);
-                decimal? cg_ = context.Operators.ConvertIntegerToDecimal(cf_);
-                decimal? ch_ = context.Operators.Multiply(bm_, (bz_ ?? cg_) ?? 1.0m);
-                decimal? ci_ = context.Operators.Divide(be_, ch_);
-                decimal? cj_ = context.Operators.ConvertIntegerToDecimal(1);
-                decimal? ck_ = context.Operators.Subtract(bb_ ?? ci_, cj_);
-                CqlQuantity cl_ = this.Quantity(context, ck_, "day");
-                CqlDate cm_ = context.Operators.Add(g_ ?? j_, cl_);
-                CqlInterval<CqlDate> cn_ = context.Operators.Interval(g_ ?? j_, cm_, true, true);
-                return cn_;
+                IEnumerable<CqlTime> bb_ = context.Operators.Select<string, CqlTime>(az_, ba_);
+                int? bc_ = context.Operators.Count<CqlTime>(bb_);
+                decimal? bd_ = context.Operators.ConvertIntegerToDecimal(bc_);
+                decimal? be_ = context.Operators.Multiply(y_, (al_ ?? bd_) ?? 1.0m);
+                decimal? bf_ = context.Operators.Divide(q_, be_);
+                decimal? bg_ = context.Operators.ConvertIntegerToDecimal(1);
+                decimal? bh_ = context.Operators.Subtract(n_ ?? bf_, bg_);
+                CqlQuantity bi_ = this.Quantity(context, bh_, "day");
+                CqlDate bj_ = context.Operators.Add(g_ ?? j_, bi_);
+                CqlInterval<CqlDate> bk_ = context.Operators.Interval(g_ ?? j_, bj_, true, true);
+                return bk_;
             }
             else
             {
@@ -1562,114 +1433,81 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             FhirDateTime h_ = D?.WhenPreparedElement;
             CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
             CqlDate j_ = context.Operators.DateFrom(i_);
+            Quantity k_ = D?.DaysSupply;
+            CqlQuantity l_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, k_);
+            CqlQuantity m_ = context.Operators.ConvertQuantity(l_, "d");
+            decimal? n_ = m_?.value;
+            Quantity o_ = D?.Quantity;
+            CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_);
+            decimal? q_ = p_?.value;
+            List<Dosage> r_ = D?.DosageInstruction;
+            Dosage s_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)r_);
+            List<Dosage.DoseAndRateComponent> t_ = s_?.DoseAndRate;
+            Dosage.DoseAndRateComponent u_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)t_);
+            DataType v_ = u_?.Dose;
+            object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+            CqlQuantity x_ = context.Operators.End(w_ as CqlInterval<CqlQuantity>);
+            decimal? y_ = (x_ ?? w_ as CqlQuantity)?.value;
+            Timing z_ = s_?.Timing;
+            Timing.RepeatComponent aa_ = z_?.Repeat;
+            PositiveInt ab_ = aa_?.FrequencyMaxElement;
+            int? ac_ = ab_?.Value;
+            PositiveInt ad_ = aa_?.FrequencyElement;
+            int? ae_ = ad_?.Value;
+            FhirDecimal af_ = aa_?.PeriodElement;
+            decimal? ag_ = af_?.Value;
+            Code<Timing.UnitsOfTime> ah_ = aa_?.PeriodUnitElement;
+            Timing.UnitsOfTime? ai_ = ah_?.Value;
+            string aj_ = context.Operators.Convert<string>(ai_);
+            CqlQuantity ak_ = this.Quantity(context, ag_, aj_);
+            decimal? al_ = this.ToDaily(context, ac_ ?? ae_, ak_);
+            List<Time> am_ = aa_?.TimeOfDayElement;
 
-            CqlBoolean k_() {
-                Quantity l_ = D?.DaysSupply;
-                CqlQuantity m_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, l_);
-                CqlQuantity n_ = context.Operators.ConvertQuantity(m_, "d");
-                decimal? o_ = n_?.value;
-                Quantity p_ = D?.Quantity;
-                CqlQuantity q_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, p_);
-                decimal? r_ = q_?.value;
-                List<Dosage> s_ = D?.DosageInstruction;
-                Dosage t_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)s_);
-                List<Dosage.DoseAndRateComponent> u_ = t_?.DoseAndRate;
-                Dosage.DoseAndRateComponent v_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)u_);
-                DataType w_ = v_?.Dose;
-                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                CqlQuantity y_ = context.Operators.End(x_ as CqlInterval<CqlQuantity>);
-                decimal? z_ = (y_ ?? x_ as CqlQuantity)?.value;
-                Timing aa_ = t_?.Timing;
-                Timing.RepeatComponent ab_ = aa_?.Repeat;
-                PositiveInt ac_ = ab_?.FrequencyMaxElement;
-                int? ad_ = ac_?.Value;
-                PositiveInt ae_ = ab_?.FrequencyElement;
-                int? af_ = ae_?.Value;
-                FhirDecimal ag_ = ab_?.PeriodElement;
-                decimal? ah_ = ag_?.Value;
-                Code<Timing.UnitsOfTime> ai_ = ab_?.PeriodUnitElement;
-                Timing.UnitsOfTime? aj_ = ai_?.Value;
-                string ak_ = context.Operators.Convert<string>(aj_);
-                CqlQuantity al_ = this.Quantity(context, ah_, ak_);
-                decimal? am_ = this.ToDaily(context, ad_ ?? af_, al_);
-                List<Time> an_ = ab_?.TimeOfDayElement;
-
-                string ao_(Time @this) {
-                    string aw_ = @this?.Value;
-                    return aw_;
-                }
-
-                IEnumerable<string> ap_ = context.Operators.Select<Time, string>((IEnumerable<Time>)an_, ao_);
-
-                CqlTime aq_(string @string) {
-                    CqlTime ax_ = context.Operators.ConvertStringToTime(@string);
-                    return ax_;
-                }
-
-                IEnumerable<CqlTime> ar_ = context.Operators.Select<string, CqlTime>(ap_, aq_);
-                int? as_ = context.Operators.Count<CqlTime>(ar_);
-                decimal? at_ = context.Operators.ConvertIntegerToDecimal(as_);
-                decimal? au_ = context.Operators.Multiply(z_, (am_ ?? at_) ?? 1.0m);
-                decimal? av_ = context.Operators.Divide(r_, au_);
-                return (o_ ?? av_) is not null;
+            string an_(Time @this) {
+                string aw_ = @this?.Value;
+                return aw_;
             }
 
+            IEnumerable<string> ao_ = context.Operators.Select<Time, string>((IEnumerable<Time>)am_, an_);
+
+            CqlTime ap_(string @string) {
+                CqlTime ax_ = context.Operators.ConvertStringToTime(@string);
+                return ax_;
+            }
+
+            IEnumerable<CqlTime> aq_ = context.Operators.Select<string, CqlTime>(ao_, ap_);
+            int? ar_ = context.Operators.Count<CqlTime>(aq_);
+            decimal? as_ = context.Operators.ConvertIntegerToDecimal(ar_);
+            decimal? at_ = context.Operators.Multiply(y_, (al_ ?? as_) ?? 1.0m);
+            decimal? au_ = context.Operators.Divide(q_, at_);
+            CqlBoolean av_ = (CqlBoolean)((n_ ?? au_) is not null);
             if ((CqlBoolean)((g_ ?? j_) is not null)
-                /* CQL 'and' (438:10-438:64) */ && k_())
+                /* CQL 'and' (438:10-438:64) */ && av_)
             {
-                Quantity ay_ = D?.DaysSupply;
-                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_);
-                CqlQuantity ba_ = context.Operators.ConvertQuantity(az_, "d");
-                decimal? bb_ = ba_?.value;
-                Quantity bc_ = D?.Quantity;
-                CqlQuantity bd_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bc_);
-                decimal? be_ = bd_?.value;
-                List<Dosage> bf_ = D?.DosageInstruction;
-                Dosage bg_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)bf_);
-                List<Dosage.DoseAndRateComponent> bh_ = bg_?.DoseAndRate;
-                Dosage.DoseAndRateComponent bi_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)bh_);
-                DataType bj_ = bi_?.Dose;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                CqlQuantity bl_ = context.Operators.End(bk_ as CqlInterval<CqlQuantity>);
-                decimal? bm_ = (bl_ ?? bk_ as CqlQuantity)?.value;
-                Timing bn_ = bg_?.Timing;
-                Timing.RepeatComponent bo_ = bn_?.Repeat;
-                PositiveInt bp_ = bo_?.FrequencyMaxElement;
-                int? bq_ = bp_?.Value;
-                PositiveInt br_ = bo_?.FrequencyElement;
-                int? bs_ = br_?.Value;
-                FhirDecimal bt_ = bo_?.PeriodElement;
-                decimal? bu_ = bt_?.Value;
-                Code<Timing.UnitsOfTime> bv_ = bo_?.PeriodUnitElement;
-                Timing.UnitsOfTime? bw_ = bv_?.Value;
-                string bx_ = context.Operators.Convert<string>(bw_);
-                CqlQuantity by_ = this.Quantity(context, bu_, bx_);
-                decimal? bz_ = this.ToDaily(context, bq_ ?? bs_, by_);
-                List<Time> ca_ = bo_?.TimeOfDayElement;
 
-                string cb_(Time @this) {
-                    string co_ = @this?.Value;
-                    return co_;
+                string ay_(Time @this) {
+                    string bl_ = @this?.Value;
+                    return bl_;
                 }
 
-                IEnumerable<string> cc_ = context.Operators.Select<Time, string>((IEnumerable<Time>)ca_, cb_);
+                IEnumerable<string> az_ = context.Operators.Select<Time, string>((IEnumerable<Time>)am_, ay_);
 
-                CqlTime cd_(string @string) {
-                    CqlTime cp_ = context.Operators.ConvertStringToTime(@string);
-                    return cp_;
+                CqlTime ba_(string @string) {
+                    CqlTime bm_ = context.Operators.ConvertStringToTime(@string);
+                    return bm_;
                 }
 
-                IEnumerable<CqlTime> ce_ = context.Operators.Select<string, CqlTime>(cc_, cd_);
-                int? cf_ = context.Operators.Count<CqlTime>(ce_);
-                decimal? cg_ = context.Operators.ConvertIntegerToDecimal(cf_);
-                decimal? ch_ = context.Operators.Multiply(bm_, (bz_ ?? cg_) ?? 1.0m);
-                decimal? ci_ = context.Operators.Divide(be_, ch_);
-                decimal? cj_ = context.Operators.ConvertIntegerToDecimal(1);
-                decimal? ck_ = context.Operators.Subtract(bb_ ?? ci_, cj_);
-                CqlQuantity cl_ = this.Quantity(context, ck_, "day");
-                CqlDate cm_ = context.Operators.Add(g_ ?? j_, cl_);
-                CqlInterval<CqlDate> cn_ = context.Operators.Interval(g_ ?? j_, cm_, true, true);
-                return cn_;
+                IEnumerable<CqlTime> bb_ = context.Operators.Select<string, CqlTime>(az_, ba_);
+                int? bc_ = context.Operators.Count<CqlTime>(bb_);
+                decimal? bd_ = context.Operators.ConvertIntegerToDecimal(bc_);
+                decimal? be_ = context.Operators.Multiply(y_, (al_ ?? bd_) ?? 1.0m);
+                decimal? bf_ = context.Operators.Divide(q_, be_);
+                decimal? bg_ = context.Operators.ConvertIntegerToDecimal(1);
+                decimal? bh_ = context.Operators.Subtract(n_ ?? bf_, bg_);
+                CqlQuantity bi_ = this.Quantity(context, bh_, "day");
+                CqlDate bj_ = context.Operators.Add(g_ ?? j_, bi_);
+                CqlInterval<CqlDate> bk_ = context.Operators.Interval(g_ ?? j_, bj_, true, true);
+                return bk_;
             }
             else
             {
@@ -1703,25 +1541,18 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
             CqlDateTime g_ = context.Operators.Start(f_ as CqlInterval<CqlDateTime>);
             CqlDate h_ = context.Operators.DateFrom(g_);
-
-            CqlBoolean i_() {
-                DataType j_ = Administration?.Medication;
-                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-                CqlQuantity l_ = this.TherapeuticDuration(context, k_ as CqlConcept);
-                return l_ is not null;
-            }
-
+            DataType i_ = Administration?.Medication;
+            object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
+            CqlQuantity k_ = this.TherapeuticDuration(context, j_ as CqlConcept);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
             if ((CqlBoolean)(h_ is not null)
-                /* CQL 'and' (475:10-475:66) */ && i_())
+                /* CQL 'and' (475:10-475:66) */ && l_)
             {
-                DataType m_ = Administration?.Medication;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlQuantity o_ = this.TherapeuticDuration(context, n_ as CqlConcept);
-                CqlDate p_ = context.Operators.Add(h_, o_);
-                CqlQuantity q_ = context.Operators.ConvertIntegerToQuantity(1);
-                CqlDate r_ = context.Operators.Subtract(p_, q_);
-                CqlInterval<CqlDate> s_ = context.Operators.Interval(h_, r_, true, true);
-                return s_;
+                CqlDate m_ = context.Operators.Add(h_, k_);
+                CqlQuantity n_ = context.Operators.ConvertIntegerToQuantity(1);
+                CqlDate o_ = context.Operators.Subtract(m_, n_);
+                CqlInterval<CqlDate> p_ = context.Operators.Interval(h_, o_, true, true);
+                return p_;
             }
             else
             {
@@ -1747,25 +1578,18 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
             CqlDateTime g_ = context.Operators.Start(f_ as CqlInterval<CqlDateTime>);
             CqlDate h_ = context.Operators.DateFrom(g_);
-
-            CqlBoolean i_() {
-                DataType j_ = Administration?.Medication;
-                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-                CqlQuantity l_ = this.TherapeuticDuration(context, k_ as CqlConcept);
-                return l_ is not null;
-            }
-
+            DataType i_ = Administration?.Medication;
+            object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
+            CqlQuantity k_ = this.TherapeuticDuration(context, j_ as CqlConcept);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
             if ((CqlBoolean)(h_ is not null)
-                /* CQL 'and' (503:10-503:66) */ && i_())
+                /* CQL 'and' (503:10-503:66) */ && l_)
             {
-                DataType m_ = Administration?.Medication;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlQuantity o_ = this.TherapeuticDuration(context, n_ as CqlConcept);
-                CqlDate p_ = context.Operators.Add(h_, o_);
-                CqlQuantity q_ = context.Operators.ConvertIntegerToQuantity(1);
-                CqlDate r_ = context.Operators.Subtract(p_, q_);
-                CqlInterval<CqlDate> s_ = context.Operators.Interval(h_, r_, true, true);
-                return s_;
+                CqlDate m_ = context.Operators.Add(h_, k_);
+                CqlQuantity n_ = context.Operators.ConvertIntegerToQuantity(1);
+                CqlDate o_ = context.Operators.Subtract(m_, n_);
+                CqlInterval<CqlDate> p_ = context.Operators.Interval(h_, o_, true, true);
+                return p_;
             }
             else
             {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Hospice-6.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Hospice-6.18.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("Hospice", "6.18.000")]
 public partial class Hospice_6_18_000 : ILibrary, ISingleton<Hospice_6_18_000>
 {
@@ -120,184 +120,148 @@ public partial class Hospice_6_18_000 : ILibrary, ISingleton<Hospice_6_18_000>
         IEnumerable<Encounter> c_ = Status_1_15_000.Instance.isEncounterPerformed(context, b_);
 
         bool? d_(Encounter InpatientEncounter) {
-            Encounter.HospitalizationComponent k_ = InpatientEncounter?.Hospitalization;
-            CodeableConcept l_ = k_?.DischargeDisposition;
-            CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-            CqlCode n_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
-            CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-            CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-
-            CqlBoolean q_() {
-                Encounter.HospitalizationComponent s_ = InpatientEncounter?.Hospitalization;
-                CodeableConcept t_ = s_?.DischargeDisposition;
-                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                CqlCode v_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
-                CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
-                CqlBoolean x_ = context.Operators.Equivalent(u_, w_);
-                return x_;
-            }
-
-
-            CqlBoolean r_() {
-                Period y_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.End(z_);
-                CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
-                CqlBoolean ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, "day");
-                return ac_;
-            }
-
-            return (p_
-                /* CQL 'or' (28:13-30:7) */ || q_())
-                /* CQL 'and' (28:7-31:77) */ && r_();
+            Encounter.HospitalizationComponent al_ = InpatientEncounter?.Hospitalization;
+            CodeableConcept am_ = al_?.DischargeDisposition;
+            CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
+            CqlCode ao_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
+            CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+            CqlBoolean aq_ = context.Operators.Equivalent(an_, ap_);
+            CqlCode ar_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
+            CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+            CqlBoolean at_ = context.Operators.Equivalent(an_, as_);
+            CqlBoolean au_ = at_;
+            Period av_ = InpatientEncounter?.Period;
+            CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+            CqlDateTime ax_ = context.Operators.End(aw_);
+            CqlInterval<CqlDateTime> ay_ = this.Measurement_Period(context);
+            CqlBoolean az_ = context.Operators.In<CqlDateTime>(ax_, ay_, "day");
+            CqlBoolean ba_ = az_;
+            return (aq_
+                /* CQL 'or' (28:13-30:7) */ || au_)
+                /* CQL 'and' (28:7-31:77) */ && ba_;
         }
 
         CqlBoolean e_ = context.Operators.WhereAny<Encounter>(c_, d_);
+        CqlValueSet f_ = this.Hospice_Encounter(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> h_ = Status_1_15_000.Instance.isEncounterPerformed(context, g_);
 
-        CqlBoolean f_() {
-            CqlValueSet ad_ = this.Hospice_Encounter(context);
-            IEnumerable<Encounter> ae_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ad_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-            IEnumerable<Encounter> af_ = Status_1_15_000.Instance.isEncounterPerformed(context, ae_);
-
-            bool? ag_(Encounter HospiceEncounter) {
-                Period ai_ = HospiceEncounter?.Period;
-                CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
-                CqlInterval<CqlDateTime> ak_ = this.Measurement_Period(context);
-                CqlBoolean al_ = context.Operators.Overlaps(aj_, ak_, "day");
-                return al_;
-            }
-
-            CqlBoolean ah_ = context.Operators.WhereAny<Encounter>(af_, ag_);
-            return ah_;
+        bool? i_(Encounter HospiceEncounter) {
+            Period bb_ = HospiceEncounter?.Period;
+            CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
+            CqlInterval<CqlDateTime> bd_ = this.Measurement_Period(context);
+            CqlBoolean be_ = context.Operators.Overlaps(bc_, bd_, "day");
+            return be_;
         }
 
+        CqlBoolean j_ = context.Operators.WhereAny<Encounter>(h_, i_);
+        CqlBoolean k_ = j_;
+        CqlCode l_ = this.Hospice_care__Minimum_Data_Set_(context);
+        IEnumerable<CqlCode> m_ = context.Operators.ToList<CqlCode>(l_);
+        IEnumerable<Observation> n_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, m_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> o_ = Status_1_15_000.Instance.isAssessmentPerformed(context, n_);
 
-        CqlBoolean g_() {
-            CqlCode am_ = this.Hospice_care__Minimum_Data_Set_(context);
-            IEnumerable<CqlCode> an_ = context.Operators.ToList<CqlCode>(am_);
-            IEnumerable<Observation> ao_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, an_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
-            IEnumerable<Observation> ap_ = Status_1_15_000.Instance.isAssessmentPerformed(context, ao_);
-
-            bool? aq_(Observation HospiceAssessment) {
-                DataType as_ = HospiceAssessment?.Value;
-                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                CqlCode au_ = this.Yes__qualifier_value_(context);
-                CqlConcept av_ = context.Operators.ConvertCodeToConcept(au_);
-                CqlBoolean aw_ = context.Operators.Equivalent(at_ as CqlConcept, av_);
-
-                CqlBoolean ax_() {
-                    DataType ay_ = HospiceAssessment?.Effective;
-                    object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                    CqlInterval<CqlDateTime> ba_ = QICoreCommon_4_0_000.Instance.toInterval(context, az_);
-                    CqlInterval<CqlDateTime> bb_ = this.Measurement_Period(context);
-                    CqlBoolean bc_ = context.Operators.Overlaps(ba_, bb_, "day");
-                    return bc_;
-                }
-
-                return aw_
-                    /* CQL 'and' (37:9-38:91) */ && ax_();
-            }
-
-            CqlBoolean ar_ = context.Operators.WhereAny<Observation>(ap_, aq_);
-            return ar_;
+        bool? p_(Observation HospiceAssessment) {
+            DataType bf_ = HospiceAssessment?.Value;
+            object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+            CqlCode bh_ = this.Yes__qualifier_value_(context);
+            CqlConcept bi_ = context.Operators.ConvertCodeToConcept(bh_);
+            CqlBoolean bj_ = context.Operators.Equivalent(bg_ as CqlConcept, bi_);
+            DataType bk_ = HospiceAssessment?.Effective;
+            object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+            CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_);
+            CqlInterval<CqlDateTime> bn_ = this.Measurement_Period(context);
+            CqlBoolean bo_ = context.Operators.Overlaps(bm_, bn_, "day");
+            CqlBoolean bp_ = bo_;
+            return bj_
+                /* CQL 'and' (37:9-38:91) */ && bp_;
         }
 
+        CqlBoolean q_ = context.Operators.WhereAny<Observation>(o_, p_);
+        CqlBoolean r_ = q_;
+        CqlValueSet s_ = this.Hospice_Care_Ambulatory(context);
+        IEnumerable<ServiceRequest> t_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, s_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+        IEnumerable<ServiceRequest> u_ = Status_1_15_000.Instance.isInterventionOrder(context, t_);
 
-        CqlBoolean h_() {
-            CqlValueSet bd_ = this.Hospice_Care_Ambulatory(context);
-            IEnumerable<ServiceRequest> be_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, bd_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
-            IEnumerable<ServiceRequest> bf_ = Status_1_15_000.Instance.isInterventionOrder(context, be_);
-
-            bool? bg_(ServiceRequest HospiceOrder) {
-                FhirDateTime bi_ = HospiceOrder?.AuthoredOnElement;
-                CqlDateTime bj_ = context.Operators.Convert<CqlDateTime>(bi_);
-                CqlInterval<CqlDateTime> bk_ = this.Measurement_Period(context);
-                CqlBoolean bl_ = context.Operators.In<CqlDateTime>(bj_, bk_, "day");
-                return bl_;
-            }
-
-            CqlBoolean bh_ = context.Operators.WhereAny<ServiceRequest>(bf_, bg_);
-            return bh_;
+        bool? v_(ServiceRequest HospiceOrder) {
+            FhirDateTime bq_ = HospiceOrder?.AuthoredOnElement;
+            CqlDateTime br_ = context.Operators.Convert<CqlDateTime>(bq_);
+            CqlInterval<CqlDateTime> bs_ = this.Measurement_Period(context);
+            CqlBoolean bt_ = context.Operators.In<CqlDateTime>(br_, bs_, "day");
+            return bt_;
         }
 
+        CqlBoolean w_ = context.Operators.WhereAny<ServiceRequest>(u_, v_);
+        CqlBoolean x_ = w_;
+        IEnumerable<Procedure> y_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, s_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> z_ = Status_1_15_000.Instance.isInterventionPerformed(context, y_);
 
-        CqlBoolean i_() {
-            CqlValueSet bm_ = this.Hospice_Care_Ambulatory(context);
-            IEnumerable<Procedure> bn_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, bm_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-            IEnumerable<Procedure> bo_ = Status_1_15_000.Instance.isInterventionPerformed(context, bn_);
-
-            bool? bp_(Procedure HospicePerformed) {
-                object br_;
-                DataType bv_ = HospicePerformed?.Performed;
-                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                bool bx_ = bw_ is CqlDateTime;
-                if (bx_)
+        bool? aa_(Procedure HospicePerformed) {
+            object bu_;
+            DataType by_ = HospicePerformed?.Performed;
+            object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
+            bool ca_ = bz_ is CqlDateTime;
+            if (ca_)
+            {
+                bu_ = bz_ as CqlDateTime;
+            }
+            else
+            {
+                bool cb_ = bz_ is CqlQuantity;
+                if (cb_)
                 {
-                    br_ = bw_ as CqlDateTime;
+                    bu_ = bz_ as CqlQuantity;
                 }
                 else
                 {
-                    bool by_ = bw_ is CqlQuantity;
-                    if (by_)
+                    bool cc_ = bz_ is CqlInterval<CqlDateTime>;
+                    if (cc_)
                     {
-                        br_ = bw_ as CqlQuantity;
+                        bu_ = bz_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bz_ = bw_ is CqlInterval<CqlDateTime>;
-                        if (bz_)
+                        bool cd_ = bz_ is CqlInterval<CqlQuantity>;
+                        if (cd_)
                         {
-                            br_ = bw_ as CqlInterval<CqlDateTime>;
+                            bu_ = bz_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool ca_ = bw_ is CqlInterval<CqlQuantity>;
-                            if (ca_)
-                            {
-                                br_ = bw_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                br_ = null;
-                            }
+                            bu_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bs_ = QICoreCommon_4_0_000.Instance.toInterval(context, br_);
-                CqlInterval<CqlDateTime> bt_ = this.Measurement_Period(context);
-                CqlBoolean bu_ = context.Operators.Overlaps(bs_, bt_, "day");
-                return bu_;
             }
-
-            CqlBoolean bq_ = context.Operators.WhereAny<Procedure>(bo_, bp_);
-            return bq_;
+            CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_);
+            CqlInterval<CqlDateTime> bw_ = this.Measurement_Period(context);
+            CqlBoolean bx_ = context.Operators.Overlaps(bv_, bw_, "day");
+            return bx_;
         }
 
+        CqlBoolean ab_ = context.Operators.WhereAny<Procedure>(z_, aa_);
+        CqlBoolean ac_ = ab_;
+        CqlValueSet ad_ = this.Hospice_Diagnosis(context);
+        IEnumerable<Condition> ae_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ad_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> af_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ad_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> ag_ = context.Operators.Union<Condition>(ae_ as IEnumerable<Condition>, af_ as IEnumerable<Condition>);
+        IEnumerable<Condition> ah_ = Status_1_15_000.Instance.verified(context, ag_);
 
-        CqlBoolean j_() {
-            CqlValueSet cb_ = this.Hospice_Diagnosis(context);
-            IEnumerable<Condition> cc_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, cb_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> cd_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, cb_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> ce_ = context.Operators.Union<Condition>(cc_ as IEnumerable<Condition>, cd_ as IEnumerable<Condition>);
-            IEnumerable<Condition> cf_ = Status_1_15_000.Instance.verified(context, ce_);
-
-            bool? cg_(Condition HospiceCareDiagnosis) {
-                CqlInterval<CqlDateTime> ci_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis);
-                CqlInterval<CqlDateTime> cj_ = this.Measurement_Period(context);
-                CqlBoolean ck_ = context.Operators.Overlaps(ci_, cj_, "day");
-                return ck_;
-            }
-
-            CqlBoolean ch_ = context.Operators.WhereAny<Condition>(cf_, cg_);
-            return ch_;
+        bool? ai_(Condition HospiceCareDiagnosis) {
+            CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis);
+            CqlInterval<CqlDateTime> cf_ = this.Measurement_Period(context);
+            CqlBoolean cg_ = context.Operators.Overlaps(ce_, cf_, "day");
+            return cg_;
         }
 
+        CqlBoolean aj_ = context.Operators.WhereAny<Condition>(ah_, ai_);
+        CqlBoolean ak_ = aj_;
         return e_
-            /* CQL 'or' (27:3-35:5) */ || f_()
-            /* CQL 'or' (27:3-39:5) */ || g_()
-            /* CQL 'or' (27:3-42:5) */ || h_()
-            /* CQL 'or' (27:3-45:5) */ || i_()
-            /* CQL 'or' (27:3-49:5) */ || j_();
+            /* CQL 'or' (27:3-35:5) */ || k_
+            /* CQL 'or' (27:3-39:5) */ || r_
+            /* CQL 'or' (27:3-42:5) */ || x_
+            /* CQL 'or' (27:3-45:5) */ || ac_
+            /* CQL 'or' (27:3-49:5) */ || ak_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/NHSNHelpers-0.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/NHSNHelpers-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("NHSNHelpers", "0.1.000")]
 public partial class NHSNHelpers_0_1_000 : ILibrary, ISingleton<NHSNHelpers_0_1_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("PCMaternal", "5.25.000")]
 public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_000>
 {
@@ -145,45 +145,34 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 IEnumerable<Encounter> ah_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ag_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? ai_(Encounter LastObs) {
-                    Period bh_ = LastObs?.Period;
-                    CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bh_);
-                    CqlDateTime bj_ = context.Operators.End(bi_);
-                    Period bk_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
-                    CqlDateTime bm_ = context.Operators.Start(bl_);
-                    CqlQuantity bn_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime bo_ = context.Operators.Subtract(bm_, bn_);
-                    CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bo_, bm_, true, true);
-                    CqlBoolean bq_ = context.Operators.In<CqlDateTime>(bj_, bp_, (string)default);
-
-                    CqlBoolean br_() {
-                        Period bt_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bt_);
-                        CqlDateTime bv_ = context.Operators.Start(bu_);
-                        return bv_ is not null;
-                    }
-
-
-                    CqlBoolean bs_() {
-                        Code<Encounter.EncounterStatus> bw_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? bx_ = bw_?.Value;
-                        Code<Encounter.EncounterStatus> by_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bx_);
-                        CqlBoolean bz_ = context.Operators.Equal(by_, "finished");
-                        return bz_;
-                    }
-
-                    return bq_
-                        /* CQL 'and' (53:15-53:83) */ && br_()
-                        /* CQL 'and' (53:9-54:41) */ && bs_();
+                    Period bt_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bt_);
+                    CqlDateTime bv_ = context.Operators.End(bu_);
+                    Period bw_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bw_);
+                    CqlDateTime by_ = context.Operators.Start(bx_);
+                    CqlQuantity bz_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ca_ = context.Operators.Subtract(by_, bz_);
+                    CqlInterval<CqlDateTime> cb_ = context.Operators.Interval(ca_, by_, true, true);
+                    CqlBoolean cc_ = context.Operators.In<CqlDateTime>(bv_, cb_, (string)default);
+                    CqlBoolean cd_ = (CqlBoolean)(by_ is not null);
+                    Code<Encounter.EncounterStatus> ce_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? cf_ = ce_?.Value;
+                    Code<Encounter.EncounterStatus> cg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cf_);
+                    CqlBoolean ch_ = context.Operators.Equal(cg_, "finished");
+                    CqlBoolean ci_ = ch_;
+                    return cc_
+                        /* CQL 'and' (53:15-53:83) */ && cd_
+                        /* CQL 'and' (53:9-54:41) */ && ci_;
                 }
 
                 IEnumerable<Encounter> aj_ = context.Operators.Where<Encounter>(ah_, ai_);
 
                 object ak_(Encounter @this) {
-                    Period ca_ = @this?.Period;
-                    CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ca_);
-                    CqlDateTime cc_ = context.Operators.End(cb_);
-                    return cc_;
+                    Period cj_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cj_);
+                    CqlDateTime cl_ = context.Operators.End(ck_);
+                    return cl_;
                 }
 
                 IEnumerable<Encounter> al_ = context.Operators.SortBy<Encounter>(aj_, ak_, System.ComponentModel.ListSortDirection.Ascending);
@@ -198,45 +187,34 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 CqlDateTime au_ = context.Operators.Subtract(ap_ ?? as_, at_);
 
                 bool? av_(Encounter LastObs) {
-                    Period cd_ = LastObs?.Period;
-                    CqlInterval<CqlDateTime> ce_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cd_);
-                    CqlDateTime cf_ = context.Operators.End(ce_);
-                    Period cg_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> ch_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cg_);
-                    CqlDateTime ci_ = context.Operators.Start(ch_);
-                    CqlQuantity cj_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime ck_ = context.Operators.Subtract(ci_, cj_);
-                    CqlInterval<CqlDateTime> cl_ = context.Operators.Interval(ck_, ci_, true, true);
-                    CqlBoolean cm_ = context.Operators.In<CqlDateTime>(cf_, cl_, (string)default);
-
-                    CqlBoolean cn_() {
-                        Period cp_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
-                        CqlDateTime cr_ = context.Operators.Start(cq_);
-                        return cr_ is not null;
-                    }
-
-
-                    CqlBoolean co_() {
-                        Code<Encounter.EncounterStatus> cs_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? ct_ = cs_?.Value;
-                        Code<Encounter.EncounterStatus> cu_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ct_);
-                        CqlBoolean cv_ = context.Operators.Equal(cu_, "finished");
-                        return cv_;
-                    }
-
-                    return cm_
-                        /* CQL 'and' (53:15-53:83) */ && cn_()
-                        /* CQL 'and' (53:9-54:41) */ && co_();
+                    Period cm_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
+                    CqlDateTime co_ = context.Operators.End(cn_);
+                    Period cp_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
+                    CqlDateTime cr_ = context.Operators.Start(cq_);
+                    CqlQuantity cs_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ct_ = context.Operators.Subtract(cr_, cs_);
+                    CqlInterval<CqlDateTime> cu_ = context.Operators.Interval(ct_, cr_, true, true);
+                    CqlBoolean cv_ = context.Operators.In<CqlDateTime>(co_, cu_, (string)default);
+                    CqlBoolean cw_ = (CqlBoolean)(cr_ is not null);
+                    Code<Encounter.EncounterStatus> cx_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? cy_ = cx_?.Value;
+                    Code<Encounter.EncounterStatus> cz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cy_);
+                    CqlBoolean da_ = context.Operators.Equal(cz_, "finished");
+                    CqlBoolean db_ = da_;
+                    return cv_
+                        /* CQL 'and' (53:15-53:83) */ && cw_
+                        /* CQL 'and' (53:9-54:41) */ && db_;
                 }
 
                 IEnumerable<Encounter> aw_ = context.Operators.Where<Encounter>(ah_, av_);
 
                 object ax_(Encounter @this) {
-                    Period cw_ = @this?.Period;
-                    CqlInterval<CqlDateTime> cx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cw_);
-                    CqlDateTime cy_ = context.Operators.End(cx_);
-                    return cy_;
+                    Period dc_ = @this?.Period;
+                    CqlInterval<CqlDateTime> dd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dc_);
+                    CqlDateTime de_ = context.Operators.End(dd_);
+                    return de_;
                 }
 
                 IEnumerable<Encounter> ay_ = context.Operators.SortBy<Encounter>(aw_, ax_, System.ComponentModel.ListSortDirection.Ascending);
@@ -247,84 +225,60 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(au_, bc_ ?? as_, true, true);
                 CqlBoolean be_ = context.Operators.In<CqlDateTime>(af_, bd_, (string)default);
 
-                CqlBoolean bf_() {
-                    CqlValueSet cz_ = this.Observation_Services(context);
-                    IEnumerable<Encounter> da_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, cz_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                    bool? db_(Encounter LastObs) {
-                        Period dm_ = LastObs?.Period;
-                        CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dm_);
-                        CqlDateTime do_ = context.Operators.End(dn_);
-                        Period dp_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> dq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dp_);
-                        CqlDateTime dr_ = context.Operators.Start(dq_);
-                        CqlQuantity ds_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime dt_ = context.Operators.Subtract(dr_, ds_);
-                        CqlInterval<CqlDateTime> du_ = context.Operators.Interval(dt_, dr_, true, true);
-                        CqlBoolean dv_ = context.Operators.In<CqlDateTime>(do_, du_, (string)default);
-
-                        CqlBoolean dw_() {
-                            Period dy_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
-                            CqlDateTime ea_ = context.Operators.Start(dz_);
-                            return ea_ is not null;
-                        }
-
-
-                        CqlBoolean dx_() {
-                            Code<Encounter.EncounterStatus> eb_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? ec_ = eb_?.Value;
-                            Code<Encounter.EncounterStatus> ed_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ec_);
-                            CqlBoolean ee_ = context.Operators.Equal(ed_, "finished");
-                            return ee_;
-                        }
-
-                        return dv_
-                            /* CQL 'and' (53:15-53:83) */ && dw_()
-                            /* CQL 'and' (53:9-54:41) */ && dx_();
-                    }
-
-                    IEnumerable<Encounter> dc_ = context.Operators.Where<Encounter>(da_, db_);
-
-                    object dd_(Encounter @this) {
-                        Period ef_ = @this?.Period;
-                        CqlInterval<CqlDateTime> eg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ef_);
-                        CqlDateTime eh_ = context.Operators.End(eg_);
-                        return eh_;
-                    }
-
-                    IEnumerable<Encounter> de_ = context.Operators.SortBy<Encounter>(dc_, dd_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter df_ = context.Operators.Last<Encounter>(de_);
-                    Period dg_ = df_?.Period;
-                    CqlInterval<CqlDateTime> dh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dg_);
-                    CqlDateTime di_ = context.Operators.Start(dh_);
-                    Period dj_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dj_);
-                    CqlDateTime dl_ = context.Operators.Start(dk_);
-                    return (di_ ?? dl_) is not null;
+                bool? bf_(Encounter LastObs) {
+                    Period df_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> dg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, df_);
+                    CqlDateTime dh_ = context.Operators.End(dg_);
+                    Period di_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> dj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, di_);
+                    CqlDateTime dk_ = context.Operators.Start(dj_);
+                    CqlQuantity dl_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime dm_ = context.Operators.Subtract(dk_, dl_);
+                    CqlInterval<CqlDateTime> dn_ = context.Operators.Interval(dm_, dk_, true, true);
+                    CqlBoolean do_ = context.Operators.In<CqlDateTime>(dh_, dn_, (string)default);
+                    CqlBoolean dp_ = (CqlBoolean)(dk_ is not null);
+                    Code<Encounter.EncounterStatus> dq_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? dr_ = dq_?.Value;
+                    Code<Encounter.EncounterStatus> ds_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dr_);
+                    CqlBoolean dt_ = context.Operators.Equal(ds_, "finished");
+                    CqlBoolean du_ = dt_;
+                    return do_
+                        /* CQL 'and' (53:15-53:83) */ && dp_
+                        /* CQL 'and' (53:9-54:41) */ && du_;
                 }
 
+                IEnumerable<Encounter> bg_ = context.Operators.Where<Encounter>(ah_, bf_);
 
-                CqlBoolean bg_() {
-                    Code<Encounter.EncounterStatus> ei_ = LastEDOBTriage?.StatusElement;
-                    Encounter.EncounterStatus? ej_ = ei_?.Value;
-                    Code<Encounter.EncounterStatus> ek_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ej_);
-                    CqlBoolean el_ = context.Operators.Equal(ek_, "finished");
-                    return el_;
+                object bh_(Encounter @this) {
+                    Period dv_ = @this?.Period;
+                    CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
+                    CqlDateTime dx_ = context.Operators.End(dw_);
+                    return dx_;
                 }
 
+                IEnumerable<Encounter> bi_ = context.Operators.SortBy<Encounter>(bg_, bh_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter bj_ = context.Operators.Last<Encounter>(bi_);
+                Period bk_ = bj_?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                CqlDateTime bm_ = context.Operators.Start(bl_);
+                CqlBoolean bn_ = (CqlBoolean)((bm_ ?? as_) is not null);
+                Code<Encounter.EncounterStatus> bo_ = LastEDOBTriage?.StatusElement;
+                Encounter.EncounterStatus? bp_ = bo_?.Value;
+                Code<Encounter.EncounterStatus> bq_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bp_);
+                CqlBoolean br_ = context.Operators.Equal(bq_, "finished");
+                CqlBoolean bs_ = br_;
                 return be_
-                    /* CQL 'and' (60:15-60:79) */ && bf_()
-                    /* CQL 'and' (60:9-61:48) */ && bg_();
+                    /* CQL 'and' (60:15-60:79) */ && bn_
+                    /* CQL 'and' (60:9-61:48) */ && bs_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 
             object i_(Encounter @this) {
-                Period em_ = @this?.Period;
-                CqlInterval<CqlDateTime> en_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, em_);
-                CqlDateTime eo_ = context.Operators.End(en_);
-                return eo_;
+                Period dy_ = @this?.Period;
+                CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
+                CqlDateTime ea_ = context.Operators.End(dz_);
+                return ea_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -336,45 +290,34 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
             IEnumerable<Encounter> p_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? q_(Encounter LastObs) {
-                Period ep_ = LastObs?.Period;
-                CqlInterval<CqlDateTime> eq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ep_);
-                CqlDateTime er_ = context.Operators.End(eq_);
-                Period es_ = Visit?.Period;
-                CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, es_);
-                CqlDateTime eu_ = context.Operators.Start(et_);
-                CqlQuantity ev_ = context.Operators.Quantity(1m, "hour");
-                CqlDateTime ew_ = context.Operators.Subtract(eu_, ev_);
-                CqlInterval<CqlDateTime> ex_ = context.Operators.Interval(ew_, eu_, true, true);
-                CqlBoolean ey_ = context.Operators.In<CqlDateTime>(er_, ex_, (string)default);
-
-                CqlBoolean ez_() {
-                    Period fb_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> fc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fb_);
-                    CqlDateTime fd_ = context.Operators.Start(fc_);
-                    return fd_ is not null;
-                }
-
-
-                CqlBoolean fa_() {
-                    Code<Encounter.EncounterStatus> fe_ = LastObs?.StatusElement;
-                    Encounter.EncounterStatus? ff_ = fe_?.Value;
-                    Code<Encounter.EncounterStatus> fg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ff_);
-                    CqlBoolean fh_ = context.Operators.Equal(fg_, "finished");
-                    return fh_;
-                }
-
-                return ey_
-                    /* CQL 'and' (53:15-53:83) */ && ez_()
-                    /* CQL 'and' (53:9-54:41) */ && fa_();
+                Period eb_ = LastObs?.Period;
+                CqlInterval<CqlDateTime> ec_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eb_);
+                CqlDateTime ed_ = context.Operators.End(ec_);
+                Period ee_ = Visit?.Period;
+                CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ee_);
+                CqlDateTime eg_ = context.Operators.Start(ef_);
+                CqlQuantity eh_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime ei_ = context.Operators.Subtract(eg_, eh_);
+                CqlInterval<CqlDateTime> ej_ = context.Operators.Interval(ei_, eg_, true, true);
+                CqlBoolean ek_ = context.Operators.In<CqlDateTime>(ed_, ej_, (string)default);
+                CqlBoolean el_ = (CqlBoolean)(eg_ is not null);
+                Code<Encounter.EncounterStatus> em_ = LastObs?.StatusElement;
+                Encounter.EncounterStatus? en_ = em_?.Value;
+                Code<Encounter.EncounterStatus> eo_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(en_);
+                CqlBoolean ep_ = context.Operators.Equal(eo_, "finished");
+                CqlBoolean eq_ = ep_;
+                return ek_
+                    /* CQL 'and' (53:15-53:83) */ && el_
+                    /* CQL 'and' (53:9-54:41) */ && eq_;
             }
 
             IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 
             object s_(Encounter @this) {
-                Period fi_ = @this?.Period;
-                CqlInterval<CqlDateTime> fj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fi_);
-                CqlDateTime fk_ = context.Operators.End(fj_);
-                return fk_;
+                Period er_ = @this?.Period;
+                CqlInterval<CqlDateTime> es_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, er_);
+                CqlDateTime et_ = context.Operators.End(es_);
+                return et_;
             }
 
             IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
@@ -415,53 +358,49 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    object m_;
-                    DataType r_ = DeliveryProcedure?.Performed;
-                    object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                    bool t_ = s_ is CqlDateTime;
-                    if (t_)
+                object l_;
+                DataType r_ = DeliveryProcedure?.Performed;
+                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+                bool t_ = s_ is CqlDateTime;
+                if (t_)
+                {
+                    l_ = s_ as CqlDateTime;
+                }
+                else
+                {
+                    bool u_ = s_ is CqlQuantity;
+                    if (u_)
                     {
-                        m_ = s_ as CqlDateTime;
+                        l_ = s_ as CqlQuantity;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlQuantity;
-                        if (u_)
+                        bool v_ = s_ is CqlInterval<CqlDateTime>;
+                        if (v_)
                         {
-                            m_ = s_ as CqlQuantity;
+                            l_ = s_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool v_ = s_ is CqlInterval<CqlDateTime>;
-                            if (v_)
+                            bool w_ = s_ is CqlInterval<CqlQuantity>;
+                            if (w_)
                             {
-                                m_ = s_ as CqlInterval<CqlDateTime>;
+                                l_ = s_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool w_ = s_ is CqlInterval<CqlQuantity>;
-                                if (w_)
-                                {
-                                    m_ = s_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    m_ = null;
-                                }
+                                l_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                    CqlDateTime o_ = context.Operators.Start(n_);
-                    CqlInterval<CqlDateTime> p_ = this.hospitalizationWithEDOBTriageObservation(context, EncounterWithAge);
-                    CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                    return q_;
                 }
-
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = this.hospitalizationWithEDOBTriageObservation(context, EncounterWithAge);
+                CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                CqlBoolean q_ = p_;
                 return k_
-                    /* CQL 'and' (27:27-28:138) */ && l_();
+                    /* CQL 'and' (27:27-28:138) */ && q_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -495,102 +434,87 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
         bool? d_(Observation TimeOfDelivery) {
             DataType k_ = TimeOfDelivery?.Value;
             object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-
-            CqlBoolean m_() {
-                Code<ObservationStatus> p_ = TimeOfDelivery?.StatusElement;
-                ObservationStatus? q_ = p_?.Value;
-                string r_ = context.Operators.Convert<string>(q_);
-                string[] s_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
-                return t_;
+            Code<ObservationStatus> m_ = TimeOfDelivery?.StatusElement;
+            ObservationStatus? n_ = m_?.Value;
+            string o_ = context.Operators.Convert<string>(n_);
+            string[] p_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+            CqlBoolean r_ = q_;
+            object s_;
+            DataType z_ = TimeOfDelivery?.Effective;
+            object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+            bool ab_ = aa_ is CqlDateTime;
+            if (ab_)
+            {
+                s_ = aa_ as CqlDateTime;
             }
-
-
-            CqlBoolean n_() {
-                object u_;
-                DataType y_ = TimeOfDelivery?.Effective;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
+            else
+            {
+                if (ab_)
                 {
-                    u_ = z_ as CqlDateTime;
+                    s_ = aa_ as CqlDateTime;
                 }
                 else
                 {
-                    if (aa_)
+                    bool ac_ = aa_ is CqlInterval<CqlDateTime>;
+                    if (ac_)
                     {
-                        u_ = z_ as CqlDateTime;
+                        s_ = aa_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ab_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ab_)
-                        {
-                            u_ = z_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            u_ = null;
-                        }
+                        s_ = null;
                     }
                 }
-                CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
-                CqlInterval<CqlDateTime> w_ = this.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
-                CqlBoolean x_ = context.Operators.In<CqlDateTime>(v_, w_, (string)default);
-                return x_;
             }
-
-
-            CqlBoolean o_() {
-                DataType ac_ = TimeOfDelivery?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                CqlInterval<CqlDateTime> ae_ = this.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
-                CqlBoolean af_ = context.Operators.In<CqlDateTime>(ad_ as CqlDateTime, ae_, (string)default);
-                return af_;
-            }
-
+            CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
+            CqlInterval<CqlDateTime> u_ = this.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
+            CqlBoolean v_ = context.Operators.In<CqlDateTime>(t_, u_, (string)default);
+            CqlBoolean w_ = v_;
+            CqlBoolean x_ = context.Operators.In<CqlDateTime>(l_ as CqlDateTime, u_, (string)default);
+            CqlBoolean y_ = x_;
             return (CqlBoolean)((l_ as CqlDateTime) is not null)
-                /* CQL 'and' (93:13-94:72) */ && m_()
-                /* CQL 'and' (93:13-95:112) */ && n_()
-                /* CQL 'and' (93:7-96:107) */ && o_();
+                /* CQL 'and' (93:13-94:72) */ && r_
+                /* CQL 'and' (93:13-95:112) */ && w_
+                /* CQL 'and' (93:7-96:107) */ && y_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         object f_(Observation @this) {
-            object ag_;
-            DataType ai_ = @this?.Effective;
-            object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-            bool ak_ = aj_ is CqlDateTime;
-            if (ak_)
+            object ad_;
+            DataType af_ = @this?.Effective;
+            object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+            bool ah_ = ag_ is CqlDateTime;
+            if (ah_)
             {
-                ag_ = aj_ as CqlDateTime;
+                ad_ = ag_ as CqlDateTime;
             }
             else
             {
-                if (ak_)
+                if (ah_)
                 {
-                    ag_ = aj_ as CqlDateTime;
+                    ad_ = ag_ as CqlDateTime;
                 }
                 else
                 {
-                    bool al_ = aj_ is CqlInterval<CqlDateTime>;
-                    if (al_)
+                    bool ai_ = ag_ is CqlInterval<CqlDateTime>;
+                    if (ai_)
                     {
-                        ag_ = aj_ as CqlInterval<CqlDateTime>;
+                        ad_ = ag_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        ag_ = null;
+                        ad_ = null;
                     }
                 }
             }
-            CqlDateTime ah_ = QICoreCommon_4_0_000.Instance.earliest(context, ag_);
-            return ah_;
+            CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
+            return ae_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
@@ -611,62 +535,54 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
         bool? d_(Observation EstimatedDateOfDelivery) {
             DataType k_ = EstimatedDateOfDelivery?.Value;
             object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-
-            CqlBoolean m_() {
-                Code<ObservationStatus> o_ = EstimatedDateOfDelivery?.StatusElement;
-                ObservationStatus? p_ = o_?.Value;
-                string q_ = context.Operators.Convert<string>(p_);
-                string[] r_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
-                return s_;
+            Code<ObservationStatus> m_ = EstimatedDateOfDelivery?.StatusElement;
+            ObservationStatus? n_ = m_?.Value;
+            string o_ = context.Operators.Convert<string>(n_);
+            string[] p_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+            CqlBoolean r_ = q_;
+            object s_;
+            DataType aa_ = EstimatedDateOfDelivery?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            bool ac_ = ab_ is CqlDateTime;
+            if (ac_)
+            {
+                s_ = ab_ as CqlDateTime;
             }
-
-
-            CqlBoolean n_() {
-                object t_;
-                DataType aa_ = EstimatedDateOfDelivery?.Effective;
-                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                bool ac_ = ab_ is CqlDateTime;
+            else
+            {
                 if (ac_)
                 {
-                    t_ = ab_ as CqlDateTime;
+                    s_ = ab_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ac_)
+                    bool ad_ = ab_ is CqlInterval<CqlDateTime>;
+                    if (ad_)
                     {
-                        t_ = ab_ as CqlDateTime;
+                        s_ = ab_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ad_ = ab_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
-                        {
-                            t_ = ab_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            t_ = null;
-                        }
+                        s_ = null;
                     }
                 }
-                CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
-                CqlDateTime v_ = this.lastTimeOfDelivery(context, TheEncounter);
-                CqlQuantity w_ = context.Operators.Quantity(42m, "weeks");
-                CqlDateTime x_ = context.Operators.Subtract(v_, w_);
-                CqlInterval<CqlDateTime> y_ = context.Operators.Interval(x_, v_, true, true);
-                CqlBoolean z_ = context.Operators.In<CqlDateTime>(u_, y_, (string)default);
-                return z_
-                    /* CQL 'and' (74:13-74:123) */ && ((this.lastTimeOfDelivery(context, TheEncounter)) is not null);
             }
-
+            CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
+            CqlDateTime u_ = this.lastTimeOfDelivery(context, TheEncounter);
+            CqlQuantity v_ = context.Operators.Quantity(42m, "weeks");
+            CqlDateTime w_ = context.Operators.Subtract(u_, v_);
+            CqlInterval<CqlDateTime> x_ = context.Operators.Interval(w_, u_, true, true);
+            CqlBoolean y_ = context.Operators.In<CqlDateTime>(t_, x_, (string)default);
+            CqlBoolean z_ = y_
+                /* CQL 'and' (74:13-74:123) */ && ((this.lastTimeOfDelivery(context, TheEncounter)) is not null);
             return (CqlBoolean)((l_ as CqlDateTime) is not null)
-                /* CQL 'and' (72:13-73:81) */ && m_()
-                /* CQL 'and' (72:7-74:123) */ && n_();
+                /* CQL 'and' (72:13-73:81) */ && r_
+                /* CQL 'and' (72:7-74:123) */ && z_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -742,25 +658,25 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
 
         bool? c_(Observation EstimatedGestationalAge) {
             object j_;
-            DataType t_ = EstimatedGestationalAge?.Effective;
-            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-            bool v_ = u_ is CqlDateTime;
-            if (v_)
+            DataType ai_ = EstimatedGestationalAge?.Effective;
+            object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+            bool ak_ = aj_ is CqlDateTime;
+            if (ak_)
             {
-                j_ = u_ as CqlDateTime;
+                j_ = aj_ as CqlDateTime;
             }
             else
             {
-                if (v_)
+                if (ak_)
                 {
-                    j_ = u_ as CqlDateTime;
+                    j_ = aj_ as CqlDateTime;
                 }
                 else
                 {
-                    bool w_ = u_ is CqlInterval<CqlDateTime>;
-                    if (w_)
+                    bool al_ = aj_ is CqlInterval<CqlDateTime>;
+                    if (al_)
                     {
-                        j_ = u_ as CqlInterval<CqlDateTime>;
+                        j_ = aj_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -774,145 +690,121 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
             CqlDateTime n_ = context.Operators.Subtract(l_, m_);
             CqlInterval<CqlDateTime> o_ = context.Operators.Interval(n_, l_, true, true);
             CqlBoolean p_ = context.Operators.In<CqlDateTime>(k_, o_, (string)default);
-
-            CqlBoolean q_() {
-                DataType x_ = EstimatedGestationalAge?.Value;
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                return y_ is not null;
+            DataType q_ = EstimatedGestationalAge?.Value;
+            object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+            CqlBoolean s_ = (CqlBoolean)(r_ is not null);
+            Code<ObservationStatus> t_ = EstimatedGestationalAge?.StatusElement;
+            ObservationStatus? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
+            object z_;
+            DataType am_ = EstimatedGestationalAge?.Effective;
+            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            bool ao_ = an_ is CqlDateTime;
+            if (ao_)
+            {
+                z_ = an_ as CqlDateTime;
             }
-
-
-            CqlBoolean r_() {
-                Code<ObservationStatus> z_ = EstimatedGestationalAge?.StatusElement;
-                ObservationStatus? aa_ = z_?.Value;
-                string ab_ = context.Operators.Convert<string>(aa_);
-                string[] ac_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
-                return ad_;
-            }
-
-
-            CqlBoolean s_() {
-                object ae_;
-                DataType ak_ = EstimatedGestationalAge?.Effective;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                bool am_ = al_ is CqlDateTime;
-                if (am_)
+            else
+            {
+                if (ao_)
                 {
-                    ae_ = al_ as CqlDateTime;
+                    z_ = an_ as CqlDateTime;
                 }
                 else
                 {
-                    if (am_)
+                    bool ap_ = an_ is CqlInterval<CqlDateTime>;
+                    if (ap_)
                     {
-                        ae_ = al_ as CqlDateTime;
+                        z_ = an_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool an_ = al_ is CqlInterval<CqlDateTime>;
-                        if (an_)
-                        {
-                            ae_ = al_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ae_ = null;
-                        }
+                        z_ = null;
                     }
                 }
-                CqlDateTime af_ = QICoreCommon_4_0_000.Instance.earliest(context, ae_);
-                CqlDateTime ag_ = this.lastTimeOfDelivery(context, TheEncounter);
-                CqlBoolean ah_ = context.Operators.SameAs(af_, ag_, "day");
-
-                CqlBoolean ai_() {
-                    object ao_;
-                    DataType as_ = EstimatedGestationalAge?.Effective;
-                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                    bool au_ = at_ is CqlDateTime;
-                    if (au_)
-                    {
-                        ao_ = at_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        if (au_)
-                        {
-                            ao_ = at_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool av_ = at_ is CqlInterval<CqlDateTime>;
-                            if (av_)
-                            {
-                                ao_ = at_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                ao_ = null;
-                            }
-                        }
-                    }
-                    CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
-                    CqlInterval<CqlDateTime> aq_ = this.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
-                    CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
-                    return ar_;
-                }
-
-
-                CqlBoolean aj_() {
-                    DataType aw_ = EstimatedGestationalAge?.Value;
-                    object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                    return ax_ is not null;
-                }
-
-                return ah_
-                    /* CQL 'and' (85:8-86:82) */ && ai_()
-                    /* CQL 'and' (85:7-87:52) */ && aj_();
             }
-
+            CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, z_);
+            CqlBoolean ab_ = context.Operators.SameAs(aa_, l_, "day");
+            object ac_;
+            DataType aq_ = EstimatedGestationalAge?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            bool as_ = ar_ is CqlDateTime;
+            if (as_)
+            {
+                ac_ = ar_ as CqlDateTime;
+            }
+            else
+            {
+                if (as_)
+                {
+                    ac_ = ar_ as CqlDateTime;
+                }
+                else
+                {
+                    bool at_ = ar_ is CqlInterval<CqlDateTime>;
+                    if (at_)
+                    {
+                        ac_ = ar_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        ac_ = null;
+                    }
+                }
+            }
+            CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.earliest(context, ac_);
+            CqlInterval<CqlDateTime> ae_ = this.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
+            CqlBoolean af_ = context.Operators.In<CqlDateTime>(ad_, ae_, (string)default);
+            CqlBoolean ag_ = af_;
+            CqlBoolean ah_ = ab_
+                /* CQL 'and' (85:8-86:82) */ && ag_
+                /* CQL 'and' (85:7-87:52) */ && s_;
             return (p_
                 /* CQL 'and' (82:4-82:77) */ && ((this.lastTimeOfDelivery(context, TheEncounter)) is not null)
-                /* CQL 'and' (82:4-83:47) */ && q_()
-                /* CQL 'and' (82:3-84:76) */ && r_())
-                /* CQL 'or' (81:64-87:52) */ || s_();
+                /* CQL 'and' (82:4-83:47) */ && s_
+                /* CQL 'and' (82:3-84:76) */ && y_)
+                /* CQL 'or' (81:64-87:52) */ || ah_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
         object e_(Observation @this) {
-            object ay_;
-            DataType ba_ = @this?.Effective;
-            object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-            bool bc_ = bb_ is CqlDateTime;
-            if (bc_)
+            object au_;
+            DataType aw_ = @this?.Effective;
+            object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+            bool ay_ = ax_ is CqlDateTime;
+            if (ay_)
             {
-                ay_ = bb_ as CqlDateTime;
+                au_ = ax_ as CqlDateTime;
             }
             else
             {
-                if (bc_)
+                if (ay_)
                 {
-                    ay_ = bb_ as CqlDateTime;
+                    au_ = ax_ as CqlDateTime;
                 }
                 else
                 {
-                    bool bd_ = bb_ is CqlInterval<CqlDateTime>;
-                    if (bd_)
+                    bool az_ = ax_ is CqlInterval<CqlDateTime>;
+                    if (az_)
                     {
-                        ay_ = bb_ as CqlInterval<CqlDateTime>;
+                        au_ = ax_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        ay_ = null;
+                        au_ = null;
                     }
                 }
             }
-            CqlDateTime az_ = QICoreCommon_4_0_000.Instance.earliest(context, ay_);
-            return az_;
+            CqlDateTime av_ = QICoreCommon_4_0_000.Instance.earliest(context, au_);
+            return av_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/PalliativeCare-1.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/PalliativeCare-1.18.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("PalliativeCare", "1.18.000")]
 public partial class PalliativeCare_1_18_000 : ILibrary, ISingleton<PalliativeCare_1_18_000>
 {
@@ -97,109 +97,97 @@ public partial class PalliativeCare_1_18_000 : ILibrary, ISingleton<PalliativeCa
         IEnumerable<Observation> d_ = Status_1_15_000.Instance.isAssessmentPerformed(context, c_);
 
         bool? e_(Observation PalliativeAssessment) {
-            DataType j_ = PalliativeAssessment?.Effective;
-            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-            CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
-            CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-            CqlBoolean n_ = context.Operators.Overlaps(l_, m_, "day");
-            return n_;
+            DataType aa_ = PalliativeAssessment?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+            CqlInterval<CqlDateTime> ad_ = this.Measurement_Period(context);
+            CqlBoolean ae_ = context.Operators.Overlaps(ac_, ad_, "day");
+            return ae_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
+        CqlValueSet g_ = this.Palliative_Care_Diagnosis(context);
+        IEnumerable<Condition> h_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> i_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> j_ = context.Operators.Union<Condition>(h_ as IEnumerable<Condition>, i_ as IEnumerable<Condition>);
+        IEnumerable<Condition> k_ = Status_1_15_000.Instance.verified(context, j_);
 
-        CqlBoolean g_() {
-            CqlValueSet o_ = this.Palliative_Care_Diagnosis(context);
-            IEnumerable<Condition> p_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> q_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> r_ = context.Operators.Union<Condition>(p_ as IEnumerable<Condition>, q_ as IEnumerable<Condition>);
-            IEnumerable<Condition> s_ = Status_1_15_000.Instance.verified(context, r_);
-
-            bool? t_(Condition PalliativeDiagnosis) {
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeDiagnosis);
-                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                CqlBoolean x_ = context.Operators.Overlaps(v_, w_, "day");
-                return x_;
-            }
-
-            CqlBoolean u_ = context.Operators.WhereAny<Condition>(s_, t_);
-            return u_;
+        bool? l_(Condition PalliativeDiagnosis) {
+            CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeDiagnosis);
+            CqlInterval<CqlDateTime> ag_ = this.Measurement_Period(context);
+            CqlBoolean ah_ = context.Operators.Overlaps(af_, ag_, "day");
+            return ah_;
         }
 
+        CqlBoolean m_ = context.Operators.WhereAny<Condition>(k_, l_);
+        CqlBoolean n_ = m_;
+        CqlValueSet o_ = this.Palliative_Care_Encounter(context);
+        IEnumerable<Encounter> p_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> q_ = Status_1_15_000.Instance.isEncounterPerformed(context, p_);
 
-        CqlBoolean h_() {
-            CqlValueSet y_ = this.Palliative_Care_Encounter(context);
-            IEnumerable<Encounter> z_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-            IEnumerable<Encounter> aa_ = Status_1_15_000.Instance.isEncounterPerformed(context, z_);
-
-            bool? ab_(Encounter PalliativeEncounter) {
-                Period ad_ = PalliativeEncounter?.Period;
-                CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
-                CqlBoolean ag_ = context.Operators.Overlaps(ae_, af_, "day");
-                return ag_;
-            }
-
-            CqlBoolean ac_ = context.Operators.WhereAny<Encounter>(aa_, ab_);
-            return ac_;
-        }
-
-
-        CqlBoolean i_() {
-            CqlValueSet ah_ = this.Palliative_Care_Intervention(context);
-            IEnumerable<Procedure> ai_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-            IEnumerable<Procedure> aj_ = Status_1_15_000.Instance.isInterventionPerformed(context, ai_);
-
-            bool? ak_(Procedure PalliativeIntervention) {
-                object am_;
-                DataType aq_ = PalliativeIntervention?.Performed;
-                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                bool as_ = ar_ is CqlDateTime;
-                if (as_)
-                {
-                    am_ = ar_ as CqlDateTime;
-                }
-                else
-                {
-                    bool at_ = ar_ is CqlQuantity;
-                    if (at_)
-                    {
-                        am_ = ar_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool au_ = ar_ is CqlInterval<CqlDateTime>;
-                        if (au_)
-                        {
-                            am_ = ar_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool av_ = ar_ is CqlInterval<CqlQuantity>;
-                            if (av_)
-                            {
-                                am_ = ar_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                am_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
-                CqlInterval<CqlDateTime> ao_ = this.Measurement_Period(context);
-                CqlBoolean ap_ = context.Operators.Overlaps(an_, ao_, "day");
-                return ap_;
-            }
-
-            CqlBoolean al_ = context.Operators.WhereAny<Procedure>(aj_, ak_);
+        bool? r_(Encounter PalliativeEncounter) {
+            Period ai_ = PalliativeEncounter?.Period;
+            CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
+            CqlInterval<CqlDateTime> ak_ = this.Measurement_Period(context);
+            CqlBoolean al_ = context.Operators.Overlaps(aj_, ak_, "day");
             return al_;
         }
 
+        CqlBoolean s_ = context.Operators.WhereAny<Encounter>(q_, r_);
+        CqlBoolean t_ = s_;
+        CqlValueSet u_ = this.Palliative_Care_Intervention(context);
+        IEnumerable<Procedure> v_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, u_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> w_ = Status_1_15_000.Instance.isInterventionPerformed(context, v_);
+
+        bool? x_(Procedure PalliativeIntervention) {
+            object am_;
+            DataType aq_ = PalliativeIntervention?.Performed;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            bool as_ = ar_ is CqlDateTime;
+            if (as_)
+            {
+                am_ = ar_ as CqlDateTime;
+            }
+            else
+            {
+                bool at_ = ar_ is CqlQuantity;
+                if (at_)
+                {
+                    am_ = ar_ as CqlQuantity;
+                }
+                else
+                {
+                    bool au_ = ar_ is CqlInterval<CqlDateTime>;
+                    if (au_)
+                    {
+                        am_ = ar_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool av_ = ar_ is CqlInterval<CqlQuantity>;
+                        if (av_)
+                        {
+                            am_ = ar_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            am_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
+            CqlInterval<CqlDateTime> ao_ = this.Measurement_Period(context);
+            CqlBoolean ap_ = context.Operators.Overlaps(an_, ao_, "day");
+            return ap_;
+        }
+
+        CqlBoolean y_ = context.Operators.WhereAny<Procedure>(w_, x_);
+        CqlBoolean z_ = y_;
         return f_
-            /* CQL 'or' (22:3-28:5) */ || g_()
-            /* CQL 'or' (22:3-31:5) */ || h_()
-            /* CQL 'or' (22:3-34:5) */ || i_();
+            /* CQL 'or' (22:3-28:5) */ || n_
+            /* CQL 'or' (22:3-31:5) */ || t_
+            /* CQL 'or' (22:3-34:5) */ || z_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Status-1.15.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Status-1.15.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("Status", "1.15.000")]
 public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
 {
@@ -87,51 +87,27 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
         bool? a_(Condition C) {
             CodeableConcept c_ = C?.VerificationStatus;
             CqlConcept d_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, c_);
-
-            CqlBoolean e_() {
-                CodeableConcept f_ = C?.VerificationStatus;
-                CqlConcept g_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, f_);
-                CqlCode h_ = this.confirmed(context);
-                CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
-                CqlBoolean j_ = context.Operators.Equivalent(g_, i_);
-
-                CqlBoolean k_() {
-                    CodeableConcept n_ = C?.VerificationStatus;
-                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                    CqlCode p_ = this.unconfirmed(context);
-                    CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                    CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-                    return r_;
-                }
-
-
-                CqlBoolean l_() {
-                    CodeableConcept s_ = C?.VerificationStatus;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlCode u_ = this.provisional(context);
-                    CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                    CqlBoolean w_ = context.Operators.Equivalent(t_, v_);
-                    return w_;
-                }
-
-
-                CqlBoolean m_() {
-                    CodeableConcept x_ = C?.VerificationStatus;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlCode z_ = this.differential(context);
-                    CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
-                    CqlBoolean ab_ = context.Operators.Equivalent(y_, aa_);
-                    return ab_;
-                }
-
-                return j_
-                    /* CQL 'or' (26:8-27:47) */ || k_()
-                    /* CQL 'or' (26:8-28:47) */ || l_()
-                    /* CQL 'or' (26:7-30:7) */ || m_();
-            }
-
+            CqlCode e_ = this.confirmed(context);
+            CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+            CqlBoolean g_ = context.Operators.Equivalent(d_, f_);
+            CqlCode h_ = this.unconfirmed(context);
+            CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+            CqlBoolean j_ = context.Operators.Equivalent(d_, i_);
+            CqlBoolean k_ = j_;
+            CqlCode l_ = this.provisional(context);
+            CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
+            CqlBoolean n_ = context.Operators.Equivalent(d_, m_);
+            CqlBoolean o_ = n_;
+            CqlCode p_ = this.differential(context);
+            CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+            CqlBoolean r_ = context.Operators.Equivalent(d_, q_);
+            CqlBoolean s_ = r_;
+            CqlBoolean t_ = g_
+                /* CQL 'or' (26:8-27:47) */ || k_
+                /* CQL 'or' (26:8-28:47) */ || o_
+                /* CQL 'or' (26:7-30:7) */ || s_;
             return (CqlBoolean)(d_ is null)
-                /* CQL 'implies' (25:5-30:7) */ || e_();
+                /* CQL 'implies' (25:5-30:7) */ || t_;
         }
 
         IEnumerable<Condition> b_ = context.Operators.Where<Condition>(conditions, a_);
@@ -175,25 +151,21 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "completed",
             ];
             CqlBoolean h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
-
-            CqlBoolean i_() {
-                Code<RequestIntent> j_ = D?.IntentElement;
-                RequestIntent? k_ = j_?.Value;
-                Code<RequestIntent> l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                return o_;
-            }
-
+            Code<RequestIntent> i_ = D?.IntentElement;
+            RequestIntent? j_ = i_?.Value;
+            Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
             return h_
-                /* CQL 'and' (40:5-41:99) */ && i_();
+                /* CQL 'and' (40:5-41:99) */ && o_;
         }
 
         IEnumerable<DeviceRequest> b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
@@ -215,25 +187,21 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "completed",
             ];
             CqlBoolean h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
-
-            CqlBoolean i_() {
-                Code<RequestIntent> j_ = S?.IntentElement;
-                RequestIntent? k_ = j_?.Value;
-                Code<RequestIntent> l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                return o_;
-            }
-
+            Code<RequestIntent> i_ = S?.IntentElement;
+            RequestIntent? j_ = i_?.Value;
+            Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
             return h_
-                /* CQL 'and' (46:5-47:99) */ && i_();
+                /* CQL 'and' (46:5-47:99) */ && o_;
         }
 
         IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
@@ -255,25 +223,21 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "completed",
             ];
             CqlBoolean h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
-
-            CqlBoolean i_() {
-                Code<RequestIntent> j_ = S?.IntentElement;
-                RequestIntent? k_ = j_?.Value;
-                Code<RequestIntent> l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                return o_;
-            }
-
+            Code<RequestIntent> i_ = S?.IntentElement;
+            RequestIntent? j_ = i_?.Value;
+            Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
             return h_
-                /* CQL 'and' (52:5-53:99) */ && i_();
+                /* CQL 'and' (52:5-53:99) */ && o_;
         }
 
         IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
@@ -295,25 +259,21 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "completed",
             ];
             CqlBoolean h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
-
-            CqlBoolean i_() {
-                Code<RequestIntent> j_ = S?.IntentElement;
-                RequestIntent? k_ = j_?.Value;
-                Code<RequestIntent> l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                return o_;
-            }
-
+            Code<RequestIntent> i_ = S?.IntentElement;
+            RequestIntent? j_ = i_?.Value;
+            Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
             return h_
-                /* CQL 'and' (58:5-59:99) */ && i_();
+                /* CQL 'and' (58:5-59:99) */ && o_;
         }
 
         IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
@@ -335,30 +295,26 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "corrected",
             ];
             CqlBoolean g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
+            List<CodeableConcept> h_ = O?.Category;
 
-            CqlBoolean h_() {
-                List<CodeableConcept> i_ = O?.Category;
-
-                CqlConcept j_(CodeableConcept @this) {
-                    CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return n_;
-                }
-
-
-                bool? k_(CqlConcept ObservationCategory) {
-                    CqlCode o_ = this.imaging(context);
-                    CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
-                    CqlBoolean q_ = context.Operators.Equivalent(ObservationCategory, p_);
-                    return q_;
-                }
-
-                IEnumerable<CqlConcept> l_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_, k_);
-                CqlBoolean m_ = context.Operators.Exists<CqlConcept>(l_);
-                return m_;
+            CqlConcept i_(CodeableConcept @this) {
+                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return n_;
             }
 
+
+            bool? j_(CqlConcept ObservationCategory) {
+                CqlCode o_ = this.imaging(context);
+                CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
+                CqlBoolean q_ = context.Operators.Equivalent(ObservationCategory, p_);
+                return q_;
+            }
+
+            IEnumerable<CqlConcept> k_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_, j_);
+            CqlBoolean l_ = context.Operators.Exists<CqlConcept>(k_);
+            CqlBoolean m_ = l_;
             return g_
-                /* CQL 'and' (64:5-67:5) */ && h_();
+                /* CQL 'and' (64:5-67:5) */ && m_;
         }
 
         IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
@@ -465,24 +421,20 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
             MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
             string e_ = context.Operators.Convert<string>(d_);
             CqlBoolean f_ = context.Operators.Equal(e_, "active");
-
-            CqlBoolean g_() {
-                Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
-                string j_ = context.Operators.Convert<string>(i_);
-                string[] k_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-                return l_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> g_ = M?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? h_ = g_?.Value;
+            string i_ = context.Operators.Convert<string>(h_);
+            string[] j_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
+            CqlBoolean l_ = k_;
             return f_
-                /* CQL 'and' (98:5-99:99) */ && g_();
+                /* CQL 'and' (98:5-99:99) */ && l_;
         }
 
         IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
@@ -525,24 +477,20 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "completed",
             ];
             CqlBoolean g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
-
-            CqlBoolean h_() {
-                Code<MedicationRequest.MedicationRequestIntent> i_ = M?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? j_ = i_?.Value;
-                string k_ = context.Operators.Convert<string>(j_);
-                string[] l_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-                return m_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
+            string j_ = context.Operators.Convert<string>(i_);
+            string[] k_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
+            CqlBoolean m_ = l_;
             return g_
-                /* CQL 'and' (109:5-110:97) */ && h_();
+                /* CQL 'and' (109:5-110:97) */ && m_;
         }
 
         IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
@@ -564,30 +512,26 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "corrected",
             ];
             CqlBoolean g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
+            List<CodeableConcept> h_ = O?.Category;
 
-            CqlBoolean h_() {
-                List<CodeableConcept> i_ = O?.Category;
-
-                CqlConcept j_(CodeableConcept @this) {
-                    CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return n_;
-                }
-
-
-                bool? k_(CqlConcept ObservationCategory) {
-                    CqlCode o_ = this.exam(context);
-                    CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
-                    CqlBoolean q_ = context.Operators.Equivalent(ObservationCategory, p_);
-                    return q_;
-                }
-
-                IEnumerable<CqlConcept> l_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_, k_);
-                CqlBoolean m_ = context.Operators.Exists<CqlConcept>(l_);
-                return m_;
+            CqlConcept i_(CodeableConcept @this) {
+                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return n_;
             }
 
+
+            bool? j_(CqlConcept ObservationCategory) {
+                CqlCode o_ = this.exam(context);
+                CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
+                CqlBoolean q_ = context.Operators.Equivalent(ObservationCategory, p_);
+                return q_;
+            }
+
+            IEnumerable<CqlConcept> k_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_, j_);
+            CqlBoolean l_ = context.Operators.Exists<CqlConcept>(k_);
+            CqlBoolean m_ = l_;
             return g_
-                /* CQL 'and' (115:5-118:7) */ && h_();
+                /* CQL 'and' (115:5-118:7) */ && m_;
         }
 
         IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("SupplementalDataElements", "5.1.000")]
 public partial class SupplementalDataElements_5_1_000 : ILibrary, ISingleton<SupplementalDataElements_5_1_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("TJCOverall", "8.25.000")]
 public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_000>
 {
@@ -107,18 +107,12 @@ public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_
             CqlDate l_ = context.Operators.DateFrom(k_);
             int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
             CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 18);
-
-            CqlBoolean o_() {
-                Period p_ = NonElectiveEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.End(q_);
-                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
-                return t_;
-            }
-
+            CqlDateTime o_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+            CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+            CqlBoolean r_ = q_;
             return n_
-                /* CQL 'and' (25:9-26:80) */ && o_();
+                /* CQL 'and' (25:9-26:80) */ && r_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -163,51 +157,23 @@ public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_
             CqlConcept f_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, e_);
             CqlValueSet g_ = this.Discharge_To_Acute_Care_Facility(context);
             CqlBoolean h_ = context.Operators.ConceptInValueSet(f_, g_);
-
-            CqlBoolean i_() {
-                Encounter.HospitalizationComponent m_ = IschemicStrokeEncounter?.Hospitalization;
-                CodeableConcept n_ = m_?.DischargeDisposition;
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlValueSet p_ = this.Left_Against_Medical_Advice(context);
-                CqlBoolean q_ = context.Operators.ConceptInValueSet(o_, p_);
-                return q_;
-            }
-
-
-            CqlBoolean j_() {
-                Encounter.HospitalizationComponent r_ = IschemicStrokeEncounter?.Hospitalization;
-                CodeableConcept s_ = r_?.DischargeDisposition;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlValueSet u_ = this.Patient_Expired(context);
-                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                return v_;
-            }
-
-
-            CqlBoolean k_() {
-                Encounter.HospitalizationComponent w_ = IschemicStrokeEncounter?.Hospitalization;
-                CodeableConcept x_ = w_?.DischargeDisposition;
-                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                CqlValueSet z_ = this.Discharged_to_Home_for_Hospice_Care(context);
-                CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                return aa_;
-            }
-
-
-            CqlBoolean l_() {
-                Encounter.HospitalizationComponent ab_ = IschemicStrokeEncounter?.Hospitalization;
-                CodeableConcept ac_ = ab_?.DischargeDisposition;
-                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
-                CqlValueSet ae_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care(context);
-                CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
-                return af_;
-            }
-
+            CqlValueSet i_ = this.Left_Against_Medical_Advice(context);
+            CqlBoolean j_ = context.Operators.ConceptInValueSet(f_, i_);
+            CqlBoolean k_ = j_;
+            CqlValueSet l_ = this.Patient_Expired(context);
+            CqlBoolean m_ = context.Operators.ConceptInValueSet(f_, l_);
+            CqlBoolean n_ = m_;
+            CqlValueSet o_ = this.Discharged_to_Home_for_Hospice_Care(context);
+            CqlBoolean p_ = context.Operators.ConceptInValueSet(f_, o_);
+            CqlBoolean q_ = p_;
+            CqlValueSet r_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care(context);
+            CqlBoolean s_ = context.Operators.ConceptInValueSet(f_, r_);
+            CqlBoolean t_ = s_;
             return h_
-                /* CQL 'or' (35:11-36:47) */ || i_()
-                /* CQL 'or' (35:11-37:35) */ || j_()
-                /* CQL 'or' (35:11-38:55) */ || k_()
-                /* CQL 'or' (35:4-39:71) */ || l_();
+                /* CQL 'or' (35:11-36:47) */ || k_
+                /* CQL 'or' (35:11-37:35) */ || n_
+                /* CQL 'or' (35:11-38:55) */ || q_
+                /* CQL 'or' (35:4-39:71) */ || t_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -237,25 +203,21 @@ public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_
                 "on-hold",
             ];
             CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-
-            CqlBoolean o_() {
-                Code<RequestIntent> p_ = ComfortCare?.IntentElement;
-                RequestIntent? q_ = p_?.Value;
-                Code<RequestIntent> r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                return u_;
-            }
-
+            Code<RequestIntent> o_ = ComfortCare?.IntentElement;
+            RequestIntent? p_ = o_?.Value;
+            Code<RequestIntent> q_ = context.Operators.Convert<Code<RequestIntent>>(p_);
+            string r_ = context.Operators.Convert<string>(q_);
+            string[] s_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
+            CqlBoolean u_ = t_;
             return n_
-                /* CQL 'and' (48:5-49:111) */ && o_();
+                /* CQL 'and' (48:5-49:111) */ && u_;
         }
 
         IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/VTE-8.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/VTE-8.18.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("VTE", "8.18.000")]
 public partial class VTE_8_18_000 : ILibrary, ISingleton<VTE_8_18_000>
 {
@@ -76,36 +76,32 @@ public partial class VTE_8_18_000 : ILibrary, ISingleton<VTE_8_18_000>
             IEnumerable<Condition> e_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, E);
 
             bool? f_(Condition @this) {
-                CodeableConcept k_ = @this?.Code;
-                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-                return l_ is not null;
+                CodeableConcept o_ = @this?.Code;
+                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
+                return p_ is not null;
             }
 
 
             CqlConcept g_(Condition @this) {
-                CodeableConcept m_ = @this?.Code;
-                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-                return n_;
+                CodeableConcept q_ = @this?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                return r_;
             }
 
             IEnumerable<CqlConcept> h_ = context.Operators.WhereSelect<Condition, CqlConcept>(e_, f_, g_);
             CqlBoolean i_ = context.Operators.ConceptsInValueSet(h_, DiagnosisValueSet);
+            List<CodeableConcept> j_ = E?.ReasonCode;
 
-            CqlBoolean j_() {
-                List<CodeableConcept> o_ = E?.ReasonCode;
-
-                CqlConcept p_(CodeableConcept @this) {
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return s_;
-                }
-
-                IEnumerable<CqlConcept> q_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)o_, p_);
-                CqlBoolean r_ = context.Operators.ConceptsInValueSet(q_, DiagnosisValueSet);
-                return r_;
+            CqlConcept k_(CodeableConcept @this) {
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return s_;
             }
 
+            IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, DiagnosisValueSet);
+            CqlBoolean n_ = m_;
             return i_
-                /* CQL 'or' (42:13-43:43) */ || j_();
+                /* CQL 'or' (42:13-43:43) */ || n_;
         }
 
         IEnumerable<bool?> c_ = context.Operators.SelectDistinct<Encounter, bool?>((IEnumerable<Encounter>)a_, b_);
@@ -127,23 +123,15 @@ public partial class VTE_8_18_000 : ILibrary, ISingleton<VTE_8_18_000>
         bool? b_(Encounter InpatientEncounter) {
             CqlValueSet d_ = this.Obstetrical_or_Pregnancy_Related_Conditions(context);
             CqlBoolean e_ = this.hasEncDiagnosisOf(context, InpatientEncounter, d_);
-
-            CqlBoolean f_() {
-                CqlValueSet h_ = this.Venous_Thromboembolism(context);
-                CqlBoolean i_ = this.hasEncDiagnosisOf(context, InpatientEncounter, h_);
-                return i_;
-            }
-
-
-            CqlBoolean g_() {
-                CqlValueSet j_ = this.Obstetrics_VTE(context);
-                CqlBoolean k_ = this.hasEncDiagnosisOf(context, InpatientEncounter, j_);
-                return k_;
-            }
-
+            CqlValueSet f_ = this.Venous_Thromboembolism(context);
+            CqlBoolean g_ = this.hasEncDiagnosisOf(context, InpatientEncounter, f_);
+            CqlBoolean h_ = g_;
+            CqlValueSet i_ = this.Obstetrics_VTE(context);
+            CqlBoolean j_ = this.hasEncDiagnosisOf(context, InpatientEncounter, i_);
+            CqlBoolean k_ = j_;
             return !((bool?)(e_
-                /* CQL 'or' (25:14-26:78) */ || f_()
-                /* CQL 'or' (25:13-28:13) */ || g_()));
+                /* CQL 'or' (25:14-26:78) */ || h_
+                /* CQL 'or' (25:13-28:13) */ || k_));
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -222,30 +210,26 @@ public partial class VTE_8_18_000 : ILibrary, ISingleton<VTE_8_18_000>
             DataType f_ = e_?.Procedure;
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlBoolean h_ = context.Operators.ConceptInValueSet(g_ as CqlConcept, DiagnosisValueSet);
+            IEnumerable<Procedure> i_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-            CqlBoolean i_() {
-                IEnumerable<Procedure> j_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-                bool? k_(Procedure P) {
-                    Claim.ProcedureComponent q_ = CQMCommon_4_1_000.Instance.principalProcedure(context, E);
-                    DataType r_ = q_?.Procedure;
-                    object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                    Id t_ = P?.IdElement;
-                    string u_ = t_?.Value;
-                    CqlBoolean v_ = QICoreCommon_4_0_000.Instance.references(context, s_ as ResourceReference, u_);
-                    return v_;
-                }
-
-                IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
-                Procedure m_ = context.Operators.SingletonFrom<Procedure>(l_);
-                CodeableConcept n_ = m_?.Code;
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                CqlBoolean p_ = context.Operators.ConceptInValueSet(o_, DiagnosisValueSet);
-                return p_;
+            bool? j_(Procedure P) {
+                Claim.ProcedureComponent q_ = CQMCommon_4_1_000.Instance.principalProcedure(context, E);
+                DataType r_ = q_?.Procedure;
+                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+                Id t_ = P?.IdElement;
+                string u_ = t_?.Value;
+                CqlBoolean v_ = QICoreCommon_4_0_000.Instance.references(context, s_ as ResourceReference, u_);
+                return v_;
             }
 
+            IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
+            Procedure l_ = context.Operators.SingletonFrom<Procedure>(k_);
+            CodeableConcept m_ = l_?.Code;
+            CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
+            CqlBoolean o_ = context.Operators.ConceptInValueSet(n_, DiagnosisValueSet);
+            CqlBoolean p_ = o_;
             return h_
-                /* CQL 'or' (51:13-52:39) */ || i_();
+                /* CQL 'or' (51:13-52:39) */ || p_;
         }
 
         IEnumerable<bool?> c_ = context.Operators.SelectDistinct<Encounter, bool?>((IEnumerable<Encounter>)a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS0334FHIRPCCesareanBirth", "1.0.000")]
 public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<CMS0334FHIRPCCesareanBirth_1_0_000>
 {
@@ -146,16 +146,12 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
         bool? b_(Encounter DeliveryEncounter) {
             int? d_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
-
-            CqlBoolean e_() {
-                CqlQuantity f_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
-                CqlQuantity g_ = context.Operators.Quantity(37m, "weeks");
-                CqlBoolean h_ = context.Operators.GreaterOrEqual(f_, g_);
-                return h_;
-            }
-
+            CqlQuantity e_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
+            CqlQuantity f_ = context.Operators.Quantity(37m, "weeks");
+            CqlBoolean g_ = context.Operators.GreaterOrEqual(e_, f_);
+            CqlBoolean h_ = g_;
             return (CqlBoolean)(d_ is null)
-                /* CQL 'and' (42:5-43:71) */ && e_();
+                /* CQL 'and' (42:5-43:71) */ && h_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -175,48 +171,39 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
         bool? b_(Encounter DeliveryEncounter) {
             int? d_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
+            List<CodeableConcept> e_ = DeliveryEncounter?.ReasonCode;
 
-            CqlBoolean e_() {
-                List<CodeableConcept> f_ = DeliveryEncounter?.ReasonCode;
-
-                CqlConcept g_(CodeableConcept @this) {
-                    CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return l_;
-                }
-
-                IEnumerable<CqlConcept> h_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)f_, g_);
-                CqlValueSet i_ = this._37_to_42_Plus_Weeks_Gestation(context);
-                CqlBoolean j_ = context.Operators.ConceptsInValueSet(h_, i_);
-
-                CqlBoolean k_() {
-                    IEnumerable<Condition> m_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, DeliveryEncounter);
-
-                    bool? n_(Condition @this) {
-                        CodeableConcept s_ = @this?.Code;
-                        CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                        return t_ is not null;
-                    }
-
-
-                    CqlConcept o_(Condition @this) {
-                        CodeableConcept u_ = @this?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        return v_;
-                    }
-
-                    IEnumerable<CqlConcept> p_ = context.Operators.WhereSelect<Condition, CqlConcept>(m_, n_, o_);
-                    CqlValueSet q_ = this._37_to_42_Plus_Weeks_Gestation(context);
-                    CqlBoolean r_ = context.Operators.ConceptsInValueSet(p_, q_);
-                    return r_;
-                }
-
-                return j_
-                    /* CQL 'or' (56:11-58:7) */ || k_();
+            CqlConcept f_(CodeableConcept @this) {
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return q_;
             }
 
+            IEnumerable<CqlConcept> g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
+            CqlValueSet h_ = this._37_to_42_Plus_Weeks_Gestation(context);
+            CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
+            IEnumerable<Condition> j_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, DeliveryEncounter);
+
+            bool? k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_ is not null;
+            }
+
+
+            CqlConcept l_(Condition @this) {
+                CodeableConcept t_ = @this?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                return u_;
+            }
+
+            IEnumerable<CqlConcept> m_ = context.Operators.WhereSelect<Condition, CqlConcept>(j_, k_, l_);
+            CqlBoolean n_ = context.Operators.ConceptsInValueSet(m_, h_);
+            CqlBoolean o_ = n_;
+            CqlBoolean p_ = i_
+                /* CQL 'or' (56:11-58:7) */ || o_;
             return (CqlBoolean)(d_ is null)
                 /* CQL 'and' (54:11-55:21) */ && ((PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter)) is null)
-                /* CQL 'and' (54:5-58:7) */ && e_();
+                /* CQL 'and' (54:5-58:7) */ && p_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -255,38 +242,33 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             List<CodeableConcept> d_ = DeliveryEncounter?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Delivery_of_Singleton(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, DeliveryEncounter);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, DeliveryEncounter);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.Delivery_of_Singleton(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'or' (124:5-125:81) */ || i_();
+                /* CQL 'or' (124:5-125:81) */ || n_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -304,62 +286,54 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
         bool? d_(Observation Gravida) {
             DataType k_ = Gravida?.Value;
             object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-
-            CqlBoolean m_() {
-                Code<ObservationStatus> o_ = Gravida?.StatusElement;
-                ObservationStatus? p_ = o_?.Value;
-                string q_ = context.Operators.Convert<string>(p_);
-                string[] r_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
-                return s_;
+            Code<ObservationStatus> m_ = Gravida?.StatusElement;
+            ObservationStatus? n_ = m_?.Value;
+            string o_ = context.Operators.Convert<string>(n_);
+            string[] p_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+            CqlBoolean r_ = q_;
+            object s_;
+            DataType aa_ = Gravida?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            bool ac_ = ab_ is CqlDateTime;
+            if (ac_)
+            {
+                s_ = ab_ as CqlDateTime;
             }
-
-
-            CqlBoolean n_() {
-                object t_;
-                DataType aa_ = Gravida?.Effective;
-                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                bool ac_ = ab_ is CqlDateTime;
+            else
+            {
                 if (ac_)
                 {
-                    t_ = ab_ as CqlDateTime;
+                    s_ = ab_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ac_)
+                    bool ad_ = ab_ is CqlInterval<CqlDateTime>;
+                    if (ad_)
                     {
-                        t_ = ab_ as CqlDateTime;
+                        s_ = ab_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ad_ = ab_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
-                        {
-                            t_ = ab_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            t_ = null;
-                        }
+                        s_ = null;
                     }
                 }
-                CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
-                CqlDateTime v_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TheEncounter);
-                CqlQuantity w_ = context.Operators.Quantity(42m, "weeks");
-                CqlDateTime x_ = context.Operators.Subtract(v_, w_);
-                CqlInterval<CqlDateTime> y_ = context.Operators.Interval(x_, v_, true, false);
-                CqlBoolean z_ = context.Operators.In<CqlDateTime>(u_, y_, (string)default);
-                return z_
-                    /* CQL 'and' (131:13-131:98) */ && ((PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TheEncounter)) is not null);
             }
-
+            CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
+            CqlDateTime u_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TheEncounter);
+            CqlQuantity v_ = context.Operators.Quantity(42m, "weeks");
+            CqlDateTime w_ = context.Operators.Subtract(u_, v_);
+            CqlInterval<CqlDateTime> x_ = context.Operators.Interval(w_, u_, true, false);
+            CqlBoolean y_ = context.Operators.In<CqlDateTime>(t_, x_, (string)default);
+            CqlBoolean z_ = y_
+                /* CQL 'and' (131:13-131:98) */ && ((PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TheEncounter)) is not null);
             return (CqlBoolean)(l_ is not null)
-                /* CQL 'and' (129:13-130:65) */ && m_()
-                /* CQL 'and' (129:7-131:98) */ && n_();
+                /* CQL 'and' (129:13-130:65) */ && r_
+                /* CQL 'and' (129:7-131:98) */ && z_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -413,25 +387,25 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
         bool? d_(Observation Parity) {
             object k_;
-            DataType t_ = Parity?.Effective;
-            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-            bool v_ = u_ is CqlDateTime;
-            if (v_)
+            DataType aa_ = Parity?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            bool ac_ = ab_ is CqlDateTime;
+            if (ac_)
             {
-                k_ = u_ as CqlDateTime;
+                k_ = ab_ as CqlDateTime;
             }
             else
             {
-                if (v_)
+                if (ac_)
                 {
-                    k_ = u_ as CqlDateTime;
+                    k_ = ab_ as CqlDateTime;
                 }
                 else
                 {
-                    bool w_ = u_ is CqlInterval<CqlDateTime>;
-                    if (w_)
+                    bool ad_ = ab_ is CqlInterval<CqlDateTime>;
+                    if (ad_)
                     {
-                        k_ = u_ as CqlInterval<CqlDateTime>;
+                        k_ = ab_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -445,31 +419,23 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlDateTime o_ = context.Operators.Subtract(m_, n_);
             CqlInterval<CqlDateTime> p_ = context.Operators.Interval(o_, m_, true, false);
             CqlBoolean q_ = context.Operators.In<CqlDateTime>(l_, p_, (string)default);
-
-            CqlBoolean r_() {
-                Code<ObservationStatus> x_ = Parity?.StatusElement;
-                ObservationStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                return ab_;
-            }
-
-
-            CqlBoolean s_() {
-                DataType ac_ = Parity?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
+            Code<ObservationStatus> r_ = Parity?.StatusElement;
+            ObservationStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            CqlBoolean w_ = v_;
+            DataType x_ = Parity?.Value;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            CqlBoolean z_ = (CqlBoolean)(y_ is not null);
             return q_
                 /* CQL 'and' (153:13-153:97) */ && ((PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TheEncounter)) is not null)
-                /* CQL 'and' (153:13-154:64) */ && r_()
-                /* CQL 'and' (153:7-155:36) */ && s_();
+                /* CQL 'and' (153:13-154:64) */ && w_
+                /* CQL 'and' (153:7-155:36) */ && z_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -523,25 +489,25 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
         bool? d_(Observation PretermBirth) {
             object k_;
-            DataType t_ = PretermBirth?.Effective;
-            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-            bool v_ = u_ is CqlDateTime;
-            if (v_)
+            DataType aa_ = PretermBirth?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            bool ac_ = ab_ is CqlDateTime;
+            if (ac_)
             {
-                k_ = u_ as CqlDateTime;
+                k_ = ab_ as CqlDateTime;
             }
             else
             {
-                if (v_)
+                if (ac_)
                 {
-                    k_ = u_ as CqlDateTime;
+                    k_ = ab_ as CqlDateTime;
                 }
                 else
                 {
-                    bool w_ = u_ is CqlInterval<CqlDateTime>;
-                    if (w_)
+                    bool ad_ = ab_ is CqlInterval<CqlDateTime>;
+                    if (ad_)
                     {
-                        k_ = u_ as CqlInterval<CqlDateTime>;
+                        k_ = ab_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -555,31 +521,23 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlDateTime o_ = context.Operators.Subtract(m_, n_);
             CqlInterval<CqlDateTime> p_ = context.Operators.Interval(o_, m_, true, false);
             CqlBoolean q_ = context.Operators.In<CqlDateTime>(l_, p_, (string)default);
-
-            CqlBoolean r_() {
-                Code<ObservationStatus> x_ = PretermBirth?.StatusElement;
-                ObservationStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                return ab_;
-            }
-
-
-            CqlBoolean s_() {
-                DataType ac_ = PretermBirth?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
+            Code<ObservationStatus> r_ = PretermBirth?.StatusElement;
+            ObservationStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            CqlBoolean w_ = v_;
+            DataType x_ = PretermBirth?.Value;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            CqlBoolean z_ = (CqlBoolean)(y_ is not null);
             return q_
                 /* CQL 'and' (137:13-137:103) */ && ((PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TheEncounter)) is not null)
-                /* CQL 'and' (137:13-138:70) */ && r_()
-                /* CQL 'and' (137:7-139:42) */ && s_();
+                /* CQL 'and' (137:13-138:70) */ && w_
+                /* CQL 'and' (137:7-139:42) */ && z_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -633,25 +591,25 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
         bool? d_(Observation TermBirth) {
             object k_;
-            DataType t_ = TermBirth?.Effective;
-            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-            bool v_ = u_ is CqlDateTime;
-            if (v_)
+            DataType aa_ = TermBirth?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            bool ac_ = ab_ is CqlDateTime;
+            if (ac_)
             {
-                k_ = u_ as CqlDateTime;
+                k_ = ab_ as CqlDateTime;
             }
             else
             {
-                if (v_)
+                if (ac_)
                 {
-                    k_ = u_ as CqlDateTime;
+                    k_ = ab_ as CqlDateTime;
                 }
                 else
                 {
-                    bool w_ = u_ is CqlInterval<CqlDateTime>;
-                    if (w_)
+                    bool ad_ = ab_ is CqlInterval<CqlDateTime>;
+                    if (ad_)
                     {
-                        k_ = u_ as CqlInterval<CqlDateTime>;
+                        k_ = ab_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -665,31 +623,23 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlDateTime o_ = context.Operators.Subtract(m_, n_);
             CqlInterval<CqlDateTime> p_ = context.Operators.Interval(o_, m_, true, false);
             CqlBoolean q_ = context.Operators.In<CqlDateTime>(l_, p_, (string)default);
-
-            CqlBoolean r_() {
-                Code<ObservationStatus> x_ = TermBirth?.StatusElement;
-                ObservationStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                return ab_;
-            }
-
-
-            CqlBoolean s_() {
-                DataType ac_ = TermBirth?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
+            Code<ObservationStatus> r_ = TermBirth?.StatusElement;
+            ObservationStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            CqlBoolean w_ = v_;
+            DataType x_ = TermBirth?.Value;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            CqlBoolean z_ = (CqlBoolean)(y_ is not null);
             return q_
                 /* CQL 'and' (145:13-145:100) */ && ((PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TheEncounter)) is not null)
-                /* CQL 'and' (145:13-146:67) */ && r_()
-                /* CQL 'and' (145:7-147:39) */ && s_();
+                /* CQL 'and' (145:13-146:67) */ && w_
+                /* CQL 'and' (145:7-147:39) */ && z_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -749,31 +699,19 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
         bool? d_(Encounter SingletonEncounterGE37Weeks) {
             int? f_ = this.lastGravida(context, SingletonEncounterGE37Weeks);
             CqlBoolean g_ = context.Operators.Equal(f_, 1);
-
-            CqlBoolean h_() {
-                int? j_ = this.lastParity(context, SingletonEncounterGE37Weeks);
-                CqlBoolean k_ = context.Operators.Equal(j_, 0);
-                return k_;
-            }
-
-
-            CqlBoolean i_() {
-                int? l_ = this.lastHistoryPretermBirth(context, SingletonEncounterGE37Weeks);
-                CqlBoolean m_ = context.Operators.Equal(l_, 0);
-
-                CqlBoolean n_() {
-                    int? o_ = this.lastHistoryTermBirth(context, SingletonEncounterGE37Weeks);
-                    CqlBoolean p_ = context.Operators.Equal(o_, 0);
-                    return p_;
-                }
-
-                return m_
-                    /* CQL 'and' (106:12-108:9) */ && n_();
-            }
-
+            int? h_ = this.lastParity(context, SingletonEncounterGE37Weeks);
+            CqlBoolean i_ = context.Operators.Equal(h_, 0);
+            CqlBoolean j_ = i_;
+            int? k_ = this.lastHistoryPretermBirth(context, SingletonEncounterGE37Weeks);
+            CqlBoolean l_ = context.Operators.Equal(k_, 0);
+            int? m_ = this.lastHistoryTermBirth(context, SingletonEncounterGE37Weeks);
+            CqlBoolean n_ = context.Operators.Equal(m_, 0);
+            CqlBoolean o_ = n_;
+            CqlBoolean p_ = l_
+                /* CQL 'and' (106:12-108:9) */ && o_;
             return g_
-                /* CQL 'or' (104:13-105:61) */ || h_()
-                /* CQL 'or' (104:5-109:5) */ || i_();
+                /* CQL 'or' (104:13-105:61) */ || j_
+                /* CQL 'or' (104:5-109:5) */ || p_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
@@ -793,554 +731,530 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
         bool? b_(Encounter ThirtySevenWeeksPlusEncounter) {
             object d_;
-            CqlValueSet j_ = this.Abnormal_Presentation(context);
-            IEnumerable<Observation> k_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, j_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
+            CqlValueSet t_ = this.Abnormal_Presentation(context);
+            IEnumerable<Observation> u_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, t_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
 
-            bool? l_(Observation AbnormalPresentation) {
-                object t_;
-                DataType y_ = AbnormalPresentation?.Effective;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
+            bool? v_(Observation AbnormalPresentation) {
+                object ad_;
+                DataType an_ = AbnormalPresentation?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                bool ap_ = ao_ is CqlDateTime;
+                if (ap_)
                 {
-                    t_ = z_ as CqlDateTime;
+                    ad_ = ao_ as CqlDateTime;
                 }
                 else
                 {
-                    if (aa_)
+                    if (ap_)
                     {
-                        t_ = z_ as CqlDateTime;
+                        ad_ = ao_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ab_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ab_)
+                        bool aq_ = ao_ is CqlInterval<CqlDateTime>;
+                        if (aq_)
                         {
-                            t_ = z_ as CqlInterval<CqlDateTime>;
+                            ad_ = ao_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            t_ = null;
+                            ad_ = null;
                         }
                     }
                 }
-                CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
-                CqlDateTime v_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                CqlBoolean w_ = context.Operators.SameOrBefore(u_, v_, (string)default);
+                CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
+                CqlDateTime af_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
+                CqlBoolean ag_ = context.Operators.SameOrBefore(ae_, af_, (string)default);
+                Code<ObservationStatus> ah_ = AbnormalPresentation?.StatusElement;
+                ObservationStatus? ai_ = ah_?.Value;
+                string aj_ = context.Operators.Convert<string>(ai_);
+                string[] ak_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+                CqlBoolean am_ = al_;
+                return ag_
+                    /* CQL 'and' (114:9-115:80) */ && am_;
+            }
 
-                CqlBoolean x_() {
-                    Code<ObservationStatus> ac_ = AbnormalPresentation?.StatusElement;
-                    ObservationStatus? ad_ = ac_?.Value;
-                    string ae_ = context.Operators.Convert<string>(ad_);
-                    string[] af_ = [
+            IEnumerable<Observation> w_ = context.Operators.Where<Observation>(u_, v_);
+
+            object x_(Observation @this) {
+                object ar_;
+                DataType at_ = @this?.Effective;
+                object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                bool av_ = au_ is CqlDateTime;
+                if (av_)
+                {
+                    ar_ = au_ as CqlDateTime;
+                }
+                else
+                {
+                    if (av_)
+                    {
+                        ar_ = au_ as CqlDateTime;
+                    }
+                    else
+                    {
+                        bool aw_ = au_ is CqlInterval<CqlDateTime>;
+                        if (aw_)
+                        {
+                            ar_ = au_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            ar_ = null;
+                        }
+                    }
+                }
+                CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
+                return as_;
+            }
+
+            IEnumerable<Observation> y_ = context.Operators.SortBy<Observation>(w_, x_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation z_ = context.Operators.Last<Observation>(y_);
+            DataType aa_ = z_?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            bool ac_ = ab_ is CqlDateTime;
+            if (ac_)
+            {
+
+                bool? ax_(Observation AbnormalPresentation) {
+                    object be_;
+                    DataType bo_ = AbnormalPresentation?.Effective;
+                    object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                    bool bq_ = bp_ is CqlDateTime;
+                    if (bq_)
+                    {
+                        be_ = bp_ as CqlDateTime;
+                    }
+                    else
+                    {
+                        if (bq_)
+                        {
+                            be_ = bp_ as CqlDateTime;
+                        }
+                        else
+                        {
+                            bool br_ = bp_ is CqlInterval<CqlDateTime>;
+                            if (br_)
+                            {
+                                be_ = bp_ as CqlInterval<CqlDateTime>;
+                            }
+                            else
+                            {
+                                be_ = null;
+                            }
+                        }
+                    }
+                    CqlDateTime bf_ = QICoreCommon_4_0_000.Instance.earliest(context, be_);
+                    CqlDateTime bg_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
+                    CqlBoolean bh_ = context.Operators.SameOrBefore(bf_, bg_, (string)default);
+                    Code<ObservationStatus> bi_ = AbnormalPresentation?.StatusElement;
+                    ObservationStatus? bj_ = bi_?.Value;
+                    string bk_ = context.Operators.Convert<string>(bj_);
+                    string[] bl_ = [
                         "final",
                         "amended",
                         "corrected",
                     ];
-                    CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                    return ag_;
+                    CqlBoolean bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
+                    CqlBoolean bn_ = bm_;
+                    return bh_
+                        /* CQL 'and' (114:9-115:80) */ && bn_;
                 }
 
-                return w_
-                    /* CQL 'and' (114:9-115:80) */ && x_();
-            }
+                IEnumerable<Observation> ay_ = context.Operators.Where<Observation>(u_, ax_);
 
-            IEnumerable<Observation> m_ = context.Operators.Where<Observation>(k_, l_);
-
-            object n_(Observation @this) {
-                object ah_;
-                DataType aj_ = @this?.Effective;
-                object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                bool al_ = ak_ is CqlDateTime;
-                if (al_)
-                {
-                    ah_ = ak_ as CqlDateTime;
-                }
-                else
-                {
-                    if (al_)
+                object az_(Observation @this) {
+                    object bs_;
+                    DataType bu_ = @this?.Effective;
+                    object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+                    bool bw_ = bv_ is CqlDateTime;
+                    if (bw_)
                     {
-                        ah_ = ak_ as CqlDateTime;
+                        bs_ = bv_ as CqlDateTime;
                     }
                     else
                     {
-                        bool am_ = ak_ is CqlInterval<CqlDateTime>;
-                        if (am_)
+                        if (bw_)
                         {
-                            ah_ = ak_ as CqlInterval<CqlDateTime>;
+                            bs_ = bv_ as CqlDateTime;
                         }
                         else
                         {
-                            ah_ = null;
-                        }
-                    }
-                }
-                CqlDateTime ai_ = QICoreCommon_4_0_000.Instance.earliest(context, ah_);
-                return ai_;
-            }
-
-            IEnumerable<Observation> o_ = context.Operators.SortBy<Observation>(m_, n_, System.ComponentModel.ListSortDirection.Ascending);
-            Observation p_ = context.Operators.Last<Observation>(o_);
-            DataType q_ = p_?.Effective;
-            object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-            bool s_ = r_ is CqlDateTime;
-            if (s_)
-            {
-
-                bool? an_(Observation AbnormalPresentation) {
-                    object au_;
-                    DataType az_ = AbnormalPresentation?.Effective;
-                    object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                    bool bb_ = ba_ is CqlDateTime;
-                    if (bb_)
-                    {
-                        au_ = ba_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        if (bb_)
-                        {
-                            au_ = ba_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool bc_ = ba_ is CqlInterval<CqlDateTime>;
-                            if (bc_)
+                            bool bx_ = bv_ is CqlInterval<CqlDateTime>;
+                            if (bx_)
                             {
-                                au_ = ba_ as CqlInterval<CqlDateTime>;
+                                bs_ = bv_ as CqlInterval<CqlDateTime>;
                             }
                             else
                             {
-                                au_ = null;
+                                bs_ = null;
                             }
                         }
                     }
-                    CqlDateTime av_ = QICoreCommon_4_0_000.Instance.earliest(context, au_);
-                    CqlDateTime aw_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                    CqlBoolean ax_ = context.Operators.SameOrBefore(av_, aw_, (string)default);
-
-                    CqlBoolean ay_() {
-                        Code<ObservationStatus> bd_ = AbnormalPresentation?.StatusElement;
-                        ObservationStatus? be_ = bd_?.Value;
-                        string bf_ = context.Operators.Convert<string>(be_);
-                        string[] bg_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean bh_ = context.Operators.In<string>(bf_, (IEnumerable<string>)bg_);
-                        return bh_;
-                    }
-
-                    return ax_
-                        /* CQL 'and' (114:9-115:80) */ && ay_();
+                    CqlDateTime bt_ = QICoreCommon_4_0_000.Instance.earliest(context, bs_);
+                    return bt_;
                 }
 
-                IEnumerable<Observation> ao_ = context.Operators.Where<Observation>(k_, an_);
-
-                object ap_(Observation @this) {
-                    object bi_;
-                    DataType bk_ = @this?.Effective;
-                    object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                    bool bm_ = bl_ is CqlDateTime;
-                    if (bm_)
-                    {
-                        bi_ = bl_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        if (bm_)
-                        {
-                            bi_ = bl_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool bn_ = bl_ is CqlInterval<CqlDateTime>;
-                            if (bn_)
-                            {
-                                bi_ = bl_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bi_ = null;
-                            }
-                        }
-                    }
-                    CqlDateTime bj_ = QICoreCommon_4_0_000.Instance.earliest(context, bi_);
-                    return bj_;
-                }
-
-                IEnumerable<Observation> aq_ = context.Operators.SortBy<Observation>(ao_, ap_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation ar_ = context.Operators.Last<Observation>(aq_);
-                DataType as_ = ar_?.Effective;
-                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                d_ = at_ as CqlDateTime;
+                IEnumerable<Observation> ba_ = context.Operators.SortBy<Observation>(ay_, az_, System.ComponentModel.ListSortDirection.Ascending);
+                Observation bb_ = context.Operators.Last<Observation>(ba_);
+                DataType bc_ = bb_?.Effective;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                d_ = bd_ as CqlDateTime;
             }
             else
             {
 
-                bool? bo_(Observation AbnormalPresentation) {
-                    object bw_;
-                    DataType cb_ = AbnormalPresentation?.Effective;
-                    object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                    bool cd_ = cc_ is CqlDateTime;
-                    if (cd_)
+                bool? by_(Observation AbnormalPresentation) {
+                    object cg_;
+                    DataType cq_ = AbnormalPresentation?.Effective;
+                    object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                    bool cs_ = cr_ is CqlDateTime;
+                    if (cs_)
                     {
-                        bw_ = cc_ as CqlDateTime;
+                        cg_ = cr_ as CqlDateTime;
                     }
                     else
                     {
-                        if (cd_)
+                        if (cs_)
                         {
-                            bw_ = cc_ as CqlDateTime;
+                            cg_ = cr_ as CqlDateTime;
                         }
                         else
                         {
-                            bool ce_ = cc_ is CqlInterval<CqlDateTime>;
-                            if (ce_)
+                            bool ct_ = cr_ is CqlInterval<CqlDateTime>;
+                            if (ct_)
                             {
-                                bw_ = cc_ as CqlInterval<CqlDateTime>;
+                                cg_ = cr_ as CqlInterval<CqlDateTime>;
                             }
                             else
                             {
-                                bw_ = null;
+                                cg_ = null;
                             }
                         }
                     }
-                    CqlDateTime bx_ = QICoreCommon_4_0_000.Instance.earliest(context, bw_);
-                    CqlDateTime by_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                    CqlBoolean bz_ = context.Operators.SameOrBefore(bx_, by_, (string)default);
+                    CqlDateTime ch_ = QICoreCommon_4_0_000.Instance.earliest(context, cg_);
+                    CqlDateTime ci_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
+                    CqlBoolean cj_ = context.Operators.SameOrBefore(ch_, ci_, (string)default);
+                    Code<ObservationStatus> ck_ = AbnormalPresentation?.StatusElement;
+                    ObservationStatus? cl_ = ck_?.Value;
+                    string cm_ = context.Operators.Convert<string>(cl_);
+                    string[] cn_ = [
+                        "final",
+                        "amended",
+                        "corrected",
+                    ];
+                    CqlBoolean co_ = context.Operators.In<string>(cm_, (IEnumerable<string>)cn_);
+                    CqlBoolean cp_ = co_;
+                    return cj_
+                        /* CQL 'and' (114:9-115:80) */ && cp_;
+                }
 
-                    CqlBoolean ca_() {
-                        Code<ObservationStatus> cf_ = AbnormalPresentation?.StatusElement;
-                        ObservationStatus? cg_ = cf_?.Value;
-                        string ch_ = context.Operators.Convert<string>(cg_);
-                        string[] ci_ = [
+                IEnumerable<Observation> bz_ = context.Operators.Where<Observation>(u_, by_);
+
+                object ca_(Observation @this) {
+                    object cu_;
+                    DataType cw_ = @this?.Effective;
+                    object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                    bool cy_ = cx_ is CqlDateTime;
+                    if (cy_)
+                    {
+                        cu_ = cx_ as CqlDateTime;
+                    }
+                    else
+                    {
+                        if (cy_)
+                        {
+                            cu_ = cx_ as CqlDateTime;
+                        }
+                        else
+                        {
+                            bool cz_ = cx_ is CqlInterval<CqlDateTime>;
+                            if (cz_)
+                            {
+                                cu_ = cx_ as CqlInterval<CqlDateTime>;
+                            }
+                            else
+                            {
+                                cu_ = null;
+                            }
+                        }
+                    }
+                    CqlDateTime cv_ = QICoreCommon_4_0_000.Instance.earliest(context, cu_);
+                    return cv_;
+                }
+
+                IEnumerable<Observation> cb_ = context.Operators.SortBy<Observation>(bz_, ca_, System.ComponentModel.ListSortDirection.Ascending);
+                Observation cc_ = context.Operators.Last<Observation>(cb_);
+                DataType cd_ = cc_?.Effective;
+                object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                bool cf_ = ce_ is CqlDateTime;
+                if (cf_)
+                {
+
+                    bool? da_(Observation AbnormalPresentation) {
+                        object dh_;
+                        DataType dr_ = AbnormalPresentation?.Effective;
+                        object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                        bool dt_ = ds_ is CqlDateTime;
+                        if (dt_)
+                        {
+                            dh_ = ds_ as CqlDateTime;
+                        }
+                        else
+                        {
+                            if (dt_)
+                            {
+                                dh_ = ds_ as CqlDateTime;
+                            }
+                            else
+                            {
+                                bool du_ = ds_ is CqlInterval<CqlDateTime>;
+                                if (du_)
+                                {
+                                    dh_ = ds_ as CqlInterval<CqlDateTime>;
+                                }
+                                else
+                                {
+                                    dh_ = null;
+                                }
+                            }
+                        }
+                        CqlDateTime di_ = QICoreCommon_4_0_000.Instance.earliest(context, dh_);
+                        CqlDateTime dj_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
+                        CqlBoolean dk_ = context.Operators.SameOrBefore(di_, dj_, (string)default);
+                        Code<ObservationStatus> dl_ = AbnormalPresentation?.StatusElement;
+                        ObservationStatus? dm_ = dl_?.Value;
+                        string dn_ = context.Operators.Convert<string>(dm_);
+                        string[] do_ = [
                             "final",
                             "amended",
                             "corrected",
                         ];
-                        CqlBoolean cj_ = context.Operators.In<string>(ch_, (IEnumerable<string>)ci_);
-                        return cj_;
+                        CqlBoolean dp_ = context.Operators.In<string>(dn_, (IEnumerable<string>)do_);
+                        CqlBoolean dq_ = dp_;
+                        return dk_
+                            /* CQL 'and' (114:9-115:80) */ && dq_;
                     }
 
-                    return bz_
-                        /* CQL 'and' (114:9-115:80) */ && ca_();
-                }
+                    IEnumerable<Observation> db_ = context.Operators.Where<Observation>(u_, da_);
 
-                IEnumerable<Observation> bp_ = context.Operators.Where<Observation>(k_, bo_);
-
-                object bq_(Observation @this) {
-                    object ck_;
-                    DataType cm_ = @this?.Effective;
-                    object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                    bool co_ = cn_ is CqlDateTime;
-                    if (co_)
-                    {
-                        ck_ = cn_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        if (co_)
+                    object dc_(Observation @this) {
+                        object dv_;
+                        DataType dx_ = @this?.Effective;
+                        object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
+                        bool dz_ = dy_ is CqlDateTime;
+                        if (dz_)
                         {
-                            ck_ = cn_ as CqlDateTime;
+                            dv_ = dy_ as CqlDateTime;
                         }
                         else
                         {
-                            bool cp_ = cn_ is CqlInterval<CqlDateTime>;
-                            if (cp_)
+                            if (dz_)
                             {
-                                ck_ = cn_ as CqlInterval<CqlDateTime>;
+                                dv_ = dy_ as CqlDateTime;
                             }
                             else
                             {
-                                ck_ = null;
-                            }
-                        }
-                    }
-                    CqlDateTime cl_ = QICoreCommon_4_0_000.Instance.earliest(context, ck_);
-                    return cl_;
-                }
-
-                IEnumerable<Observation> br_ = context.Operators.SortBy<Observation>(bp_, bq_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation bs_ = context.Operators.Last<Observation>(br_);
-                DataType bt_ = bs_?.Effective;
-                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                bool bv_ = bu_ is CqlDateTime;
-                if (bv_)
-                {
-
-                    bool? cq_(Observation AbnormalPresentation) {
-                        object cx_;
-                        DataType dc_ = AbnormalPresentation?.Effective;
-                        object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
-                        bool de_ = dd_ is CqlDateTime;
-                        if (de_)
-                        {
-                            cx_ = dd_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            if (de_)
-                            {
-                                cx_ = dd_ as CqlDateTime;
-                            }
-                            else
-                            {
-                                bool df_ = dd_ is CqlInterval<CqlDateTime>;
-                                if (df_)
+                                bool ea_ = dy_ is CqlInterval<CqlDateTime>;
+                                if (ea_)
                                 {
-                                    cx_ = dd_ as CqlInterval<CqlDateTime>;
+                                    dv_ = dy_ as CqlInterval<CqlDateTime>;
                                 }
                                 else
                                 {
-                                    cx_ = null;
+                                    dv_ = null;
                                 }
                             }
                         }
-                        CqlDateTime cy_ = QICoreCommon_4_0_000.Instance.earliest(context, cx_);
-                        CqlDateTime cz_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                        CqlBoolean da_ = context.Operators.SameOrBefore(cy_, cz_, (string)default);
-
-                        CqlBoolean db_() {
-                            Code<ObservationStatus> dg_ = AbnormalPresentation?.StatusElement;
-                            ObservationStatus? dh_ = dg_?.Value;
-                            string di_ = context.Operators.Convert<string>(dh_);
-                            string[] dj_ = [
-                                "final",
-                                "amended",
-                                "corrected",
-                            ];
-                            CqlBoolean dk_ = context.Operators.In<string>(di_, (IEnumerable<string>)dj_);
-                            return dk_;
-                        }
-
-                        return da_
-                            /* CQL 'and' (114:9-115:80) */ && db_();
+                        CqlDateTime dw_ = QICoreCommon_4_0_000.Instance.earliest(context, dv_);
+                        return dw_;
                     }
 
-                    IEnumerable<Observation> cr_ = context.Operators.Where<Observation>(k_, cq_);
-
-                    object cs_(Observation @this) {
-                        object dl_;
-                        DataType dn_ = @this?.Effective;
-                        object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
-                        bool dp_ = do_ is CqlDateTime;
-                        if (dp_)
-                        {
-                            dl_ = do_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            if (dp_)
-                            {
-                                dl_ = do_ as CqlDateTime;
-                            }
-                            else
-                            {
-                                bool dq_ = do_ is CqlInterval<CqlDateTime>;
-                                if (dq_)
-                                {
-                                    dl_ = do_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    dl_ = null;
-                                }
-                            }
-                        }
-                        CqlDateTime dm_ = QICoreCommon_4_0_000.Instance.earliest(context, dl_);
-                        return dm_;
-                    }
-
-                    IEnumerable<Observation> ct_ = context.Operators.SortBy<Observation>(cr_, cs_, System.ComponentModel.ListSortDirection.Ascending);
-                    Observation cu_ = context.Operators.Last<Observation>(ct_);
-                    DataType cv_ = cu_?.Effective;
-                    object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                    d_ = cw_ as CqlDateTime;
+                    IEnumerable<Observation> dd_ = context.Operators.SortBy<Observation>(db_, dc_, System.ComponentModel.ListSortDirection.Ascending);
+                    Observation de_ = context.Operators.Last<Observation>(dd_);
+                    DataType df_ = de_?.Effective;
+                    object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                    d_ = dg_ as CqlDateTime;
                 }
                 else
                 {
 
-                    bool? dr_(Observation AbnormalPresentation) {
-                        object dz_;
-                        DataType ee_ = AbnormalPresentation?.Effective;
-                        object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
-                        bool eg_ = ef_ is CqlDateTime;
-                        if (eg_)
+                    bool? eb_(Observation AbnormalPresentation) {
+                        object ej_;
+                        DataType et_ = AbnormalPresentation?.Effective;
+                        object eu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, et_);
+                        bool ev_ = eu_ is CqlDateTime;
+                        if (ev_)
                         {
-                            dz_ = ef_ as CqlDateTime;
+                            ej_ = eu_ as CqlDateTime;
                         }
                         else
                         {
-                            if (eg_)
+                            if (ev_)
                             {
-                                dz_ = ef_ as CqlDateTime;
+                                ej_ = eu_ as CqlDateTime;
                             }
                             else
                             {
-                                bool eh_ = ef_ is CqlInterval<CqlDateTime>;
-                                if (eh_)
+                                bool ew_ = eu_ is CqlInterval<CqlDateTime>;
+                                if (ew_)
                                 {
-                                    dz_ = ef_ as CqlInterval<CqlDateTime>;
+                                    ej_ = eu_ as CqlInterval<CqlDateTime>;
                                 }
                                 else
                                 {
-                                    dz_ = null;
+                                    ej_ = null;
                                 }
                             }
                         }
-                        CqlDateTime ea_ = QICoreCommon_4_0_000.Instance.earliest(context, dz_);
-                        CqlDateTime eb_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                        CqlBoolean ec_ = context.Operators.SameOrBefore(ea_, eb_, (string)default);
+                        CqlDateTime ek_ = QICoreCommon_4_0_000.Instance.earliest(context, ej_);
+                        CqlDateTime el_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
+                        CqlBoolean em_ = context.Operators.SameOrBefore(ek_, el_, (string)default);
+                        Code<ObservationStatus> en_ = AbnormalPresentation?.StatusElement;
+                        ObservationStatus? eo_ = en_?.Value;
+                        string ep_ = context.Operators.Convert<string>(eo_);
+                        string[] eq_ = [
+                            "final",
+                            "amended",
+                            "corrected",
+                        ];
+                        CqlBoolean er_ = context.Operators.In<string>(ep_, (IEnumerable<string>)eq_);
+                        CqlBoolean es_ = er_;
+                        return em_
+                            /* CQL 'and' (114:9-115:80) */ && es_;
+                    }
 
-                        CqlBoolean ed_() {
-                            Code<ObservationStatus> ei_ = AbnormalPresentation?.StatusElement;
-                            ObservationStatus? ej_ = ei_?.Value;
-                            string ek_ = context.Operators.Convert<string>(ej_);
-                            string[] el_ = [
+                    IEnumerable<Observation> ec_ = context.Operators.Where<Observation>(u_, eb_);
+
+                    object ed_(Observation @this) {
+                        object ex_;
+                        DataType ez_ = @this?.Effective;
+                        object fa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ez_);
+                        bool fb_ = fa_ is CqlDateTime;
+                        if (fb_)
+                        {
+                            ex_ = fa_ as CqlDateTime;
+                        }
+                        else
+                        {
+                            if (fb_)
+                            {
+                                ex_ = fa_ as CqlDateTime;
+                            }
+                            else
+                            {
+                                bool fc_ = fa_ is CqlInterval<CqlDateTime>;
+                                if (fc_)
+                                {
+                                    ex_ = fa_ as CqlInterval<CqlDateTime>;
+                                }
+                                else
+                                {
+                                    ex_ = null;
+                                }
+                            }
+                        }
+                        CqlDateTime ey_ = QICoreCommon_4_0_000.Instance.earliest(context, ex_);
+                        return ey_;
+                    }
+
+                    IEnumerable<Observation> ee_ = context.Operators.SortBy<Observation>(ec_, ed_, System.ComponentModel.ListSortDirection.Ascending);
+                    Observation ef_ = context.Operators.Last<Observation>(ee_);
+                    DataType eg_ = ef_?.Effective;
+                    object eh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eg_);
+                    bool ei_ = eh_ is CqlInterval<CqlDateTime>;
+                    if (ei_)
+                    {
+
+                        bool? fd_(Observation AbnormalPresentation) {
+                            object fk_;
+                            DataType fu_ = AbnormalPresentation?.Effective;
+                            object fv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fu_);
+                            bool fw_ = fv_ is CqlDateTime;
+                            if (fw_)
+                            {
+                                fk_ = fv_ as CqlDateTime;
+                            }
+                            else
+                            {
+                                if (fw_)
+                                {
+                                    fk_ = fv_ as CqlDateTime;
+                                }
+                                else
+                                {
+                                    bool fx_ = fv_ is CqlInterval<CqlDateTime>;
+                                    if (fx_)
+                                    {
+                                        fk_ = fv_ as CqlInterval<CqlDateTime>;
+                                    }
+                                    else
+                                    {
+                                        fk_ = null;
+                                    }
+                                }
+                            }
+                            CqlDateTime fl_ = QICoreCommon_4_0_000.Instance.earliest(context, fk_);
+                            CqlDateTime fm_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
+                            CqlBoolean fn_ = context.Operators.SameOrBefore(fl_, fm_, (string)default);
+                            Code<ObservationStatus> fo_ = AbnormalPresentation?.StatusElement;
+                            ObservationStatus? fp_ = fo_?.Value;
+                            string fq_ = context.Operators.Convert<string>(fp_);
+                            string[] fr_ = [
                                 "final",
                                 "amended",
                                 "corrected",
                             ];
-                            CqlBoolean em_ = context.Operators.In<string>(ek_, (IEnumerable<string>)el_);
-                            return em_;
+                            CqlBoolean fs_ = context.Operators.In<string>(fq_, (IEnumerable<string>)fr_);
+                            CqlBoolean ft_ = fs_;
+                            return fn_
+                                /* CQL 'and' (114:9-115:80) */ && ft_;
                         }
 
-                        return ec_
-                            /* CQL 'and' (114:9-115:80) */ && ed_();
-                    }
+                        IEnumerable<Observation> fe_ = context.Operators.Where<Observation>(u_, fd_);
 
-                    IEnumerable<Observation> ds_ = context.Operators.Where<Observation>(k_, dr_);
-
-                    object dt_(Observation @this) {
-                        object en_;
-                        DataType ep_ = @this?.Effective;
-                        object eq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ep_);
-                        bool er_ = eq_ is CqlDateTime;
-                        if (er_)
-                        {
-                            en_ = eq_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            if (er_)
+                        object ff_(Observation @this) {
+                            object fy_;
+                            DataType ga_ = @this?.Effective;
+                            object gb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ga_);
+                            bool gc_ = gb_ is CqlDateTime;
+                            if (gc_)
                             {
-                                en_ = eq_ as CqlDateTime;
+                                fy_ = gb_ as CqlDateTime;
                             }
                             else
                             {
-                                bool es_ = eq_ is CqlInterval<CqlDateTime>;
-                                if (es_)
+                                if (gc_)
                                 {
-                                    en_ = eq_ as CqlInterval<CqlDateTime>;
+                                    fy_ = gb_ as CqlDateTime;
                                 }
                                 else
                                 {
-                                    en_ = null;
-                                }
-                            }
-                        }
-                        CqlDateTime eo_ = QICoreCommon_4_0_000.Instance.earliest(context, en_);
-                        return eo_;
-                    }
-
-                    IEnumerable<Observation> du_ = context.Operators.SortBy<Observation>(ds_, dt_, System.ComponentModel.ListSortDirection.Ascending);
-                    Observation dv_ = context.Operators.Last<Observation>(du_);
-                    DataType dw_ = dv_?.Effective;
-                    object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                    bool dy_ = dx_ is CqlInterval<CqlDateTime>;
-                    if (dy_)
-                    {
-
-                        bool? et_(Observation AbnormalPresentation) {
-                            object fa_;
-                            DataType ff_ = AbnormalPresentation?.Effective;
-                            object fg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ff_);
-                            bool fh_ = fg_ is CqlDateTime;
-                            if (fh_)
-                            {
-                                fa_ = fg_ as CqlDateTime;
-                            }
-                            else
-                            {
-                                if (fh_)
-                                {
-                                    fa_ = fg_ as CqlDateTime;
-                                }
-                                else
-                                {
-                                    bool fi_ = fg_ is CqlInterval<CqlDateTime>;
-                                    if (fi_)
+                                    bool gd_ = gb_ is CqlInterval<CqlDateTime>;
+                                    if (gd_)
                                     {
-                                        fa_ = fg_ as CqlInterval<CqlDateTime>;
+                                        fy_ = gb_ as CqlInterval<CqlDateTime>;
                                     }
                                     else
                                     {
-                                        fa_ = null;
+                                        fy_ = null;
                                     }
                                 }
                             }
-                            CqlDateTime fb_ = QICoreCommon_4_0_000.Instance.earliest(context, fa_);
-                            CqlDateTime fc_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                            CqlBoolean fd_ = context.Operators.SameOrBefore(fb_, fc_, (string)default);
-
-                            CqlBoolean fe_() {
-                                Code<ObservationStatus> fj_ = AbnormalPresentation?.StatusElement;
-                                ObservationStatus? fk_ = fj_?.Value;
-                                string fl_ = context.Operators.Convert<string>(fk_);
-                                string[] fm_ = [
-                                    "final",
-                                    "amended",
-                                    "corrected",
-                                ];
-                                CqlBoolean fn_ = context.Operators.In<string>(fl_, (IEnumerable<string>)fm_);
-                                return fn_;
-                            }
-
-                            return fd_
-                                /* CQL 'and' (114:9-115:80) */ && fe_();
+                            CqlDateTime fz_ = QICoreCommon_4_0_000.Instance.earliest(context, fy_);
+                            return fz_;
                         }
 
-                        IEnumerable<Observation> eu_ = context.Operators.Where<Observation>(k_, et_);
-
-                        object ev_(Observation @this) {
-                            object fo_;
-                            DataType fq_ = @this?.Effective;
-                            object fr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fq_);
-                            bool fs_ = fr_ is CqlDateTime;
-                            if (fs_)
-                            {
-                                fo_ = fr_ as CqlDateTime;
-                            }
-                            else
-                            {
-                                if (fs_)
-                                {
-                                    fo_ = fr_ as CqlDateTime;
-                                }
-                                else
-                                {
-                                    bool ft_ = fr_ is CqlInterval<CqlDateTime>;
-                                    if (ft_)
-                                    {
-                                        fo_ = fr_ as CqlInterval<CqlDateTime>;
-                                    }
-                                    else
-                                    {
-                                        fo_ = null;
-                                    }
-                                }
-                            }
-                            CqlDateTime fp_ = QICoreCommon_4_0_000.Instance.earliest(context, fo_);
-                            return fp_;
-                        }
-
-                        IEnumerable<Observation> ew_ = context.Operators.SortBy<Observation>(eu_, ev_, System.ComponentModel.ListSortDirection.Ascending);
-                        Observation ex_ = context.Operators.Last<Observation>(ew_);
-                        DataType ey_ = ex_?.Effective;
-                        object ez_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ey_);
-                        d_ = ez_ as CqlInterval<CqlDateTime>;
+                        IEnumerable<Observation> fg_ = context.Operators.SortBy<Observation>(fe_, ff_, System.ComponentModel.ListSortDirection.Ascending);
+                        Observation fh_ = context.Operators.Last<Observation>(fg_);
+                        DataType fi_ = fh_?.Effective;
+                        object fj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fi_);
+                        d_ = fj_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -1351,47 +1265,38 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlDateTime e_ = QICoreCommon_4_0_000.Instance.earliest(context, d_);
             CqlInterval<CqlDateTime> f_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, ThirtySevenWeeksPlusEncounter);
             CqlBoolean g_ = context.Operators.In<CqlDateTime>(e_, f_, (string)default);
+            IEnumerable<Condition> h_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, ThirtySevenWeeksPlusEncounter);
 
-            CqlBoolean h_() {
-                IEnumerable<Condition> fu_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, ThirtySevenWeeksPlusEncounter);
-
-                bool? fv_(Condition @this) {
-                    CodeableConcept ga_ = @this?.Code;
-                    CqlConcept gb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ga_);
-                    return gb_ is not null;
-                }
-
-
-                CqlConcept fw_(Condition @this) {
-                    CodeableConcept gc_ = @this?.Code;
-                    CqlConcept gd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gc_);
-                    return gd_;
-                }
-
-                IEnumerable<CqlConcept> fx_ = context.Operators.WhereSelect<Condition, CqlConcept>(fu_, fv_, fw_);
-                CqlValueSet fy_ = this.Abnormal_Presentation(context);
-                CqlBoolean fz_ = context.Operators.ConceptsInValueSet(fx_, fy_);
-                return fz_;
+            bool? i_(Condition @this) {
+                CodeableConcept ge_ = @this?.Code;
+                CqlConcept gf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ge_);
+                return gf_ is not null;
             }
 
 
-            CqlBoolean i_() {
-                List<CodeableConcept> ge_ = ThirtySevenWeeksPlusEncounter?.ReasonCode;
+            CqlConcept j_(Condition @this) {
+                CodeableConcept gg_ = @this?.Code;
+                CqlConcept gh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gg_);
+                return gh_;
+            }
 
-                CqlConcept gf_(CodeableConcept @this) {
-                    CqlConcept gj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return gj_;
-                }
+            IEnumerable<CqlConcept> k_ = context.Operators.WhereSelect<Condition, CqlConcept>(h_, i_, j_);
+            CqlValueSet l_ = this.Abnormal_Presentation(context);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(k_, l_);
+            CqlBoolean n_ = m_;
+            List<CodeableConcept> o_ = ThirtySevenWeeksPlusEncounter?.ReasonCode;
 
-                IEnumerable<CqlConcept> gg_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ge_, gf_);
-                CqlValueSet gh_ = this.Abnormal_Presentation(context);
-                CqlBoolean gi_ = context.Operators.ConceptsInValueSet(gg_, gh_);
+            CqlConcept p_(CodeableConcept @this) {
+                CqlConcept gi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                 return gi_;
             }
 
+            IEnumerable<CqlConcept> q_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)o_, p_);
+            CqlBoolean r_ = context.Operators.ConceptsInValueSet(q_, l_);
+            CqlBoolean s_ = r_;
             return g_
-                /* CQL 'or' (118:11-119:93) */ || h_()
-                /* CQL 'or' (118:5-120:76) */ || i_();
+                /* CQL 'or' (118:11-119:93) */ || n_
+                /* CQL 'or' (118:5-120:76) */ || s_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1413,78 +1318,62 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             IEnumerable<Condition> d_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, ThirtySevenWeeksPlusEncounter);
 
             bool? e_(Condition @this) {
-                CodeableConcept m_ = @this?.Code;
-                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-                return n_ is not null;
+                CodeableConcept y_ = @this?.Code;
+                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+                return z_ is not null;
             }
 
 
             CqlConcept f_(Condition @this) {
-                CodeableConcept o_ = @this?.Code;
-                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                return p_;
+                CodeableConcept aa_ = @this?.Code;
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
+                return ab_;
             }
 
             IEnumerable<CqlConcept> g_ = context.Operators.WhereSelect<Condition, CqlConcept>(d_, e_, f_);
             CqlValueSet h_ = this.Placenta_Accreta_Spectrum_Previa_or_Vasa_Previa(context);
             CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
 
-            CqlBoolean j_() {
-                IEnumerable<Condition> q_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, ThirtySevenWeeksPlusEncounter);
-
-                bool? r_(Condition @this) {
-                    CodeableConcept w_ = @this?.Code;
-                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                    return x_ is not null;
-                }
-
-
-                CqlConcept s_(Condition @this) {
-                    CodeableConcept y_ = @this?.Code;
-                    CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                    return z_;
-                }
-
-                IEnumerable<CqlConcept> t_ = context.Operators.WhereSelect<Condition, CqlConcept>(q_, r_, s_);
-                CqlValueSet u_ = this.Genital_Herpes(context);
-                CqlBoolean v_ = context.Operators.ConceptsInValueSet(t_, u_);
-                return v_;
+            bool? j_(Condition @this) {
+                CodeableConcept ac_ = @this?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                return ad_ is not null;
             }
 
 
-            CqlBoolean k_() {
-                List<CodeableConcept> aa_ = ThirtySevenWeeksPlusEncounter?.ReasonCode;
-
-                CqlConcept ab_(CodeableConcept @this) {
-                    CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return af_;
-                }
-
-                IEnumerable<CqlConcept> ac_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)aa_, ab_);
-                CqlValueSet ad_ = this.Genital_Herpes(context);
-                CqlBoolean ae_ = context.Operators.ConceptsInValueSet(ac_, ad_);
-                return ae_;
+            CqlConcept k_(Condition @this) {
+                CodeableConcept ae_ = @this?.Code;
+                CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_);
+                return af_;
             }
 
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(d_, j_, k_);
+            CqlValueSet m_ = this.Genital_Herpes(context);
+            CqlBoolean n_ = context.Operators.ConceptsInValueSet(l_, m_);
+            CqlBoolean o_ = n_;
+            List<CodeableConcept> p_ = ThirtySevenWeeksPlusEncounter?.ReasonCode;
 
-            CqlBoolean l_() {
-                List<CodeableConcept> ag_ = ThirtySevenWeeksPlusEncounter?.ReasonCode;
-
-                CqlConcept ah_(CodeableConcept @this) {
-                    CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return al_;
-                }
-
-                IEnumerable<CqlConcept> ai_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ag_, ah_);
-                CqlValueSet aj_ = this.Placenta_Accreta_Spectrum_Previa_or_Vasa_Previa(context);
-                CqlBoolean ak_ = context.Operators.ConceptsInValueSet(ai_, aj_);
-                return ak_;
+            CqlConcept q_(CodeableConcept @this) {
+                CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ag_;
             }
 
+            IEnumerable<CqlConcept> r_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)p_, q_);
+            CqlBoolean s_ = context.Operators.ConceptsInValueSet(r_, m_);
+            CqlBoolean t_ = s_;
+
+            CqlConcept u_(CodeableConcept @this) {
+                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ah_;
+            }
+
+            IEnumerable<CqlConcept> v_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)p_, u_);
+            CqlBoolean w_ = context.Operators.ConceptsInValueSet(v_, h_);
+            CqlBoolean x_ = w_;
             return i_
-                /* CQL 'or' (95:13-96:88) */ || j_()
-                /* CQL 'or' (95:13-97:71) */ || k_()
-                /* CQL 'or' (95:5-99:5) */ || l_();
+                /* CQL 'or' (95:13-96:88) */ || o_
+                /* CQL 'or' (95:13-97:71) */ || t_
+                /* CQL 'or' (95:5-99:5) */ || x_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1563,33 +1452,33 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             bool? f_(Procedure CSection) {
                 CqlInterval<CqlDateTime> h_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, ThirtySevenWeeksPlusEncounter);
                 object i_;
-                DataType m_ = CSection?.Performed;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                bool o_ = n_ is CqlDateTime;
-                if (o_)
+                DataType q_ = CSection?.Performed;
+                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+                bool s_ = r_ is CqlDateTime;
+                if (s_)
                 {
-                    i_ = n_ as CqlDateTime;
+                    i_ = r_ as CqlDateTime;
                 }
                 else
                 {
-                    bool p_ = n_ is CqlQuantity;
-                    if (p_)
+                    bool t_ = r_ is CqlQuantity;
+                    if (t_)
                     {
-                        i_ = n_ as CqlQuantity;
+                        i_ = r_ as CqlQuantity;
                     }
                     else
                     {
-                        bool q_ = n_ is CqlInterval<CqlDateTime>;
-                        if (q_)
+                        bool u_ = r_ is CqlInterval<CqlDateTime>;
+                        if (u_)
                         {
-                            i_ = n_ as CqlInterval<CqlDateTime>;
+                            i_ = r_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool r_ = n_ is CqlInterval<CqlQuantity>;
-                            if (r_)
+                            bool v_ = r_ is CqlInterval<CqlQuantity>;
+                            if (v_)
                             {
-                                i_ = n_ as CqlInterval<CqlQuantity>;
+                                i_ = r_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1600,17 +1489,13 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
                 }
                 CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
                 CqlBoolean k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, (string)default);
-
-                CqlBoolean l_() {
-                    Code<EventStatus> s_ = CSection?.StatusElement;
-                    EventStatus? t_ = s_?.Value;
-                    string u_ = context.Operators.Convert<string>(t_);
-                    CqlBoolean v_ = context.Operators.Equal(u_, "completed");
-                    return v_;
-                }
-
+                Code<EventStatus> l_ = CSection?.StatusElement;
+                EventStatus? m_ = l_?.Value;
+                string n_ = context.Operators.Convert<string>(m_);
+                CqlBoolean o_ = context.Operators.Equal(n_, "completed");
+                CqlBoolean p_ = o_;
                 return k_
-                    /* CQL 'and' (90:17-91:41) */ && l_();
+                    /* CQL 'and' (90:17-91:41) */ && p_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1017FHIRHHFI", "1.0.000")]
 public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRHHFI_1_0_000>
 {
@@ -191,23 +191,19 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
             CqlInterval<CqlDateTime> d_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
             int? e_ = CQMCommon_4_1_000.Instance.lengthInDays(context, d_);
             CqlBoolean f_ = context.Operators.LessOrEqual(e_, 120);
-
-            CqlBoolean g_() {
-                Patient h_ = this.Patient(context);
-                Date i_ = h_?.BirthDateElement;
-                string j_ = i_?.Value;
-                CqlDate k_ = context.Operators.ConvertStringToDate(j_);
-                Period l_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlDate o_ = context.Operators.DateFrom(n_);
-                int? p_ = context.Operators.CalculateAgeAt(k_, o_, "year");
-                CqlBoolean q_ = context.Operators.GreaterOrEqual(p_, 18);
-                return q_;
-            }
-
+            Patient g_ = this.Patient(context);
+            Date h_ = g_?.BirthDateElement;
+            string i_ = h_?.Value;
+            CqlDate j_ = context.Operators.ConvertStringToDate(i_);
+            Period k_ = InpatientEncounter?.Period;
+            CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+            CqlDateTime m_ = context.Operators.Start(l_);
+            CqlDate n_ = context.Operators.DateFrom(m_);
+            int? o_ = context.Operators.CalculateAgeAt(j_, n_, "year");
+            CqlBoolean p_ = context.Operators.GreaterOrEqual(o_, 18);
+            CqlBoolean q_ = p_;
             return f_
-                /* CQL 'and' (49:5-50:74) */ && g_();
+                /* CQL 'and' (49:5-50:74) */ && q_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -282,38 +278,33 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
             List<CodeableConcept> d_ = QualifyingFall?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Inpatient_Falls(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = this.encountersDiagnosis(context, QualifyingFall);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = this.encountersDiagnosis(context, QualifyingFall);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.Inpatient_Falls(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'or' (94:5-95:73) */ || i_();
+                /* CQL 'or' (94:5-95:73) */ || n_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -379,32 +370,24 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
             FinancialResourceStatusCodes? h_ = g_?.Value;
             Code<FinancialResourceStatusCodes> i_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(h_);
             CqlBoolean j_ = context.Operators.Equal(i_, "active");
+            Code<ClaimUseCode> k_ = C?.UseElement;
+            ClaimUseCode? l_ = k_?.Value;
+            Code<ClaimUseCode> m_ = context.Operators.Convert<Code<ClaimUseCode>>(l_);
+            CqlBoolean n_ = context.Operators.Equal(m_, "claim");
+            CqlBoolean o_ = n_;
+            List<Claim.ItemComponent> p_ = C?.Item;
 
-            CqlBoolean k_() {
-                Code<ClaimUseCode> m_ = C?.UseElement;
-                ClaimUseCode? n_ = m_?.Value;
-                Code<ClaimUseCode> o_ = context.Operators.Convert<Code<ClaimUseCode>>(n_);
-                CqlBoolean p_ = context.Operators.Equal(o_, "claim");
-                return p_;
+            bool? q_(Claim.ItemComponent I) {
+                List<ResourceReference> t_ = I?.Encounter;
+                CqlBoolean u_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)t_, encounter);
+                return u_;
             }
 
-
-            CqlBoolean l_() {
-                List<Claim.ItemComponent> q_ = C?.Item;
-
-                bool? r_(Claim.ItemComponent I) {
-                    List<ResourceReference> t_ = I?.Encounter;
-                    CqlBoolean u_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)t_, encounter);
-                    return u_;
-                }
-
-                CqlBoolean s_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)q_, r_);
-                return s_;
-            }
-
+            CqlBoolean r_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)p_, q_);
+            CqlBoolean s_ = r_;
             return j_
-                /* CQL 'and' (300:13-301:27) */ && k_()
-                /* CQL 'and' (300:7-304:9) */ && l_();
+                /* CQL 'and' (300:13-301:27) */ && o_
+                /* CQL 'and' (300:7-304:9) */ && s_;
         }
 
 
@@ -415,57 +398,39 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                 List<Claim.ItemComponent> y_ = C?.Item;
 
                 bool? z_(Claim.ItemComponent I) {
-                    List<ResourceReference> ad_ = I?.Encounter;
-                    CqlBoolean ae_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)ad_, encounter);
+                    List<ResourceReference> al_ = I?.Encounter;
+                    CqlBoolean am_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)al_, encounter);
+                    PositiveInt an_ = D?.SequenceElement;
+                    int? ao_ = an_?.Value;
+                    List<PositiveInt> ap_ = I?.DiagnosisSequenceElement;
 
-                    CqlBoolean af_() {
-                        PositiveInt ag_ = D?.SequenceElement;
-                        int? ah_ = ag_?.Value;
-                        List<PositiveInt> ai_ = I?.DiagnosisSequenceElement;
-
-                        int? aj_(PositiveInt @this) {
-                            int? am_ = @this?.Value;
-                            return am_;
-                        }
-
-                        IEnumerable<int?> ak_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)ai_, aj_);
-                        CqlBoolean al_ = context.Operators.In<int?>(ah_, ak_);
-                        return al_;
+                    int? aq_(PositiveInt @this) {
+                        int? au_ = @this?.Value;
+                        return au_;
                     }
 
-                    return ae_
-                        /* CQL 'and' (307:13-308:51) */ && af_();
+                    IEnumerable<int?> ar_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)ap_, aq_);
+                    CqlBoolean as_ = context.Operators.In<int?>(ao_, ar_);
+                    CqlBoolean at_ = as_;
+                    return am_
+                        /* CQL 'and' (307:13-308:51) */ && at_;
                 }
 
                 CqlBoolean aa_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)y_, z_);
-
-                CqlBoolean ab_() {
-                    CodeableConcept an_ = D?.OnAdmission;
-                    CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, an_);
-
-                    CqlBoolean ap_() {
-                        CodeableConcept aq_ = D?.OnAdmission;
-                        CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
-                        CqlValueSet as_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
-                        CqlBoolean at_ = context.Operators.ConceptInValueSet(ar_, as_);
-                        return at_;
-                    }
-
-                    return (CqlBoolean)(ao_ is null)
-                        /* CQL 'or' (310:15-312:11) */ || ap_();
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType au_ = D?.Diagnosis;
-                    object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                    CqlBoolean aw_ = context.Operators.ConceptInValueSet(av_ as CqlConcept, diagnosisValueSet);
-                    return aw_;
-                }
-
+                CodeableConcept ab_ = D?.OnAdmission;
+                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
+                CqlValueSet ad_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
+                CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+                CqlBoolean af_ = ae_;
+                CqlBoolean ag_ = (CqlBoolean)(ac_ is null)
+                    /* CQL 'or' (310:15-312:11) */ || af_;
+                DataType ah_ = D?.Diagnosis;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = context.Operators.ConceptInValueSet(ai_ as CqlConcept, diagnosisValueSet);
+                CqlBoolean ak_ = aj_;
                 return aa_
-                    /* CQL 'and' (306:15-312:11) */ && ab_()
-                    /* CQL 'and' (306:9-313:46) */ && ac_();
+                    /* CQL 'and' (306:15-312:11) */ && ag_
+                    /* CQL 'and' (306:9-313:46) */ && ak_;
             }
 
             IEnumerable<Claim.DiagnosisComponent> x_ = context.Operators.Where<Claim.DiagnosisComponent>((IEnumerable<Claim.DiagnosisComponent>)v_, w_);
@@ -516,40 +481,23 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
             bool? e_(Claim.DiagnosisComponent MajorFallOccurred) {
                 CodeableConcept g_ = MajorFallOccurred?.OnAdmission;
                 CqlConcept h_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, g_);
-
-                CqlBoolean i_() {
-                    CodeableConcept k_ = MajorFallOccurred?.OnAdmission;
-                    CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-                    CqlValueSet m_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
-                    CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
-                    return n_;
-                }
-
-
-                CqlBoolean j_() {
-                    DataType o_ = MajorFallOccurred?.Diagnosis;
-                    object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                    CqlValueSet q_ = this.Major_Injuries(context);
-                    CqlBoolean r_ = context.Operators.ConceptInValueSet(p_ as CqlConcept, q_);
-
-                    CqlBoolean s_() {
-                        DataType t_ = MajorFallOccurred?.Diagnosis;
-                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                        Condition v_ = CQMCommon_4_1_000.Instance.getCondition(context, u_ as ResourceReference);
-                        CodeableConcept w_ = v_?.Code;
-                        CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                        CqlValueSet y_ = this.Major_Injuries(context);
-                        CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-                        return z_;
-                    }
-
-                    return r_
-                        /* CQL 'or' (79:15-81:11) */ || s_();
-                }
-
+                CqlValueSet i_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
+                CqlBoolean j_ = context.Operators.ConceptInValueSet(h_, i_);
+                CqlBoolean k_ = j_;
+                DataType l_ = MajorFallOccurred?.Diagnosis;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlValueSet n_ = this.Major_Injuries(context);
+                CqlBoolean o_ = context.Operators.ConceptInValueSet(m_ as CqlConcept, n_);
+                Condition p_ = CQMCommon_4_1_000.Instance.getCondition(context, m_ as ResourceReference);
+                CodeableConcept q_ = p_?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlBoolean s_ = context.Operators.ConceptInValueSet(r_, n_);
+                CqlBoolean t_ = s_;
+                CqlBoolean u_ = o_
+                    /* CQL 'or' (79:15-81:11) */ || t_;
                 return ((CqlBoolean)(h_ is null)
-                    /* CQL 'or' (76:15-78:9) */ || i_())
-                    /* CQL 'and' (76:9-81:11) */ && j_();
+                    /* CQL 'or' (76:15-78:9) */ || k_)
+                    /* CQL 'and' (76:9-81:11) */ && u_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Claim.DiagnosisComponent>(d_, e_);
@@ -577,40 +525,23 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
             bool? e_(Claim.DiagnosisComponent ModerateFallOccurred) {
                 CodeableConcept g_ = ModerateFallOccurred?.OnAdmission;
                 CqlConcept h_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, g_);
-
-                CqlBoolean i_() {
-                    CodeableConcept k_ = ModerateFallOccurred?.OnAdmission;
-                    CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-                    CqlValueSet m_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
-                    CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
-                    return n_;
-                }
-
-
-                CqlBoolean j_() {
-                    DataType o_ = ModerateFallOccurred?.Diagnosis;
-                    object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                    CqlValueSet q_ = this.Moderate_Injuries(context);
-                    CqlBoolean r_ = context.Operators.ConceptInValueSet(p_ as CqlConcept, q_);
-
-                    CqlBoolean s_() {
-                        DataType t_ = ModerateFallOccurred?.Diagnosis;
-                        object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                        Condition v_ = CQMCommon_4_1_000.Instance.getCondition(context, u_ as ResourceReference);
-                        CodeableConcept w_ = v_?.Code;
-                        CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                        CqlValueSet y_ = this.Moderate_Injuries(context);
-                        CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-                        return z_;
-                    }
-
-                    return r_
-                        /* CQL 'or' (68:15-70:11) */ || s_();
-                }
-
+                CqlValueSet i_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
+                CqlBoolean j_ = context.Operators.ConceptInValueSet(h_, i_);
+                CqlBoolean k_ = j_;
+                DataType l_ = ModerateFallOccurred?.Diagnosis;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlValueSet n_ = this.Moderate_Injuries(context);
+                CqlBoolean o_ = context.Operators.ConceptInValueSet(m_ as CqlConcept, n_);
+                Condition p_ = CQMCommon_4_1_000.Instance.getCondition(context, m_ as ResourceReference);
+                CodeableConcept q_ = p_?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlBoolean s_ = context.Operators.ConceptInValueSet(r_, n_);
+                CqlBoolean t_ = s_;
+                CqlBoolean u_ = o_
+                    /* CQL 'or' (68:15-70:11) */ || t_;
                 return ((CqlBoolean)(h_ is null)
-                    /* CQL 'or' (65:15-67:9) */ || i_())
-                    /* CQL 'and' (65:9-70:11) */ && j_();
+                    /* CQL 'or' (65:15-67:9) */ || k_)
+                    /* CQL 'and' (65:9-70:11) */ && u_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Claim.DiagnosisComponent>(d_, e_);
@@ -705,30 +636,22 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                 CqlDateTime l_ = context.Operators.Start(k_);
                 CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
                 CqlBoolean n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
-
-                CqlBoolean o_() {
-                    DataType q_ = BMI?.Value;
-                    CqlQuantity r_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, q_ as Quantity);
-                    return r_ is not null;
-                }
-
-
-                CqlBoolean p_() {
-                    Code<ObservationStatus> s_ = BMI?.StatusElement;
-                    ObservationStatus? t_ = s_?.Value;
-                    string u_ = context.Operators.Convert<string>(t_);
-                    string[] v_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
-                    return w_;
-                }
-
+                DataType o_ = BMI?.Value;
+                CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_ as Quantity);
+                CqlBoolean q_ = (CqlBoolean)(p_ is not null);
+                Code<ObservationStatus> r_ = BMI?.StatusElement;
+                ObservationStatus? s_ = r_?.Value;
+                string t_ = context.Operators.Convert<string>(s_);
+                string[] u_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+                CqlBoolean w_ = v_;
                 return n_
-                    /* CQL 'and' (116:17-117:33) */ && o_()
-                    /* CQL 'and' (116:17-118:61) */ && p_();
+                    /* CQL 'and' (116:17-117:33) */ && q_
+                    /* CQL 'and' (116:17-118:61) */ && w_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Encounter>(f_, g_);
@@ -768,32 +691,24 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                 FinancialResourceStatusCodes? af_ = ae_?.Value;
                 Code<FinancialResourceStatusCodes> ag_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(af_);
                 CqlBoolean ah_ = context.Operators.Equal(ag_, "active");
+                Code<ClaimUseCode> ai_ = C?.UseElement;
+                ClaimUseCode? aj_ = ai_?.Value;
+                Code<ClaimUseCode> ak_ = context.Operators.Convert<Code<ClaimUseCode>>(aj_);
+                CqlBoolean al_ = context.Operators.Equal(ak_, "claim");
+                CqlBoolean am_ = al_;
+                List<Claim.ItemComponent> an_ = C?.Item;
 
-                CqlBoolean ai_() {
-                    Code<ClaimUseCode> ak_ = C?.UseElement;
-                    ClaimUseCode? al_ = ak_?.Value;
-                    Code<ClaimUseCode> am_ = context.Operators.Convert<Code<ClaimUseCode>>(al_);
-                    CqlBoolean an_ = context.Operators.Equal(am_, "claim");
-                    return an_;
+                bool? ao_(Claim.ItemComponent ClaimItem) {
+                    List<ResourceReference> ar_ = ClaimItem?.Encounter;
+                    CqlBoolean as_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)ar_, InpatientEncounter);
+                    return as_;
                 }
 
-
-                CqlBoolean aj_() {
-                    List<Claim.ItemComponent> ao_ = C?.Item;
-
-                    bool? ap_(Claim.ItemComponent ClaimItem) {
-                        List<ResourceReference> ar_ = ClaimItem?.Encounter;
-                        CqlBoolean as_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)ar_, InpatientEncounter);
-                        return as_;
-                    }
-
-                    CqlBoolean aq_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)ao_, ap_);
-                    return aq_;
-                }
-
+                CqlBoolean ap_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)an_, ao_);
+                CqlBoolean aq_ = ap_;
                 return ah_
-                    /* CQL 'and' (125:15-126:29) */ && ai_()
-                    /* CQL 'and' (125:9-129:11) */ && aj_();
+                    /* CQL 'and' (125:15-126:29) */ && am_
+                    /* CQL 'and' (125:9-129:11) */ && aq_;
             }
 
             IEnumerable<Claim> h_ = context.Operators.Where<Claim>(f_, g_);
@@ -817,32 +732,24 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                 FinancialResourceStatusCodes? aw_ = av_?.Value;
                 Code<FinancialResourceStatusCodes> ax_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(aw_);
                 CqlBoolean ay_ = context.Operators.Equal(ax_, "active");
+                Code<ClaimUseCode> az_ = C?.UseElement;
+                ClaimUseCode? ba_ = az_?.Value;
+                Code<ClaimUseCode> bb_ = context.Operators.Convert<Code<ClaimUseCode>>(ba_);
+                CqlBoolean bc_ = context.Operators.Equal(bb_, "claim");
+                CqlBoolean bd_ = bc_;
+                List<Claim.ItemComponent> be_ = C?.Item;
 
-                CqlBoolean az_() {
-                    Code<ClaimUseCode> bb_ = C?.UseElement;
-                    ClaimUseCode? bc_ = bb_?.Value;
-                    Code<ClaimUseCode> bd_ = context.Operators.Convert<Code<ClaimUseCode>>(bc_);
-                    CqlBoolean be_ = context.Operators.Equal(bd_, "claim");
-                    return be_;
+                bool? bf_(Claim.ItemComponent ClaimItem) {
+                    List<ResourceReference> bi_ = ClaimItem?.Encounter;
+                    CqlBoolean bj_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bi_, InpatientEncounter);
+                    return bj_;
                 }
 
-
-                CqlBoolean ba_() {
-                    List<Claim.ItemComponent> bf_ = C?.Item;
-
-                    bool? bg_(Claim.ItemComponent ClaimItem) {
-                        List<ResourceReference> bi_ = ClaimItem?.Encounter;
-                        CqlBoolean bj_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bi_, InpatientEncounter);
-                        return bj_;
-                    }
-
-                    CqlBoolean bh_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)bf_, bg_);
-                    return bh_;
-                }
-
+                CqlBoolean bg_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)be_, bf_);
+                CqlBoolean bh_ = bg_;
                 return ay_
-                    /* CQL 'and' (125:15-126:29) */ && az_()
-                    /* CQL 'and' (125:9-129:11) */ && ba_();
+                    /* CQL 'and' (125:15-126:29) */ && bd_
+                    /* CQL 'and' (125:9-129:11) */ && bh_;
             }
 
             IEnumerable<Claim> n_ = context.Operators.Where<Claim>(f_, m_);
@@ -881,32 +788,24 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                 FinancialResourceStatusCodes? br_ = bq_?.Value;
                 Code<FinancialResourceStatusCodes> bs_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(br_);
                 CqlBoolean bt_ = context.Operators.Equal(bs_, "active");
+                Code<ClaimUseCode> bu_ = C?.UseElement;
+                ClaimUseCode? bv_ = bu_?.Value;
+                Code<ClaimUseCode> bw_ = context.Operators.Convert<Code<ClaimUseCode>>(bv_);
+                CqlBoolean bx_ = context.Operators.Equal(bw_, "claim");
+                CqlBoolean by_ = bx_;
+                List<Claim.ItemComponent> bz_ = C?.Item;
 
-                CqlBoolean bu_() {
-                    Code<ClaimUseCode> bw_ = C?.UseElement;
-                    ClaimUseCode? bx_ = bw_?.Value;
-                    Code<ClaimUseCode> by_ = context.Operators.Convert<Code<ClaimUseCode>>(bx_);
-                    CqlBoolean bz_ = context.Operators.Equal(by_, "claim");
-                    return bz_;
+                bool? ca_(Claim.ItemComponent ClaimItem) {
+                    List<ResourceReference> cd_ = ClaimItem?.Encounter;
+                    CqlBoolean ce_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)cd_, InpatientEncounter);
+                    return ce_;
                 }
 
-
-                CqlBoolean bv_() {
-                    List<Claim.ItemComponent> ca_ = C?.Item;
-
-                    bool? cb_(Claim.ItemComponent ClaimItem) {
-                        List<ResourceReference> cd_ = ClaimItem?.Encounter;
-                        CqlBoolean ce_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)cd_, InpatientEncounter);
-                        return ce_;
-                    }
-
-                    CqlBoolean cc_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)ca_, cb_);
-                    return cc_;
-                }
-
+                CqlBoolean cb_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)bz_, ca_);
+                CqlBoolean cc_ = cb_;
                 return bt_
-                    /* CQL 'and' (125:15-126:29) */ && bu_()
-                    /* CQL 'and' (125:9-129:11) */ && bv_();
+                    /* CQL 'and' (125:15-126:29) */ && by_
+                    /* CQL 'and' (125:9-129:11) */ && cc_;
             }
 
             IEnumerable<Claim> w_ = context.Operators.Where<Claim>(f_, v_);
@@ -930,17 +829,11 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                 CqlConcept ci_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ch_);
                 CqlValueSet cj_ = this.Present_on_Admission_or_Clinically_Undetermined(context);
                 CqlBoolean ck_ = context.Operators.ConceptInValueSet(ci_, cj_);
-
-                CqlBoolean cl_() {
-                    CodeableConcept cm_ = Diag?.OnAdmission;
-                    CqlConcept cn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cm_);
-                    CqlValueSet co_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
-                    CqlBoolean cp_ = context.Operators.ConceptInValueSet(cn_, co_);
-                    return cp_;
-                }
-
+                CqlValueSet cl_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine(context);
+                CqlBoolean cm_ = context.Operators.ConceptInValueSet(ci_, cl_);
+                CqlBoolean cn_ = cm_;
                 return ck_
-                    /* CQL 'or' (139:9-140:102) */ || cl_();
+                    /* CQL 'or' (139:9-140:102) */ || cn_;
             }
 
             IEnumerable<Claim.DiagnosisComponent> ac_ = context.Operators.Where<Claim.DiagnosisComponent>(aa_, ab_);
@@ -967,16 +860,11 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
             CqlValueSet d_ = this.Abnormal_Weight_Loss(context);
             CqlValueSet e_ = this.Present_on_Admission_or_Clinically_Undetermined(context);
             CqlBoolean f_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, InpatientEncounter, d_, e_);
-
-            CqlBoolean g_() {
-                CqlValueSet h_ = this.Malnutrition(context);
-                CqlValueSet i_ = this.Present_on_Admission_or_Clinically_Undetermined(context);
-                CqlBoolean j_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, InpatientEncounter, h_, i_);
-                return j_;
-            }
-
+            CqlValueSet g_ = this.Malnutrition(context);
+            CqlBoolean h_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, InpatientEncounter, g_, e_);
+            CqlBoolean i_ = h_;
             return f_
-                /* CQL 'or' (145:5-146:127) */ || g_();
+                /* CQL 'or' (145:5-146:127) */ || i_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1006,17 +894,13 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Anticoagulants_for_All_Indications(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Anticoagulants_for_All_Indications(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1037,68 +921,49 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> af_ = Anticoagulants?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-
-                    CqlBoolean aj_() {
-                        Code<MedicationRequest.MedicationRequestIntent> ak_ = Anticoagulants?.IntentElement;
-                        MedicationRequest.MedicationRequestIntent? al_ = ak_?.Value;
-                        string am_ = context.Operators.Convert<string>(al_);
-                        CqlBoolean an_ = context.Operators.Equal(am_, "plan");
-
-                        CqlBoolean ao_() {
-                            ResourceReference ap_ = Anticoagulants?.Subject;
-                            FhirString aq_ = ap_?.ReferenceElement;
-                            string ar_ = aq_?.Value;
-                            string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
-                            Id at_;
-                            Patient aw_ = this.Patient(context);
-                            bool ax_ = aw_ is Resource;
-                            if (ax_)
-                            {
-                                at_ = (aw_ as Resource).IdElement;
-                            }
-                            else
-                            {
-                                at_ = default;
-                            }
-                            string au_ = at_?.Value;
-                            CqlBoolean av_ = context.Operators.Equal(as_, au_);
-                            return av_;
-                        }
-
-                        return an_
-                            /* CQL 'and' (153:16-155:13) */ && ao_();
-                    }
-
-                    return ai_
-                        /* CQL 'or' (152:13-156:9) */ || aj_();
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = Anticoagulants?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                CqlBoolean ag_ = context.Operators.Equal(af_, "order");
+                CqlBoolean ah_ = context.Operators.Equal(af_, "plan");
+                ResourceReference ai_ = Anticoagulants?.Subject;
+                FhirString aj_ = ai_?.ReferenceElement;
+                string ak_ = aj_?.Value;
+                string al_ = QICoreCommon_4_0_000.Instance.getId(context, ak_);
+                Id am_;
+                Patient be_ = this.Patient(context);
+                bool bf_ = be_ is Resource;
+                if (bf_)
+                {
+                    am_ = (be_ as Resource).IdElement;
                 }
-
-
-                CqlBoolean ae_() {
-                    CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, Anticoagulants);
-                    CqlDate az_ = ay_?.low;
-                    CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
-                    CqlDate bb_ = ay_?.high;
-                    CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
-                    CqlBoolean bd_ = ay_?.lowClosed;
-                    CqlBoolean be_ = ay_?.highClosed;
-                    CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ba_, bc_, bd_, be_);
-                    Period bg_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    CqlBoolean bi_ = context.Operators.OverlapsBefore(bf_, bh_, "day");
-                    return bi_;
+                else
+                {
+                    am_ = default;
                 }
-
+                string an_ = am_?.Value;
+                CqlBoolean ao_ = context.Operators.Equal(al_, an_);
+                CqlBoolean ap_ = ao_;
+                CqlBoolean aq_ = ah_
+                    /* CQL 'and' (153:16-155:13) */ && ap_;
+                CqlBoolean ar_ = ag_
+                    /* CQL 'or' (152:13-156:9) */ || aq_;
+                CqlInterval<CqlDate> as_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, Anticoagulants);
+                CqlDate at_ = as_?.low;
+                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
+                CqlDate av_ = as_?.high;
+                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+                CqlBoolean ax_ = as_?.lowClosed;
+                CqlBoolean ay_ = as_?.highClosed;
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(au_, aw_, ax_, ay_);
+                Period ba_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
+                CqlBoolean bc_ = context.Operators.OverlapsBefore(az_, bb_, "day");
+                CqlBoolean bd_ = bc_;
                 return ac_
-                    /* CQL 'and' (151:17-156:9) */ && ad_()
+                    /* CQL 'and' (151:17-156:9) */ && ar_
                     /* CQL 'and' (151:17-157:42) */ && QICoreCommon_4_0_000.Instance.isCommunity(context, Anticoagulants as MedicationRequest)
-                    /* CQL 'and' (151:17-158:103) */ && ae_();
+                    /* CQL 'and' (151:17-158:103) */ && bd_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -1132,17 +997,13 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Anticoagulants_for_All_Indications(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Anticoagulants_for_All_Indications(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1161,21 +1022,17 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                 CqlDateTime ab_ = context.Operators.Start(aa_);
                 CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
                 CqlBoolean ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
-
-                CqlBoolean ae_() {
-                    Code<MedicationAdministration.MedicationAdministrationStatusCodes> af_ = Anticoagulants?.StatusElement;
-                    MedicationAdministration.MedicationAdministrationStatusCodes? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    string[] ai_ = [
-                        "in-progress",
-                        "completed",
-                    ];
-                    CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-                    return aj_;
-                }
-
+                Code<MedicationAdministration.MedicationAdministrationStatusCodes> ae_ = Anticoagulants?.StatusElement;
+                MedicationAdministration.MedicationAdministrationStatusCodes? af_ = ae_?.Value;
+                string ag_ = context.Operators.Convert<string>(af_);
+                string[] ah_ = [
+                    "in-progress",
+                    "completed",
+                ];
+                CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
+                CqlBoolean aj_ = ai_;
                 return ad_
-                    /* CQL 'and' (163:17-164:67) */ && ae_();
+                    /* CQL 'and' (163:17-164:67) */ && aj_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationAdministration>(i_, j_);
@@ -1209,17 +1066,13 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Antidepressants(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Antidepressants(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1240,68 +1093,49 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> af_ = AntidepressantMed?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-
-                    CqlBoolean aj_() {
-                        Code<MedicationRequest.MedicationRequestIntent> ak_ = AntidepressantMed?.IntentElement;
-                        MedicationRequest.MedicationRequestIntent? al_ = ak_?.Value;
-                        string am_ = context.Operators.Convert<string>(al_);
-                        CqlBoolean an_ = context.Operators.Equal(am_, "plan");
-
-                        CqlBoolean ao_() {
-                            ResourceReference ap_ = AntidepressantMed?.Subject;
-                            FhirString aq_ = ap_?.ReferenceElement;
-                            string ar_ = aq_?.Value;
-                            string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
-                            Id at_;
-                            Patient aw_ = this.Patient(context);
-                            bool ax_ = aw_ is Resource;
-                            if (ax_)
-                            {
-                                at_ = (aw_ as Resource).IdElement;
-                            }
-                            else
-                            {
-                                at_ = default;
-                            }
-                            string au_ = at_?.Value;
-                            CqlBoolean av_ = context.Operators.Equal(as_, au_);
-                            return av_;
-                        }
-
-                        return an_
-                            /* CQL 'and' (171:16-173:13) */ && ao_();
-                    }
-
-                    return ai_
-                        /* CQL 'or' (170:13-174:9) */ || aj_();
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = AntidepressantMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                CqlBoolean ag_ = context.Operators.Equal(af_, "order");
+                CqlBoolean ah_ = context.Operators.Equal(af_, "plan");
+                ResourceReference ai_ = AntidepressantMed?.Subject;
+                FhirString aj_ = ai_?.ReferenceElement;
+                string ak_ = aj_?.Value;
+                string al_ = QICoreCommon_4_0_000.Instance.getId(context, ak_);
+                Id am_;
+                Patient be_ = this.Patient(context);
+                bool bf_ = be_ is Resource;
+                if (bf_)
+                {
+                    am_ = (be_ as Resource).IdElement;
                 }
-
-
-                CqlBoolean ae_() {
-                    CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AntidepressantMed);
-                    CqlDate az_ = ay_?.low;
-                    CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
-                    CqlDate bb_ = ay_?.high;
-                    CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
-                    CqlBoolean bd_ = ay_?.lowClosed;
-                    CqlBoolean be_ = ay_?.highClosed;
-                    CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ba_, bc_, bd_, be_);
-                    Period bg_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    CqlBoolean bi_ = context.Operators.OverlapsBefore(bf_, bh_, "day");
-                    return bi_;
+                else
+                {
+                    am_ = default;
                 }
-
+                string an_ = am_?.Value;
+                CqlBoolean ao_ = context.Operators.Equal(al_, an_);
+                CqlBoolean ap_ = ao_;
+                CqlBoolean aq_ = ah_
+                    /* CQL 'and' (171:16-173:13) */ && ap_;
+                CqlBoolean ar_ = ag_
+                    /* CQL 'or' (170:13-174:9) */ || aq_;
+                CqlInterval<CqlDate> as_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AntidepressantMed);
+                CqlDate at_ = as_?.low;
+                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
+                CqlDate av_ = as_?.high;
+                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+                CqlBoolean ax_ = as_?.lowClosed;
+                CqlBoolean ay_ = as_?.highClosed;
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(au_, aw_, ax_, ay_);
+                Period ba_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
+                CqlBoolean bc_ = context.Operators.OverlapsBefore(az_, bb_, "day");
+                CqlBoolean bd_ = bc_;
                 return ac_
-                    /* CQL 'and' (169:17-174:9) */ && ad_()
+                    /* CQL 'and' (169:17-174:9) */ && ar_
                     /* CQL 'and' (169:17-175:45) */ && QICoreCommon_4_0_000.Instance.isCommunity(context, AntidepressantMed as MedicationRequest)
-                    /* CQL 'and' (169:17-176:106) */ && ae_();
+                    /* CQL 'and' (169:17-176:106) */ && bd_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -1335,17 +1169,13 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Antihypertensives(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Antihypertensives(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1366,68 +1196,49 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> af_ = BPMed?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-
-                    CqlBoolean aj_() {
-                        Code<MedicationRequest.MedicationRequestIntent> ak_ = BPMed?.IntentElement;
-                        MedicationRequest.MedicationRequestIntent? al_ = ak_?.Value;
-                        string am_ = context.Operators.Convert<string>(al_);
-                        CqlBoolean an_ = context.Operators.Equal(am_, "plan");
-
-                        CqlBoolean ao_() {
-                            ResourceReference ap_ = BPMed?.Subject;
-                            FhirString aq_ = ap_?.ReferenceElement;
-                            string ar_ = aq_?.Value;
-                            string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
-                            Id at_;
-                            Patient aw_ = this.Patient(context);
-                            bool ax_ = aw_ is Resource;
-                            if (ax_)
-                            {
-                                at_ = (aw_ as Resource).IdElement;
-                            }
-                            else
-                            {
-                                at_ = default;
-                            }
-                            string au_ = at_?.Value;
-                            CqlBoolean av_ = context.Operators.Equal(as_, au_);
-                            return av_;
-                        }
-
-                        return an_
-                            /* CQL 'and' (183:16-185:13) */ && ao_();
-                    }
-
-                    return ai_
-                        /* CQL 'or' (182:13-186:9) */ || aj_();
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = BPMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                CqlBoolean ag_ = context.Operators.Equal(af_, "order");
+                CqlBoolean ah_ = context.Operators.Equal(af_, "plan");
+                ResourceReference ai_ = BPMed?.Subject;
+                FhirString aj_ = ai_?.ReferenceElement;
+                string ak_ = aj_?.Value;
+                string al_ = QICoreCommon_4_0_000.Instance.getId(context, ak_);
+                Id am_;
+                Patient be_ = this.Patient(context);
+                bool bf_ = be_ is Resource;
+                if (bf_)
+                {
+                    am_ = (be_ as Resource).IdElement;
                 }
-
-
-                CqlBoolean ae_() {
-                    CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, BPMed);
-                    CqlDate az_ = ay_?.low;
-                    CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
-                    CqlDate bb_ = ay_?.high;
-                    CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
-                    CqlBoolean bd_ = ay_?.lowClosed;
-                    CqlBoolean be_ = ay_?.highClosed;
-                    CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ba_, bc_, bd_, be_);
-                    Period bg_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    CqlBoolean bi_ = context.Operators.OverlapsBefore(bf_, bh_, "day");
-                    return bi_;
+                else
+                {
+                    am_ = default;
                 }
-
+                string an_ = am_?.Value;
+                CqlBoolean ao_ = context.Operators.Equal(al_, an_);
+                CqlBoolean ap_ = ao_;
+                CqlBoolean aq_ = ah_
+                    /* CQL 'and' (183:16-185:13) */ && ap_;
+                CqlBoolean ar_ = ag_
+                    /* CQL 'or' (182:13-186:9) */ || aq_;
+                CqlInterval<CqlDate> as_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, BPMed);
+                CqlDate at_ = as_?.low;
+                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
+                CqlDate av_ = as_?.high;
+                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+                CqlBoolean ax_ = as_?.lowClosed;
+                CqlBoolean ay_ = as_?.highClosed;
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(au_, aw_, ax_, ay_);
+                Period ba_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
+                CqlBoolean bc_ = context.Operators.OverlapsBefore(az_, bb_, "day");
+                CqlBoolean bd_ = bc_;
                 return ac_
-                    /* CQL 'and' (181:17-186:9) */ && ad_()
+                    /* CQL 'and' (181:17-186:9) */ && ar_
                     /* CQL 'and' (181:17-187:33) */ && QICoreCommon_4_0_000.Instance.isCommunity(context, BPMed as MedicationRequest)
-                    /* CQL 'and' (181:17-188:94) */ && ae_();
+                    /* CQL 'and' (181:17-188:94) */ && bd_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -1461,17 +1272,13 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Central_Nervous_System_Depressants(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Central_Nervous_System_Depressants(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1492,68 +1299,49 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> af_ = CNSMed?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-
-                    CqlBoolean aj_() {
-                        Code<MedicationRequest.MedicationRequestIntent> ak_ = CNSMed?.IntentElement;
-                        MedicationRequest.MedicationRequestIntent? al_ = ak_?.Value;
-                        string am_ = context.Operators.Convert<string>(al_);
-                        CqlBoolean an_ = context.Operators.Equal(am_, "plan");
-
-                        CqlBoolean ao_() {
-                            ResourceReference ap_ = CNSMed?.Subject;
-                            FhirString aq_ = ap_?.ReferenceElement;
-                            string ar_ = aq_?.Value;
-                            string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
-                            Id at_;
-                            Patient aw_ = this.Patient(context);
-                            bool ax_ = aw_ is Resource;
-                            if (ax_)
-                            {
-                                at_ = (aw_ as Resource).IdElement;
-                            }
-                            else
-                            {
-                                at_ = default;
-                            }
-                            string au_ = at_?.Value;
-                            CqlBoolean av_ = context.Operators.Equal(as_, au_);
-                            return av_;
-                        }
-
-                        return an_
-                            /* CQL 'and' (195:16-197:13) */ && ao_();
-                    }
-
-                    return ai_
-                        /* CQL 'or' (194:13-198:9) */ || aj_();
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = CNSMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                CqlBoolean ag_ = context.Operators.Equal(af_, "order");
+                CqlBoolean ah_ = context.Operators.Equal(af_, "plan");
+                ResourceReference ai_ = CNSMed?.Subject;
+                FhirString aj_ = ai_?.ReferenceElement;
+                string ak_ = aj_?.Value;
+                string al_ = QICoreCommon_4_0_000.Instance.getId(context, ak_);
+                Id am_;
+                Patient be_ = this.Patient(context);
+                bool bf_ = be_ is Resource;
+                if (bf_)
+                {
+                    am_ = (be_ as Resource).IdElement;
                 }
-
-
-                CqlBoolean ae_() {
-                    CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, CNSMed);
-                    CqlDate az_ = ay_?.low;
-                    CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
-                    CqlDate bb_ = ay_?.high;
-                    CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
-                    CqlBoolean bd_ = ay_?.lowClosed;
-                    CqlBoolean be_ = ay_?.highClosed;
-                    CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ba_, bc_, bd_, be_);
-                    Period bg_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    CqlBoolean bi_ = context.Operators.OverlapsBefore(bf_, bh_, "day");
-                    return bi_;
+                else
+                {
+                    am_ = default;
                 }
-
+                string an_ = am_?.Value;
+                CqlBoolean ao_ = context.Operators.Equal(al_, an_);
+                CqlBoolean ap_ = ao_;
+                CqlBoolean aq_ = ah_
+                    /* CQL 'and' (195:16-197:13) */ && ap_;
+                CqlBoolean ar_ = ag_
+                    /* CQL 'or' (194:13-198:9) */ || aq_;
+                CqlInterval<CqlDate> as_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, CNSMed);
+                CqlDate at_ = as_?.low;
+                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
+                CqlDate av_ = as_?.high;
+                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+                CqlBoolean ax_ = as_?.lowClosed;
+                CqlBoolean ay_ = as_?.highClosed;
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(au_, aw_, ax_, ay_);
+                Period ba_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
+                CqlBoolean bc_ = context.Operators.OverlapsBefore(az_, bb_, "day");
+                CqlBoolean bd_ = bc_;
                 return ac_
-                    /* CQL 'and' (193:17-198:9) */ && ad_()
+                    /* CQL 'and' (193:17-198:9) */ && ar_
                     /* CQL 'and' (193:17-199:34) */ && QICoreCommon_4_0_000.Instance.isCommunity(context, CNSMed as MedicationRequest)
-                    /* CQL 'and' (193:17-200:95) */ && ae_();
+                    /* CQL 'and' (193:17-200:95) */ && bd_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -1587,17 +1375,13 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Diuretics(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Diuretics(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1618,68 +1402,49 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> af_ = DiureticMed?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-
-                    CqlBoolean aj_() {
-                        Code<MedicationRequest.MedicationRequestIntent> ak_ = DiureticMed?.IntentElement;
-                        MedicationRequest.MedicationRequestIntent? al_ = ak_?.Value;
-                        string am_ = context.Operators.Convert<string>(al_);
-                        CqlBoolean an_ = context.Operators.Equal(am_, "plan");
-
-                        CqlBoolean ao_() {
-                            ResourceReference ap_ = DiureticMed?.Subject;
-                            FhirString aq_ = ap_?.ReferenceElement;
-                            string ar_ = aq_?.Value;
-                            string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
-                            Id at_;
-                            Patient aw_ = this.Patient(context);
-                            bool ax_ = aw_ is Resource;
-                            if (ax_)
-                            {
-                                at_ = (aw_ as Resource).IdElement;
-                            }
-                            else
-                            {
-                                at_ = default;
-                            }
-                            string au_ = at_?.Value;
-                            CqlBoolean av_ = context.Operators.Equal(as_, au_);
-                            return av_;
-                        }
-
-                        return an_
-                            /* CQL 'and' (207:16-209:13) */ && ao_();
-                    }
-
-                    return ai_
-                        /* CQL 'or' (206:13-210:9) */ || aj_();
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = DiureticMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                CqlBoolean ag_ = context.Operators.Equal(af_, "order");
+                CqlBoolean ah_ = context.Operators.Equal(af_, "plan");
+                ResourceReference ai_ = DiureticMed?.Subject;
+                FhirString aj_ = ai_?.ReferenceElement;
+                string ak_ = aj_?.Value;
+                string al_ = QICoreCommon_4_0_000.Instance.getId(context, ak_);
+                Id am_;
+                Patient be_ = this.Patient(context);
+                bool bf_ = be_ is Resource;
+                if (bf_)
+                {
+                    am_ = (be_ as Resource).IdElement;
                 }
-
-
-                CqlBoolean ae_() {
-                    CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DiureticMed);
-                    CqlDate az_ = ay_?.low;
-                    CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
-                    CqlDate bb_ = ay_?.high;
-                    CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
-                    CqlBoolean bd_ = ay_?.lowClosed;
-                    CqlBoolean be_ = ay_?.highClosed;
-                    CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ba_, bc_, bd_, be_);
-                    Period bg_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    CqlBoolean bi_ = context.Operators.OverlapsBefore(bf_, bh_, "day");
-                    return bi_;
+                else
+                {
+                    am_ = default;
                 }
-
+                string an_ = am_?.Value;
+                CqlBoolean ao_ = context.Operators.Equal(al_, an_);
+                CqlBoolean ap_ = ao_;
+                CqlBoolean aq_ = ah_
+                    /* CQL 'and' (207:16-209:13) */ && ap_;
+                CqlBoolean ar_ = ag_
+                    /* CQL 'or' (206:13-210:9) */ || aq_;
+                CqlInterval<CqlDate> as_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, DiureticMed);
+                CqlDate at_ = as_?.low;
+                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
+                CqlDate av_ = as_?.high;
+                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+                CqlBoolean ax_ = as_?.lowClosed;
+                CqlBoolean ay_ = as_?.highClosed;
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(au_, aw_, ax_, ay_);
+                Period ba_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
+                CqlBoolean bc_ = context.Operators.OverlapsBefore(az_, bb_, "day");
+                CqlBoolean bd_ = bc_;
                 return ac_
-                    /* CQL 'and' (205:17-210:9) */ && ad_()
+                    /* CQL 'and' (205:17-210:9) */ && ar_
                     /* CQL 'and' (205:17-211:39) */ && QICoreCommon_4_0_000.Instance.isCommunity(context, DiureticMed as MedicationRequest)
-                    /* CQL 'and' (205:17-212:100) */ && ae_();
+                    /* CQL 'and' (205:17-212:100) */ && bd_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -1713,17 +1478,13 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Opioids(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Opioids(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1744,68 +1505,49 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> af_ = OpioidMed?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-
-                    CqlBoolean aj_() {
-                        Code<MedicationRequest.MedicationRequestIntent> ak_ = OpioidMed?.IntentElement;
-                        MedicationRequest.MedicationRequestIntent? al_ = ak_?.Value;
-                        string am_ = context.Operators.Convert<string>(al_);
-                        CqlBoolean an_ = context.Operators.Equal(am_, "plan");
-
-                        CqlBoolean ao_() {
-                            ResourceReference ap_ = OpioidMed?.Subject;
-                            FhirString aq_ = ap_?.ReferenceElement;
-                            string ar_ = aq_?.Value;
-                            string as_ = QICoreCommon_4_0_000.Instance.getId(context, ar_);
-                            Id at_;
-                            Patient aw_ = this.Patient(context);
-                            bool ax_ = aw_ is Resource;
-                            if (ax_)
-                            {
-                                at_ = (aw_ as Resource).IdElement;
-                            }
-                            else
-                            {
-                                at_ = default;
-                            }
-                            string au_ = at_?.Value;
-                            CqlBoolean av_ = context.Operators.Equal(as_, au_);
-                            return av_;
-                        }
-
-                        return an_
-                            /* CQL 'and' (219:16-221:13) */ && ao_();
-                    }
-
-                    return ai_
-                        /* CQL 'or' (218:13-222:9) */ || aj_();
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = OpioidMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                CqlBoolean ag_ = context.Operators.Equal(af_, "order");
+                CqlBoolean ah_ = context.Operators.Equal(af_, "plan");
+                ResourceReference ai_ = OpioidMed?.Subject;
+                FhirString aj_ = ai_?.ReferenceElement;
+                string ak_ = aj_?.Value;
+                string al_ = QICoreCommon_4_0_000.Instance.getId(context, ak_);
+                Id am_;
+                Patient be_ = this.Patient(context);
+                bool bf_ = be_ is Resource;
+                if (bf_)
+                {
+                    am_ = (be_ as Resource).IdElement;
                 }
-
-
-                CqlBoolean ae_() {
-                    CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OpioidMed);
-                    CqlDate az_ = ay_?.low;
-                    CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
-                    CqlDate bb_ = ay_?.high;
-                    CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
-                    CqlBoolean bd_ = ay_?.lowClosed;
-                    CqlBoolean be_ = ay_?.highClosed;
-                    CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ba_, bc_, bd_, be_);
-                    Period bg_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    CqlBoolean bi_ = context.Operators.OverlapsBefore(bf_, bh_, "day");
-                    return bi_;
+                else
+                {
+                    am_ = default;
                 }
-
+                string an_ = am_?.Value;
+                CqlBoolean ao_ = context.Operators.Equal(al_, an_);
+                CqlBoolean ap_ = ao_;
+                CqlBoolean aq_ = ah_
+                    /* CQL 'and' (219:16-221:13) */ && ap_;
+                CqlBoolean ar_ = ag_
+                    /* CQL 'or' (218:13-222:9) */ || aq_;
+                CqlInterval<CqlDate> as_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OpioidMed);
+                CqlDate at_ = as_?.low;
+                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
+                CqlDate av_ = as_?.high;
+                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+                CqlBoolean ax_ = as_?.lowClosed;
+                CqlBoolean ay_ = as_?.highClosed;
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(au_, aw_, ax_, ay_);
+                Period ba_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
+                CqlBoolean bc_ = context.Operators.OverlapsBefore(az_, bb_, "day");
+                CqlBoolean bd_ = bc_;
                 return ac_
-                    /* CQL 'and' (217:17-222:9) */ && ad_()
+                    /* CQL 'and' (217:17-222:9) */ && ar_
                     /* CQL 'and' (217:17-223:37) */ && QICoreCommon_4_0_000.Instance.isCommunity(context, OpioidMed as MedicationRequest)
-                    /* CQL 'and' (217:17-224:98) */ && ae_();
+                    /* CQL 'and' (217:17-224:98) */ && bd_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1028FHIRPCSevereOBComps", "1.0.000")]
 public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<CMS1028FHIRPCSevereOBComps_1_0_000>
 {
@@ -441,16 +441,12 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
 
         bool? b_(Encounter DeliveryEncounter) {
             int? d_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
-
-            CqlBoolean e_() {
-                CqlQuantity f_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
-                CqlQuantity g_ = context.Operators.Quantity(20m, "weeks");
-                CqlBoolean h_ = context.Operators.GreaterOrEqual(f_, g_);
-                return h_;
-            }
-
+            CqlQuantity e_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
+            CqlQuantity f_ = context.Operators.Quantity(20m, "weeks");
+            CqlBoolean g_ = context.Operators.GreaterOrEqual(e_, f_);
+            CqlBoolean h_ = g_;
             return (CqlBoolean)(d_ is null)
-                /* CQL 'and' (177:5-178:75) */ && e_();
+                /* CQL 'and' (177:5-178:75) */ && h_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -470,48 +466,39 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
 
         bool? b_(Encounter DeliveryEncounter) {
             int? d_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
+            List<CodeableConcept> e_ = DeliveryEncounter?.ReasonCode;
 
-            CqlBoolean e_() {
-                List<CodeableConcept> f_ = DeliveryEncounter?.ReasonCode;
-
-                CqlConcept g_(CodeableConcept @this) {
-                    CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return l_;
-                }
-
-                IEnumerable<CqlConcept> h_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)f_, g_);
-                CqlValueSet i_ = this._20_to_42_Plus_Weeks_Gestation(context);
-                CqlBoolean j_ = context.Operators.ConceptsInValueSet(h_, i_);
-
-                CqlBoolean k_() {
-                    IEnumerable<Condition> m_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, DeliveryEncounter);
-
-                    bool? n_(Condition @this) {
-                        CodeableConcept s_ = @this?.Code;
-                        CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                        return t_ is not null;
-                    }
-
-
-                    CqlConcept o_(Condition @this) {
-                        CodeableConcept u_ = @this?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        return v_;
-                    }
-
-                    IEnumerable<CqlConcept> p_ = context.Operators.WhereSelect<Condition, CqlConcept>(m_, n_, o_);
-                    CqlValueSet q_ = this._20_to_42_Plus_Weeks_Gestation(context);
-                    CqlBoolean r_ = context.Operators.ConceptsInValueSet(p_, q_);
-                    return r_;
-                }
-
-                return j_
-                    /* CQL 'or' (220:11-222:7) */ || k_();
+            CqlConcept f_(CodeableConcept @this) {
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return q_;
             }
 
+            IEnumerable<CqlConcept> g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
+            CqlValueSet h_ = this._20_to_42_Plus_Weeks_Gestation(context);
+            CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
+            IEnumerable<Condition> j_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, DeliveryEncounter);
+
+            bool? k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_ is not null;
+            }
+
+
+            CqlConcept l_(Condition @this) {
+                CodeableConcept t_ = @this?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                return u_;
+            }
+
+            IEnumerable<CqlConcept> m_ = context.Operators.WhereSelect<Condition, CqlConcept>(j_, k_, l_);
+            CqlBoolean n_ = context.Operators.ConceptsInValueSet(m_, h_);
+            CqlBoolean o_ = n_;
+            CqlBoolean p_ = i_
+                /* CQL 'or' (220:11-222:7) */ || o_;
             return (CqlBoolean)(d_ is null)
                 /* CQL 'and' (218:11-219:67) */ && ((PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter)) is null)
-                /* CQL 'and' (218:5-222:7) */ && e_();
+                /* CQL 'and' (218:5-222:7) */ && p_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -550,71 +537,63 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             CqlValueSet d_ = this.Severe_Maternal_Morbidity_Diagnoses(context);
             CqlValueSet e_ = this.Present_on_Admission_is_No_or_Unable_To_Determine(context);
             CqlBoolean f_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, TwentyWeeksPlusEncounter, d_, e_);
+            CqlValueSet g_ = this.Severe_Maternal_Morbidity_Procedures(context);
+            IEnumerable<Procedure> h_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-            CqlBoolean g_() {
-                CqlValueSet h_ = this.Severe_Maternal_Morbidity_Procedures(context);
-                IEnumerable<Procedure> i_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-                bool? j_(Procedure SMMProcedures) {
-                    Code<EventStatus> l_ = SMMProcedures?.StatusElement;
-                    EventStatus? m_ = l_?.Value;
-                    string n_ = context.Operators.Convert<string>(m_);
-                    CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-                    CqlBoolean p_() {
-                        object q_;
-                        DataType v_ = SMMProcedures?.Performed;
-                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                        bool x_ = w_ is CqlDateTime;
-                        if (x_)
+            bool? i_(Procedure SMMProcedures) {
+                Code<EventStatus> l_ = SMMProcedures?.StatusElement;
+                EventStatus? m_ = l_?.Value;
+                string n_ = context.Operators.Convert<string>(m_);
+                CqlBoolean o_ = context.Operators.Equal(n_, "completed");
+                object p_;
+                DataType v_ = SMMProcedures?.Performed;
+                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                bool x_ = w_ is CqlDateTime;
+                if (x_)
+                {
+                    p_ = w_ as CqlDateTime;
+                }
+                else
+                {
+                    bool y_ = w_ is CqlQuantity;
+                    if (y_)
+                    {
+                        p_ = w_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool z_ = w_ is CqlInterval<CqlDateTime>;
+                        if (z_)
                         {
-                            q_ = w_ as CqlDateTime;
+                            p_ = w_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool y_ = w_ is CqlQuantity;
-                            if (y_)
+                            bool aa_ = w_ is CqlInterval<CqlQuantity>;
+                            if (aa_)
                             {
-                                q_ = w_ as CqlQuantity;
+                                p_ = w_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool z_ = w_ is CqlInterval<CqlDateTime>;
-                                if (z_)
-                                {
-                                    q_ = w_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool aa_ = w_ is CqlInterval<CqlQuantity>;
-                                    if (aa_)
-                                    {
-                                        q_ = w_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        q_ = null;
-                                    }
-                                }
+                                p_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                        CqlDateTime s_ = context.Operators.Start(r_);
-                        CqlInterval<CqlDateTime> t_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                        CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, (string)default);
-                        return u_;
                     }
-
-                    return o_
-                        /* CQL 'and' (233:13-234:140) */ && p_();
                 }
-
-                CqlBoolean k_ = context.Operators.WhereAny<Procedure>(i_, j_);
-                return k_;
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlInterval<CqlDateTime> s_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
+                CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
+                CqlBoolean u_ = t_;
+                return o_
+                    /* CQL 'and' (233:13-234:140) */ && u_;
             }
 
+            CqlBoolean j_ = context.Operators.WhereAny<Procedure>(h_, i_);
+            CqlBoolean k_ = j_;
             return f_
-                /* CQL 'or' (231:5-236:7) */ || g_();
+                /* CQL 'or' (231:5-236:7) */ || k_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -665,53 +644,49 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    object m_;
-                    DataType r_ = BloodTransfusion?.Performed;
-                    object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                    bool t_ = s_ is CqlDateTime;
-                    if (t_)
+                object l_;
+                DataType r_ = BloodTransfusion?.Performed;
+                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+                bool t_ = s_ is CqlDateTime;
+                if (t_)
+                {
+                    l_ = s_ as CqlDateTime;
+                }
+                else
+                {
+                    bool u_ = s_ is CqlQuantity;
+                    if (u_)
                     {
-                        m_ = s_ as CqlDateTime;
+                        l_ = s_ as CqlQuantity;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlQuantity;
-                        if (u_)
+                        bool v_ = s_ is CqlInterval<CqlDateTime>;
+                        if (v_)
                         {
-                            m_ = s_ as CqlQuantity;
+                            l_ = s_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool v_ = s_ is CqlInterval<CqlDateTime>;
-                            if (v_)
+                            bool w_ = s_ is CqlInterval<CqlQuantity>;
+                            if (w_)
                             {
-                                m_ = s_ as CqlInterval<CqlDateTime>;
+                                l_ = s_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool w_ = s_ is CqlInterval<CqlQuantity>;
-                                if (w_)
-                                {
-                                    m_ = s_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    m_ = null;
-                                }
+                                l_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                    CqlDateTime o_ = context.Operators.Start(n_);
-                    CqlInterval<CqlDateTime> p_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                    CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                    return q_;
                 }
-
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
+                CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                CqlBoolean q_ = p_;
                 return k_
-                    /* CQL 'and' (409:17-410:137) */ && l_();
+                    /* CQL 'and' (409:17-410:137) */ && q_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -759,53 +734,49 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    object m_;
-                    DataType r_ = Hysterectomy?.Performed;
-                    object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                    bool t_ = s_ is CqlDateTime;
-                    if (t_)
+                object l_;
+                DataType r_ = Hysterectomy?.Performed;
+                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+                bool t_ = s_ is CqlDateTime;
+                if (t_)
+                {
+                    l_ = s_ as CqlDateTime;
+                }
+                else
+                {
+                    bool u_ = s_ is CqlQuantity;
+                    if (u_)
                     {
-                        m_ = s_ as CqlDateTime;
+                        l_ = s_ as CqlQuantity;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlQuantity;
-                        if (u_)
+                        bool v_ = s_ is CqlInterval<CqlDateTime>;
+                        if (v_)
                         {
-                            m_ = s_ as CqlQuantity;
+                            l_ = s_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool v_ = s_ is CqlInterval<CqlDateTime>;
-                            if (v_)
+                            bool w_ = s_ is CqlInterval<CqlQuantity>;
+                            if (w_)
                             {
-                                m_ = s_ as CqlInterval<CqlDateTime>;
+                                l_ = s_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool w_ = s_ is CqlInterval<CqlQuantity>;
-                                if (w_)
-                                {
-                                    m_ = s_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    m_ = null;
-                                }
+                                l_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                    CqlDateTime o_ = context.Operators.Start(n_);
-                    CqlInterval<CqlDateTime> p_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                    CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                    return q_;
                 }
-
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
+                CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                CqlBoolean q_ = p_;
                 return k_
-                    /* CQL 'and' (209:17-210:133) */ && l_();
+                    /* CQL 'and' (209:17-210:133) */ && q_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -855,53 +826,49 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 EventStatus? h_ = g_?.Value;
                 string i_ = context.Operators.Convert<string>(h_);
                 CqlBoolean j_ = context.Operators.Equal(i_, "completed");
-
-                CqlBoolean k_() {
-                    object l_;
-                    DataType q_ = ConvTrachVentProcedures?.Performed;
-                    object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                    bool s_ = r_ is CqlDateTime;
-                    if (s_)
+                object k_;
+                DataType q_ = ConvTrachVentProcedures?.Performed;
+                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+                bool s_ = r_ is CqlDateTime;
+                if (s_)
+                {
+                    k_ = r_ as CqlDateTime;
+                }
+                else
+                {
+                    bool t_ = r_ is CqlQuantity;
+                    if (t_)
                     {
-                        l_ = r_ as CqlDateTime;
+                        k_ = r_ as CqlQuantity;
                     }
                     else
                     {
-                        bool t_ = r_ is CqlQuantity;
-                        if (t_)
+                        bool u_ = r_ is CqlInterval<CqlDateTime>;
+                        if (u_)
                         {
-                            l_ = r_ as CqlQuantity;
+                            k_ = r_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool u_ = r_ is CqlInterval<CqlDateTime>;
-                            if (u_)
+                            bool v_ = r_ is CqlInterval<CqlQuantity>;
+                            if (v_)
                             {
-                                l_ = r_ as CqlInterval<CqlDateTime>;
+                                k_ = r_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool v_ = r_ is CqlInterval<CqlQuantity>;
-                                if (v_)
-                                {
-                                    l_ = r_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    l_ = null;
-                                }
+                                k_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
-                    CqlDateTime n_ = context.Operators.Start(m_);
-                    CqlInterval<CqlDateTime> o_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                    CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
-                    return p_;
                 }
-
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                CqlInterval<CqlDateTime> n_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
+                CqlBoolean o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
+                CqlBoolean p_ = o_;
                 return j_
-                    /* CQL 'and' (195:17-196:144) */ && k_();
+                    /* CQL 'and' (195:17-196:144) */ && p_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Procedure>(d_, e_);
@@ -927,63 +894,50 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             List<CodeableConcept> k_ = SOCEncounter?.ReasonCode;
 
             CqlConcept l_(CodeableConcept @this) {
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return r_;
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ab_;
             }
 
             IEnumerable<CqlConcept> m_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)k_, l_);
             CqlValueSet n_ = this.Placenta_Increta_or_Percreta(context);
             CqlBoolean o_ = context.Operators.ConceptsInValueSet(m_, n_);
+            IEnumerable<Condition> p_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, SOCEncounter);
 
-            CqlBoolean p_() {
-                IEnumerable<Condition> s_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, SOCEncounter);
-
-                bool? t_(Condition @this) {
-                    CodeableConcept y_ = @this?.Code;
-                    CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                    return z_ is not null;
-                }
-
-
-                CqlConcept u_(Condition @this) {
-                    CodeableConcept aa_ = @this?.Code;
-                    CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
-                    return ab_;
-                }
-
-                IEnumerable<CqlConcept> v_ = context.Operators.WhereSelect<Condition, CqlConcept>(s_, t_, u_);
-                CqlValueSet w_ = this.Placenta_Increta_or_Percreta(context);
-                CqlBoolean x_ = context.Operators.ConceptsInValueSet(v_, w_);
-                return x_;
+            bool? q_(Condition @this) {
+                CodeableConcept ac_ = @this?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                return ad_ is not null;
             }
 
 
-            CqlBoolean q_() {
-                IEnumerable<Encounter> ac_ = this.Delivery_Encounters_With_Blood_Transfusion(context);
-                CqlBoolean ad_ = context.Operators.Exists<Encounter>(ac_);
-
-                CqlBoolean ae_() {
-                    IEnumerable<Encounter> af_ = this.Delivery_Encounters_With_Hysterectomy(context);
-                    CqlBoolean ag_ = context.Operators.Exists<Encounter>(af_);
-                    return ag_;
-                }
-
-                return ad_
-                    /* CQL 'or' (151:13-153:9) */ || ae_();
+            CqlConcept r_(Condition @this) {
+                CodeableConcept ae_ = @this?.Code;
+                CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_);
+                return af_;
             }
 
+            IEnumerable<CqlConcept> s_ = context.Operators.WhereSelect<Condition, CqlConcept>(p_, q_, r_);
+            CqlBoolean t_ = context.Operators.ConceptsInValueSet(s_, n_);
+            CqlBoolean u_ = t_;
+            IEnumerable<Encounter> v_ = this.Delivery_Encounters_With_Blood_Transfusion(context);
+            CqlBoolean w_ = context.Operators.Exists<Encounter>(v_);
+            IEnumerable<Encounter> x_ = this.Delivery_Encounters_With_Hysterectomy(context);
+            CqlBoolean y_ = context.Operators.Exists<Encounter>(x_);
+            CqlBoolean z_ = y_;
+            CqlBoolean aa_ = w_
+                /* CQL 'or' (151:13-153:9) */ || z_;
             return (o_
-                /* CQL 'or' (148:13-150:7) */ || p_())
-                /* CQL 'and' (148:7-153:9) */ && q_();
+                /* CQL 'or' (148:13-150:7) */ || u_)
+                /* CQL 'and' (148:7-153:9) */ && aa_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter SOCEncounter) {
-            CqlValueSet ah_ = this.Severe_Maternal_Morbidity_Diagnoses(context);
-            CqlValueSet ai_ = this.Present_on_Admission_is_No_or_Unable_To_Determine(context);
-            CqlBoolean aj_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, SOCEncounter, ah_, ai_);
-            return aj_;
+            CqlValueSet ag_ = this.Severe_Maternal_Morbidity_Diagnoses(context);
+            CqlValueSet ah_ = this.Present_on_Admission_is_No_or_Unable_To_Determine(context);
+            CqlBoolean ai_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, SOCEncounter, ag_, ah_);
+            return ai_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(a_, d_);
@@ -1044,53 +998,49 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 EventStatus? n_ = m_?.Value;
                 string o_ = context.Operators.Convert<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(o_, "completed");
-
-                CqlBoolean q_() {
-                    object r_;
-                    DataType w_ = SMMProcedures?.Performed;
-                    object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                    bool y_ = x_ is CqlDateTime;
-                    if (y_)
+                object q_;
+                DataType w_ = SMMProcedures?.Performed;
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                bool y_ = x_ is CqlDateTime;
+                if (y_)
+                {
+                    q_ = x_ as CqlDateTime;
+                }
+                else
+                {
+                    bool z_ = x_ is CqlQuantity;
+                    if (z_)
                     {
-                        r_ = x_ as CqlDateTime;
+                        q_ = x_ as CqlQuantity;
                     }
                     else
                     {
-                        bool z_ = x_ is CqlQuantity;
-                        if (z_)
+                        bool aa_ = x_ is CqlInterval<CqlDateTime>;
+                        if (aa_)
                         {
-                            r_ = x_ as CqlQuantity;
+                            q_ = x_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool aa_ = x_ is CqlInterval<CqlDateTime>;
-                            if (aa_)
+                            bool ab_ = x_ is CqlInterval<CqlQuantity>;
+                            if (ab_)
                             {
-                                r_ = x_ as CqlInterval<CqlDateTime>;
+                                q_ = x_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ab_ = x_ is CqlInterval<CqlQuantity>;
-                                if (ab_)
-                                {
-                                    r_ = x_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    r_ = null;
-                                }
+                                q_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.Start(s_);
-                    CqlInterval<CqlDateTime> u_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, Encounter);
-                    CqlBoolean v_ = context.Operators.In<CqlDateTime>(t_, u_, (string)default);
-                    return v_;
                 }
-
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlInterval<CqlDateTime> t_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, Encounter);
+                CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, (string)default);
+                CqlBoolean v_ = u_;
                 return p_
-                    /* CQL 'and' (112:7-113:119) */ && q_();
+                    /* CQL 'and' (112:7-113:119) */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Procedure>(j_, k_);
@@ -1314,25 +1264,20 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             bool? j_(object Complication) {
                 CqlValueSet p_ = this.Severe_Maternal_Morbidity_Diagnoses(context);
                 CqlBoolean q_ = context.Operators.ConceptInValueSet(Complication as CqlConcept, p_);
-
-                CqlBoolean r_() {
-                    Condition s_ = CQMCommon_4_1_000.Instance.getCondition(context, Complication as ResourceReference);
-                    CodeableConcept t_ = s_?.Code;
-                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                    CqlValueSet v_ = this.Severe_Maternal_Morbidity_Diagnoses(context);
-                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
-                    return w_;
-                }
-
+                Condition r_ = CQMCommon_4_1_000.Instance.getCondition(context, Complication as ResourceReference);
+                CodeableConcept s_ = r_?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(t_, p_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'or' (122:9-123:88) */ || r_();
+                    /* CQL 'or' (122:9-123:88) */ || v_;
             }
 
 
             (CqlTupleMetadata, object code, string SOCDxCategory)? k_(object Complication) {
-                string x_ = this.sOCDxCategory(context, Complication as CqlConcept);
-                (CqlTupleMetadata, object code, string SOCDxCategory)? y_ = (CqlTupleMetadata_FiRiQVZbDYjPPThNBPPBDcKQI, Complication, x_);
-                return y_;
+                string w_ = this.sOCDxCategory(context, Complication as CqlConcept);
+                (CqlTupleMetadata, object code, string SOCDxCategory)? x_ = (CqlTupleMetadata_FiRiQVZbDYjPPThNBPPBDcKQI, Complication, w_);
+                return x_;
             }
 
             IEnumerable<(CqlTupleMetadata, object code, string SOCDxCategory)?> l_ = context.Operators.WhereSelect<object, (CqlTupleMetadata, object code, string SOCDxCategory)?>(i_, j_, k_);
@@ -1360,53 +1305,49 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             EventStatus? i_ = h_?.Value;
             string j_ = context.Operators.Convert<string>(i_);
             CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-            CqlBoolean l_() {
-                object m_;
-                DataType r_ = SMMProcedures?.Performed;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
-                if (t_)
+            object l_;
+            DataType r_ = SMMProcedures?.Performed;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
+            {
+                l_ = s_ as CqlDateTime;
+            }
+            else
+            {
+                bool u_ = s_ is CqlQuantity;
+                if (u_)
                 {
-                    m_ = s_ as CqlDateTime;
+                    l_ = s_ as CqlQuantity;
                 }
                 else
                 {
-                    bool u_ = s_ is CqlQuantity;
-                    if (u_)
+                    bool v_ = s_ is CqlInterval<CqlDateTime>;
+                    if (v_)
                     {
-                        m_ = s_ as CqlQuantity;
+                        l_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool v_ = s_ is CqlInterval<CqlDateTime>;
-                        if (v_)
+                        bool w_ = s_ is CqlInterval<CqlQuantity>;
+                        if (w_)
                         {
-                            m_ = s_ as CqlInterval<CqlDateTime>;
+                            l_ = s_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool w_ = s_ is CqlInterval<CqlQuantity>;
-                            if (w_)
-                            {
-                                m_ = s_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                m_ = null;
-                            }
+                            l_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlInterval<CqlDateTime> p_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
-                CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                return q_;
             }
-
+            CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+            CqlDateTime n_ = context.Operators.Start(m_);
+            CqlInterval<CqlDateTime> o_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+            CqlBoolean q_ = p_;
             return k_
-                /* CQL 'and' (536:5-537:120) */ && l_();
+                /* CQL 'and' (536:5-537:120) */ && q_;
         }
 
         IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
@@ -1616,63 +1557,50 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             List<CodeableConcept> k_ = SOCExcludingTransfusion?.ReasonCode;
 
             CqlConcept l_(CodeableConcept @this) {
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return r_;
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ab_;
             }
 
             IEnumerable<CqlConcept> m_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)k_, l_);
             CqlValueSet n_ = this.Placenta_Increta_or_Percreta(context);
             CqlBoolean o_ = context.Operators.ConceptsInValueSet(m_, n_);
+            IEnumerable<Condition> p_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, SOCExcludingTransfusion);
 
-            CqlBoolean p_() {
-                IEnumerable<Condition> s_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, SOCExcludingTransfusion);
-
-                bool? t_(Condition @this) {
-                    CodeableConcept y_ = @this?.Code;
-                    CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                    return z_ is not null;
-                }
-
-
-                CqlConcept u_(Condition @this) {
-                    CodeableConcept aa_ = @this?.Code;
-                    CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
-                    return ab_;
-                }
-
-                IEnumerable<CqlConcept> v_ = context.Operators.WhereSelect<Condition, CqlConcept>(s_, t_, u_);
-                CqlValueSet w_ = this.Placenta_Increta_or_Percreta(context);
-                CqlBoolean x_ = context.Operators.ConceptsInValueSet(v_, w_);
-                return x_;
+            bool? q_(Condition @this) {
+                CodeableConcept ac_ = @this?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                return ad_ is not null;
             }
 
 
-            CqlBoolean q_() {
-                IEnumerable<Encounter> ac_ = this.Delivery_Encounters_With_Blood_Transfusion(context);
-                CqlBoolean ad_ = context.Operators.Exists<Encounter>(ac_);
-
-                CqlBoolean ae_() {
-                    IEnumerable<Encounter> af_ = this.Delivery_Encounters_With_Hysterectomy(context);
-                    CqlBoolean ag_ = context.Operators.Exists<Encounter>(af_);
-                    return ag_;
-                }
-
-                return ad_
-                    /* CQL 'or' (253:13-255:9) */ || ae_();
+            CqlConcept r_(Condition @this) {
+                CodeableConcept ae_ = @this?.Code;
+                CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_);
+                return af_;
             }
 
+            IEnumerable<CqlConcept> s_ = context.Operators.WhereSelect<Condition, CqlConcept>(p_, q_, r_);
+            CqlBoolean t_ = context.Operators.ConceptsInValueSet(s_, n_);
+            CqlBoolean u_ = t_;
+            IEnumerable<Encounter> v_ = this.Delivery_Encounters_With_Blood_Transfusion(context);
+            CqlBoolean w_ = context.Operators.Exists<Encounter>(v_);
+            IEnumerable<Encounter> x_ = this.Delivery_Encounters_With_Hysterectomy(context);
+            CqlBoolean y_ = context.Operators.Exists<Encounter>(x_);
+            CqlBoolean z_ = y_;
+            CqlBoolean aa_ = w_
+                /* CQL 'or' (253:13-255:9) */ || z_;
             return (o_
-                /* CQL 'or' (250:13-252:7) */ || p_())
-                /* CQL 'and' (250:7-255:9) */ && q_();
+                /* CQL 'or' (250:13-252:7) */ || u_)
+                /* CQL 'and' (250:7-255:9) */ && aa_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter SOCExcludingTransfusion) {
-            CqlValueSet ah_ = this.Severe_Maternal_Morbidity_Diagnoses(context);
-            CqlValueSet ai_ = this.Present_on_Admission_is_No_or_Unable_To_Determine(context);
-            CqlBoolean aj_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, SOCExcludingTransfusion, ah_, ai_);
-            return aj_;
+            CqlValueSet ag_ = this.Severe_Maternal_Morbidity_Diagnoses(context);
+            CqlValueSet ah_ = this.Present_on_Admission_is_No_or_Unable_To_Determine(context);
+            CqlBoolean ai_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, SOCExcludingTransfusion, ag_, ah_);
+            return ai_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(a_, d_);
@@ -2184,16 +2112,11 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             CqlValueSet d_ = this.Placenta_Accreta(context);
             CqlValueSet e_ = this.Present_On_Admission_is_Yes_or_Exempt(context);
             CqlBoolean f_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, TwentyWeeksPlusEncounter, d_, e_);
-
-            CqlBoolean g_() {
-                CqlValueSet h_ = this.Placenta_Increta_or_Percreta(context);
-                CqlValueSet i_ = this.Present_On_Admission_is_Yes_or_Exempt(context);
-                CqlBoolean j_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, TwentyWeeksPlusEncounter, h_, i_);
-                return j_;
-            }
-
+            CqlValueSet g_ = this.Placenta_Increta_or_Percreta(context);
+            CqlBoolean h_ = CQMCommon_4_1_000.Instance.isDiagnosisPresentOnAdmission(context, TwentyWeeksPlusEncounter, g_, e_);
+            CqlBoolean i_ = h_;
             return f_
-                /* CQL 'or' (354:5-355:139) */ || g_();
+                /* CQL 'or' (354:5-355:139) */ || i_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -2369,58 +2292,40 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             int? g_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
             CqlInterval<int?> h_ = context.Operators.Interval(20, 36, true, true);
             CqlBoolean i_ = context.Operators.In<int?>(g_, h_, (string)default);
-
-            CqlBoolean j_() {
-                int? k_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
-
-                CqlBoolean l_() {
-                    CqlQuantity m_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
-                    CqlQuantity n_ = context.Operators.Quantity(20m, "weeks");
-                    CqlBoolean o_ = context.Operators.GreaterOrEqual(m_, n_);
-
-                    CqlBoolean p_() {
-                        CqlQuantity q_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
-                        CqlQuantity r_ = context.Operators.Quantity(36m, "weeks");
-                        CqlBoolean s_ = context.Operators.LessOrEqual(q_, r_);
-                        return s_;
-                    }
-
-                    return o_
-                        /* CQL 'and' (391:17-393:13) */ && p_();
-                }
-
-                return (CqlBoolean)(k_ is null)
-                    /* CQL 'and' (390:12-394:9) */ && l_();
-            }
-
+            CqlQuantity j_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
+            CqlQuantity k_ = context.Operators.Quantity(20m, "weeks");
+            CqlBoolean l_ = context.Operators.GreaterOrEqual(j_, k_);
+            CqlQuantity m_ = context.Operators.Quantity(36m, "weeks");
+            CqlBoolean n_ = context.Operators.LessOrEqual(j_, m_);
+            CqlBoolean o_ = n_;
+            CqlBoolean p_ = l_
+                /* CQL 'and' (391:17-393:13) */ && o_;
+            CqlBoolean q_ = (CqlBoolean)(g_ is null)
+                /* CQL 'and' (390:12-394:9) */ && p_;
             return i_
-                /* CQL 'or' (389:7-394:9) */ || j_();
+                /* CQL 'or' (389:7-394:9) */ || q_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter DeliveryEncounter) {
-            int? t_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
+            int? r_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
+            IEnumerable<Claim.DiagnosisComponent> s_ = CQMCommon_4_1_000.Instance.claimDiagnosis(context, DeliveryEncounter);
 
-            CqlBoolean u_() {
-                IEnumerable<Claim.DiagnosisComponent> v_ = CQMCommon_4_1_000.Instance.claimDiagnosis(context, DeliveryEncounter);
-
-                bool? w_(Claim.DiagnosisComponent CDiagnosis) {
-                    CodeableConcept y_ = CDiagnosis?.OnAdmission;
-                    CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                    CqlCode aa_ = this.POA_Y(context);
-                    CqlConcept ab_ = context.Operators.ConvertCodeToConcept(aa_);
-                    CqlBoolean ac_ = context.Operators.Equivalent(z_, ab_);
-                    return ac_;
-                }
-
-                CqlBoolean x_ = context.Operators.WhereAny<Claim.DiagnosisComponent>(v_, w_);
-                return x_;
+            bool? t_(Claim.DiagnosisComponent CDiagnosis) {
+                CodeableConcept w_ = CDiagnosis?.OnAdmission;
+                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
+                CqlCode y_ = this.POA_Y(context);
+                CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
+                CqlBoolean aa_ = context.Operators.Equivalent(x_, z_);
+                return aa_;
             }
 
-            return (CqlBoolean)(t_ is null)
+            CqlBoolean u_ = context.Operators.WhereAny<Claim.DiagnosisComponent>(s_, t_);
+            CqlBoolean v_ = u_;
+            return (CqlBoolean)(r_ is null)
                 /* CQL 'and' (399:15-400:25) */ && ((PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter)) is null)
-                /* CQL 'and' (399:9-403:11) */ && u_();
+                /* CQL 'and' (399:9-403:11) */ && v_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(a_, d_);
@@ -2456,30 +2361,22 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ae_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ad_, ae_, true, true);
                 CqlBoolean ag_ = context.Operators.In<CqlDateTime>(z_, af_, (string)default);
-
-                CqlBoolean ah_() {
-                    Code<ObservationStatus> aj_ = Hematocrit?.StatusElement;
-                    ObservationStatus? ak_ = aj_?.Value;
-                    string al_ = context.Operators.Convert<string>(ak_);
-                    string[] am_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
-                    return an_;
-                }
-
-
-                CqlBoolean ai_() {
-                    DataType ao_ = Hematocrit?.Value;
-                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                    return ap_ is not null;
-                }
-
+                Code<ObservationStatus> ah_ = Hematocrit?.StatusElement;
+                ObservationStatus? ai_ = ah_?.Value;
+                string aj_ = context.Operators.Convert<string>(ai_);
+                string[] ak_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+                CqlBoolean am_ = al_;
+                DataType an_ = Hematocrit?.Value;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlBoolean ap_ = (CqlBoolean)(ao_ is not null);
                 return ag_
-                    /* CQL 'and' (421:15-422:70) */ && ah_()
-                    /* CQL 'and' (421:9-423:42) */ && ai_();
+                    /* CQL 'and' (421:15-422:70) */ && am_
+                    /* CQL 'and' (421:9-423:42) */ && ap_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -2508,30 +2405,22 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime bb_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(ba_, bb_, true, true);
                 CqlBoolean bd_ = context.Operators.In<CqlDateTime>(aw_, bc_, (string)default);
-
-                CqlBoolean be_() {
-                    Code<ObservationStatus> bg_ = Hematocrit?.StatusElement;
-                    ObservationStatus? bh_ = bg_?.Value;
-                    string bi_ = context.Operators.Convert<string>(bh_);
-                    string[] bj_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bk_ = context.Operators.In<string>(bi_, (IEnumerable<string>)bj_);
-                    return bk_;
-                }
-
-
-                CqlBoolean bf_() {
-                    DataType bl_ = Hematocrit?.Value;
-                    object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                    return bm_ is not null;
-                }
-
+                Code<ObservationStatus> be_ = Hematocrit?.StatusElement;
+                ObservationStatus? bf_ = be_?.Value;
+                string bg_ = context.Operators.Convert<string>(bf_);
+                string[] bh_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bi_ = context.Operators.In<string>(bg_, (IEnumerable<string>)bh_);
+                CqlBoolean bj_ = bi_;
+                DataType bk_ = Hematocrit?.Value;
+                object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                CqlBoolean bm_ = (CqlBoolean)(bl_ is not null);
                 return bd_
-                    /* CQL 'and' (421:15-422:70) */ && be_()
-                    /* CQL 'and' (421:9-423:42) */ && bf_();
+                    /* CQL 'and' (421:15-422:70) */ && bj_
+                    /* CQL 'and' (421:9-423:42) */ && bm_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -2585,30 +2474,22 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ae_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ad_, ae_, true, true);
                 CqlBoolean ag_ = context.Operators.In<CqlDateTime>(z_, af_, (string)default);
-
-                CqlBoolean ah_() {
-                    Code<ObservationStatus> aj_ = WBC?.StatusElement;
-                    ObservationStatus? ak_ = aj_?.Value;
-                    string al_ = context.Operators.Convert<string>(ak_);
-                    string[] am_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
-                    return an_;
-                }
-
-
-                CqlBoolean ai_() {
-                    DataType ao_ = WBC?.Value;
-                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                    return ap_ is not null;
-                }
-
+                Code<ObservationStatus> ah_ = WBC?.StatusElement;
+                ObservationStatus? ai_ = ah_?.Value;
+                string aj_ = context.Operators.Convert<string>(ai_);
+                string[] ak_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+                CqlBoolean am_ = al_;
+                DataType an_ = WBC?.Value;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlBoolean ap_ = (CqlBoolean)(ao_ is not null);
                 return ag_
-                    /* CQL 'and' (441:15-442:63) */ && ah_()
-                    /* CQL 'and' (441:9-443:35) */ && ai_();
+                    /* CQL 'and' (441:15-442:63) */ && am_
+                    /* CQL 'and' (441:9-443:35) */ && ap_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -2637,30 +2518,22 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime bb_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(ba_, bb_, true, true);
                 CqlBoolean bd_ = context.Operators.In<CqlDateTime>(aw_, bc_, (string)default);
-
-                CqlBoolean be_() {
-                    Code<ObservationStatus> bg_ = WBC?.StatusElement;
-                    ObservationStatus? bh_ = bg_?.Value;
-                    string bi_ = context.Operators.Convert<string>(bh_);
-                    string[] bj_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bk_ = context.Operators.In<string>(bi_, (IEnumerable<string>)bj_);
-                    return bk_;
-                }
-
-
-                CqlBoolean bf_() {
-                    DataType bl_ = WBC?.Value;
-                    object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                    return bm_ is not null;
-                }
-
+                Code<ObservationStatus> be_ = WBC?.StatusElement;
+                ObservationStatus? bf_ = be_?.Value;
+                string bg_ = context.Operators.Convert<string>(bf_);
+                string[] bh_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bi_ = context.Operators.In<string>(bg_, (IEnumerable<string>)bh_);
+                CqlBoolean bj_ = bi_;
+                DataType bk_ = WBC?.Value;
+                object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+                CqlBoolean bm_ = (CqlBoolean)(bl_ is not null);
                 return bd_
-                    /* CQL 'and' (441:15-442:63) */ && be_()
-                    /* CQL 'and' (441:9-443:35) */ && bf_();
+                    /* CQL 'and' (441:15-442:63) */ && bj_
+                    /* CQL 'and' (441:9-443:35) */ && bm_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -2713,22 +2586,18 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ad_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ac_, ad_, true, true);
                 CqlBoolean af_ = context.Operators.In<CqlDateTime>(y_, ae_, (string)default);
-
-                CqlBoolean ag_() {
-                    Code<ObservationStatus> ah_ = HeartRate?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
+                Code<ObservationStatus> ag_ = HeartRate?.StatusElement;
+                ObservationStatus? ah_ = ag_?.Value;
+                string ai_ = context.Operators.Convert<string>(ah_);
+                string[] aj_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
+                CqlBoolean al_ = ak_;
                 return af_
-                    /* CQL 'and' (463:9-464:69) */ && ag_();
+                    /* CQL 'and' (463:9-464:69) */ && al_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -2756,22 +2625,18 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime aw_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(av_, aw_, true, true);
                 CqlBoolean ay_ = context.Operators.In<CqlDateTime>(ar_, ax_, (string)default);
-
-                CqlBoolean az_() {
-                    Code<ObservationStatus> ba_ = HeartRate?.StatusElement;
-                    ObservationStatus? bb_ = ba_?.Value;
-                    string bc_ = context.Operators.Convert<string>(bb_);
-                    string[] bd_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean be_ = context.Operators.In<string>(bc_, (IEnumerable<string>)bd_);
-                    return be_;
-                }
-
+                Code<ObservationStatus> az_ = HeartRate?.StatusElement;
+                ObservationStatus? ba_ = az_?.Value;
+                string bb_ = context.Operators.Convert<string>(ba_);
+                string[] bc_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bd_ = context.Operators.In<string>(bb_, (IEnumerable<string>)bc_);
+                CqlBoolean be_ = bd_;
                 return ay_
-                    /* CQL 'and' (463:9-464:69) */ && az_();
+                    /* CQL 'and' (463:9-464:69) */ && be_;
             }
 
             IEnumerable<Observation> o_ = context.Operators.Where<Observation>(f_, n_);
@@ -2823,44 +2688,36 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ah_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ag_, ah_, true, true);
                 CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, (string)default);
+                Code<ObservationStatus> ak_ = BP?.StatusElement;
+                ObservationStatus? al_ = ak_?.Value;
+                string am_ = context.Operators.Convert<string>(al_);
+                string[] an_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
+                CqlBoolean ap_ = ao_;
+                List<Observation.ComponentComponent> aq_ = BP?.Component;
 
-                CqlBoolean ak_() {
-                    Code<ObservationStatus> am_ = BP?.StatusElement;
-                    ObservationStatus? an_ = am_?.Value;
-                    string ao_ = context.Operators.Convert<string>(an_);
-                    string[] ap_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean aq_ = context.Operators.In<string>(ao_, (IEnumerable<string>)ap_);
-                    return aq_;
+                bool? ar_(Observation.ComponentComponent @this) {
+                    DataType av_ = @this?.Value;
+                    object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                    return aw_ is not null;
                 }
 
 
-                CqlBoolean al_() {
-                    List<Observation.ComponentComponent> ar_ = BP?.Component;
-
-                    bool? as_(Observation.ComponentComponent @this) {
-                        DataType av_ = @this?.Value;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        return aw_ is not null;
-                    }
-
-
-                    object at_(Observation.ComponentComponent @this) {
-                        DataType ax_ = @this?.Value;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        return ay_;
-                    }
-
-                    IEnumerable<object> au_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)ar_, as_, at_);
-                    return au_ is not null;
+                object as_(Observation.ComponentComponent @this) {
+                    DataType ax_ = @this?.Value;
+                    object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                    return ay_;
                 }
 
+                IEnumerable<object> at_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)aq_, ar_, as_);
+                CqlBoolean au_ = (CqlBoolean)(at_ is not null);
                 return aj_
-                    /* CQL 'and' (484:15-485:62) */ && ak_()
-                    /* CQL 'and' (484:9-486:44) */ && al_();
+                    /* CQL 'and' (484:15-485:62) */ && ap_
+                    /* CQL 'and' (484:9-486:44) */ && au_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -2907,44 +2764,36 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime bq_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                 CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bp_, bq_, true, true);
                 CqlBoolean bs_ = context.Operators.In<CqlDateTime>(bl_, br_, (string)default);
+                Code<ObservationStatus> bt_ = BP?.StatusElement;
+                ObservationStatus? bu_ = bt_?.Value;
+                string bv_ = context.Operators.Convert<string>(bu_);
+                string[] bw_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
+                CqlBoolean by_ = bx_;
+                List<Observation.ComponentComponent> bz_ = BP?.Component;
 
-                CqlBoolean bt_() {
-                    Code<ObservationStatus> bv_ = BP?.StatusElement;
-                    ObservationStatus? bw_ = bv_?.Value;
-                    string bx_ = context.Operators.Convert<string>(bw_);
-                    string[] by_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bz_ = context.Operators.In<string>(bx_, (IEnumerable<string>)by_);
-                    return bz_;
+                bool? ca_(Observation.ComponentComponent @this) {
+                    DataType ce_ = @this?.Value;
+                    object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                    return cf_ is not null;
                 }
 
 
-                CqlBoolean bu_() {
-                    List<Observation.ComponentComponent> ca_ = BP?.Component;
-
-                    bool? cb_(Observation.ComponentComponent @this) {
-                        DataType ce_ = @this?.Value;
-                        object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
-                        return cf_ is not null;
-                    }
-
-
-                    object cc_(Observation.ComponentComponent @this) {
-                        DataType cg_ = @this?.Value;
-                        object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
-                        return ch_;
-                    }
-
-                    IEnumerable<object> cd_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)ca_, cb_, cc_);
-                    return cd_ is not null;
+                object cb_(Observation.ComponentComponent @this) {
+                    DataType cg_ = @this?.Value;
+                    object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                    return ch_;
                 }
 
+                IEnumerable<object> cc_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)bz_, ca_, cb_);
+                CqlBoolean cd_ = (CqlBoolean)(cc_ is not null);
                 return bs_
-                    /* CQL 'and' (484:15-485:62) */ && bt_()
-                    /* CQL 'and' (484:9-486:44) */ && bu_();
+                    /* CQL 'and' (484:15-485:62) */ && by_
+                    /* CQL 'and' (484:9-486:44) */ && cd_;
             }
 
             IEnumerable<Observation> s_ = context.Operators.Where<Observation>(f_, r_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS104FHIRSTKDCAntithrombotic", "1.0.000")]
 public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleton<CMS104FHIRSTKDCAntithrombotic_1_0_000>
 {
@@ -135,17 +135,13 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -166,69 +162,49 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = DischargeAntithrombotic?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                string[] ag_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
+                CqlBoolean ai_ = ah_;
+                CqlBoolean aj_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAntithrombotic as MedicationRequest);
+                CqlBoolean ak_ = aj_
+                    /* CQL 'or' (36:13-38:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAntithrombotic as MedicationRequest);
+                FhirDateTime al_ = DischargeAntithrombotic?.AuthoredOnElement;
+                CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
+                Period an_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlBoolean ap_ = context.Operators.In<CqlDateTime>(am_, ao_, (string)default);
+                CqlBoolean aq_ = ap_;
+                IEnumerable<Task> ar_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> ah_ = DischargeAntithrombotic?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
+                bool? as_(Task TaskReject) {
+                    ResourceReference av_ = TaskReject?.Focus;
+                    CqlBoolean aw_ = QICoreCommon_4_0_000.Instance.references(context, av_, DischargeAntithrombotic);
+                    CodeableConcept ax_ = TaskReject?.Code;
+                    CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                    CqlCode az_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                    CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
+                    CqlBoolean bb_ = context.Operators.Equivalent(ay_, ba_);
+                    CqlBoolean bc_ = bb_;
+                    return aw_
+                        /* CQL 'and' (41:13-42:58) */ && bc_;
                 }
 
-
-                CqlBoolean ae_() {
-                    CqlBoolean am_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAntithrombotic as MedicationRequest);
-                    return am_
-                        /* CQL 'or' (36:13-38:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAntithrombotic as MedicationRequest);
-                }
-
-
-                CqlBoolean af_() {
-                    FhirDateTime an_ = DischargeAntithrombotic?.AuthoredOnElement;
-                    CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(an_);
-                    Period ap_ = IschemicStrokeEncounter?.Period;
-                    CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
-                    CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, (string)default);
-                    return ar_;
-                }
-
-
-                CqlBoolean ag_() {
-                    IEnumerable<Task> as_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
-
-                    bool? at_(Task TaskReject) {
-                        ResourceReference av_ = TaskReject?.Focus;
-                        CqlBoolean aw_ = QICoreCommon_4_0_000.Instance.references(context, av_, DischargeAntithrombotic);
-
-                        CqlBoolean ax_() {
-                            CodeableConcept ay_ = TaskReject?.Code;
-                            CqlConcept az_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ay_);
-                            CqlCode ba_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                            CqlConcept bb_ = context.Operators.ConvertCodeToConcept(ba_);
-                            CqlBoolean bc_ = context.Operators.Equivalent(az_, bb_);
-                            return bc_;
-                        }
-
-                        return aw_
-                            /* CQL 'and' (41:13-42:58) */ && ax_();
-                    }
-
-                    CqlBoolean au_ = context.Operators.WhereAny<Task>(as_, at_);
-                    return !au_;
-                }
-
+                CqlBoolean at_ = context.Operators.WhereAny<Task>(ar_, as_);
+                CqlBoolean au_ = (CqlBoolean)!at_;
                 return ac_
-                    /* CQL 'and' (34:17-35:125) */ && ad_()
-                    /* CQL 'and' (34:17-38:9) */ && ae_()
-                    /* CQL 'and' (34:17-39:84) */ && af_()
-                    /* CQL 'and' (34:17-43:9) */ && ag_();
+                    /* CQL 'and' (34:17-35:125) */ && ai_
+                    /* CQL 'and' (34:17-38:9) */ && ak_
+                    /* CQL 'and' (34:17-39:84) */ && aq_
+                    /* CQL 'and' (34:17-43:9) */ && au_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -256,98 +232,77 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
             List<CodeableConcept> n_ = NoAntithromboticDischarge?.ReasonCode;
 
             CqlConcept o_(CodeableConcept @this) {
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return w_;
+                CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return al_;
             }
 
             IEnumerable<CqlConcept> p_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)n_, o_);
             CqlValueSet q_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
             CqlBoolean r_ = context.Operators.ConceptsInValueSet(p_, q_);
 
-            CqlBoolean s_() {
-                List<CodeableConcept> x_ = NoAntithromboticDischarge?.ReasonCode;
-
-                CqlConcept y_(CodeableConcept @this) {
-                    CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return ac_;
-                }
-
-                IEnumerable<CqlConcept> z_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)x_, y_);
-                CqlValueSet aa_ = this.Patient_Refusal(context);
-                CqlBoolean ab_ = context.Operators.ConceptsInValueSet(z_, aa_);
-                return ab_;
+            CqlConcept s_(CodeableConcept @this) {
+                CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return am_;
             }
 
-
-            CqlBoolean t_() {
-                CqlBoolean ad_ = QICoreCommon_4_0_000.Instance.isCommunity(context, NoAntithromboticDischarge as MedicationRequest);
-                return ad_
-                    /* CQL 'or' (59:13-61:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, NoAntithromboticDischarge as MedicationRequest);
-            }
-
-
-            CqlBoolean u_() {
-                Code<MedicationRequest.MedicationrequestStatus> ae_ = NoAntithromboticDischarge?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? af_ = ae_?.Value;
-                string ag_ = context.Operators.Convert<string>(af_);
-                string[] ah_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                return ai_;
-            }
-
-
-            CqlBoolean v_() {
-                Code<MedicationRequest.MedicationRequestIntent> aj_ = NoAntithromboticDischarge?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ak_ = aj_?.Value;
-                string al_ = context.Operators.Convert<string>(ak_);
-                string[] am_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
-                return an_;
-            }
-
+            IEnumerable<CqlConcept> t_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)n_, s_);
+            CqlValueSet u_ = this.Patient_Refusal(context);
+            CqlBoolean v_ = context.Operators.ConceptsInValueSet(t_, u_);
+            CqlBoolean w_ = v_;
+            CqlBoolean x_ = QICoreCommon_4_0_000.Instance.isCommunity(context, NoAntithromboticDischarge as MedicationRequest);
+            CqlBoolean y_ = x_
+                /* CQL 'or' (59:13-61:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, NoAntithromboticDischarge as MedicationRequest);
+            Code<MedicationRequest.MedicationrequestStatus> z_ = NoAntithromboticDischarge?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            CqlBoolean ae_ = ad_;
+            Code<MedicationRequest.MedicationRequestIntent> af_ = NoAntithromboticDischarge?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+            string ah_ = context.Operators.Convert<string>(ag_);
+            string[] ai_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+            CqlBoolean ak_ = aj_;
             return (r_
-                /* CQL 'or' (56:13-58:7) */ || s_())
-                /* CQL 'and' (56:13-61:9) */ && t_()
-                /* CQL 'and' (56:13-62:73) */ && u_()
-                /* CQL 'and' (56:7-63:127) */ && v_();
+                /* CQL 'or' (56:13-58:7) */ || w_)
+                /* CQL 'and' (56:13-61:9) */ && y_
+                /* CQL 'and' (56:13-62:73) */ && ae_
+                /* CQL 'and' (56:7-63:127) */ && ak_;
         }
 
         IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
         bool? g_(MedicationRequest MR) {
-            IEnumerable<Medication> ao_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            IEnumerable<Medication> an_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ap_(Medication M) {
-                object ar_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object as_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> at_ = context.Operators.Split((string)as_, "/");
-                string au_ = context.Operators.Last<string>(at_);
-                CqlBoolean av_ = context.Operators.Equal(ar_, au_);
-
-                CqlBoolean aw_() {
-                    CodeableConcept ax_ = M?.Code;
-                    CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
-                    CqlValueSet az_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                    CqlBoolean ba_ = context.Operators.ConceptInValueSet(ay_, az_);
-                    return ba_;
-                }
-
-                return av_
-                    /* CQL 'and' */ && aw_();
+            bool? ao_(Medication M) {
+                object aq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ar_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> as_ = context.Operators.Split((string)ar_, "/");
+                string at_ = context.Operators.Last<string>(as_);
+                CqlBoolean au_ = context.Operators.Equal(aq_, at_);
+                CodeableConcept av_ = M?.Code;
+                CqlConcept aw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, av_);
+                CqlValueSet ax_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                CqlBoolean ay_ = context.Operators.ConceptInValueSet(aw_, ax_);
+                CqlBoolean az_ = ay_;
+                return au_
+                    /* CQL 'and' */ && az_;
             }
 
-            CqlBoolean aq_ = context.Operators.WhereAny<Medication>(ao_, ap_);
-            return aq_;
+            CqlBoolean ap_ = context.Operators.WhereAny<Medication>(an_, ao_);
+            return ap_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -355,61 +310,43 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(h_, i_);
 
         bool? k_(MedicationRequest MedReqAntithrombotic) {
-            IEnumerable<Task> bb_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+            IEnumerable<Task> ba_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            bool? bc_(Task TaskReject) {
-                ResourceReference be_ = TaskReject?.Focus;
-                CqlBoolean bf_ = QICoreCommon_4_0_000.Instance.references(context, be_, MedReqAntithrombotic);
-
-                CqlBoolean bg_() {
-                    CodeableConcept bj_ = TaskReject?.StatusReason;
-                    CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
-                    CqlValueSet bl_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                    CqlBoolean bm_ = context.Operators.ConceptInValueSet(bk_, bl_);
-
-                    CqlBoolean bn_() {
-                        CodeableConcept bo_ = TaskReject?.StatusReason;
-                        CqlConcept bp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
-                        CqlValueSet bq_ = this.Patient_Refusal(context);
-                        CqlBoolean br_ = context.Operators.ConceptInValueSet(bp_, bq_);
-                        return br_;
-                    }
-
-                    return bm_
-                        /* CQL 'or' (68:17-70:13) */ || bn_();
-                }
-
-
-                CqlBoolean bh_() {
-                    Code<MedicationRequest.MedicationrequestStatus> bs_ = MedReqAntithrombotic?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? bt_ = bs_?.Value;
-                    string bu_ = context.Operators.Convert<string>(bt_);
-                    string[] bv_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
-                    return bw_;
-                }
-
-
-                CqlBoolean bi_() {
-                    CodeableConcept bx_ = TaskReject?.Code;
-                    CqlConcept by_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bx_);
-                    CqlCode bz_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                    CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
-                    CqlBoolean cb_ = context.Operators.Equivalent(by_, ca_);
-                    return cb_;
-                }
-
-                return bf_
-                    /* CQL 'and' (67:21-70:13) */ && bg_()
-                    /* CQL 'and' (67:21-71:72) */ && bh_()
-                    /* CQL 'and' (67:21-72:56) */ && bi_();
+            bool? bb_(Task TaskReject) {
+                ResourceReference bd_ = TaskReject?.Focus;
+                CqlBoolean be_ = QICoreCommon_4_0_000.Instance.references(context, bd_, MedReqAntithrombotic);
+                CodeableConcept bf_ = TaskReject?.StatusReason;
+                CqlConcept bg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bf_);
+                CqlValueSet bh_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                CqlBoolean bi_ = context.Operators.ConceptInValueSet(bg_, bh_);
+                CqlValueSet bj_ = this.Patient_Refusal(context);
+                CqlBoolean bk_ = context.Operators.ConceptInValueSet(bg_, bj_);
+                CqlBoolean bl_ = bk_;
+                CqlBoolean bm_ = bi_
+                    /* CQL 'or' (68:17-70:13) */ || bl_;
+                Code<MedicationRequest.MedicationrequestStatus> bn_ = MedReqAntithrombotic?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? bo_ = bn_?.Value;
+                string bp_ = context.Operators.Convert<string>(bo_);
+                string[] bq_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
+                CqlBoolean bs_ = br_;
+                CodeableConcept bt_ = TaskReject?.Code;
+                CqlConcept bu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bt_);
+                CqlCode bv_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept bw_ = context.Operators.ConvertCodeToConcept(bv_);
+                CqlBoolean bx_ = context.Operators.Equivalent(bu_, bw_);
+                CqlBoolean by_ = bx_;
+                return be_
+                    /* CQL 'and' (67:21-70:13) */ && bm_
+                    /* CQL 'and' (67:21-71:72) */ && bs_
+                    /* CQL 'and' (67:21-72:56) */ && by_;
             }
 
-            CqlBoolean bd_ = context.Operators.WhereAny<Task>(bb_, bc_);
-            return bd_;
+            CqlBoolean bc_ = context.Operators.WhereAny<Task>(ba_, bb_);
+            return bc_;
         }
 
         IEnumerable<MedicationRequest> l_ = context.Operators.Where<MedicationRequest>(j_, k_);
@@ -468,17 +405,13 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -492,39 +425,31 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
 
         bool? g_(MedicationRequest PharmacologicalContraindications) {
             CqlBoolean v_ = QICoreCommon_4_0_000.Instance.isCommunity(context, PharmacologicalContraindications as MedicationRequest);
-
-            CqlBoolean w_() {
-                Code<MedicationRequest.MedicationrequestStatus> y_ = PharmacologicalContraindications?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
-            }
-
-
-            CqlBoolean x_() {
-                Code<MedicationRequest.MedicationRequestIntent> ad_ = PharmacologicalContraindications?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
-                string af_ = context.Operators.Convert<string>(ae_);
-                string[] ag_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                return ah_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> w_ = PharmacologicalContraindications?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
+            Code<MedicationRequest.MedicationRequestIntent> ac_ = PharmacologicalContraindications?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+            string ae_ = context.Operators.Convert<string>(ad_);
+            string[] af_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+            CqlBoolean ah_ = ag_;
             return (v_
                 /* CQL 'or' (82:11-84:5) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, PharmacologicalContraindications as MedicationRequest))
-                /* CQL 'and' (82:11-85:78) */ && w_()
-                /* CQL 'and' (82:5-86:132) */ && x_();
+                /* CQL 'and' (82:11-85:78) */ && ab_
+                /* CQL 'and' (82:5-86:132) */ && ah_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1056FHIRCTClinical-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1056FHIRCTClinical-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1056FHIRCTClinical", "1.0.000")]
 public partial class CMS1056FHIRCTClinical_1_0_000 : ILibrary, ISingleton<CMS1056FHIRCTClinical_1_0_000>
 {
@@ -149,34 +149,25 @@ public partial class CMS1056FHIRCTClinical_1_0_000 : ILibrary, ISingleton<CMS105
                 "corrected",
             ];
             CqlBoolean j_ = context.Operators.In<string>(h_, (IEnumerable<string>)i_);
-
-            CqlBoolean k_() {
-                DataType m_ = CTScanResult?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                CqlBoolean r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
-                return r_;
-            }
-
-
-            CqlBoolean l_() {
-                Patient s_ = this.Patient(context);
-                Date t_ = s_?.BirthDateElement;
-                string u_ = t_?.Value;
-                CqlDate v_ = context.Operators.ConvertStringToDate(u_);
-                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                CqlDate y_ = context.Operators.DateFrom(x_);
-                int? z_ = context.Operators.CalculateAgeAt(v_, y_, "year");
-                CqlBoolean aa_ = context.Operators.GreaterOrEqual(z_, 18);
-                return aa_;
-            }
-
+            DataType k_ = CTScanResult?.Effective;
+            object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+            CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+            CqlDateTime n_ = context.Operators.End(m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+            CqlBoolean q_ = p_;
+            Patient r_ = this.Patient(context);
+            Date s_ = r_?.BirthDateElement;
+            string t_ = s_?.Value;
+            CqlDate u_ = context.Operators.ConvertStringToDate(t_);
+            CqlDateTime v_ = context.Operators.Start(o_);
+            CqlDate w_ = context.Operators.DateFrom(v_);
+            int? x_ = context.Operators.CalculateAgeAt(u_, w_, "year");
+            CqlBoolean y_ = context.Operators.GreaterOrEqual(x_, 18);
+            CqlBoolean z_ = y_;
             return j_
-                /* CQL 'and' (35:11-36:87) */ && k_()
-                /* CQL 'and' (35:5-37:73) */ && l_();
+                /* CQL 'and' (35:11-36:87) */ && q_
+                /* CQL 'and' (35:5-37:73) */ && z_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -196,16 +187,12 @@ public partial class CMS1056FHIRCTClinical_1_0_000 : ILibrary, ISingleton<CMS105
 
         bool? b_(Observation CTScan) {
             decimal? d_ = AlaraCommonFunctions_1_10_000.Instance.globalNoiseValue(context, CTScan);
-
-            CqlBoolean e_() {
-                DataType f_ = CTScan?.Value;
-                object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
-                return g_ is not null;
-            }
-
+            DataType e_ = CTScan?.Value;
+            object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
+            CqlBoolean g_ = (CqlBoolean)(f_ is not null);
             return (CqlBoolean)(d_ is not null)
                 /* CQL 'and' (41:11-42:50) */ && ((AlaraCommonFunctions_1_10_000.Instance.sizeAdjustedValue(context, CTScan)) is not null)
-                /* CQL 'and' (41:5-43:34) */ && e_();
+                /* CQL 'and' (41:5-43:34) */ && g_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1074FHIRCTIQR", "1.0.000")]
 public partial class CMS1074FHIRCTIQR_1_0_000 : ILibrary, ISingleton<CMS1074FHIRCTIQR_1_0_000>
 {
@@ -99,33 +99,24 @@ public partial class CMS1074FHIRCTIQR_1_0_000 : ILibrary, ISingleton<CMS1074FHIR
             Encounter.EncounterStatus? f_ = e_?.Value;
             Code<Encounter.EncounterStatus> g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
             CqlBoolean h_ = context.Operators.Equivalent(g_, "finished");
-
-            CqlBoolean i_() {
-                Period k_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlDateTime m_ = context.Operators.End(l_);
-                CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
-                CqlBoolean o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
-                return o_;
-            }
-
-
-            CqlBoolean j_() {
-                Patient p_ = this.Patient(context);
-                Date q_ = p_?.BirthDateElement;
-                string r_ = q_?.Value;
-                CqlDate s_ = context.Operators.ConvertStringToDate(r_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlDateTime u_ = context.Operators.Start(t_);
-                CqlDate v_ = context.Operators.DateFrom(u_);
-                int? w_ = context.Operators.CalculateAgeAt(s_, v_, "year");
-                CqlBoolean x_ = context.Operators.GreaterOrEqual(w_, 18);
-                return x_;
-            }
-
+            Period i_ = InpatientEncounter?.Period;
+            CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+            CqlDateTime k_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+            CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+            CqlBoolean n_ = m_;
+            Patient o_ = this.Patient(context);
+            Date p_ = o_?.BirthDateElement;
+            string q_ = p_?.Value;
+            CqlDate r_ = context.Operators.ConvertStringToDate(q_);
+            CqlDateTime s_ = context.Operators.Start(l_);
+            CqlDate t_ = context.Operators.DateFrom(s_);
+            int? u_ = context.Operators.CalculateAgeAt(r_, t_, "year");
+            CqlBoolean v_ = context.Operators.GreaterOrEqual(u_, 18);
+            CqlBoolean w_ = v_;
             return h_
-                /* CQL 'and' (25:11-26:75) */ && i_()
-                /* CQL 'and' (25:5-27:69) */ && j_();
+                /* CQL 'and' (25:11-26:75) */ && n_
+                /* CQL 'and' (25:5-27:69) */ && w_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -210,32 +201,21 @@ public partial class CMS1074FHIRCTIQR_1_0_000 : ILibrary, ISingleton<CMS1074FHIR
                     "corrected",
                 ];
                 CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-
-                CqlBoolean n_() {
-                    DataType p_ = CTScan?.Effective;
-                    object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                    CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    CqlDateTime s_ = context.Operators.Start(r_);
-                    Period t_ = InpatientEncounters?.Period;
-                    CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                    CqlBoolean v_ = context.Operators.In<CqlDateTime>(s_, u_, (string)default);
-                    return v_;
-                }
-
-
-                CqlBoolean o_() {
-                    DataType w_ = CTScan?.Effective;
-                    object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                    CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
-                    CqlDateTime z_ = context.Operators.End(y_);
-                    CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
-                    CqlBoolean ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
-                    return ab_;
-                }
-
+                DataType n_ = CTScan?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                Period r_ = InpatientEncounters?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlBoolean t_ = context.Operators.In<CqlDateTime>(q_, s_, (string)default);
+                CqlBoolean u_ = t_;
+                CqlDateTime v_ = context.Operators.End(p_);
+                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
+                CqlBoolean x_ = context.Operators.In<CqlDateTime>(v_, w_, "day");
+                CqlBoolean y_ = x_;
                 return m_
-                    /* CQL 'and' (64:17-65:84) */ && n_()
-                    /* CQL 'and' (64:17-66:83) */ && o_();
+                    /* CQL 'and' (64:17-65:84) */ && u_
+                    /* CQL 'and' (64:17-66:83) */ && y_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Encounter>(f_, g_);
@@ -259,16 +239,12 @@ public partial class CMS1074FHIRCTIQR_1_0_000 : ILibrary, ISingleton<CMS1074FHIR
 
         bool? b_(Observation CTScan) {
             decimal? d_ = AlaraCommonFunctions_1_10_000.Instance.globalNoiseValue(context, CTScan);
-
-            CqlBoolean e_() {
-                DataType f_ = CTScan?.Value;
-                object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
-                return g_ is not null;
-            }
-
+            DataType e_ = CTScan?.Value;
+            object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
+            CqlBoolean g_ = (CqlBoolean)(f_ is not null);
             return (CqlBoolean)(d_ is not null)
                 /* CQL 'and' (57:11-58:50) */ && ((AlaraCommonFunctions_1_10_000.Instance.sizeAdjustedValue(context, CTScan)) is not null)
-                /* CQL 'and' (57:5-59:34) */ && e_();
+                /* CQL 'and' (57:5-59:34) */ && g_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS108FHIRVTEProphylaxis-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS108FHIRVTEProphylaxis-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS108FHIRVTEProphylaxis", "1.0.000")]
 public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS108FHIRVTEProphylaxis_1_0_000>
 {
@@ -338,52 +338,32 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 List<CodeableConcept> i_ = h_?.Type;
 
                 CqlConcept j_(CodeableConcept @this) {
-                    CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return q_;
+                    CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ac_;
                 }
 
                 IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
                 CqlValueSet l_ = this.Intensive_Care_Unit(context);
                 CqlBoolean m_ = context.Operators.ConceptsInValueSet(k_, l_);
-
-                CqlBoolean n_() {
-                    Period r_ = Location?.Period;
-                    CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                    int? t_ = CQMCommon_4_1_000.Instance.lengthInDays(context, s_);
-                    CqlBoolean u_ = context.Operators.GreaterOrEqual(t_, 1);
-                    return u_;
-                }
-
-
-                CqlBoolean o_() {
-                    Period v_ = Location?.Period;
-                    CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                    CqlDateTime x_ = context.Operators.Start(w_);
-                    Period y_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.Start(z_);
-                    CqlBoolean ab_ = context.Operators.SameOrAfter(x_, aa_, (string)default);
-                    return ab_;
-                }
-
-
-                CqlBoolean p_() {
-                    Period ac_ = Location?.Period;
-                    CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                    CqlDateTime ae_ = context.Operators.Start(ad_);
-                    CqlDate af_ = context.Operators.DateFrom(ae_);
-                    Period ag_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                    CqlDateTime ai_ = context.Operators.Start(ah_);
-                    CqlInterval<CqlDate> aj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ai_);
-                    CqlBoolean ak_ = context.Operators.In<CqlDate>(af_, aj_, (string)default);
-                    return ak_;
-                }
-
+                Period n_ = Location?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                int? p_ = CQMCommon_4_1_000.Instance.lengthInDays(context, o_);
+                CqlBoolean q_ = context.Operators.GreaterOrEqual(p_, 1);
+                CqlBoolean r_ = q_;
+                CqlDateTime s_ = context.Operators.Start(o_);
+                Period t_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlBoolean w_ = context.Operators.SameOrAfter(s_, v_, (string)default);
+                CqlBoolean x_ = w_;
+                CqlDate y_ = context.Operators.DateFrom(s_);
+                CqlInterval<CqlDate> z_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, v_);
+                CqlBoolean aa_ = context.Operators.In<CqlDate>(y_, z_, (string)default);
+                CqlBoolean ab_ = aa_;
                 return m_
-                    /* CQL 'and' (91:15-92:51) */ && n_()
-                    /* CQL 'and' (91:15-93:84) */ && o_()
-                    /* CQL 'and' (91:9-94:127) */ && p_();
+                    /* CQL 'and' (91:15-92:51) */ && r_
+                    /* CQL 'and' (91:15-93:84) */ && x_
+                    /* CQL 'and' (91:9-94:127) */ && ab_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)d_, e_);
@@ -408,23 +388,15 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.Mental_Health_Diagnoses(context);
             CqlBoolean e_ = CQMCommon_4_1_000.Instance.hasPrincipalDiagnosisOf(context, QualifyingEncounter, d_);
-
-            CqlBoolean f_() {
-                CqlValueSet h_ = this.Hemorrhagic_Stroke(context);
-                CqlBoolean i_ = CQMCommon_4_1_000.Instance.hasPrincipalDiagnosisOf(context, QualifyingEncounter, h_);
-                return i_;
-            }
-
-
-            CqlBoolean g_() {
-                CqlValueSet j_ = this.Ischemic_Stroke(context);
-                CqlBoolean k_ = CQMCommon_4_1_000.Instance.hasPrincipalDiagnosisOf(context, QualifyingEncounter, j_);
-                return k_;
-            }
-
+            CqlValueSet f_ = this.Hemorrhagic_Stroke(context);
+            CqlBoolean g_ = CQMCommon_4_1_000.Instance.hasPrincipalDiagnosisOf(context, QualifyingEncounter, f_);
+            CqlBoolean h_ = g_;
+            CqlValueSet i_ = this.Ischemic_Stroke(context);
+            CqlBoolean j_ = CQMCommon_4_1_000.Instance.hasPrincipalDiagnosisOf(context, QualifyingEncounter, i_);
+            CqlBoolean k_ = j_;
             return e_
-                /* CQL 'or' (99:11-100:77) */ || f_()
-                /* CQL 'or' (99:5-101:74) */ || g_();
+                /* CQL 'or' (99:11-100:77) */ || h_
+                /* CQL 'or' (99:5-101:74) */ || k_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -445,55 +417,31 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         bool? b_(Encounter QualifyingEncounter) {
             CqlValueSet d_ = this.General_Surgery(context);
             CqlBoolean e_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, d_);
-
-            CqlBoolean f_() {
-                CqlValueSet l_ = this.Gynecological_Surgery(context);
-                CqlBoolean m_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, l_);
-                return m_;
-            }
-
-
-            CqlBoolean g_() {
-                CqlValueSet n_ = this.Hip_Fracture_Surgery(context);
-                CqlBoolean o_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, n_);
-                return o_;
-            }
-
-
-            CqlBoolean h_() {
-                CqlValueSet p_ = this.Hip_Replacement_Surgery(context);
-                CqlBoolean q_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, p_);
-                return q_;
-            }
-
-
-            CqlBoolean i_() {
-                CqlValueSet r_ = this.Intracranial_Neurosurgery(context);
-                CqlBoolean s_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, r_);
-                return s_;
-            }
-
-
-            CqlBoolean j_() {
-                CqlValueSet t_ = this.Knee_Replacement_Surgery(context);
-                CqlBoolean u_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CqlValueSet v_ = this.Urological_Surgery(context);
-                CqlBoolean w_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, v_);
-                return w_;
-            }
-
+            CqlValueSet f_ = this.Gynecological_Surgery(context);
+            CqlBoolean g_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, f_);
+            CqlBoolean h_ = g_;
+            CqlValueSet i_ = this.Hip_Fracture_Surgery(context);
+            CqlBoolean j_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, i_);
+            CqlBoolean k_ = j_;
+            CqlValueSet l_ = this.Hip_Replacement_Surgery(context);
+            CqlBoolean m_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, l_);
+            CqlBoolean n_ = m_;
+            CqlValueSet o_ = this.Intracranial_Neurosurgery(context);
+            CqlBoolean p_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, o_);
+            CqlBoolean q_ = p_;
+            CqlValueSet r_ = this.Knee_Replacement_Surgery(context);
+            CqlBoolean s_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, r_);
+            CqlBoolean t_ = s_;
+            CqlValueSet u_ = this.Urological_Surgery(context);
+            CqlBoolean v_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounter, u_);
+            CqlBoolean w_ = v_;
             return e_
-                /* CQL 'or' (105:11-106:80) */ || f_()
-                /* CQL 'or' (105:11-107:79) */ || g_()
-                /* CQL 'or' (105:11-108:82) */ || h_()
-                /* CQL 'or' (105:11-109:84) */ || i_()
-                /* CQL 'or' (105:11-110:83) */ || j_()
-                /* CQL 'or' (105:5-111:77) */ || k_();
+                /* CQL 'or' (105:11-106:80) */ || h_
+                /* CQL 'or' (105:11-107:79) */ || k_
+                /* CQL 'or' (105:11-108:82) */ || n_
+                /* CQL 'or' (105:11-109:84) */ || q_
+                /* CQL 'or' (105:11-110:83) */ || t_
+                /* CQL 'or' (105:5-111:77) */ || w_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -525,22 +473,18 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 "instance-order",
             ];
             CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-
-            CqlBoolean o_() {
-                Code<RequestStatus> p_ = InterventionRequest?.StatusElement;
-                RequestStatus? q_ = p_?.Value;
-                Code<RequestStatus> r_ = context.Operators.Convert<Code<RequestStatus>>(q_);
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                return u_;
-            }
-
+            Code<RequestStatus> o_ = InterventionRequest?.StatusElement;
+            RequestStatus? p_ = o_?.Value;
+            Code<RequestStatus> q_ = context.Operators.Convert<Code<RequestStatus>>(p_);
+            string r_ = context.Operators.Convert<string>(q_);
+            string[] s_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
+            CqlBoolean u_ = t_;
             return n_
-                /* CQL 'and' (115:7-116:67) */ && o_();
+                /* CQL 'and' (115:7-116:67) */ && u_;
         }
 
         IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
@@ -681,267 +625,259 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object r_;
-                DataType aa_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
-                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                bool ac_ = ab_ is CqlDateTime;
-                if (ac_)
-                {
-                    r_ = ab_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ad_ = ab_ is CqlQuantity;
-                    if (ad_)
-                    {
-                        r_ = ab_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ae_ = ab_ is CqlInterval<CqlDateTime>;
-                        if (ae_)
-                        {
-                            r_ = ab_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool af_ = ab_ is CqlInterval<CqlQuantity>;
-                            if (af_)
-                            {
-                                r_ = ab_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                r_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.End(s_);
-                Period u_ = tuple_hbjscqgbuhismoaytymvucjfi?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime y_ = context.Operators.Add(w_, x_);
-                CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-                return z_;
+            object p_;
+            DataType bd_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            bool bf_ = be_ is CqlDateTime;
+            if (bf_)
+            {
+                p_ = be_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                object ag_;
-                object bj_ = context.Operators.LateBoundProperty<object>(tuple_hbjscqgbuhismoaytymvucjfi?.ComfortMeasure, "performed");
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                bool bl_ = bk_ is CqlDateTime;
-                if (bl_)
+            else
+            {
+                bool bg_ = be_ is CqlQuantity;
+                if (bg_)
                 {
-                    ag_ = bk_ as CqlDateTime;
+                    p_ = be_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bm_ = bk_ is CqlQuantity;
-                    if (bm_)
+                    bool bh_ = be_ is CqlInterval<CqlDateTime>;
+                    if (bh_)
                     {
-                        ag_ = bk_ as CqlQuantity;
+                        p_ = be_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bn_ = bk_ is CqlInterval<CqlDateTime>;
-                        if (bn_)
+                        bool bi_ = be_ is CqlInterval<CqlQuantity>;
+                        if (bi_)
                         {
-                            ag_ = bk_ as CqlInterval<CqlDateTime>;
+                            p_ = be_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bo_ = bk_ is CqlInterval<CqlQuantity>;
-                            if (bo_)
-                            {
-                                ag_ = bk_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ag_ = null;
-                            }
+                            p_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
-                CqlDateTime ai_ = context.Operators.Start(ah_);
-                object aj_ = context.Operators.LateBoundProperty<object>(tuple_hbjscqgbuhismoaytymvucjfi?.ComfortMeasure, "authoredOn");
-                CqlDateTime ak_ = context.Operators.LateBoundProperty<CqlDateTime>(aj_, "value");
-                object al_;
-                DataType bp_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
-                {
-                    al_ = bq_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bs_ = bq_ is CqlQuantity;
-                    if (bs_)
-                    {
-                        al_ = bq_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bt_)
-                        {
-                            al_ = bq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
-                            if (bu_)
-                            {
-                                al_ = bq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                al_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                CqlDateTime an_ = context.Operators.End(am_);
-                CqlInterval<CqlDate> ao_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, an_);
-                CqlDate ap_ = ao_?.low;
-                CqlDateTime aq_ = context.Operators.ConvertDateToDateTime(ap_);
-                object ar_;
-                DataType bv_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
-                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                bool bx_ = bw_ is CqlDateTime;
-                if (bx_)
-                {
-                    ar_ = bw_ as CqlDateTime;
-                }
-                else
-                {
-                    bool by_ = bw_ is CqlQuantity;
-                    if (by_)
-                    {
-                        ar_ = bw_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bz_ = bw_ is CqlInterval<CqlDateTime>;
-                        if (bz_)
-                        {
-                            ar_ = bw_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ca_ = bw_ is CqlInterval<CqlQuantity>;
-                            if (ca_)
-                            {
-                                ar_ = bw_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ar_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.End(as_);
-                CqlInterval<CqlDate> au_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, at_);
-                CqlDate av_ = au_?.high;
-                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
-                object ax_;
-                DataType cb_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
-                object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                bool cd_ = cc_ is CqlDateTime;
-                if (cd_)
-                {
-                    ax_ = cc_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ce_ = cc_ is CqlQuantity;
-                    if (ce_)
-                    {
-                        ax_ = cc_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cf_ = cc_ is CqlInterval<CqlDateTime>;
-                        if (cf_)
-                        {
-                            ax_ = cc_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cg_ = cc_ is CqlInterval<CqlQuantity>;
-                            if (cg_)
-                            {
-                                ax_ = cc_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ax_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
-                CqlDateTime az_ = context.Operators.End(ay_);
-                CqlInterval<CqlDate> ba_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, az_);
-                CqlBoolean bb_ = ba_?.lowClosed;
-                object bc_;
-                DataType ch_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
-                object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                bool cj_ = ci_ is CqlDateTime;
-                if (cj_)
-                {
-                    bc_ = ci_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ck_ = ci_ is CqlQuantity;
-                    if (ck_)
-                    {
-                        bc_ = ci_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cl_ = ci_ is CqlInterval<CqlDateTime>;
-                        if (cl_)
-                        {
-                            bc_ = ci_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cm_ = ci_ is CqlInterval<CqlQuantity>;
-                            if (cm_)
-                            {
-                                bc_ = ci_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bc_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-                CqlDateTime be_ = context.Operators.End(bd_);
-                CqlInterval<CqlDate> bf_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, be_);
-                CqlBoolean bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(aq_, aw_, bb_, bg_);
-                CqlBoolean bi_ = context.Operators.In<CqlDateTime>(ai_ ?? ak_, bh_, "day");
-                return bi_;
             }
-
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.End(q_);
+            Period s_ = tuple_hbjscqgbuhismoaytymvucjfi?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
+            CqlDateTime u_ = context.Operators.Start(t_);
+            CqlQuantity v_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime w_ = context.Operators.Add(u_, v_);
+            CqlBoolean x_ = context.Operators.SameAs(r_, w_, "day");
+            CqlBoolean y_ = x_;
+            object z_;
+            object bj_ = context.Operators.LateBoundProperty<object>(tuple_hbjscqgbuhismoaytymvucjfi?.ComfortMeasure, "performed");
+            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+            bool bl_ = bk_ is CqlDateTime;
+            if (bl_)
+            {
+                z_ = bk_ as CqlDateTime;
+            }
+            else
+            {
+                bool bm_ = bk_ is CqlQuantity;
+                if (bm_)
+                {
+                    z_ = bk_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bn_ = bk_ is CqlInterval<CqlDateTime>;
+                    if (bn_)
+                    {
+                        z_ = bk_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bo_ = bk_ is CqlInterval<CqlQuantity>;
+                        if (bo_)
+                        {
+                            z_ = bk_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            z_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
+            CqlDateTime ab_ = context.Operators.Start(aa_);
+            object ac_ = context.Operators.LateBoundProperty<object>(tuple_hbjscqgbuhismoaytymvucjfi?.ComfortMeasure, "authoredOn");
+            CqlDateTime ad_ = context.Operators.LateBoundProperty<CqlDateTime>(ac_, "value");
+            object ae_;
+            DataType bp_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
+            object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            bool br_ = bq_ is CqlDateTime;
+            if (br_)
+            {
+                ae_ = bq_ as CqlDateTime;
+            }
+            else
+            {
+                bool bs_ = bq_ is CqlQuantity;
+                if (bs_)
+                {
+                    ae_ = bq_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bt_ = bq_ is CqlInterval<CqlDateTime>;
+                    if (bt_)
+                    {
+                        ae_ = bq_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bu_ = bq_ is CqlInterval<CqlQuantity>;
+                        if (bu_)
+                        {
+                            ae_ = bq_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ae_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+            CqlDateTime ag_ = context.Operators.End(af_);
+            CqlInterval<CqlDate> ah_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ag_);
+            CqlDate ai_ = ah_?.low;
+            CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
+            object ak_;
+            DataType bv_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            bool bx_ = bw_ is CqlDateTime;
+            if (bx_)
+            {
+                ak_ = bw_ as CqlDateTime;
+            }
+            else
+            {
+                bool by_ = bw_ is CqlQuantity;
+                if (by_)
+                {
+                    ak_ = bw_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bz_ = bw_ is CqlInterval<CqlDateTime>;
+                    if (bz_)
+                    {
+                        ak_ = bw_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ca_ = bw_ is CqlInterval<CqlQuantity>;
+                        if (ca_)
+                        {
+                            ak_ = bw_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ak_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
+            CqlDateTime am_ = context.Operators.End(al_);
+            CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, am_);
+            CqlDate ao_ = an_?.high;
+            CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(ao_);
+            object aq_;
+            DataType cb_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
+            object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+            bool cd_ = cc_ is CqlDateTime;
+            if (cd_)
+            {
+                aq_ = cc_ as CqlDateTime;
+            }
+            else
+            {
+                bool ce_ = cc_ is CqlQuantity;
+                if (ce_)
+                {
+                    aq_ = cc_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cf_ = cc_ is CqlInterval<CqlDateTime>;
+                    if (cf_)
+                    {
+                        aq_ = cc_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cg_ = cc_ is CqlInterval<CqlQuantity>;
+                        if (cg_)
+                        {
+                            aq_ = cc_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            aq_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.End(ar_);
+            CqlInterval<CqlDate> at_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, as_);
+            CqlBoolean au_ = at_?.lowClosed;
+            object av_;
+            DataType ch_ = tuple_hbjscqgbuhismoaytymvucjfi?.AnesthesiaProcedure?.Performed;
+            object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+            bool cj_ = ci_ is CqlDateTime;
+            if (cj_)
+            {
+                av_ = ci_ as CqlDateTime;
+            }
+            else
+            {
+                bool ck_ = ci_ is CqlQuantity;
+                if (ck_)
+                {
+                    av_ = ci_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cl_ = ci_ is CqlInterval<CqlDateTime>;
+                    if (cl_)
+                    {
+                        av_ = ci_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cm_ = ci_ is CqlInterval<CqlQuantity>;
+                        if (cm_)
+                        {
+                            av_ = ci_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            av_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
+            CqlDateTime ax_ = context.Operators.End(aw_);
+            CqlInterval<CqlDate> ay_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ax_);
+            CqlBoolean az_ = ay_?.highClosed;
+            CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(aj_, ap_, au_, az_);
+            CqlBoolean bb_ = context.Operators.In<CqlDateTime>(ab_ ?? ad_, ba_, "day");
+            CqlBoolean bc_ = bb_;
             return o_
-                /* CQL 'and' (127:11-128:114) */ && p_()
-                /* CQL 'and' (127:5-129:191) */ && q_();
+                /* CQL 'and' (127:11-128:114) */ && y_
+                /* CQL 'and' (127:5-129:191) */ && bc_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, object ComfortMeasure)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, object ComfortMeasure)?>(e_, f_, g_);
@@ -993,17 +929,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> be_ = context.Operators.Split((string)bd_, "/");
                 string bf_ = context.Operators.Last<string>(be_);
                 CqlBoolean bg_ = context.Operators.Equal(bc_, bf_);
-
-                CqlBoolean bh_() {
-                    CodeableConcept bi_ = M?.Code;
-                    CqlConcept bj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bi_);
-                    CqlValueSet bk_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean bl_ = context.Operators.ConceptInValueSet(bj_, bk_);
-                    return bl_;
-                }
-
+                CodeableConcept bh_ = M?.Code;
+                CqlConcept bi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bh_);
+                CqlValueSet bj_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean bk_ = context.Operators.ConceptInValueSet(bi_, bj_);
+                CqlBoolean bl_ = bk_;
                 return bg_
-                    /* CQL 'and' */ && bh_();
+                    /* CQL 'and' */ && bl_;
             }
 
             CqlBoolean bb_ = context.Operators.WhereAny<Medication>(az_, ba_);
@@ -1020,18 +952,14 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             MedicationAdministration.MedicationAdministrationStatusCodes? bn_ = bm_?.Value;
             string bo_ = context.Operators.Convert<string>(bn_);
             CqlBoolean bp_ = context.Operators.Equal(bo_, "completed");
-
-            CqlBoolean bq_() {
-                MedicationAdministration.DosageComponent br_ = VTEMedication?.Dosage;
-                CodeableConcept bs_ = br_?.Route;
-                CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bs_);
-                CqlValueSet bu_ = this.Subcutaneous_route(context);
-                CqlBoolean bv_ = context.Operators.ConceptInValueSet(bt_, bu_);
-                return bv_;
-            }
-
+            MedicationAdministration.DosageComponent bq_ = VTEMedication?.Dosage;
+            CodeableConcept br_ = bq_?.Route;
+            CqlConcept bs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, br_);
+            CqlValueSet bt_ = this.Subcutaneous_route(context);
+            CqlBoolean bu_ = context.Operators.ConceptInValueSet(bs_, bt_);
+            CqlBoolean bv_ = bu_;
             return bp_
-                /* CQL 'and' (150:7-151:62) */ && bq_();
+                /* CQL 'and' (150:7-151:62) */ && bv_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
@@ -1045,17 +973,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> cb_ = context.Operators.Split((string)ca_, "/");
                 string cc_ = context.Operators.Last<string>(cb_);
                 CqlBoolean cd_ = context.Operators.Equal(bz_, cc_);
-
-                CqlBoolean ce_() {
-                    CodeableConcept cf_ = M?.Code;
-                    CqlConcept cg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cf_);
-                    CqlValueSet ch_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean ci_ = context.Operators.ConceptInValueSet(cg_, ch_);
-                    return ci_;
-                }
-
+                CodeableConcept ce_ = M?.Code;
+                CqlConcept cf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ce_);
+                CqlValueSet cg_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean ch_ = context.Operators.ConceptInValueSet(cf_, cg_);
+                CqlBoolean ci_ = ch_;
                 return cd_
-                    /* CQL 'and' */ && ce_();
+                    /* CQL 'and' */ && ci_;
             }
 
             CqlBoolean by_ = context.Operators.WhereAny<Medication>(bw_, bx_);
@@ -1087,17 +1011,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> cs_ = context.Operators.Split((string)cr_, "/");
                 string ct_ = context.Operators.Last<string>(cs_);
                 CqlBoolean cu_ = context.Operators.Equal(cq_, ct_);
-
-                CqlBoolean cv_() {
-                    CodeableConcept cw_ = M?.Code;
-                    CqlConcept cx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cw_);
-                    CqlValueSet cy_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                    CqlBoolean cz_ = context.Operators.ConceptInValueSet(cx_, cy_);
-                    return cz_;
-                }
-
+                CodeableConcept cv_ = M?.Code;
+                CqlConcept cw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cv_);
+                CqlValueSet cx_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                CqlBoolean cy_ = context.Operators.ConceptInValueSet(cw_, cx_);
+                CqlBoolean cz_ = cy_;
                 return cu_
-                    /* CQL 'and' */ && cv_();
+                    /* CQL 'and' */ && cz_;
             }
 
             CqlBoolean cp_ = context.Operators.WhereAny<Medication>(cn_, co_);
@@ -1128,17 +1048,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> dj_ = context.Operators.Split((string)di_, "/");
                 string dk_ = context.Operators.Last<string>(dj_);
                 CqlBoolean dl_ = context.Operators.Equal(dh_, dk_);
-
-                CqlBoolean dm_() {
-                    CodeableConcept dn_ = M?.Code;
-                    CqlConcept do_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dn_);
-                    CqlValueSet dp_ = this.Warfarin(context);
-                    CqlBoolean dq_ = context.Operators.ConceptInValueSet(do_, dp_);
-                    return dq_;
-                }
-
+                CodeableConcept dm_ = M?.Code;
+                CqlConcept dn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dm_);
+                CqlValueSet do_ = this.Warfarin(context);
+                CqlBoolean dp_ = context.Operators.ConceptInValueSet(dn_, do_);
+                CqlBoolean dq_ = dp_;
                 return dl_
-                    /* CQL 'and' */ && dm_();
+                    /* CQL 'and' */ && dq_;
             }
 
             CqlBoolean dg_ = context.Operators.WhereAny<Medication>(de_, df_);
@@ -1171,17 +1087,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> ea_ = context.Operators.Split((string)dz_, "/");
                 string eb_ = context.Operators.Last<string>(ea_);
                 CqlBoolean ec_ = context.Operators.Equal(dy_, eb_);
-
-                CqlBoolean ed_() {
-                    CodeableConcept ee_ = M?.Code;
-                    CqlConcept ef_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ee_);
-                    CqlValueSet eg_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                    CqlBoolean eh_ = context.Operators.ConceptInValueSet(ef_, eg_);
-                    return eh_;
-                }
-
+                CodeableConcept ed_ = M?.Code;
+                CqlConcept ee_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ed_);
+                CqlValueSet ef_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                CqlBoolean eg_ = context.Operators.ConceptInValueSet(ee_, ef_);
+                CqlBoolean eh_ = eg_;
                 return ec_
-                    /* CQL 'and' */ && ed_();
+                    /* CQL 'and' */ && eh_;
             }
 
             CqlBoolean dx_ = context.Operators.WhereAny<Medication>(dv_, dw_);
@@ -1316,268 +1228,260 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             EventStatus? ap_ = ao_?.Value;
             string aq_ = context.Operators.Convert<string>(ap_);
             CqlBoolean ar_ = context.Operators.Equal(aq_, "completed");
-
-            CqlBoolean as_() {
-                object au_;
-                DataType bd_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
-                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                bool bf_ = be_ is CqlDateTime;
-                if (bf_)
-                {
-                    au_ = be_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bg_ = be_ is CqlQuantity;
-                    if (bg_)
-                    {
-                        au_ = be_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bh_ = be_ is CqlInterval<CqlDateTime>;
-                        if (bh_)
-                        {
-                            au_ = be_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bi_ = be_ is CqlInterval<CqlQuantity>;
-                            if (bi_)
-                            {
-                                au_ = be_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                au_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.toInterval(context, au_);
-                CqlDateTime aw_ = context.Operators.End(av_);
-                Period ax_ = tuple_bnvctjfzpousixdcefwhciwq?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
-                CqlDateTime az_ = context.Operators.Start(ay_);
-                CqlQuantity ba_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime bb_ = context.Operators.Add(az_, ba_);
-                CqlBoolean bc_ = context.Operators.SameAs(aw_, bb_, "day");
-                return bc_;
+            object as_;
+            DataType ch_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
+            object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+            bool cj_ = ci_ is CqlDateTime;
+            if (cj_)
+            {
+                as_ = ci_ as CqlDateTime;
             }
-
-
-            CqlBoolean at_() {
-                object bj_ = context.Operators.LateBoundProperty<object>(tuple_bnvctjfzpousixdcefwhciwq?.VTEProphylaxis, "effective");
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                CqlInterval<CqlDateTime> bl_ = QICoreCommon_4_0_000.Instance.toInterval(context, bk_);
-                object bm_;
-                object cn_ = context.Operators.LateBoundProperty<object>(tuple_bnvctjfzpousixdcefwhciwq?.VTEProphylaxis, "performed");
-                object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                bool cp_ = co_ is CqlDateTime;
-                if (cp_)
+            else
+            {
+                bool ck_ = ci_ is CqlQuantity;
+                if (ck_)
                 {
-                    bm_ = co_ as CqlDateTime;
+                    as_ = ci_ as CqlQuantity;
                 }
                 else
                 {
-                    bool cq_ = co_ is CqlQuantity;
-                    if (cq_)
+                    bool cl_ = ci_ is CqlInterval<CqlDateTime>;
+                    if (cl_)
                     {
-                        bm_ = co_ as CqlQuantity;
+                        as_ = ci_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cr_ = co_ is CqlInterval<CqlDateTime>;
-                        if (cr_)
+                        bool cm_ = ci_ is CqlInterval<CqlQuantity>;
+                        if (cm_)
                         {
-                            bm_ = co_ as CqlInterval<CqlDateTime>;
+                            as_ = ci_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool cs_ = co_ is CqlInterval<CqlQuantity>;
-                            if (cs_)
-                            {
-                                bm_ = co_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bm_ = null;
-                            }
+                            as_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bn_ = QICoreCommon_4_0_000.Instance.toInterval(context, bm_);
-                CqlDateTime bo_ = context.Operators.Start(bl_ ?? bn_);
-                object bp_;
-                DataType ct_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
-                object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                bool cv_ = cu_ is CqlDateTime;
-                if (cv_)
-                {
-                    bp_ = cu_ as CqlDateTime;
-                }
-                else
-                {
-                    bool cw_ = cu_ is CqlQuantity;
-                    if (cw_)
-                    {
-                        bp_ = cu_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cx_ = cu_ is CqlInterval<CqlDateTime>;
-                        if (cx_)
-                        {
-                            bp_ = cu_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cy_ = cu_ is CqlInterval<CqlQuantity>;
-                            if (cy_)
-                            {
-                                bp_ = cu_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bp_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bq_ = QICoreCommon_4_0_000.Instance.toInterval(context, bp_);
-                CqlDateTime br_ = context.Operators.End(bq_);
-                CqlInterval<CqlDate> bs_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, br_);
-                CqlDate bt_ = bs_?.low;
-                CqlDateTime bu_ = context.Operators.ConvertDateToDateTime(bt_);
-                object bv_;
-                DataType cz_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
-                object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
-                bool db_ = da_ is CqlDateTime;
-                if (db_)
-                {
-                    bv_ = da_ as CqlDateTime;
-                }
-                else
-                {
-                    bool dc_ = da_ is CqlQuantity;
-                    if (dc_)
-                    {
-                        bv_ = da_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool dd_ = da_ is CqlInterval<CqlDateTime>;
-                        if (dd_)
-                        {
-                            bv_ = da_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool de_ = da_ is CqlInterval<CqlQuantity>;
-                            if (de_)
-                            {
-                                bv_ = da_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bv_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bw_ = QICoreCommon_4_0_000.Instance.toInterval(context, bv_);
-                CqlDateTime bx_ = context.Operators.End(bw_);
-                CqlInterval<CqlDate> by_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bx_);
-                CqlDate bz_ = by_?.high;
-                CqlDateTime ca_ = context.Operators.ConvertDateToDateTime(bz_);
-                object cb_;
-                DataType df_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
-                object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                bool dh_ = dg_ is CqlDateTime;
-                if (dh_)
-                {
-                    cb_ = dg_ as CqlDateTime;
-                }
-                else
-                {
-                    bool di_ = dg_ is CqlQuantity;
-                    if (di_)
-                    {
-                        cb_ = dg_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool dj_ = dg_ is CqlInterval<CqlDateTime>;
-                        if (dj_)
-                        {
-                            cb_ = dg_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool dk_ = dg_ is CqlInterval<CqlQuantity>;
-                            if (dk_)
-                            {
-                                cb_ = dg_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                cb_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
-                CqlDateTime cd_ = context.Operators.End(cc_);
-                CqlInterval<CqlDate> ce_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cd_);
-                CqlBoolean cf_ = ce_?.lowClosed;
-                object cg_;
-                DataType dl_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
-                object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                bool dn_ = dm_ is CqlDateTime;
-                if (dn_)
-                {
-                    cg_ = dm_ as CqlDateTime;
-                }
-                else
-                {
-                    bool do_ = dm_ is CqlQuantity;
-                    if (do_)
-                    {
-                        cg_ = dm_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool dp_ = dm_ is CqlInterval<CqlDateTime>;
-                        if (dp_)
-                        {
-                            cg_ = dm_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool dq_ = dm_ is CqlInterval<CqlQuantity>;
-                            if (dq_)
-                            {
-                                cg_ = dm_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                cg_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ch_ = QICoreCommon_4_0_000.Instance.toInterval(context, cg_);
-                CqlDateTime ci_ = context.Operators.End(ch_);
-                CqlInterval<CqlDate> cj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ci_);
-                CqlBoolean ck_ = cj_?.highClosed;
-                CqlInterval<CqlDateTime> cl_ = context.Operators.Interval(bu_, ca_, cf_, ck_);
-                CqlBoolean cm_ = context.Operators.In<CqlDateTime>(bo_, cl_, "day");
-                return cm_;
             }
-
+            CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
+            CqlDateTime au_ = context.Operators.End(at_);
+            Period av_ = tuple_bnvctjfzpousixdcefwhciwq?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+            CqlDateTime ax_ = context.Operators.Start(aw_);
+            CqlQuantity ay_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime az_ = context.Operators.Add(ax_, ay_);
+            CqlBoolean ba_ = context.Operators.SameAs(au_, az_, "day");
+            CqlBoolean bb_ = ba_;
+            object bc_ = context.Operators.LateBoundProperty<object>(tuple_bnvctjfzpousixdcefwhciwq?.VTEProphylaxis, "effective");
+            object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+            CqlInterval<CqlDateTime> be_ = QICoreCommon_4_0_000.Instance.toInterval(context, bd_);
+            object bf_;
+            object cn_ = context.Operators.LateBoundProperty<object>(tuple_bnvctjfzpousixdcefwhciwq?.VTEProphylaxis, "performed");
+            object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+            bool cp_ = co_ is CqlDateTime;
+            if (cp_)
+            {
+                bf_ = co_ as CqlDateTime;
+            }
+            else
+            {
+                bool cq_ = co_ is CqlQuantity;
+                if (cq_)
+                {
+                    bf_ = co_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cr_ = co_ is CqlInterval<CqlDateTime>;
+                    if (cr_)
+                    {
+                        bf_ = co_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cs_ = co_ is CqlInterval<CqlQuantity>;
+                        if (cs_)
+                        {
+                            bf_ = co_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bf_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bg_ = QICoreCommon_4_0_000.Instance.toInterval(context, bf_);
+            CqlDateTime bh_ = context.Operators.Start(be_ ?? bg_);
+            object bi_;
+            DataType ct_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
+            object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+            bool cv_ = cu_ is CqlDateTime;
+            if (cv_)
+            {
+                bi_ = cu_ as CqlDateTime;
+            }
+            else
+            {
+                bool cw_ = cu_ is CqlQuantity;
+                if (cw_)
+                {
+                    bi_ = cu_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cx_ = cu_ is CqlInterval<CqlDateTime>;
+                    if (cx_)
+                    {
+                        bi_ = cu_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cy_ = cu_ is CqlInterval<CqlQuantity>;
+                        if (cy_)
+                        {
+                            bi_ = cu_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bi_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
+            CqlDateTime bk_ = context.Operators.End(bj_);
+            CqlInterval<CqlDate> bl_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bk_);
+            CqlDate bm_ = bl_?.low;
+            CqlDateTime bn_ = context.Operators.ConvertDateToDateTime(bm_);
+            object bo_;
+            DataType cz_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
+            object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
+            bool db_ = da_ is CqlDateTime;
+            if (db_)
+            {
+                bo_ = da_ as CqlDateTime;
+            }
+            else
+            {
+                bool dc_ = da_ is CqlQuantity;
+                if (dc_)
+                {
+                    bo_ = da_ as CqlQuantity;
+                }
+                else
+                {
+                    bool dd_ = da_ is CqlInterval<CqlDateTime>;
+                    if (dd_)
+                    {
+                        bo_ = da_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool de_ = da_ is CqlInterval<CqlQuantity>;
+                        if (de_)
+                        {
+                            bo_ = da_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bo_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_);
+            CqlDateTime bq_ = context.Operators.End(bp_);
+            CqlInterval<CqlDate> br_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bq_);
+            CqlDate bs_ = br_?.high;
+            CqlDateTime bt_ = context.Operators.ConvertDateToDateTime(bs_);
+            object bu_;
+            DataType df_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
+            object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+            bool dh_ = dg_ is CqlDateTime;
+            if (dh_)
+            {
+                bu_ = dg_ as CqlDateTime;
+            }
+            else
+            {
+                bool di_ = dg_ is CqlQuantity;
+                if (di_)
+                {
+                    bu_ = dg_ as CqlQuantity;
+                }
+                else
+                {
+                    bool dj_ = dg_ is CqlInterval<CqlDateTime>;
+                    if (dj_)
+                    {
+                        bu_ = dg_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool dk_ = dg_ is CqlInterval<CqlQuantity>;
+                        if (dk_)
+                        {
+                            bu_ = dg_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bu_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_);
+            CqlDateTime bw_ = context.Operators.End(bv_);
+            CqlInterval<CqlDate> bx_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bw_);
+            CqlBoolean by_ = bx_?.lowClosed;
+            object bz_;
+            DataType dl_ = tuple_bnvctjfzpousixdcefwhciwq?.AnesthesiaProcedure?.Performed;
+            object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+            bool dn_ = dm_ is CqlDateTime;
+            if (dn_)
+            {
+                bz_ = dm_ as CqlDateTime;
+            }
+            else
+            {
+                bool do_ = dm_ is CqlQuantity;
+                if (do_)
+                {
+                    bz_ = dm_ as CqlQuantity;
+                }
+                else
+                {
+                    bool dp_ = dm_ is CqlInterval<CqlDateTime>;
+                    if (dp_)
+                    {
+                        bz_ = dm_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool dq_ = dm_ is CqlInterval<CqlQuantity>;
+                        if (dq_)
+                        {
+                            bz_ = dm_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bz_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ca_ = QICoreCommon_4_0_000.Instance.toInterval(context, bz_);
+            CqlDateTime cb_ = context.Operators.End(ca_);
+            CqlInterval<CqlDate> cc_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cb_);
+            CqlBoolean cd_ = cc_?.highClosed;
+            CqlInterval<CqlDateTime> ce_ = context.Operators.Interval(bn_, bt_, by_, cd_);
+            CqlBoolean cf_ = context.Operators.In<CqlDateTime>(bh_, ce_, "day");
+            CqlBoolean cg_ = cf_;
             return ar_
-                /* CQL 'and' (182:15-183:118) */ && as_()
-                /* CQL 'and' (182:9-184:205) */ && at_();
+                /* CQL 'and' (182:15-183:118) */ && bb_
+                /* CQL 'and' (182:9-184:205) */ && cg_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, object VTEProphylaxis)?> n_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, object VTEProphylaxis)?>(k_, l_, m_);
@@ -1608,17 +1512,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> ae_ = context.Operators.Split((string)ad_, "/");
                 string af_ = context.Operators.Last<string>(ae_);
                 CqlBoolean ag_ = context.Operators.Equal(ac_, af_);
-
-                CqlBoolean ah_() {
-                    CodeableConcept ai_ = M?.Code;
-                    CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ai_);
-                    CqlValueSet ak_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                    CqlBoolean al_ = context.Operators.ConceptInValueSet(aj_, ak_);
-                    return al_;
-                }
-
+                CodeableConcept ah_ = M?.Code;
+                CqlConcept ai_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ah_);
+                CqlValueSet aj_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                CqlBoolean ak_ = context.Operators.ConceptInValueSet(ai_, aj_);
+                CqlBoolean al_ = ak_;
                 return ag_
-                    /* CQL 'and' */ && ah_();
+                    /* CQL 'and' */ && al_;
             }
 
             CqlBoolean ab_ = context.Operators.WhereAny<Medication>(z_, aa_);
@@ -1642,29 +1542,25 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             MedicationAdministration.MedicationAdministrationStatusCodes? ao_ = an_?.Value;
             string ap_ = context.Operators.Convert<string>(ao_);
             CqlBoolean aq_ = context.Operators.Equal(ap_, "completed");
-
-            CqlBoolean ar_() {
-                DataType as_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.FactorXaMedication?.Effective;
-                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
-                CqlDateTime av_ = context.Operators.Start(au_);
-                Period aw_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
-                CqlDateTime ay_ = context.Operators.Start(ax_);
-                CqlInterval<CqlDate> az_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ay_);
-                CqlDate ba_ = az_?.low;
-                CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
-                CqlDate bc_ = az_?.high;
-                CqlDateTime bd_ = context.Operators.ConvertDateToDateTime(bc_);
-                CqlBoolean be_ = az_?.lowClosed;
-                CqlBoolean bf_ = az_?.highClosed;
-                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(bb_, bd_, be_, bf_);
-                CqlBoolean bh_ = context.Operators.In<CqlDateTime>(av_, bg_, "day");
-                return bh_;
-            }
-
+            DataType ar_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.FactorXaMedication?.Effective;
+            object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+            CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
+            CqlDateTime au_ = context.Operators.Start(at_);
+            Period av_ = tuple_cdbvhiekdcojzrccbhjghhgeo?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
+            CqlDateTime ax_ = context.Operators.Start(aw_);
+            CqlInterval<CqlDate> ay_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ax_);
+            CqlDate az_ = ay_?.low;
+            CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
+            CqlDate bb_ = ay_?.high;
+            CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
+            CqlBoolean bd_ = ay_?.lowClosed;
+            CqlBoolean be_ = ay_?.highClosed;
+            CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ba_, bc_, bd_, be_);
+            CqlBoolean bg_ = context.Operators.In<CqlDateTime>(au_, bf_, "day");
+            CqlBoolean bh_ = bg_;
             return aq_
-                /* CQL 'and' (192:7-193:144) */ && ar_();
+                /* CQL 'and' (192:7-193:144) */ && bh_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)?> k_ = context.Operators.SelectWhere<ValueTuple<Encounter, MedicationAdministration>, (CqlTupleMetadata, Encounter QualifyingEncounter, MedicationAdministration FactorXaMedication)?>(h_, i_, j_);
@@ -1682,17 +1578,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> bn_ = context.Operators.Split((string)bm_, "/");
                 string bo_ = context.Operators.Last<string>(bn_);
                 CqlBoolean bp_ = context.Operators.Equal(bl_, bo_);
-
-                CqlBoolean bq_() {
-                    CodeableConcept br_ = M?.Code;
-                    CqlConcept bs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, br_);
-                    CqlValueSet bt_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                    CqlBoolean bu_ = context.Operators.ConceptInValueSet(bs_, bt_);
-                    return bu_;
-                }
-
+                CodeableConcept bq_ = M?.Code;
+                CqlConcept br_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
+                CqlValueSet bs_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                CqlBoolean bt_ = context.Operators.ConceptInValueSet(br_, bs_);
+                CqlBoolean bu_ = bt_;
                 return bp_
-                    /* CQL 'and' */ && bq_();
+                    /* CQL 'and' */ && bu_;
             }
 
             CqlBoolean bk_ = context.Operators.WhereAny<Medication>(bi_, bj_);
@@ -1714,241 +1606,229 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             MedicationAdministration.MedicationAdministrationStatusCodes? bx_ = bw_?.Value;
             string by_ = context.Operators.Convert<string>(bx_);
             CqlBoolean bz_ = context.Operators.Equal(by_, "completed");
-
-            CqlBoolean ca_() {
-                Code<EventStatus> cd_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.StatusElement;
-                EventStatus? ce_ = cd_?.Value;
-                string cf_ = context.Operators.Convert<string>(ce_);
-                CqlBoolean cg_ = context.Operators.Equal(cf_, "completed");
-                return cg_;
+            Code<EventStatus> ca_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? cb_ = ca_?.Value;
+            string cc_ = context.Operators.Convert<string>(cb_);
+            CqlBoolean cd_ = context.Operators.Equal(cc_, "completed");
+            CqlBoolean ce_ = cd_;
+            object cf_;
+            DataType ds_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+            object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
+            bool du_ = dt_ is CqlDateTime;
+            if (du_)
+            {
+                cf_ = dt_ as CqlDateTime;
             }
-
-
-            CqlBoolean cb_() {
-                object ch_;
-                DataType cq_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                bool cs_ = cr_ is CqlDateTime;
-                if (cs_)
+            else
+            {
+                bool dv_ = dt_ is CqlQuantity;
+                if (dv_)
                 {
-                    ch_ = cr_ as CqlDateTime;
+                    cf_ = dt_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ct_ = cr_ is CqlQuantity;
-                    if (ct_)
+                    bool dw_ = dt_ is CqlInterval<CqlDateTime>;
+                    if (dw_)
                     {
-                        ch_ = cr_ as CqlQuantity;
+                        cf_ = dt_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cu_ = cr_ is CqlInterval<CqlDateTime>;
-                        if (cu_)
+                        bool dx_ = dt_ is CqlInterval<CqlQuantity>;
+                        if (dx_)
                         {
-                            ch_ = cr_ as CqlInterval<CqlDateTime>;
+                            cf_ = dt_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool cv_ = cr_ is CqlInterval<CqlQuantity>;
-                            if (cv_)
-                            {
-                                ch_ = cr_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ch_ = null;
-                            }
+                            cf_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ci_ = QICoreCommon_4_0_000.Instance.toInterval(context, ch_);
-                CqlDateTime cj_ = context.Operators.End(ci_);
-                Period ck_ = tuple_dejnabiogwrwyxienqokgepgj?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ck_);
-                CqlDateTime cm_ = context.Operators.Start(cl_);
-                CqlQuantity cn_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime co_ = context.Operators.Add(cm_, cn_);
-                CqlBoolean cp_ = context.Operators.SameAs(cj_, co_, "day");
-                return cp_;
             }
-
-
-            CqlBoolean cc_() {
-                DataType cw_ = tuple_dejnabiogwrwyxienqokgepgj?.FactorXaMedication?.Effective;
-                object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                CqlInterval<CqlDateTime> cy_ = QICoreCommon_4_0_000.Instance.toInterval(context, cx_);
-                CqlDateTime cz_ = context.Operators.Start(cy_);
-                object da_;
-                DataType dy_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
-                bool ea_ = dz_ is CqlDateTime;
-                if (ea_)
-                {
-                    da_ = dz_ as CqlDateTime;
-                }
-                else
-                {
-                    bool eb_ = dz_ is CqlQuantity;
-                    if (eb_)
-                    {
-                        da_ = dz_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ec_ = dz_ is CqlInterval<CqlDateTime>;
-                        if (ec_)
-                        {
-                            da_ = dz_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ed_ = dz_ is CqlInterval<CqlQuantity>;
-                            if (ed_)
-                            {
-                                da_ = dz_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                da_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> db_ = QICoreCommon_4_0_000.Instance.toInterval(context, da_);
-                CqlDateTime dc_ = context.Operators.End(db_);
-                CqlInterval<CqlDate> dd_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dc_);
-                CqlDate de_ = dd_?.low;
-                CqlDateTime df_ = context.Operators.ConvertDateToDateTime(de_);
-                object dg_;
-                DataType ee_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
-                bool eg_ = ef_ is CqlDateTime;
-                if (eg_)
-                {
-                    dg_ = ef_ as CqlDateTime;
-                }
-                else
-                {
-                    bool eh_ = ef_ is CqlQuantity;
-                    if (eh_)
-                    {
-                        dg_ = ef_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ei_ = ef_ is CqlInterval<CqlDateTime>;
-                        if (ei_)
-                        {
-                            dg_ = ef_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ej_ = ef_ is CqlInterval<CqlQuantity>;
-                            if (ej_)
-                            {
-                                dg_ = ef_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                dg_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> dh_ = QICoreCommon_4_0_000.Instance.toInterval(context, dg_);
-                CqlDateTime di_ = context.Operators.End(dh_);
-                CqlInterval<CqlDate> dj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, di_);
-                CqlDate dk_ = dj_?.high;
-                CqlDateTime dl_ = context.Operators.ConvertDateToDateTime(dk_);
-                object dm_;
-                DataType ek_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                object el_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ek_);
-                bool em_ = el_ is CqlDateTime;
-                if (em_)
-                {
-                    dm_ = el_ as CqlDateTime;
-                }
-                else
-                {
-                    bool en_ = el_ is CqlQuantity;
-                    if (en_)
-                    {
-                        dm_ = el_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool eo_ = el_ is CqlInterval<CqlDateTime>;
-                        if (eo_)
-                        {
-                            dm_ = el_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ep_ = el_ is CqlInterval<CqlQuantity>;
-                            if (ep_)
-                            {
-                                dm_ = el_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                dm_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> dn_ = QICoreCommon_4_0_000.Instance.toInterval(context, dm_);
-                CqlDateTime do_ = context.Operators.End(dn_);
-                CqlInterval<CqlDate> dp_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, do_);
-                CqlBoolean dq_ = dp_?.lowClosed;
-                object dr_;
-                DataType eq_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
-                object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
-                bool es_ = er_ is CqlDateTime;
-                if (es_)
-                {
-                    dr_ = er_ as CqlDateTime;
-                }
-                else
-                {
-                    bool et_ = er_ is CqlQuantity;
-                    if (et_)
-                    {
-                        dr_ = er_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool eu_ = er_ is CqlInterval<CqlDateTime>;
-                        if (eu_)
-                        {
-                            dr_ = er_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ev_ = er_ is CqlInterval<CqlQuantity>;
-                            if (ev_)
-                            {
-                                dr_ = er_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                dr_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ds_ = QICoreCommon_4_0_000.Instance.toInterval(context, dr_);
-                CqlDateTime dt_ = context.Operators.End(ds_);
-                CqlInterval<CqlDate> du_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dt_);
-                CqlBoolean dv_ = du_?.highClosed;
-                CqlInterval<CqlDateTime> dw_ = context.Operators.Interval(df_, dl_, dq_, dv_);
-                CqlBoolean dx_ = context.Operators.In<CqlDateTime>(cz_, dw_, "day");
-                return dx_;
+            CqlInterval<CqlDateTime> cg_ = QICoreCommon_4_0_000.Instance.toInterval(context, cf_);
+            CqlDateTime ch_ = context.Operators.End(cg_);
+            Period ci_ = tuple_dejnabiogwrwyxienqokgepgj?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ci_);
+            CqlDateTime ck_ = context.Operators.Start(cj_);
+            CqlQuantity cl_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime cm_ = context.Operators.Add(ck_, cl_);
+            CqlBoolean cn_ = context.Operators.SameAs(ch_, cm_, "day");
+            CqlBoolean co_ = cn_;
+            DataType cp_ = tuple_dejnabiogwrwyxienqokgepgj?.FactorXaMedication?.Effective;
+            object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+            CqlInterval<CqlDateTime> cr_ = QICoreCommon_4_0_000.Instance.toInterval(context, cq_);
+            CqlDateTime cs_ = context.Operators.Start(cr_);
+            object ct_;
+            DataType dy_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+            object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
+            bool ea_ = dz_ is CqlDateTime;
+            if (ea_)
+            {
+                ct_ = dz_ as CqlDateTime;
             }
-
+            else
+            {
+                bool eb_ = dz_ is CqlQuantity;
+                if (eb_)
+                {
+                    ct_ = dz_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ec_ = dz_ is CqlInterval<CqlDateTime>;
+                    if (ec_)
+                    {
+                        ct_ = dz_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ed_ = dz_ is CqlInterval<CqlQuantity>;
+                        if (ed_)
+                        {
+                            ct_ = dz_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ct_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> cu_ = QICoreCommon_4_0_000.Instance.toInterval(context, ct_);
+            CqlDateTime cv_ = context.Operators.End(cu_);
+            CqlInterval<CqlDate> cw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cv_);
+            CqlDate cx_ = cw_?.low;
+            CqlDateTime cy_ = context.Operators.ConvertDateToDateTime(cx_);
+            object cz_;
+            DataType ee_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+            object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
+            bool eg_ = ef_ is CqlDateTime;
+            if (eg_)
+            {
+                cz_ = ef_ as CqlDateTime;
+            }
+            else
+            {
+                bool eh_ = ef_ is CqlQuantity;
+                if (eh_)
+                {
+                    cz_ = ef_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ei_ = ef_ is CqlInterval<CqlDateTime>;
+                    if (ei_)
+                    {
+                        cz_ = ef_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ej_ = ef_ is CqlInterval<CqlQuantity>;
+                        if (ej_)
+                        {
+                            cz_ = ef_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            cz_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> da_ = QICoreCommon_4_0_000.Instance.toInterval(context, cz_);
+            CqlDateTime db_ = context.Operators.End(da_);
+            CqlInterval<CqlDate> dc_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, db_);
+            CqlDate dd_ = dc_?.high;
+            CqlDateTime de_ = context.Operators.ConvertDateToDateTime(dd_);
+            object df_;
+            DataType ek_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+            object el_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ek_);
+            bool em_ = el_ is CqlDateTime;
+            if (em_)
+            {
+                df_ = el_ as CqlDateTime;
+            }
+            else
+            {
+                bool en_ = el_ is CqlQuantity;
+                if (en_)
+                {
+                    df_ = el_ as CqlQuantity;
+                }
+                else
+                {
+                    bool eo_ = el_ is CqlInterval<CqlDateTime>;
+                    if (eo_)
+                    {
+                        df_ = el_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ep_ = el_ is CqlInterval<CqlQuantity>;
+                        if (ep_)
+                        {
+                            df_ = el_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            df_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> dg_ = QICoreCommon_4_0_000.Instance.toInterval(context, df_);
+            CqlDateTime dh_ = context.Operators.End(dg_);
+            CqlInterval<CqlDate> di_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dh_);
+            CqlBoolean dj_ = di_?.lowClosed;
+            object dk_;
+            DataType eq_ = tuple_dejnabiogwrwyxienqokgepgj?.AnesthesiaProcedure?.Performed;
+            object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+            bool es_ = er_ is CqlDateTime;
+            if (es_)
+            {
+                dk_ = er_ as CqlDateTime;
+            }
+            else
+            {
+                bool et_ = er_ is CqlQuantity;
+                if (et_)
+                {
+                    dk_ = er_ as CqlQuantity;
+                }
+                else
+                {
+                    bool eu_ = er_ is CqlInterval<CqlDateTime>;
+                    if (eu_)
+                    {
+                        dk_ = er_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ev_ = er_ is CqlInterval<CqlQuantity>;
+                        if (ev_)
+                        {
+                            dk_ = er_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            dk_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> dl_ = QICoreCommon_4_0_000.Instance.toInterval(context, dk_);
+            CqlDateTime dm_ = context.Operators.End(dl_);
+            CqlInterval<CqlDate> dn_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dm_);
+            CqlBoolean do_ = dn_?.highClosed;
+            CqlInterval<CqlDateTime> dp_ = context.Operators.Interval(cy_, de_, dj_, do_);
+            CqlBoolean dq_ = context.Operators.In<CqlDateTime>(cs_, dp_, "day");
+            CqlBoolean dr_ = dq_;
             return bz_
-                /* CQL 'and' (200:15-201:54) */ && ca_()
-                /* CQL 'and' (200:15-202:118) */ && cb_()
-                /* CQL 'and' (200:9-203:162) */ && cc_();
+                /* CQL 'and' (200:15-201:54) */ && ce_
+                /* CQL 'and' (200:15-202:118) */ && co_
+                /* CQL 'and' (200:9-203:162) */ && dr_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?> v_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, MedicationAdministration>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?>(s_, t_, u_);
@@ -1976,43 +1856,27 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             bool? l_(Condition AtrialFibrillation) {
                 CodeableConcept n_ = AtrialFibrillation?.VerificationStatus;
                 CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-
-                CqlBoolean p_() {
-                    CodeableConcept q_ = AtrialFibrillation?.VerificationStatus;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    CqlCode s_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                    CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-
-                    CqlBoolean v_() {
-                        CodeableConcept x_ = AtrialFibrillation?.VerificationStatus;
-                        CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                        CqlCode z_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
-                        CqlBoolean ab_ = context.Operators.Equivalent(y_, aa_);
-                        return !ab_;
-                    }
-
-
-                    CqlBoolean w_() {
-                        DataType ac_ = AtrialFibrillation?.Onset;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
-                        CqlDateTime af_ = context.Operators.Start(ae_);
-                        Period ag_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                        CqlDateTime ai_ = context.Operators.End(ah_);
-                        CqlBoolean aj_ = context.Operators.SameOrBefore(af_, ai_, (string)default);
-                        return aj_;
-                    }
-
-                    return (CqlBoolean)!u_
-                        /* CQL 'and' (210:77-212:9) */ && v_()
-                        /* CQL 'and' (210:77-213:107) */ && w_();
-                }
-
+                CqlCode p_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+                CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
+                CqlCode s_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
+                CqlBoolean u_ = context.Operators.Equivalent(o_, t_);
+                CqlBoolean v_ = (CqlBoolean)!u_;
+                DataType w_ = AtrialFibrillation?.Onset;
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                Period aa_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
+                CqlDateTime ac_ = context.Operators.End(ab_);
+                CqlBoolean ad_ = context.Operators.SameOrBefore(z_, ac_, (string)default);
+                CqlBoolean ae_ = ad_;
+                CqlBoolean af_ = (CqlBoolean)!r_
+                    /* CQL 'and' (210:77-212:9) */ && v_
+                    /* CQL 'and' (210:77-213:107) */ && ae_;
                 return (CqlBoolean)(o_ is null)
-                    /* CQL 'implies' (210:19-213:107) */ || p_();
+                    /* CQL 'implies' (210:19-213:107) */ || af_;
             }
 
             CqlBoolean m_ = context.Operators.WhereAny<Condition>(k_, l_);
@@ -2022,104 +1886,72 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter QualifyingEncounter) {
-            CqlValueSet ak_ = this.Atrial_Fibrillation_or_Flutter(context);
-            CqlBoolean al_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounter, ak_);
-            return al_;
+            CqlValueSet ag_ = this.Atrial_Fibrillation_or_Flutter(context);
+            CqlBoolean ah_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounter, ag_);
+            return ah_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(a_, d_);
         IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(c_, e_);
 
         bool? g_(Encounter QualifyingEncounter) {
-            CqlValueSet am_ = this.Venous_Thromboembolism(context);
-            IEnumerable<Condition> an_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, am_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            CqlValueSet ai_ = this.Venous_Thromboembolism(context);
+            IEnumerable<Condition> aj_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            bool? ao_(Condition VTEDiagnosis) {
-                CodeableConcept aq_ = VTEDiagnosis?.ClinicalStatus;
-                CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
-                CqlCode as_ = QICoreCommon_4_0_000.Instance.inactive(context);
-                CqlConcept at_ = context.Operators.ConvertCodeToConcept(as_);
-                CqlBoolean au_ = context.Operators.Equivalent(ar_, at_);
-
-                CqlBoolean av_() {
-                    CodeableConcept az_ = VTEDiagnosis?.ClinicalStatus;
-                    CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                    CqlCode bb_ = QICoreCommon_4_0_000.Instance.remission(context);
-                    CqlConcept bc_ = context.Operators.ConvertCodeToConcept(bb_);
-                    CqlBoolean bd_ = context.Operators.Equivalent(ba_, bc_);
-                    return bd_;
+            bool? ak_(Condition VTEDiagnosis) {
+                CodeableConcept am_ = VTEDiagnosis?.ClinicalStatus;
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
+                CqlCode ao_ = QICoreCommon_4_0_000.Instance.inactive(context);
+                CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+                CqlBoolean aq_ = context.Operators.Equivalent(an_, ap_);
+                CqlCode ar_ = QICoreCommon_4_0_000.Instance.remission(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(an_, as_);
+                CqlBoolean au_ = at_;
+                CqlCode av_ = QICoreCommon_4_0_000.Instance.resolved(context);
+                CqlConcept aw_ = context.Operators.ConvertCodeToConcept(av_);
+                CqlBoolean ax_ = context.Operators.Equivalent(an_, aw_);
+                CqlBoolean ay_ = ax_;
+                CodeableConcept az_ = VTEDiagnosis?.VerificationStatus;
+                CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
+                CqlBoolean bb_ = (CqlBoolean)(ba_ is not null);
+                CqlCode bc_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept bd_ = context.Operators.ConvertCodeToConcept(bc_);
+                CqlBoolean be_ = context.Operators.Equivalent(ba_, bd_);
+                CqlCode bf_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept bg_ = context.Operators.ConvertCodeToConcept(bf_);
+                CqlBoolean bh_ = context.Operators.Equivalent(ba_, bg_);
+                CqlBoolean bi_ = (CqlBoolean)!bh_;
+                DataType bj_ = VTEDiagnosis?.Onset;
+                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                CqlInterval<CqlDateTime> bl_ = QICoreCommon_4_0_000.Instance.toInterval(context, bk_);
+                CqlInterval<CqlDateTime> bm_;
+                Period bq_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bq_);
+                CqlDateTime bs_ = context.Operators.Start(br_);
+                if (bs_ is null)
+                {
+                    bm_ = default;
                 }
-
-
-                CqlBoolean aw_() {
-                    CodeableConcept be_ = VTEDiagnosis?.ClinicalStatus;
-                    CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, be_);
-                    CqlCode bg_ = QICoreCommon_4_0_000.Instance.resolved(context);
-                    CqlConcept bh_ = context.Operators.ConvertCodeToConcept(bg_);
-                    CqlBoolean bi_ = context.Operators.Equivalent(bf_, bh_);
-                    return bi_;
+                else
+                {
+                    CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bs_, bs_, true, true);
+                    bm_ = bt_;
                 }
-
-
-                CqlBoolean ax_() {
-                    CodeableConcept bj_ = VTEDiagnosis?.VerificationStatus;
-                    CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
-                    return bk_ is not null;
-                }
-
-
-                CqlBoolean ay_() {
-                    CodeableConcept bl_ = VTEDiagnosis?.VerificationStatus;
-                    CqlConcept bm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bl_);
-                    CqlCode bn_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept bo_ = context.Operators.ConvertCodeToConcept(bn_);
-                    CqlBoolean bp_ = context.Operators.Equivalent(bm_, bo_);
-
-                    CqlBoolean bq_() {
-                        CodeableConcept bs_ = VTEDiagnosis?.VerificationStatus;
-                        CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bs_);
-                        CqlCode bu_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept bv_ = context.Operators.ConvertCodeToConcept(bu_);
-                        CqlBoolean bw_ = context.Operators.Equivalent(bt_, bv_);
-                        return !bw_;
-                    }
-
-
-                    CqlBoolean br_() {
-                        DataType bx_ = VTEDiagnosis?.Onset;
-                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                        CqlInterval<CqlDateTime> bz_ = QICoreCommon_4_0_000.Instance.toInterval(context, by_);
-                        CqlInterval<CqlDateTime> ca_;
-                        Period cc_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> cd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cc_);
-                        CqlDateTime ce_ = context.Operators.Start(cd_);
-                        if (ce_ is null)
-                        {
-                            ca_ = default;
-                        }
-                        else
-                        {
-                            CqlInterval<CqlDateTime> cf_ = context.Operators.Interval(ce_, ce_, true, true);
-                            ca_ = cf_;
-                        }
-                        CqlBoolean cb_ = context.Operators.Before(bz_, ca_, (string)default);
-                        return cb_;
-                    }
-
-                    return (CqlBoolean)!bp_
-                        /* CQL 'and' (224:69-226:11) */ && bq_()
-                        /* CQL 'and' (224:69-227:92) */ && br_();
-                }
-
-                return (CqlBoolean)(!((bool?)((au_
-                    /* CQL 'or' (220:23-221:71) */ || av_()
-                    /* CQL 'or' (220:21-223:11) */ || aw_())
-                    /* CQL 'and' (220:21-224:59) */ && ax_())))
-                    /* CQL 'implies' (220:21-227:92) */ || ay_();
+                CqlBoolean bn_ = context.Operators.Before(bl_, bm_, (string)default);
+                CqlBoolean bo_ = bn_;
+                CqlBoolean bp_ = (CqlBoolean)!be_
+                    /* CQL 'and' (224:69-226:11) */ && bi_
+                    /* CQL 'and' (224:69-227:92) */ && bo_;
+                return (CqlBoolean)(!((bool?)((aq_
+                    /* CQL 'or' (220:23-221:71) */ || au_
+                    /* CQL 'or' (220:21-223:11) */ || ay_)
+                    /* CQL 'and' (220:21-224:59) */ && bb_)))
+                    /* CQL 'implies' (220:21-227:92) */ || bp_;
             }
 
-            CqlBoolean ap_ = context.Operators.WhereAny<Condition>(an_, ao_);
-            return ap_;
+            CqlBoolean al_ = context.Operators.WhereAny<Condition>(aj_, ak_);
+            return al_;
         }
 
         IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(a_, g_);
@@ -2150,55 +1982,51 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 EventStatus? l_ = k_?.Value;
                 string m_ = context.Operators.Convert<string>(l_);
                 CqlBoolean n_ = context.Operators.Equal(m_, "completed");
-
-                CqlBoolean o_() {
-                    object p_;
-                    DataType w_ = HipKneeProcedure?.Performed;
-                    object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                    bool y_ = x_ is CqlDateTime;
-                    if (y_)
+                object o_;
+                DataType w_ = HipKneeProcedure?.Performed;
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                bool y_ = x_ is CqlDateTime;
+                if (y_)
+                {
+                    o_ = x_ as CqlDateTime;
+                }
+                else
+                {
+                    bool z_ = x_ is CqlQuantity;
+                    if (z_)
                     {
-                        p_ = x_ as CqlDateTime;
+                        o_ = x_ as CqlQuantity;
                     }
                     else
                     {
-                        bool z_ = x_ is CqlQuantity;
-                        if (z_)
+                        bool aa_ = x_ is CqlInterval<CqlDateTime>;
+                        if (aa_)
                         {
-                            p_ = x_ as CqlQuantity;
+                            o_ = x_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool aa_ = x_ is CqlInterval<CqlDateTime>;
-                            if (aa_)
+                            bool ab_ = x_ is CqlInterval<CqlQuantity>;
+                            if (ab_)
                             {
-                                p_ = x_ as CqlInterval<CqlDateTime>;
+                                o_ = x_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ab_ = x_ is CqlInterval<CqlQuantity>;
-                                if (ab_)
-                                {
-                                    p_ = x_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    p_ = null;
-                                }
+                                o_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                    CqlDateTime r_ = context.Operators.Start(q_);
-                    Period s_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                    CqlDateTime u_ = context.Operators.End(t_);
-                    CqlBoolean v_ = context.Operators.SameOrBefore(r_, u_, (string)default);
-                    return v_;
                 }
-
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                Period r_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.End(s_);
+                CqlBoolean u_ = context.Operators.SameOrBefore(q_, t_, (string)default);
+                CqlBoolean v_ = u_;
                 return n_
-                    /* CQL 'and' (234:17-235:107) */ && o_();
+                    /* CQL 'and' (234:17-235:107) */ && v_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Procedure>(h_, i_);
@@ -2227,22 +2055,18 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
             CqlValueSet ap_ = this.Low_Risk(context);
             CqlBoolean aq_ = context.Operators.ConceptInValueSet(ao_ as CqlConcept, ap_);
-
-            CqlBoolean ar_() {
-                Code<ObservationStatus> as_ = VTERiskAssessment?.StatusElement;
-                ObservationStatus? at_ = as_?.Value;
-                string au_ = context.Operators.Convert<string>(at_);
-                string[] av_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
-                return aw_;
-            }
-
+            Code<ObservationStatus> ar_ = VTERiskAssessment?.StatusElement;
+            ObservationStatus? as_ = ar_?.Value;
+            string at_ = context.Operators.Convert<string>(as_);
+            string[] au_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+            CqlBoolean aw_ = av_;
             return aq_
-                /* CQL 'and' (243:7-244:75) */ && ar_();
+                /* CQL 'and' (243:7-244:75) */ && aw_;
         }
 
 
@@ -2291,22 +2115,18 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
             CqlQuantity bi_ = context.Operators.ConvertDecimalToQuantity(3.0m);
             CqlBoolean bj_ = context.Operators.Greater(bh_ as CqlQuantity, bi_);
-
-            CqlBoolean bk_() {
-                Code<ObservationStatus> bl_ = INRLabTest?.StatusElement;
-                ObservationStatus? bm_ = bl_?.Value;
-                string bn_ = context.Operators.Convert<string>(bm_);
-                string[] bo_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean bp_ = context.Operators.In<string>(bn_, (IEnumerable<string>)bo_);
-                return bp_;
-            }
-
+            Code<ObservationStatus> bk_ = INRLabTest?.StatusElement;
+            ObservationStatus? bl_ = bk_?.Value;
+            string bm_ = context.Operators.Convert<string>(bl_);
+            string[] bn_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean bo_ = context.Operators.In<string>(bm_, (IEnumerable<string>)bn_);
+            CqlBoolean bp_ = bo_;
             return bj_
-                /* CQL 'and' (251:9-252:70) */ && bk_();
+                /* CQL 'and' (251:9-252:70) */ && bp_;
         }
 
 
@@ -2334,17 +2154,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> cb_ = context.Operators.Split((string)ca_, "/");
                 string cc_ = context.Operators.Last<string>(cb_);
                 CqlBoolean cd_ = context.Operators.Equal(bz_, cc_);
-
-                CqlBoolean ce_() {
-                    CodeableConcept cf_ = M?.Code;
-                    CqlConcept cg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cf_);
-                    CqlValueSet ch_ = this.Unfractionated_Heparin(context);
-                    CqlBoolean ci_ = context.Operators.ConceptInValueSet(cg_, ch_);
-                    return ci_;
-                }
-
+                CodeableConcept ce_ = M?.Code;
+                CqlConcept cf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ce_);
+                CqlValueSet cg_ = this.Unfractionated_Heparin(context);
+                CqlBoolean ch_ = context.Operators.ConceptInValueSet(cf_, cg_);
+                CqlBoolean ci_ = ch_;
                 return cd_
-                    /* CQL 'and' */ && ce_();
+                    /* CQL 'and' */ && ci_;
             }
 
             CqlBoolean by_ = context.Operators.WhereAny<Medication>(bw_, bx_);
@@ -2376,17 +2192,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> ct_ = context.Operators.Split((string)cs_, "/");
                 string cu_ = context.Operators.Last<string>(ct_);
                 CqlBoolean cv_ = context.Operators.Equal(cr_, cu_);
-
-                CqlBoolean cw_() {
-                    CodeableConcept cx_ = M?.Code;
-                    CqlConcept cy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cx_);
-                    CqlValueSet cz_ = this.Direct_Thrombin_Inhibitor(context);
-                    CqlBoolean da_ = context.Operators.ConceptInValueSet(cy_, cz_);
-                    return da_;
-                }
-
+                CodeableConcept cw_ = M?.Code;
+                CqlConcept cx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cw_);
+                CqlValueSet cy_ = this.Direct_Thrombin_Inhibitor(context);
+                CqlBoolean cz_ = context.Operators.ConceptInValueSet(cx_, cy_);
+                CqlBoolean da_ = cz_;
                 return cv_
-                    /* CQL 'and' */ && cw_();
+                    /* CQL 'and' */ && da_;
             }
 
             CqlBoolean cq_ = context.Operators.WhereAny<Medication>(co_, cp_);
@@ -2408,17 +2220,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> dg_ = context.Operators.Split((string)df_, "/");
                 string dh_ = context.Operators.Last<string>(dg_);
                 CqlBoolean di_ = context.Operators.Equal(de_, dh_);
-
-                CqlBoolean dj_() {
-                    CodeableConcept dk_ = M?.Code;
-                    CqlConcept dl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dk_);
-                    CqlValueSet dm_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
-                    CqlBoolean dn_ = context.Operators.ConceptInValueSet(dl_, dm_);
-                    return dn_;
-                }
-
+                CodeableConcept dj_ = M?.Code;
+                CqlConcept dk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dj_);
+                CqlValueSet dl_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
+                CqlBoolean dm_ = context.Operators.ConceptInValueSet(dk_, dl_);
+                CqlBoolean dn_ = dm_;
                 return di_
-                    /* CQL 'and' */ && dj_();
+                    /* CQL 'and' */ && dn_;
             }
 
             CqlBoolean dd_ = context.Operators.WhereAny<Medication>(db_, dc_);
@@ -2519,228 +2327,220 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object r_;
-                DataType aa_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
-                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                bool ac_ = ab_ is CqlDateTime;
-                if (ac_)
-                {
-                    r_ = ab_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ad_ = ab_ is CqlQuantity;
-                    if (ad_)
-                    {
-                        r_ = ab_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ae_ = ab_ is CqlInterval<CqlDateTime>;
-                        if (ae_)
-                        {
-                            r_ = ab_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool af_ = ab_ is CqlInterval<CqlQuantity>;
-                            if (af_)
-                            {
-                                r_ = ab_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                r_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.End(s_);
-                Period u_ = tuple_gwhjghwetinfdseedvamgjivv?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime y_ = context.Operators.Add(w_, x_);
-                CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-                return z_;
+            object p_;
+            DataType az_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
+            object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+            bool bb_ = ba_ is CqlDateTime;
+            if (bb_)
+            {
+                p_ = ba_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ag_ = tuple_gwhjghwetinfdseedvamgjivv?.LowRiskForVTE?.LowRiskDatetime;
-                object ah_;
-                DataType bf_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
-                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                bool bh_ = bg_ is CqlDateTime;
-                if (bh_)
+            else
+            {
+                bool bc_ = ba_ is CqlQuantity;
+                if (bc_)
                 {
-                    ah_ = bg_ as CqlDateTime;
+                    p_ = ba_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bi_ = bg_ is CqlQuantity;
-                    if (bi_)
+                    bool bd_ = ba_ is CqlInterval<CqlDateTime>;
+                    if (bd_)
                     {
-                        ah_ = bg_ as CqlQuantity;
+                        p_ = ba_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bj_ = bg_ is CqlInterval<CqlDateTime>;
-                        if (bj_)
+                        bool be_ = ba_ is CqlInterval<CqlQuantity>;
+                        if (be_)
                         {
-                            ah_ = bg_ as CqlInterval<CqlDateTime>;
+                            p_ = ba_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bk_ = bg_ is CqlInterval<CqlQuantity>;
-                            if (bk_)
-                            {
-                                ah_ = bg_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ah_ = null;
-                            }
+                            p_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.End(ai_);
-                CqlInterval<CqlDate> ak_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aj_);
-                CqlDate al_ = ak_?.low;
-                CqlDateTime am_ = context.Operators.ConvertDateToDateTime(al_);
-                object an_;
-                DataType bl_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
-                object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                bool bn_ = bm_ is CqlDateTime;
-                if (bn_)
-                {
-                    an_ = bm_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bo_ = bm_ is CqlQuantity;
-                    if (bo_)
-                    {
-                        an_ = bm_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bp_ = bm_ is CqlInterval<CqlDateTime>;
-                        if (bp_)
-                        {
-                            an_ = bm_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bq_ = bm_ is CqlInterval<CqlQuantity>;
-                            if (bq_)
-                            {
-                                an_ = bm_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                an_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_);
-                CqlDateTime ap_ = context.Operators.End(ao_);
-                CqlInterval<CqlDate> aq_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ap_);
-                CqlDate ar_ = aq_?.high;
-                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
-                object at_;
-                DataType br_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
-                object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
-                bool bt_ = bs_ is CqlDateTime;
-                if (bt_)
-                {
-                    at_ = bs_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bu_ = bs_ is CqlQuantity;
-                    if (bu_)
-                    {
-                        at_ = bs_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bv_ = bs_ is CqlInterval<CqlDateTime>;
-                        if (bv_)
-                        {
-                            at_ = bs_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bw_ = bs_ is CqlInterval<CqlQuantity>;
-                            if (bw_)
-                            {
-                                at_ = bs_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                at_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
-                CqlDateTime av_ = context.Operators.End(au_);
-                CqlInterval<CqlDate> aw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, av_);
-                CqlBoolean ax_ = aw_?.lowClosed;
-                object ay_;
-                DataType bx_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
-                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                bool bz_ = by_ is CqlDateTime;
-                if (bz_)
-                {
-                    ay_ = by_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ca_ = by_ is CqlQuantity;
-                    if (ca_)
-                    {
-                        ay_ = by_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cb_ = by_ is CqlInterval<CqlDateTime>;
-                        if (cb_)
-                        {
-                            ay_ = by_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cc_ = by_ is CqlInterval<CqlQuantity>;
-                            if (cc_)
-                            {
-                                ay_ = by_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ay_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_);
-                CqlDateTime ba_ = context.Operators.End(az_);
-                CqlInterval<CqlDate> bb_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
-                CqlBoolean bc_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(am_, as_, ax_, bc_);
-                CqlBoolean be_ = context.Operators.In<CqlDateTime>(ag_, bd_, "day");
-                return be_;
             }
-
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.End(q_);
+            Period s_ = tuple_gwhjghwetinfdseedvamgjivv?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
+            CqlDateTime u_ = context.Operators.Start(t_);
+            CqlQuantity v_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime w_ = context.Operators.Add(u_, v_);
+            CqlBoolean x_ = context.Operators.SameAs(r_, w_, "day");
+            CqlBoolean y_ = x_;
+            CqlDateTime z_ = tuple_gwhjghwetinfdseedvamgjivv?.LowRiskForVTE?.LowRiskDatetime;
+            object aa_;
+            DataType bf_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
+            object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+            bool bh_ = bg_ is CqlDateTime;
+            if (bh_)
+            {
+                aa_ = bg_ as CqlDateTime;
+            }
+            else
+            {
+                bool bi_ = bg_ is CqlQuantity;
+                if (bi_)
+                {
+                    aa_ = bg_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bj_ = bg_ is CqlInterval<CqlDateTime>;
+                    if (bj_)
+                    {
+                        aa_ = bg_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bk_ = bg_ is CqlInterval<CqlQuantity>;
+                        if (bk_)
+                        {
+                            aa_ = bg_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            aa_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
+            CqlDateTime ac_ = context.Operators.End(ab_);
+            CqlInterval<CqlDate> ad_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ac_);
+            CqlDate ae_ = ad_?.low;
+            CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
+            object ag_;
+            DataType bl_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
+            object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+            bool bn_ = bm_ is CqlDateTime;
+            if (bn_)
+            {
+                ag_ = bm_ as CqlDateTime;
+            }
+            else
+            {
+                bool bo_ = bm_ is CqlQuantity;
+                if (bo_)
+                {
+                    ag_ = bm_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bp_ = bm_ is CqlInterval<CqlDateTime>;
+                    if (bp_)
+                    {
+                        ag_ = bm_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bq_ = bm_ is CqlInterval<CqlQuantity>;
+                        if (bq_)
+                        {
+                            ag_ = bm_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ag_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
+            CqlDateTime ai_ = context.Operators.End(ah_);
+            CqlInterval<CqlDate> aj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ai_);
+            CqlDate ak_ = aj_?.high;
+            CqlDateTime al_ = context.Operators.ConvertDateToDateTime(ak_);
+            object am_;
+            DataType br_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
+            object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+            bool bt_ = bs_ is CqlDateTime;
+            if (bt_)
+            {
+                am_ = bs_ as CqlDateTime;
+            }
+            else
+            {
+                bool bu_ = bs_ is CqlQuantity;
+                if (bu_)
+                {
+                    am_ = bs_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bv_ = bs_ is CqlInterval<CqlDateTime>;
+                    if (bv_)
+                    {
+                        am_ = bs_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bw_ = bs_ is CqlInterval<CqlQuantity>;
+                        if (bw_)
+                        {
+                            am_ = bs_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            am_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
+            CqlDateTime ao_ = context.Operators.End(an_);
+            CqlInterval<CqlDate> ap_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ao_);
+            CqlBoolean aq_ = ap_?.lowClosed;
+            object ar_;
+            DataType bx_ = tuple_gwhjghwetinfdseedvamgjivv?.AnesthesiaProcedure?.Performed;
+            object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+            bool bz_ = by_ is CqlDateTime;
+            if (bz_)
+            {
+                ar_ = by_ as CqlDateTime;
+            }
+            else
+            {
+                bool ca_ = by_ is CqlQuantity;
+                if (ca_)
+                {
+                    ar_ = by_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cb_ = by_ is CqlInterval<CqlDateTime>;
+                    if (cb_)
+                    {
+                        ar_ = by_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cc_ = by_ is CqlInterval<CqlQuantity>;
+                        if (cc_)
+                        {
+                            ar_ = by_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ar_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.End(as_);
+            CqlInterval<CqlDate> au_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, at_);
+            CqlBoolean av_ = au_?.highClosed;
+            CqlInterval<CqlDateTime> aw_ = context.Operators.Interval(af_, al_, aq_, av_);
+            CqlBoolean ax_ = context.Operators.In<CqlDateTime>(z_, aw_, "day");
+            CqlBoolean ay_ = ax_;
             return o_
-                /* CQL 'and' (280:11-281:114) */ && p_()
-                /* CQL 'and' (280:5-282:137) */ && q_();
+                /* CQL 'and' (280:11-281:114) */ && y_
+                /* CQL 'and' (280:5-282:137) */ && ay_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE)?>(e_, f_, g_);
@@ -2870,21 +2670,17 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 "instance-order",
             ];
             CqlBoolean ct_ = context.Operators.In<string>(cr_, (IEnumerable<string>)cs_);
-
-            CqlBoolean cu_() {
-                Code<MedicationRequest.MedicationrequestStatus> cv_ = NoMedicationOrder?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? cw_ = cv_?.Value;
-                string cx_ = context.Operators.Convert<string>(cw_);
-                string[] cy_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean cz_ = context.Operators.In<string>(cx_, (IEnumerable<string>)cy_);
-                return cz_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> cu_ = NoMedicationOrder?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? cv_ = cu_?.Value;
+            string cw_ = context.Operators.Convert<string>(cv_);
+            string[] cx_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean cy_ = context.Operators.In<string>(cw_, (IEnumerable<string>)cx_);
+            CqlBoolean cz_ = cy_;
             return ct_
-                /* CQL 'and' (327:9-328:67) */ && cu_();
+                /* CQL 'and' (327:9-328:67) */ && cz_;
         }
 
 
@@ -2919,17 +2715,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> do_ = context.Operators.Split((string)dn_, "/");
                 string dp_ = context.Operators.Last<string>(do_);
                 CqlBoolean dq_ = context.Operators.Equal(dm_, dp_);
-
-                CqlBoolean dr_() {
-                    CodeableConcept ds_ = M?.Code;
-                    CqlConcept dt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ds_);
-                    CqlValueSet du_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean dv_ = context.Operators.ConceptInValueSet(dt_, du_);
-                    return dv_;
-                }
-
+                CodeableConcept dr_ = M?.Code;
+                CqlConcept ds_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dr_);
+                CqlValueSet dt_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean du_ = context.Operators.ConceptInValueSet(ds_, dt_);
+                CqlBoolean dv_ = du_;
                 return dq_
-                    /* CQL 'and' */ && dr_();
+                    /* CQL 'and' */ && dv_;
             }
 
             CqlBoolean dl_ = context.Operators.WhereAny<Medication>(dj_, dk_);
@@ -2949,17 +2741,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> eb_ = context.Operators.Split((string)ea_, "/");
                 string ec_ = context.Operators.Last<string>(eb_);
                 CqlBoolean ed_ = context.Operators.Equal(dz_, ec_);
-
-                CqlBoolean ee_() {
-                    CodeableConcept ef_ = M?.Code;
-                    CqlConcept eg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ef_);
-                    CqlValueSet eh_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean ei_ = context.Operators.ConceptInValueSet(eg_, eh_);
-                    return ei_;
-                }
-
+                CodeableConcept ee_ = M?.Code;
+                CqlConcept ef_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ee_);
+                CqlValueSet eg_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean eh_ = context.Operators.ConceptInValueSet(ef_, eg_);
+                CqlBoolean ei_ = eh_;
                 return ed_
-                    /* CQL 'and' */ && ee_();
+                    /* CQL 'and' */ && ei_;
             }
 
             CqlBoolean dy_ = context.Operators.WhereAny<Medication>(dw_, dx_);
@@ -2980,17 +2768,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> eo_ = context.Operators.Split((string)en_, "/");
                 string ep_ = context.Operators.Last<string>(eo_);
                 CqlBoolean eq_ = context.Operators.Equal(em_, ep_);
-
-                CqlBoolean er_() {
-                    CodeableConcept es_ = M?.Code;
-                    CqlConcept et_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, es_);
-                    CqlValueSet eu_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                    CqlBoolean ev_ = context.Operators.ConceptInValueSet(et_, eu_);
-                    return ev_;
-                }
-
+                CodeableConcept er_ = M?.Code;
+                CqlConcept es_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, er_);
+                CqlValueSet et_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                CqlBoolean eu_ = context.Operators.ConceptInValueSet(es_, et_);
+                CqlBoolean ev_ = eu_;
                 return eq_
-                    /* CQL 'and' */ && er_();
+                    /* CQL 'and' */ && ev_;
             }
 
             CqlBoolean el_ = context.Operators.WhereAny<Medication>(ej_, ek_);
@@ -3011,17 +2795,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> fb_ = context.Operators.Split((string)fa_, "/");
                 string fc_ = context.Operators.Last<string>(fb_);
                 CqlBoolean fd_ = context.Operators.Equal(ez_, fc_);
-
-                CqlBoolean fe_() {
-                    CodeableConcept ff_ = M?.Code;
-                    CqlConcept fg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ff_);
-                    CqlValueSet fh_ = this.Warfarin(context);
-                    CqlBoolean fi_ = context.Operators.ConceptInValueSet(fg_, fh_);
-                    return fi_;
-                }
-
+                CodeableConcept fe_ = M?.Code;
+                CqlConcept ff_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fe_);
+                CqlValueSet fg_ = this.Warfarin(context);
+                CqlBoolean fh_ = context.Operators.ConceptInValueSet(ff_, fg_);
+                CqlBoolean fi_ = fh_;
                 return fd_
-                    /* CQL 'and' */ && fe_();
+                    /* CQL 'and' */ && fi_;
             }
 
             CqlBoolean ey_ = context.Operators.WhereAny<Medication>(ew_, ex_);
@@ -3042,17 +2822,13 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<string> fo_ = context.Operators.Split((string)fn_, "/");
                 string fp_ = context.Operators.Last<string>(fo_);
                 CqlBoolean fq_ = context.Operators.Equal(fm_, fp_);
-
-                CqlBoolean fr_() {
-                    CodeableConcept fs_ = M?.Code;
-                    CqlConcept ft_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fs_);
-                    CqlValueSet fu_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                    CqlBoolean fv_ = context.Operators.ConceptInValueSet(ft_, fu_);
-                    return fv_;
-                }
-
+                CodeableConcept fr_ = M?.Code;
+                CqlConcept fs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fr_);
+                CqlValueSet ft_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                CqlBoolean fu_ = context.Operators.ConceptInValueSet(fs_, ft_);
+                CqlBoolean fv_ = fu_;
                 return fq_
-                    /* CQL 'and' */ && fr_();
+                    /* CQL 'and' */ && fv_;
             }
 
             CqlBoolean fl_ = context.Operators.WhereAny<Medication>(fj_, fk_);
@@ -3075,28 +2851,20 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
         bool? bs_((CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? tuple_iiuqmbcjhjbpgddolhattrue) {
             ResourceReference fx_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Focus;
             CqlBoolean fy_ = QICoreCommon_4_0_000.Instance.references(context, fx_, tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject);
-
-            CqlBoolean fz_() {
-                CodeableConcept gb_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
-                CqlConcept gc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gb_);
-                CqlCode gd_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                CqlConcept ge_ = context.Operators.ConvertCodeToConcept(gd_);
-                CqlBoolean gf_ = context.Operators.Equivalent(gc_, ge_);
-                return gf_;
-            }
-
-
-            CqlBoolean ga_() {
-                Code<MedicationRequest.MedicationrequestStatus> gg_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? gh_ = gg_?.Value;
-                string gi_ = context.Operators.Convert<string>(gh_);
-                CqlBoolean gj_ = context.Operators.Equal(gi_, "active");
-                return gj_;
-            }
-
+            CodeableConcept fz_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
+            CqlConcept ga_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fz_);
+            CqlCode gb_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+            CqlConcept gc_ = context.Operators.ConvertCodeToConcept(gb_);
+            CqlBoolean gd_ = context.Operators.Equivalent(ga_, gc_);
+            CqlBoolean ge_ = gd_;
+            Code<MedicationRequest.MedicationrequestStatus> gf_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? gg_ = gf_?.Value;
+            string gh_ = context.Operators.Convert<string>(gg_);
+            CqlBoolean gi_ = context.Operators.Equal(gh_, "active");
+            CqlBoolean gj_ = gi_;
             return fy_
-                /* CQL 'and' (342:15-343:45) */ && fz_()
-                /* CQL 'and' (342:9-344:53) */ && ga_();
+                /* CQL 'and' (342:15-343:45) */ && ge_
+                /* CQL 'and' (342:9-344:53) */ && gj_;
         }
 
         IEnumerable<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?> bt_ = context.Operators.SelectWhere<ValueTuple<MedicationRequest, Task>, (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?>(bq_, br_, bs_);
@@ -3138,23 +2906,19 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 IEnumerable<CqlConcept> g_ = NoVTEMedication?.medicationStatusReason;
                 CqlValueSet h_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
                 CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
-
-                CqlBoolean j_() {
-                    CqlDateTime k_ = NoVTEMedication?.authoredOn;
-                    CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
-                    CqlDate m_ = l_?.low;
-                    CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
-                    CqlDate o_ = l_?.high;
-                    CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
-                    CqlBoolean q_ = l_?.lowClosed;
-                    CqlBoolean r_ = l_?.highClosed;
-                    CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, p_, q_, r_);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(k_, s_, "day");
-                    return t_;
-                }
-
+                CqlDateTime j_ = NoVTEMedication?.authoredOn;
+                CqlInterval<CqlDate> k_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
+                CqlDate l_ = k_?.low;
+                CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
+                CqlDate n_ = k_?.high;
+                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
+                CqlBoolean p_ = k_?.lowClosed;
+                CqlBoolean q_ = k_?.highClosed;
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(m_, o_, p_, q_);
+                CqlBoolean s_ = context.Operators.In<CqlDateTime>(j_, r_, "day");
+                CqlBoolean t_ = s_;
                 return i_
-                    /* CQL 'and' (296:17-297:127) */ && j_();
+                    /* CQL 'and' (296:17-297:127) */ && t_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(d_, e_);
@@ -3276,36 +3040,24 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 "instance-order",
             ];
             CqlBoolean bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
-
-            CqlBoolean by_() {
-                Code<RequestStatus> cb_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject?.StatusElement;
-                RequestStatus? cc_ = cb_?.Value;
-                Code<RequestStatus> cd_ = context.Operators.Convert<Code<RequestStatus>>(cc_);
-                CqlBoolean ce_ = context.Operators.Equal(cd_, "active");
-                return ce_;
-            }
-
-
-            CqlBoolean bz_() {
-                ResourceReference cf_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Focus;
-                CqlBoolean cg_ = QICoreCommon_4_0_000.Instance.references(context, cf_, tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject);
-                return cg_;
-            }
-
-
-            CqlBoolean ca_() {
-                CodeableConcept ch_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Code;
-                CqlConcept ci_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ch_);
-                CqlCode cj_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                CqlConcept ck_ = context.Operators.ConvertCodeToConcept(cj_);
-                CqlBoolean cl_ = context.Operators.Equivalent(ci_, ck_);
-                return cl_;
-            }
-
+            Code<RequestStatus> by_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject?.StatusElement;
+            RequestStatus? bz_ = by_?.Value;
+            Code<RequestStatus> ca_ = context.Operators.Convert<Code<RequestStatus>>(bz_);
+            CqlBoolean cb_ = context.Operators.Equal(ca_, "active");
+            CqlBoolean cc_ = cb_;
+            ResourceReference cd_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Focus;
+            CqlBoolean ce_ = QICoreCommon_4_0_000.Instance.references(context, cd_, tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject);
+            CqlBoolean cf_ = ce_;
+            CodeableConcept cg_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Code;
+            CqlConcept ch_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cg_);
+            CqlCode ci_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+            CqlConcept cj_ = context.Operators.ConvertCodeToConcept(ci_);
+            CqlBoolean ck_ = context.Operators.Equivalent(ch_, cj_);
+            CqlBoolean cl_ = ck_;
             return bx_
-                /* CQL 'and' (385:15-386:49) */ && by_()
-                /* CQL 'and' (385:15-387:54) */ && bz_()
-                /* CQL 'and' (385:9-388:45) */ && ca_();
+                /* CQL 'and' (385:15-386:49) */ && cc_
+                /* CQL 'and' (385:15-387:54) */ && cf_
+                /* CQL 'and' (385:9-388:45) */ && cl_;
         }
 
         IEnumerable<(CqlTupleMetadata, ServiceRequest DeviceOrderReject, Task T)?> aa_ = context.Operators.SelectWhere<ValueTuple<ServiceRequest, Task>, (CqlTupleMetadata, ServiceRequest DeviceOrderReject, Task T)?>(x_, y_, z_);
@@ -3401,23 +3153,19 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
                 CqlConcept g_ = NoVTEDevice?.requestStatusReason;
                 CqlValueSet h_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
                 CqlBoolean i_ = context.Operators.ConceptInValueSet(g_, h_);
-
-                CqlBoolean j_() {
-                    CqlDateTime k_ = NoVTEDevice?.authoredOn;
-                    CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
-                    CqlDate m_ = l_?.low;
-                    CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
-                    CqlDate o_ = l_?.high;
-                    CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
-                    CqlBoolean q_ = l_?.lowClosed;
-                    CqlBoolean r_ = l_?.highClosed;
-                    CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, p_, q_, r_);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(k_, s_, "day");
-                    return t_;
-                }
-
+                CqlDateTime j_ = NoVTEDevice?.authoredOn;
+                CqlInterval<CqlDate> k_ = this.fromDayOfStartOfHospitalizationToDayAfterAdmission(context, QualifyingEncounter);
+                CqlDate l_ = k_?.low;
+                CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
+                CqlDate n_ = k_?.high;
+                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
+                CqlBoolean p_ = k_?.lowClosed;
+                CqlBoolean q_ = k_?.highClosed;
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(m_, o_, p_, q_);
+                CqlBoolean s_ = context.Operators.In<CqlDateTime>(j_, r_, "day");
+                CqlBoolean t_ = s_;
                 return i_
-                    /* CQL 'and' (355:17-356:123) */ && j_();
+                    /* CQL 'and' (355:17-356:123) */ && t_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>(d_, e_);
@@ -3453,238 +3201,226 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             IEnumerable<CqlConcept> l_ = tuple_chjebychscdthhbpzggacmwxe?.NoVTEMedication?.medicationStatusReason;
             CqlValueSet m_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
             CqlBoolean n_ = context.Operators.ConceptsInValueSet(l_, m_);
-
-            CqlBoolean o_() {
-                Code<EventStatus> r_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.StatusElement;
-                EventStatus? s_ = r_?.Value;
-                string t_ = context.Operators.Convert<string>(s_);
-                CqlBoolean u_ = context.Operators.Equal(t_, "completed");
-                return u_;
+            Code<EventStatus> o_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            CqlBoolean r_ = context.Operators.Equal(q_, "completed");
+            CqlBoolean s_ = r_;
+            object t_;
+            DataType bd_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            bool bf_ = be_ is CqlDateTime;
+            if (bf_)
+            {
+                t_ = be_ as CqlDateTime;
             }
-
-
-            CqlBoolean p_() {
-                object v_;
-                DataType ae_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                bool ag_ = af_ is CqlDateTime;
-                if (ag_)
+            else
+            {
+                bool bg_ = be_ is CqlQuantity;
+                if (bg_)
                 {
-                    v_ = af_ as CqlDateTime;
+                    t_ = be_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ah_ = af_ is CqlQuantity;
-                    if (ah_)
+                    bool bh_ = be_ is CqlInterval<CqlDateTime>;
+                    if (bh_)
                     {
-                        v_ = af_ as CqlQuantity;
+                        t_ = be_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                        if (ai_)
+                        bool bi_ = be_ is CqlInterval<CqlQuantity>;
+                        if (bi_)
                         {
-                            v_ = af_ as CqlInterval<CqlDateTime>;
+                            t_ = be_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                            if (aj_)
-                            {
-                                v_ = af_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                v_ = null;
-                            }
+                            t_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                Period y_ = tuple_chjebychscdthhbpzggacmwxe?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.Start(z_);
-                CqlQuantity ab_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
-                CqlBoolean ad_ = context.Operators.SameAs(x_, ac_, "day");
-                return ad_;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ak_ = tuple_chjebychscdthhbpzggacmwxe?.NoVTEMedication?.authoredOn;
-                object al_;
-                DataType bj_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                bool bl_ = bk_ is CqlDateTime;
-                if (bl_)
-                {
-                    al_ = bk_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bm_ = bk_ is CqlQuantity;
-                    if (bm_)
-                    {
-                        al_ = bk_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bn_ = bk_ is CqlInterval<CqlDateTime>;
-                        if (bn_)
-                        {
-                            al_ = bk_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bo_ = bk_ is CqlInterval<CqlQuantity>;
-                            if (bo_)
-                            {
-                                al_ = bk_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                al_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                CqlDateTime an_ = context.Operators.End(am_);
-                CqlInterval<CqlDate> ao_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, an_);
-                CqlDate ap_ = ao_?.low;
-                CqlDateTime aq_ = context.Operators.ConvertDateToDateTime(ap_);
-                object ar_;
-                DataType bp_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
-                {
-                    ar_ = bq_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bs_ = bq_ is CqlQuantity;
-                    if (bs_)
-                    {
-                        ar_ = bq_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bt_)
-                        {
-                            ar_ = bq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
-                            if (bu_)
-                            {
-                                ar_ = bq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ar_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.End(as_);
-                CqlInterval<CqlDate> au_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, at_);
-                CqlDate av_ = au_?.high;
-                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
-                object ax_;
-                DataType bv_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
-                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                bool bx_ = bw_ is CqlDateTime;
-                if (bx_)
-                {
-                    ax_ = bw_ as CqlDateTime;
-                }
-                else
-                {
-                    bool by_ = bw_ is CqlQuantity;
-                    if (by_)
-                    {
-                        ax_ = bw_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bz_ = bw_ is CqlInterval<CqlDateTime>;
-                        if (bz_)
-                        {
-                            ax_ = bw_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ca_ = bw_ is CqlInterval<CqlQuantity>;
-                            if (ca_)
-                            {
-                                ax_ = bw_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ax_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
-                CqlDateTime az_ = context.Operators.End(ay_);
-                CqlInterval<CqlDate> ba_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, az_);
-                CqlBoolean bb_ = ba_?.lowClosed;
-                object bc_;
-                DataType cb_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
-                object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                bool cd_ = cc_ is CqlDateTime;
-                if (cd_)
-                {
-                    bc_ = cc_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ce_ = cc_ is CqlQuantity;
-                    if (ce_)
-                    {
-                        bc_ = cc_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cf_ = cc_ is CqlInterval<CqlDateTime>;
-                        if (cf_)
-                        {
-                            bc_ = cc_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cg_ = cc_ is CqlInterval<CqlQuantity>;
-                            if (cg_)
-                            {
-                                bc_ = cc_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bc_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-                CqlDateTime be_ = context.Operators.End(bd_);
-                CqlInterval<CqlDate> bf_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, be_);
-                CqlBoolean bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(aq_, aw_, bb_, bg_);
-                CqlBoolean bi_ = context.Operators.In<CqlDateTime>(ak_, bh_, "day");
-                return bi_;
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+            CqlDateTime v_ = context.Operators.End(u_);
+            Period w_ = tuple_chjebychscdthhbpzggacmwxe?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlQuantity z_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime aa_ = context.Operators.Add(y_, z_);
+            CqlBoolean ab_ = context.Operators.SameAs(v_, aa_, "day");
+            CqlBoolean ac_ = ab_;
+            CqlDateTime ad_ = tuple_chjebychscdthhbpzggacmwxe?.NoVTEMedication?.authoredOn;
+            object ae_;
+            DataType bj_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
+            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+            bool bl_ = bk_ is CqlDateTime;
+            if (bl_)
+            {
+                ae_ = bk_ as CqlDateTime;
             }
-
+            else
+            {
+                bool bm_ = bk_ is CqlQuantity;
+                if (bm_)
+                {
+                    ae_ = bk_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bn_ = bk_ is CqlInterval<CqlDateTime>;
+                    if (bn_)
+                    {
+                        ae_ = bk_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bo_ = bk_ is CqlInterval<CqlQuantity>;
+                        if (bo_)
+                        {
+                            ae_ = bk_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ae_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+            CqlDateTime ag_ = context.Operators.End(af_);
+            CqlInterval<CqlDate> ah_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ag_);
+            CqlDate ai_ = ah_?.low;
+            CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
+            object ak_;
+            DataType bp_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
+            object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            bool br_ = bq_ is CqlDateTime;
+            if (br_)
+            {
+                ak_ = bq_ as CqlDateTime;
+            }
+            else
+            {
+                bool bs_ = bq_ is CqlQuantity;
+                if (bs_)
+                {
+                    ak_ = bq_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bt_ = bq_ is CqlInterval<CqlDateTime>;
+                    if (bt_)
+                    {
+                        ak_ = bq_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bu_ = bq_ is CqlInterval<CqlQuantity>;
+                        if (bu_)
+                        {
+                            ak_ = bq_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ak_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
+            CqlDateTime am_ = context.Operators.End(al_);
+            CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, am_);
+            CqlDate ao_ = an_?.high;
+            CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(ao_);
+            object aq_;
+            DataType bv_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            bool bx_ = bw_ is CqlDateTime;
+            if (bx_)
+            {
+                aq_ = bw_ as CqlDateTime;
+            }
+            else
+            {
+                bool by_ = bw_ is CqlQuantity;
+                if (by_)
+                {
+                    aq_ = bw_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bz_ = bw_ is CqlInterval<CqlDateTime>;
+                    if (bz_)
+                    {
+                        aq_ = bw_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ca_ = bw_ is CqlInterval<CqlQuantity>;
+                        if (ca_)
+                        {
+                            aq_ = bw_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            aq_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.End(ar_);
+            CqlInterval<CqlDate> at_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, as_);
+            CqlBoolean au_ = at_?.lowClosed;
+            object av_;
+            DataType cb_ = tuple_chjebychscdthhbpzggacmwxe?.AnesthesiaProcedure?.Performed;
+            object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+            bool cd_ = cc_ is CqlDateTime;
+            if (cd_)
+            {
+                av_ = cc_ as CqlDateTime;
+            }
+            else
+            {
+                bool ce_ = cc_ is CqlQuantity;
+                if (ce_)
+                {
+                    av_ = cc_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cf_ = cc_ is CqlInterval<CqlDateTime>;
+                    if (cf_)
+                    {
+                        av_ = cc_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cg_ = cc_ is CqlInterval<CqlQuantity>;
+                        if (cg_)
+                        {
+                            av_ = cc_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            av_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
+            CqlDateTime ax_ = context.Operators.End(aw_);
+            CqlInterval<CqlDate> ay_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ax_);
+            CqlBoolean az_ = ay_?.highClosed;
+            CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(aj_, ap_, au_, az_);
+            CqlBoolean bb_ = context.Operators.In<CqlDateTime>(ad_, ba_, "day");
+            CqlBoolean bc_ = bb_;
             return n_
-                /* CQL 'and' (304:11-305:50) */ && o_()
-                /* CQL 'and' (304:11-306:114) */ && p_()
-                /* CQL 'and' (304:5-307:134) */ && q_();
+                /* CQL 'and' (304:11-305:50) */ && s_
+                /* CQL 'and' (304:11-306:114) */ && ac_
+                /* CQL 'and' (304:5-307:134) */ && bc_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication)?>(e_, f_, g_);
@@ -3718,238 +3454,226 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             CqlConcept l_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.NoVTEDevice?.requestStatusReason;
             CqlValueSet m_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
             CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
-
-            CqlBoolean o_() {
-                Code<EventStatus> r_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.StatusElement;
-                EventStatus? s_ = r_?.Value;
-                string t_ = context.Operators.Convert<string>(s_);
-                CqlBoolean u_ = context.Operators.Equal(t_, "completed");
-                return u_;
+            Code<EventStatus> o_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            CqlBoolean r_ = context.Operators.Equal(q_, "completed");
+            CqlBoolean s_ = r_;
+            object t_;
+            DataType bd_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            bool bf_ = be_ is CqlDateTime;
+            if (bf_)
+            {
+                t_ = be_ as CqlDateTime;
             }
-
-
-            CqlBoolean p_() {
-                object v_;
-                DataType ae_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                bool ag_ = af_ is CqlDateTime;
-                if (ag_)
+            else
+            {
+                bool bg_ = be_ is CqlQuantity;
+                if (bg_)
                 {
-                    v_ = af_ as CqlDateTime;
+                    t_ = be_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ah_ = af_ is CqlQuantity;
-                    if (ah_)
+                    bool bh_ = be_ is CqlInterval<CqlDateTime>;
+                    if (bh_)
                     {
-                        v_ = af_ as CqlQuantity;
+                        t_ = be_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                        if (ai_)
+                        bool bi_ = be_ is CqlInterval<CqlQuantity>;
+                        if (bi_)
                         {
-                            v_ = af_ as CqlInterval<CqlDateTime>;
+                            t_ = be_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                            if (aj_)
-                            {
-                                v_ = af_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                v_ = null;
-                            }
+                            t_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                Period y_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.Start(z_);
-                CqlQuantity ab_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
-                CqlBoolean ad_ = context.Operators.SameAs(x_, ac_, "day");
-                return ad_;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ak_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.NoVTEDevice?.authoredOn;
-                object al_;
-                DataType bj_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                bool bl_ = bk_ is CqlDateTime;
-                if (bl_)
-                {
-                    al_ = bk_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bm_ = bk_ is CqlQuantity;
-                    if (bm_)
-                    {
-                        al_ = bk_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bn_ = bk_ is CqlInterval<CqlDateTime>;
-                        if (bn_)
-                        {
-                            al_ = bk_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bo_ = bk_ is CqlInterval<CqlQuantity>;
-                            if (bo_)
-                            {
-                                al_ = bk_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                al_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                CqlDateTime an_ = context.Operators.End(am_);
-                CqlInterval<CqlDate> ao_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, an_);
-                CqlDate ap_ = ao_?.low;
-                CqlDateTime aq_ = context.Operators.ConvertDateToDateTime(ap_);
-                object ar_;
-                DataType bp_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
-                {
-                    ar_ = bq_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bs_ = bq_ is CqlQuantity;
-                    if (bs_)
-                    {
-                        ar_ = bq_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bt_)
-                        {
-                            ar_ = bq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
-                            if (bu_)
-                            {
-                                ar_ = bq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ar_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.End(as_);
-                CqlInterval<CqlDate> au_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, at_);
-                CqlDate av_ = au_?.high;
-                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
-                object ax_;
-                DataType bv_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
-                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                bool bx_ = bw_ is CqlDateTime;
-                if (bx_)
-                {
-                    ax_ = bw_ as CqlDateTime;
-                }
-                else
-                {
-                    bool by_ = bw_ is CqlQuantity;
-                    if (by_)
-                    {
-                        ax_ = bw_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bz_ = bw_ is CqlInterval<CqlDateTime>;
-                        if (bz_)
-                        {
-                            ax_ = bw_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ca_ = bw_ is CqlInterval<CqlQuantity>;
-                            if (ca_)
-                            {
-                                ax_ = bw_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ax_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
-                CqlDateTime az_ = context.Operators.End(ay_);
-                CqlInterval<CqlDate> ba_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, az_);
-                CqlBoolean bb_ = ba_?.lowClosed;
-                object bc_;
-                DataType cb_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
-                object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                bool cd_ = cc_ is CqlDateTime;
-                if (cd_)
-                {
-                    bc_ = cc_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ce_ = cc_ is CqlQuantity;
-                    if (ce_)
-                    {
-                        bc_ = cc_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cf_ = cc_ is CqlInterval<CqlDateTime>;
-                        if (cf_)
-                        {
-                            bc_ = cc_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cg_ = cc_ is CqlInterval<CqlQuantity>;
-                            if (cg_)
-                            {
-                                bc_ = cc_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bc_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-                CqlDateTime be_ = context.Operators.End(bd_);
-                CqlInterval<CqlDate> bf_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, be_);
-                CqlBoolean bg_ = bf_?.highClosed;
-                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(aq_, aw_, bb_, bg_);
-                CqlBoolean bi_ = context.Operators.In<CqlDateTime>(ak_, bh_, "day");
-                return bi_;
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+            CqlDateTime v_ = context.Operators.End(u_);
+            Period w_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlQuantity z_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime aa_ = context.Operators.Add(y_, z_);
+            CqlBoolean ab_ = context.Operators.SameAs(v_, aa_, "day");
+            CqlBoolean ac_ = ab_;
+            CqlDateTime ad_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.NoVTEDevice?.authoredOn;
+            object ae_;
+            DataType bj_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
+            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+            bool bl_ = bk_ is CqlDateTime;
+            if (bl_)
+            {
+                ae_ = bk_ as CqlDateTime;
             }
-
+            else
+            {
+                bool bm_ = bk_ is CqlQuantity;
+                if (bm_)
+                {
+                    ae_ = bk_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bn_ = bk_ is CqlInterval<CqlDateTime>;
+                    if (bn_)
+                    {
+                        ae_ = bk_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bo_ = bk_ is CqlInterval<CqlQuantity>;
+                        if (bo_)
+                        {
+                            ae_ = bk_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ae_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+            CqlDateTime ag_ = context.Operators.End(af_);
+            CqlInterval<CqlDate> ah_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ag_);
+            CqlDate ai_ = ah_?.low;
+            CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
+            object ak_;
+            DataType bp_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
+            object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            bool br_ = bq_ is CqlDateTime;
+            if (br_)
+            {
+                ak_ = bq_ as CqlDateTime;
+            }
+            else
+            {
+                bool bs_ = bq_ is CqlQuantity;
+                if (bs_)
+                {
+                    ak_ = bq_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bt_ = bq_ is CqlInterval<CqlDateTime>;
+                    if (bt_)
+                    {
+                        ak_ = bq_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bu_ = bq_ is CqlInterval<CqlQuantity>;
+                        if (bu_)
+                        {
+                            ak_ = bq_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ak_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
+            CqlDateTime am_ = context.Operators.End(al_);
+            CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, am_);
+            CqlDate ao_ = an_?.high;
+            CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(ao_);
+            object aq_;
+            DataType bv_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            bool bx_ = bw_ is CqlDateTime;
+            if (bx_)
+            {
+                aq_ = bw_ as CqlDateTime;
+            }
+            else
+            {
+                bool by_ = bw_ is CqlQuantity;
+                if (by_)
+                {
+                    aq_ = bw_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bz_ = bw_ is CqlInterval<CqlDateTime>;
+                    if (bz_)
+                    {
+                        aq_ = bw_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ca_ = bw_ is CqlInterval<CqlQuantity>;
+                        if (ca_)
+                        {
+                            aq_ = bw_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            aq_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.End(ar_);
+            CqlInterval<CqlDate> at_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, as_);
+            CqlBoolean au_ = at_?.lowClosed;
+            object av_;
+            DataType cb_ = tuple_cadhcldckpqwmtcazwxfnkhgc?.AnesthesiaProcedure?.Performed;
+            object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+            bool cd_ = cc_ is CqlDateTime;
+            if (cd_)
+            {
+                av_ = cc_ as CqlDateTime;
+            }
+            else
+            {
+                bool ce_ = cc_ is CqlQuantity;
+                if (ce_)
+                {
+                    av_ = cc_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cf_ = cc_ is CqlInterval<CqlDateTime>;
+                    if (cf_)
+                    {
+                        av_ = cc_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cg_ = cc_ is CqlInterval<CqlQuantity>;
+                        if (cg_)
+                        {
+                            av_ = cc_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            av_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
+            CqlDateTime ax_ = context.Operators.End(aw_);
+            CqlInterval<CqlDate> ay_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ax_);
+            CqlBoolean az_ = ay_?.highClosed;
+            CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(aj_, ap_, au_, az_);
+            CqlBoolean bb_ = context.Operators.In<CqlDateTime>(ad_, ba_, "day");
+            CqlBoolean bc_ = bb_;
             return n_
-                /* CQL 'and' (363:11-364:50) */ && o_()
-                /* CQL 'and' (363:11-365:114) */ && p_()
-                /* CQL 'and' (363:5-366:130) */ && q_();
+                /* CQL 'and' (363:11-364:50) */ && s_
+                /* CQL 'and' (363:11-365:114) */ && ac_
+                /* CQL 'and' (363:5-366:130) */ && bc_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, (CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice)?>(e_, f_, g_);
@@ -4080,228 +3804,220 @@ public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object r_;
-                DataType aa_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
-                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                bool ac_ = ab_ is CqlDateTime;
-                if (ac_)
-                {
-                    r_ = ab_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ad_ = ab_ is CqlQuantity;
-                    if (ad_)
-                    {
-                        r_ = ab_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ae_ = ab_ is CqlInterval<CqlDateTime>;
-                        if (ae_)
-                        {
-                            r_ = ab_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool af_ = ab_ is CqlInterval<CqlQuantity>;
-                            if (af_)
-                            {
-                                r_ = ab_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                r_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.End(s_);
-                Period u_ = tuple_fpeghttqsjgusnbabduddbjbh?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                CqlQuantity x_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime y_ = context.Operators.Add(w_, x_);
-                CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-                return z_;
+            object p_;
+            DataType az_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
+            object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+            bool bb_ = ba_ is CqlDateTime;
+            if (bb_)
+            {
+                p_ = ba_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ag_ = context.Operators.LateBoundProperty<CqlDateTime>(tuple_fpeghttqsjgusnbabduddbjbh?.PatientRefusal, "authoredOn");
-                object ah_;
-                DataType bf_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
-                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                bool bh_ = bg_ is CqlDateTime;
-                if (bh_)
+            else
+            {
+                bool bc_ = ba_ is CqlQuantity;
+                if (bc_)
                 {
-                    ah_ = bg_ as CqlDateTime;
+                    p_ = ba_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bi_ = bg_ is CqlQuantity;
-                    if (bi_)
+                    bool bd_ = ba_ is CqlInterval<CqlDateTime>;
+                    if (bd_)
                     {
-                        ah_ = bg_ as CqlQuantity;
+                        p_ = ba_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bj_ = bg_ is CqlInterval<CqlDateTime>;
-                        if (bj_)
+                        bool be_ = ba_ is CqlInterval<CqlQuantity>;
+                        if (be_)
                         {
-                            ah_ = bg_ as CqlInterval<CqlDateTime>;
+                            p_ = ba_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bk_ = bg_ is CqlInterval<CqlQuantity>;
-                            if (bk_)
-                            {
-                                ah_ = bg_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ah_ = null;
-                            }
+                            p_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.End(ai_);
-                CqlInterval<CqlDate> ak_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aj_);
-                CqlDate al_ = ak_?.low;
-                CqlDateTime am_ = context.Operators.ConvertDateToDateTime(al_);
-                object an_;
-                DataType bl_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
-                object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                bool bn_ = bm_ is CqlDateTime;
-                if (bn_)
-                {
-                    an_ = bm_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bo_ = bm_ is CqlQuantity;
-                    if (bo_)
-                    {
-                        an_ = bm_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bp_ = bm_ is CqlInterval<CqlDateTime>;
-                        if (bp_)
-                        {
-                            an_ = bm_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bq_ = bm_ is CqlInterval<CqlQuantity>;
-                            if (bq_)
-                            {
-                                an_ = bm_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                an_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_);
-                CqlDateTime ap_ = context.Operators.End(ao_);
-                CqlInterval<CqlDate> aq_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ap_);
-                CqlDate ar_ = aq_?.high;
-                CqlDateTime as_ = context.Operators.ConvertDateToDateTime(ar_);
-                object at_;
-                DataType br_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
-                object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
-                bool bt_ = bs_ is CqlDateTime;
-                if (bt_)
-                {
-                    at_ = bs_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bu_ = bs_ is CqlQuantity;
-                    if (bu_)
-                    {
-                        at_ = bs_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bv_ = bs_ is CqlInterval<CqlDateTime>;
-                        if (bv_)
-                        {
-                            at_ = bs_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bw_ = bs_ is CqlInterval<CqlQuantity>;
-                            if (bw_)
-                            {
-                                at_ = bs_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                at_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
-                CqlDateTime av_ = context.Operators.End(au_);
-                CqlInterval<CqlDate> aw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, av_);
-                CqlBoolean ax_ = aw_?.lowClosed;
-                object ay_;
-                DataType bx_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
-                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                bool bz_ = by_ is CqlDateTime;
-                if (bz_)
-                {
-                    ay_ = by_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ca_ = by_ is CqlQuantity;
-                    if (ca_)
-                    {
-                        ay_ = by_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cb_ = by_ is CqlInterval<CqlDateTime>;
-                        if (cb_)
-                        {
-                            ay_ = by_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cc_ = by_ is CqlInterval<CqlQuantity>;
-                            if (cc_)
-                            {
-                                ay_ = by_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ay_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_);
-                CqlDateTime ba_ = context.Operators.End(az_);
-                CqlInterval<CqlDate> bb_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ba_);
-                CqlBoolean bc_ = bb_?.highClosed;
-                CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(am_, as_, ax_, bc_);
-                CqlBoolean be_ = context.Operators.In<CqlDateTime>(ag_, bd_, "day");
-                return be_;
             }
-
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.End(q_);
+            Period s_ = tuple_fpeghttqsjgusnbabduddbjbh?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
+            CqlDateTime u_ = context.Operators.Start(t_);
+            CqlQuantity v_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime w_ = context.Operators.Add(u_, v_);
+            CqlBoolean x_ = context.Operators.SameAs(r_, w_, "day");
+            CqlBoolean y_ = x_;
+            CqlDateTime z_ = context.Operators.LateBoundProperty<CqlDateTime>(tuple_fpeghttqsjgusnbabduddbjbh?.PatientRefusal, "authoredOn");
+            object aa_;
+            DataType bf_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
+            object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+            bool bh_ = bg_ is CqlDateTime;
+            if (bh_)
+            {
+                aa_ = bg_ as CqlDateTime;
+            }
+            else
+            {
+                bool bi_ = bg_ is CqlQuantity;
+                if (bi_)
+                {
+                    aa_ = bg_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bj_ = bg_ is CqlInterval<CqlDateTime>;
+                    if (bj_)
+                    {
+                        aa_ = bg_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bk_ = bg_ is CqlInterval<CqlQuantity>;
+                        if (bk_)
+                        {
+                            aa_ = bg_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            aa_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
+            CqlDateTime ac_ = context.Operators.End(ab_);
+            CqlInterval<CqlDate> ad_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ac_);
+            CqlDate ae_ = ad_?.low;
+            CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
+            object ag_;
+            DataType bl_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
+            object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+            bool bn_ = bm_ is CqlDateTime;
+            if (bn_)
+            {
+                ag_ = bm_ as CqlDateTime;
+            }
+            else
+            {
+                bool bo_ = bm_ is CqlQuantity;
+                if (bo_)
+                {
+                    ag_ = bm_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bp_ = bm_ is CqlInterval<CqlDateTime>;
+                    if (bp_)
+                    {
+                        ag_ = bm_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bq_ = bm_ is CqlInterval<CqlQuantity>;
+                        if (bq_)
+                        {
+                            ag_ = bm_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ag_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
+            CqlDateTime ai_ = context.Operators.End(ah_);
+            CqlInterval<CqlDate> aj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ai_);
+            CqlDate ak_ = aj_?.high;
+            CqlDateTime al_ = context.Operators.ConvertDateToDateTime(ak_);
+            object am_;
+            DataType br_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
+            object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+            bool bt_ = bs_ is CqlDateTime;
+            if (bt_)
+            {
+                am_ = bs_ as CqlDateTime;
+            }
+            else
+            {
+                bool bu_ = bs_ is CqlQuantity;
+                if (bu_)
+                {
+                    am_ = bs_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bv_ = bs_ is CqlInterval<CqlDateTime>;
+                    if (bv_)
+                    {
+                        am_ = bs_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bw_ = bs_ is CqlInterval<CqlQuantity>;
+                        if (bw_)
+                        {
+                            am_ = bs_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            am_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
+            CqlDateTime ao_ = context.Operators.End(an_);
+            CqlInterval<CqlDate> ap_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ao_);
+            CqlBoolean aq_ = ap_?.lowClosed;
+            object ar_;
+            DataType bx_ = tuple_fpeghttqsjgusnbabduddbjbh?.AnesthesiaProcedure?.Performed;
+            object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+            bool bz_ = by_ is CqlDateTime;
+            if (bz_)
+            {
+                ar_ = by_ as CqlDateTime;
+            }
+            else
+            {
+                bool ca_ = by_ is CqlQuantity;
+                if (ca_)
+                {
+                    ar_ = by_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cb_ = by_ is CqlInterval<CqlDateTime>;
+                    if (cb_)
+                    {
+                        ar_ = by_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cc_ = by_ is CqlInterval<CqlQuantity>;
+                        if (cc_)
+                        {
+                            ar_ = by_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ar_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.End(as_);
+            CqlInterval<CqlDate> au_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, at_);
+            CqlBoolean av_ = au_?.highClosed;
+            CqlInterval<CqlDateTime> aw_ = context.Operators.Interval(af_, al_, aq_, av_);
+            CqlBoolean ax_ = context.Operators.In<CqlDateTime>(z_, aw_, "day");
+            CqlBoolean ay_ = ax_;
             return o_
-                /* CQL 'and' (429:11-430:114) */ && p_()
-                /* CQL 'and' (429:5-431:133) */ && q_();
+                /* CQL 'and' (429:11-430:114) */ && y_
+                /* CQL 'and' (429:5-431:133) */ && ay_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, object PatientRefusal)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter QualifyingEncounter, Procedure AnesthesiaProcedure, object PatientRefusal)?>(e_, f_, g_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1154ScreeningPrediabetesFHIR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1154ScreeningPrediabetesFHIR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1154ScreeningPrediabetesFHIR", "1.0.000")]
 public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingleton<CMS1154ScreeningPrediabetesFHIR_1_0_000>
 {
@@ -166,51 +166,27 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
         bool? a_(Condition C) {
             CodeableConcept c_ = C?.VerificationStatus;
             CqlConcept d_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, c_);
-
-            CqlBoolean e_() {
-                CodeableConcept f_ = C?.VerificationStatus;
-                CqlConcept g_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, f_);
-                CqlCode h_ = this.confirmed(context);
-                CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
-                CqlBoolean j_ = context.Operators.Equivalent(g_, i_);
-
-                CqlBoolean k_() {
-                    CodeableConcept n_ = C?.VerificationStatus;
-                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                    CqlCode p_ = this.unconfirmed(context);
-                    CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                    CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-                    return r_;
-                }
-
-
-                CqlBoolean l_() {
-                    CodeableConcept s_ = C?.VerificationStatus;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlCode u_ = this.provisional(context);
-                    CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                    CqlBoolean w_ = context.Operators.Equivalent(t_, v_);
-                    return w_;
-                }
-
-
-                CqlBoolean m_() {
-                    CodeableConcept x_ = C?.VerificationStatus;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlCode z_ = this.differential(context);
-                    CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
-                    CqlBoolean ab_ = context.Operators.Equivalent(y_, aa_);
-                    return ab_;
-                }
-
-                return j_
-                    /* CQL 'or' (42:54-43:47) */ || k_()
-                    /* CQL 'or' (42:54-44:47) */ || l_()
-                    /* CQL 'or' (42:52-46:5) */ || m_();
-            }
-
+            CqlCode e_ = this.confirmed(context);
+            CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+            CqlBoolean g_ = context.Operators.Equivalent(d_, f_);
+            CqlCode h_ = this.unconfirmed(context);
+            CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+            CqlBoolean j_ = context.Operators.Equivalent(d_, i_);
+            CqlBoolean k_ = j_;
+            CqlCode l_ = this.provisional(context);
+            CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
+            CqlBoolean n_ = context.Operators.Equivalent(d_, m_);
+            CqlBoolean o_ = n_;
+            CqlCode p_ = this.differential(context);
+            CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+            CqlBoolean r_ = context.Operators.Equivalent(d_, q_);
+            CqlBoolean s_ = r_;
+            CqlBoolean t_ = g_
+                /* CQL 'or' (42:54-43:47) */ || k_
+                /* CQL 'or' (42:54-44:47) */ || o_
+                /* CQL 'or' (42:52-46:5) */ || s_;
             return (CqlBoolean)(d_ is null)
-                /* CQL 'implies' (42:5-46:5) */ || e_();
+                /* CQL 'implies' (42:5-46:5) */ || t_;
         }
 
         IEnumerable<Condition> b_ = context.Operators.Where<Condition>(conditions, a_);
@@ -268,17 +244,13 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> k_ = PreventiveCare?.StatusElement;
-                Encounter.EncounterStatus? l_ = k_?.Value;
-                Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
-                CqlBoolean n_ = context.Operators.Equal(m_, "finished");
-                return n_;
-            }
-
+            Code<Encounter.EncounterStatus> j_ = PreventiveCare?.StatusElement;
+            Encounter.EncounterStatus? k_ = j_?.Value;
+            Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
+            CqlBoolean m_ = context.Operators.Equal(l_, "finished");
+            CqlBoolean n_ = m_;
             return i_
-                /* CQL 'and' (81:5-82:44) */ && j_();
+                /* CQL 'and' (81:5-82:44) */ && n_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -302,17 +274,13 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
             Period f_ = OfficeVisit?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
-
-            CqlBoolean i_() {
-                Code<Encounter.EncounterStatus> j_ = OfficeVisit?.StatusElement;
-                Encounter.EncounterStatus? k_ = j_?.Value;
-                Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
-                CqlBoolean m_ = context.Operators.Equal(l_, "finished");
-                return m_;
-            }
-
+            Code<Encounter.EncounterStatus> i_ = OfficeVisit?.StatusElement;
+            Encounter.EncounterStatus? j_ = i_?.Value;
+            Code<Encounter.EncounterStatus> k_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(j_);
+            CqlBoolean l_ = context.Operators.Equal(k_, "finished");
+            CqlBoolean m_ = l_;
             return h_
-                /* CQL 'and' (100:5-101:41) */ && i_();
+                /* CQL 'and' (100:5-101:41) */ && m_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -337,22 +305,10 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 35);
-
-        CqlBoolean j_() {
-            Patient k_ = this.Patient(context);
-            Date l_ = k_?.BirthDateElement;
-            string m_ = l_?.Value;
-            CqlDate n_ = context.Operators.ConvertStringToDate(m_);
-            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
-            CqlDateTime p_ = context.Operators.Start(o_);
-            CqlDate q_ = context.Operators.DateFrom(p_);
-            int? r_ = context.Operators.CalculateAgeAt(n_, q_, "year");
-            CqlBoolean s_ = context.Operators.LessOrEqual(r_, 70);
-            return s_;
-        }
-
+        CqlBoolean j_ = context.Operators.LessOrEqual(h_, 70);
+        CqlBoolean k_ = j_;
         return i_
-            /* CQL 'and' (145:3-145:75) */ && j_();
+            /* CQL 'and' (145:3-145:75) */ && k_;
     }
 
 
@@ -366,16 +322,12 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Encounter> a_ = this.Preventive_Care_Outpatient_Visits_During_Measurement_Period(context);
         CqlBoolean b_ = context.Operators.Exists<Encounter>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Encounter> d_ = this.Office_Visit_During_the_Measurement_Period(context);
-            int? e_ = context.Operators.Count<Encounter>(d_);
-            CqlBoolean f_ = context.Operators.GreaterOrEqual(e_, 2);
-            return f_;
-        }
-
+        IEnumerable<Encounter> c_ = this.Office_Visit_During_the_Measurement_Period(context);
+        int? d_ = context.Operators.Count<Encounter>(c_);
+        CqlBoolean e_ = context.Operators.GreaterOrEqual(d_, 2);
+        CqlBoolean f_ = e_;
         return (b_
-            /* CQL 'or' (104:3-106:3) */ || c_())
+            /* CQL 'or' (104:3-106:3) */ || f_)
             /* CQL 'and' (104:3-107:62) */ && (/* CQL 'is true' (107:9-107:62) */ (this.Aged_35_to_70_at_Start_of_Measurement_Period(context)) is true);
     }
 
@@ -499,15 +451,11 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
     private bool? Initial_Population_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Patients_Aged_35_to_70_with_an_Office_Visit_During_the_Measurement_Period(context);
-
-        CqlBoolean b_() {
-            CqlBoolean c_ = this.Most_Recent_BMI_Equal_to_or_Greater_Than_25_and_Is_Not_Asian(context);
-            return c_
-                /* CQL 'or' (94:9-96:5) */ || this.Most_Recent_BMI_Equal_to_or_Greater_Than_23_and_Is_Asian(context);
-        }
-
+        CqlBoolean b_ = this.Most_Recent_BMI_Equal_to_or_Greater_Than_25_and_Is_Not_Asian(context);
+        CqlBoolean c_ = b_
+            /* CQL 'or' (94:9-96:5) */ || this.Most_Recent_BMI_Equal_to_or_Greater_Than_23_and_Is_Asian(context);
         return a_
-            /* CQL 'and' (93:3-96:5) */ && b_();
+            /* CQL 'and' (93:3-96:5) */ && c_;
     }
 
 
@@ -541,22 +489,18 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.ToInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<ObservationStatus> k_ = LabTestPerformed?.StatusElement;
-                ObservationStatus? l_ = k_?.Value;
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                return o_;
-            }
-
+            Code<ObservationStatus> j_ = LabTestPerformed?.StatusElement;
+            ObservationStatus? k_ = j_?.Value;
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
             return i_
-                /* CQL 'and' (61:5-62:72) */ && j_();
+                /* CQL 'and' (61:5-62:72) */ && o_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -593,18 +537,14 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
             CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_ as CodeableConcept);
             CqlValueSet f_ = this.Pregnancy(context);
             CqlBoolean g_ = context.Operators.ConceptInValueSet(e_, f_);
-
-            CqlBoolean h_() {
-                DataType i_ = PregnantObservation?.Effective;
-                CqlDateTime j_ = context.Operators.LateBoundProperty<CqlDateTime>(i_, "value");
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-                CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
-                CqlBoolean m_ = context.Operators.Overlaps(k_, l_, "day");
-                return m_;
-            }
-
+            DataType h_ = PregnantObservation?.Effective;
+            CqlDateTime i_ = context.Operators.LateBoundProperty<CqlDateTime>(h_, "value");
+            CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
+            CqlBoolean l_ = context.Operators.Overlaps(j_, k_, "day");
+            CqlBoolean m_ = l_;
             return g_
-                /* CQL 'and' (69:7-70:93) */ && h_();
+                /* CQL 'and' (69:7-70:93) */ && m_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Observation>(a_, b_);
@@ -724,22 +664,18 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.ToInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<ObservationStatus> k_ = LabTestPerformed?.StatusElement;
-                ObservationStatus? l_ = k_?.Value;
-                string m_ = context.Operators.Convert<string>(l_);
-                string[] n_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-                return o_;
-            }
-
+            Code<ObservationStatus> j_ = LabTestPerformed?.StatusElement;
+            ObservationStatus? k_ = j_?.Value;
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
             return i_
-                /* CQL 'and' (131:7-132:74) */ && j_();
+                /* CQL 'and' (131:7-132:74) */ && o_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Observation>(b_, c_);
@@ -756,39 +692,23 @@ public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingle
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Has_Pregnancy_Observation_During_Measurement_Period(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Condition> f_ = this.Has_Pregnancy_Diagnosis_During_Measurement_Period(context);
-            CqlBoolean g_ = context.Operators.Exists<Condition>(f_);
-            return g_;
-        }
-
-
-        CqlBoolean c_() {
-            IEnumerable<Condition> h_ = this.Has_Advanced_Illness_or_Limited_Life_Expectancy(context);
-            CqlBoolean i_ = context.Operators.Exists<Condition>(h_);
-            return i_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Condition> j_ = this.Diabetes_Diagnosis_Overlaps_2_Year_Look_Back_Period(context);
-            CqlBoolean k_ = context.Operators.Exists<Condition>(j_);
-            return k_;
-        }
-
-
-        CqlBoolean e_() {
-            IEnumerable<Condition> l_ = this.Prediabetes_Diagnosis_Overlaps_2_Year_Look_Back_Period(context);
-            CqlBoolean m_ = context.Operators.Exists<Condition>(l_);
-            return m_;
-        }
-
+        IEnumerable<Condition> b_ = this.Has_Pregnancy_Diagnosis_During_Measurement_Period(context);
+        CqlBoolean c_ = context.Operators.Exists<Condition>(b_);
+        CqlBoolean d_ = c_;
+        IEnumerable<Condition> e_ = this.Has_Advanced_Illness_or_Limited_Life_Expectancy(context);
+        CqlBoolean f_ = context.Operators.Exists<Condition>(e_);
+        CqlBoolean g_ = f_;
+        IEnumerable<Condition> h_ = this.Diabetes_Diagnosis_Overlaps_2_Year_Look_Back_Period(context);
+        CqlBoolean i_ = context.Operators.Exists<Condition>(h_);
+        CqlBoolean j_ = i_;
+        IEnumerable<Condition> k_ = this.Prediabetes_Diagnosis_Overlaps_2_Year_Look_Back_Period(context);
+        CqlBoolean l_ = context.Operators.Exists<Condition>(k_);
+        CqlBoolean m_ = l_;
         return a_
-            /* CQL 'or' (116:3-117:65) */ || b_()
-            /* CQL 'or' (116:3-118:63) */ || c_()
-            /* CQL 'or' (116:3-119:67) */ || d_()
-            /* CQL 'or' (116:3-120:70) */ || e_()
+            /* CQL 'or' (116:3-117:65) */ || d_
+            /* CQL 'or' (116:3-118:63) */ || g_
+            /* CQL 'or' (116:3-119:67) */ || j_
+            /* CQL 'or' (116:3-120:70) */ || m_
             /* CQL 'or' (116:3-121:78) */ || this.Has_Glycemic_Laboratory_Test_Performed_During_2_Year_Look_Back_Period(context);
     }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1157FHIRHIVRetention-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1157FHIRHIVRetention-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1157FHIRHIVRetention", "1.0.000")]
 public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1157FHIRHIVRetention_1_0_000>
 {
@@ -113,51 +113,27 @@ public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (96:54-97:66) */ || i_()
-                /* CQL 'or' (96:54-98:66) */ || j_()
-                /* CQL 'or' (96:52-100:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (96:54-97:66) */ || i_
+            /* CQL 'or' (96:54-98:66) */ || m_
+            /* CQL 'or' (96:52-100:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (96:3-100:3) */ || c_();
+            /* CQL 'implies' (96:3-100:3) */ || r_;
     }
 
 
@@ -328,29 +304,19 @@ public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1
                 Period ap_ = ValidEncounter?.Period;
                 CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
                 CqlBoolean ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, "day");
-
-                CqlBoolean as_() {
-                    Code<Encounter.EncounterStatus> au_ = ValidEncounter?.StatusElement;
-                    Encounter.EncounterStatus? av_ = au_?.Value;
-                    Code<Encounter.EncounterStatus> aw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(av_);
-                    CqlBoolean ax_ = context.Operators.Equal(aw_, "finished");
-                    return ax_;
-                }
-
-
-                CqlBoolean at_() {
-                    CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HIVDiagnosis);
-                    CqlDateTime az_ = context.Operators.Start(ay_);
-                    Period ba_ = ValidEncounter?.Period;
-                    CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
-                    CqlDateTime bc_ = context.Operators.Start(bb_);
-                    CqlBoolean bd_ = context.Operators.SameOrBefore(az_, bc_, "day");
-                    return bd_;
-                }
-
+                Code<Encounter.EncounterStatus> as_ = ValidEncounter?.StatusElement;
+                Encounter.EncounterStatus? at_ = as_?.Value;
+                Code<Encounter.EncounterStatus> au_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(at_);
+                CqlBoolean av_ = context.Operators.Equal(au_, "finished");
+                CqlBoolean aw_ = av_;
+                CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HIVDiagnosis);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                CqlDateTime az_ = context.Operators.Start(aq_);
+                CqlBoolean ba_ = context.Operators.SameOrBefore(ay_, az_, "day");
+                CqlBoolean bb_ = ba_;
                 return ar_
-                    /* CQL 'and' (53:19-54:48) */ && as_()
-                    /* CQL 'and' (53:19-55:107) */ && at_()
+                    /* CQL 'and' (53:19-54:48) */ && aw_
+                    /* CQL 'and' (53:19-55:107) */ && bb_
                     /* CQL 'and' (53:19-56:41) */ && this.isVerified(context, HIVDiagnosis);
             }
 
@@ -387,50 +353,29 @@ public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1
                     "corrected",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
-                    DataType p_ = ViralLoadTest?.Effective;
-                    object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                    CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, "day");
-                    return s_;
-                }
-
-
-                CqlBoolean n_() {
-                    DataType t_ = ViralLoadTest?.Effective;
-                    object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                    CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    Period x_ = EncounterWithHIV?.Period;
-                    CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
-                    CqlDateTime z_ = context.Operators.End(y_);
-                    CqlQuantity aa_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime ab_ = context.Operators.Add(z_, aa_);
-                    CqlBoolean ac_ = context.Operators.SameOrAfter(w_, ab_, "day");
-
-                    CqlBoolean ad_() {
-                        Period ae_ = EncounterWithHIV?.Period;
-                        CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
-                        CqlDateTime ag_ = context.Operators.Start(af_);
-                        DataType ah_ = ViralLoadTest?.Effective;
-                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                        CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                        CqlDateTime ak_ = context.Operators.End(aj_);
-                        CqlQuantity al_ = context.Operators.Quantity(90m, "days");
-                        CqlDateTime am_ = context.Operators.Add(ak_, al_);
-                        CqlBoolean an_ = context.Operators.SameOrAfter(ag_, am_, "day");
-                        return an_;
-                    }
-
-                    return ac_
-                        /* CQL 'or' (71:13-73:9) */ || ad_();
-                }
-
+                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
+                DataType n_ = ViralLoadTest?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
+                CqlBoolean r_ = q_;
+                CqlDateTime s_ = context.Operators.Start(p_);
+                Period t_ = EncounterWithHIV?.Period;
+                CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
+                CqlDateTime v_ = context.Operators.End(u_);
+                CqlQuantity w_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime x_ = context.Operators.Add(v_, w_);
+                CqlBoolean y_ = context.Operators.SameOrAfter(s_, x_, "day");
+                CqlDateTime z_ = context.Operators.Start(u_);
+                CqlDateTime aa_ = context.Operators.End(p_);
+                CqlDateTime ab_ = context.Operators.Add(aa_, w_);
+                CqlBoolean ac_ = context.Operators.SameOrAfter(z_, ab_, "day");
+                CqlBoolean ad_ = ac_;
+                CqlBoolean ae_ = y_
+                    /* CQL 'or' (71:13-73:9) */ || ad_;
                 return l_
-                    /* CQL 'and' (69:17-70:85) */ && m_()
-                    /* CQL 'and' (69:17-73:9) */ && n_();
+                    /* CQL 'and' (69:17-70:85) */ && r_
+                    /* CQL 'and' (69:17-73:9) */ && ae_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);
@@ -457,22 +402,18 @@ public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1
 
             bool? e_(Encounter AnotherEncounterWithHIV) {
                 CqlBoolean g_ = context.Operators.Equivalent(EncounterWithHIV, AnotherEncounterWithHIV);
-
-                CqlBoolean h_() {
-                    Period i_ = AnotherEncounterWithHIV?.Period;
-                    CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                    CqlDateTime k_ = context.Operators.Start(j_);
-                    Period l_ = EncounterWithHIV?.Period;
-                    CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                    CqlDateTime n_ = context.Operators.End(m_);
-                    CqlQuantity o_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime p_ = context.Operators.Add(n_, o_);
-                    CqlBoolean q_ = context.Operators.SameOrAfter(k_, p_, "day");
-                    return q_;
-                }
-
+                Period h_ = AnotherEncounterWithHIV?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                Period k_ = EncounterWithHIV?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                CqlDateTime m_ = context.Operators.End(l_);
+                CqlQuantity n_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime o_ = context.Operators.Add(m_, n_);
+                CqlBoolean p_ = context.Operators.SameOrAfter(j_, o_, "day");
+                CqlBoolean q_ = p_;
                 return (CqlBoolean)!g_
-                    /* CQL 'and' (92:17-93:109) */ && h_();
+                    /* CQL 'and' (92:17-93:109) */ && q_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter>(d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1173FHIRDiagnosticDelayVTE", "1.0.000")]
 public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleton<CMS1173FHIRDiagnosticDelayVTE_1_0_000>
 {
@@ -177,23 +177,19 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
             Encounter.EncounterStatus? l_ = k_?.Value;
             Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
             CqlBoolean n_ = context.Operators.Equal(m_, "finished");
-
-            CqlBoolean o_() {
-                Period p_ = Encounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                CqlQuantity u_ = context.Operators.Quantity(180m, "days");
-                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
-                CqlDateTime w_ = context.Operators.End(s_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(v_, w_, true, true);
-                CqlBoolean y_ = context.Operators.In<CqlDateTime>(r_, x_, "day");
-                return y_;
-            }
-
+            Period o_ = Encounter?.Period;
+            CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
+            CqlDateTime s_ = context.Operators.Start(r_);
+            CqlQuantity t_ = context.Operators.Quantity(180m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(s_, t_);
+            CqlDateTime v_ = context.Operators.End(r_);
+            CqlInterval<CqlDateTime> w_ = context.Operators.Interval(u_, v_, true, true);
+            CqlBoolean x_ = context.Operators.In<CqlDateTime>(q_, w_, "day");
+            CqlBoolean y_ = x_;
             return n_
-                /* CQL 'and' (66:5-67:127) */ && o_();
+                /* CQL 'and' (66:5-67:127) */ && y_;
         }
 
         IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
@@ -228,37 +224,28 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
             List<CodeableConcept> d_ = VTEEncounter?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return m_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.VTE_Diagnoses(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
-            CqlBoolean i_() {
-                CqlValueSet k_ = this.VTE_Diagnoses(context);
-                IEnumerable<Condition> l_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, k_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-
-                bool? m_(Condition VTECondition) {
-                    CqlBoolean o_ = this.isConfirmedCondition(context, VTECondition);
-
-                    CqlBoolean p_() {
-                        List<ResourceReference> q_ = VTEEncounter?.ReasonReference;
-                        CqlBoolean r_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)q_, VTECondition);
-                        return r_;
-                    }
-
-                    return o_
-                        /* CQL 'and' (87:11-88:72) */ && p_();
-                }
-
-                CqlBoolean n_ = context.Operators.WhereAny<Condition>(l_, m_);
-                return n_;
+            bool? j_(Condition VTECondition) {
+                CqlBoolean n_ = this.isConfirmedCondition(context, VTECondition);
+                List<ResourceReference> o_ = VTEEncounter?.ReasonReference;
+                CqlBoolean p_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)o_, VTECondition);
+                CqlBoolean q_ = p_;
+                return n_
+                    /* CQL 'and' (87:11-88:72) */ && q_;
             }
 
+            CqlBoolean k_ = context.Operators.WhereAny<Condition>(i_, j_);
+            CqlBoolean l_ = k_;
             return h_
-                /* CQL 'or' (85:5-89:7) */ || i_();
+                /* CQL 'or' (85:5-89:7) */ || l_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -285,23 +272,19 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
             Encounter.EncounterStatus? i_ = h_?.Value;
             Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
             CqlBoolean k_ = context.Operators.Equal(j_, "finished");
-
-            CqlBoolean l_() {
-                Period m_ = PCPVisit?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime o_ = context.Operators.End(n_);
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                CqlQuantity r_ = context.Operators.Quantity(210m, "days");
-                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
-                CqlDateTime t_ = context.Operators.End(p_);
-                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(s_, t_, true, true);
-                CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, "day");
-                return v_;
-            }
-
+            Period l_ = PCPVisit?.Period;
+            CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+            CqlDateTime n_ = context.Operators.End(m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlDateTime p_ = context.Operators.Start(o_);
+            CqlQuantity q_ = context.Operators.Quantity(210m, "days");
+            CqlDateTime r_ = context.Operators.Subtract(p_, q_);
+            CqlDateTime s_ = context.Operators.End(o_);
+            CqlInterval<CqlDateTime> t_ = context.Operators.Interval(r_, s_, true, true);
+            CqlBoolean u_ = context.Operators.In<CqlDateTime>(n_, t_, "day");
+            CqlBoolean v_ = u_;
             return k_
-                /* CQL 'and' (72:5-73:124) */ && l_();
+                /* CQL 'and' (72:5-73:124) */ && v_;
         }
 
         IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
@@ -315,51 +298,27 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (202:54-203:66) */ || i_()
-                /* CQL 'or' (202:54-204:66) */ || j_()
-                /* CQL 'or' (202:52-206:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (202:54-203:66) */ || i_
+            /* CQL 'or' (202:54-204:66) */ || m_
+            /* CQL 'or' (202:52-206:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (202:3-206:3) */ || c_();
+            /* CQL 'implies' (202:3-206:3) */ || r_;
     }
 
 
@@ -377,37 +336,28 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
             List<CodeableConcept> d_ = IndexPCPVisit?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return m_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.VTE_Symptoms(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
-            CqlBoolean i_() {
-                CqlValueSet k_ = this.VTE_Symptoms(context);
-                IEnumerable<Condition> l_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, k_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-
-                bool? m_(Condition VTESymptomCondition) {
-                    CqlBoolean o_ = this.isVerified(context, VTESymptomCondition as Condition);
-
-                    CqlBoolean p_() {
-                        List<ResourceReference> q_ = IndexPCPVisit?.ReasonReference;
-                        CqlBoolean r_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)q_, VTESymptomCondition);
-                        return r_;
-                    }
-
-                    return o_
-                        /* CQL 'and' (79:11-80:80) */ && p_();
-                }
-
-                CqlBoolean n_ = context.Operators.WhereAny<Condition>(l_, m_);
-                return n_;
+            bool? j_(Condition VTESymptomCondition) {
+                CqlBoolean n_ = this.isVerified(context, VTESymptomCondition as Condition);
+                List<ResourceReference> o_ = IndexPCPVisit?.ReasonReference;
+                CqlBoolean p_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)o_, VTESymptomCondition);
+                CqlBoolean q_ = p_;
+                return n_
+                    /* CQL 'and' (79:11-80:80) */ && q_;
             }
 
+            CqlBoolean k_ = context.Operators.WhereAny<Condition>(i_, j_);
+            CqlBoolean l_ = k_;
             return h_
-                /* CQL 'or' (77:5-81:7) */ || i_();
+                /* CQL 'or' (77:5-81:7) */ || l_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -463,17 +413,13 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Anticoagulant_Medications(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Anticoagulant_Medications(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -494,17 +440,13 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
                 "completed",
             ];
             CqlBoolean z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
-
-            CqlBoolean aa_() {
-                Code<MedicationRequest.MedicationRequestIntent> ab_ = AntiCoagulant?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ac_ = ab_?.Value;
-                string ad_ = context.Operators.Convert<string>(ac_);
-                CqlBoolean ae_ = context.Operators.Equal(ad_, "order");
-                return ae_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> aa_ = AntiCoagulant?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ab_ = aa_?.Value;
+            string ac_ = context.Operators.Convert<string>(ab_);
+            CqlBoolean ad_ = context.Operators.Equal(ac_, "order");
+            CqlBoolean ae_ = ad_;
             return z_
-                /* CQL 'and' (97:5-98:40) */ && aa_();
+                /* CQL 'and' (97:5-98:40) */ && ae_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -540,74 +482,33 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
             Period p_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEEncounter?.Period;
             CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
             CqlBoolean r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
-
-            CqlBoolean s_() {
-                FhirDateTime u_ = tuple_bundjkpliiuyymiejivrqjjcd?.AntiCoagulantOrdered?.AuthoredOnElement;
-                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
-                DataType w_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEStudy?.Effective;
-                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                CqlQuantity y_ = context.Operators.Quantity(12m, "hours");
-                CqlDateTime z_ = context.Operators.Subtract(x_ as CqlDateTime, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_ as CqlDateTime, true, false);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(v_, aa_, (string)default);
-
-                CqlBoolean ac_() {
-                    DataType ae_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEStudy?.Effective;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    return af_ is not null;
-                }
-
-
-                CqlBoolean ad_() {
-                    FhirDateTime ag_ = tuple_bundjkpliiuyymiejivrqjjcd?.AntiCoagulantOrdered?.AuthoredOnElement;
-                    CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
-                    DataType ai_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEStudy?.Effective;
-                    object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                    CqlQuantity ak_ = context.Operators.Quantity(12m, "hours");
-                    CqlDateTime al_ = context.Operators.Add(aj_ as CqlDateTime, ak_);
-                    CqlInterval<CqlDateTime> am_ = context.Operators.Interval(aj_ as CqlDateTime, al_ as CqlDateTime, false, true);
-                    CqlBoolean an_ = context.Operators.In<CqlDateTime>(ah_, am_, (string)default);
-
-                    CqlBoolean ao_() {
-                        DataType ap_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEStudy?.Effective;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return aq_ is not null;
-                    }
-
-                    return an_
-                        /* CQL 'and' (108:14-108:86) */ && ao_();
-                }
-
-                return (ab_
-                    /* CQL 'and' (107:13-107:86) */ && ac_())
-                    /* CQL 'or' (107:11-109:7) */ || ad_();
-            }
-
-
-            CqlBoolean t_() {
-                Period ar_ = tuple_bundjkpliiuyymiejivrqjjcd?.IndexPCP?.Period;
-                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.Start(as_);
-                DataType au_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEStudy?.Effective;
-                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                CqlQuantity aw_ = context.Operators.Quantity(30m, "days");
-                CqlDateTime ax_ = context.Operators.Subtract(av_ as CqlDateTime, aw_);
-                CqlInterval<CqlDateTime> ay_ = context.Operators.Interval(ax_, av_ as CqlDateTime, true, true);
-                CqlBoolean az_ = context.Operators.In<CqlDateTime>(at_, ay_, (string)default);
-
-                CqlBoolean ba_() {
-                    DataType bb_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEStudy?.Effective;
-                    object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                    return bc_ is not null;
-                }
-
-                return az_
-                    /* CQL 'and' (110:11-110:80) */ && ba_();
-            }
-
+            FhirDateTime s_ = tuple_bundjkpliiuyymiejivrqjjcd?.AntiCoagulantOrdered?.AuthoredOnElement;
+            CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
+            CqlQuantity u_ = context.Operators.Quantity(12m, "hours");
+            CqlDateTime v_ = context.Operators.Subtract(m_ as CqlDateTime, u_);
+            CqlInterval<CqlDateTime> w_ = context.Operators.Interval(v_, m_ as CqlDateTime, true, false);
+            CqlBoolean x_ = context.Operators.In<CqlDateTime>(t_, w_, (string)default);
+            CqlBoolean y_ = (CqlBoolean)(m_ is not null);
+            CqlDateTime z_ = context.Operators.Add(m_ as CqlDateTime, u_);
+            CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(m_ as CqlDateTime, z_ as CqlDateTime, false, true);
+            CqlBoolean ab_ = context.Operators.In<CqlDateTime>(t_, aa_, (string)default);
+            CqlBoolean ac_ = ab_
+                /* CQL 'and' (108:14-108:86) */ && y_;
+            CqlBoolean ad_ = (x_
+                /* CQL 'and' (107:13-107:86) */ && y_)
+                /* CQL 'or' (107:11-109:7) */ || ac_;
+            Period ae_ = tuple_bundjkpliiuyymiejivrqjjcd?.IndexPCP?.Period;
+            CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
+            CqlDateTime ag_ = context.Operators.Start(af_);
+            CqlQuantity ah_ = context.Operators.Quantity(30m, "days");
+            CqlDateTime ai_ = context.Operators.Subtract(m_ as CqlDateTime, ah_);
+            CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ai_, m_ as CqlDateTime, true, true);
+            CqlBoolean ak_ = context.Operators.In<CqlDateTime>(ag_, aj_, (string)default);
+            CqlBoolean al_ = ak_
+                /* CQL 'and' (110:11-110:80) */ && y_;
             return r_
-                /* CQL 'and' (106:11-109:7) */ && s_()
-                /* CQL 'and' (106:5-110:80) */ && t_();
+                /* CQL 'and' (106:11-109:7) */ && ad_
+                /* CQL 'and' (106:5-110:80) */ && al_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Encounter, DiagnosticReport, MedicationRequest>, (CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)?>(e_, f_, g_);
@@ -698,263 +599,214 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
             IEnumerable<Encounter> e_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? f_(Encounter InpatientEncounter) {
-                Encounter.HospitalizationComponent n_ = InpatientEncounter?.Hospitalization;
-                CodeableConcept o_ = n_?.DischargeDisposition;
-                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                CqlCode q_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
-                CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
-                CqlBoolean s_ = context.Operators.Equivalent(p_, r_);
-
-                CqlBoolean t_() {
-                    Encounter.HospitalizationComponent w_ = InpatientEncounter?.Hospitalization;
-                    CodeableConcept x_ = w_?.DischargeDisposition;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlCode z_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
-                    CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
-                    CqlBoolean ab_ = context.Operators.Equivalent(y_, aa_);
-                    return ab_;
-                }
-
-
-                CqlBoolean u_() {
-                    Period ac_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                    CqlDateTime ae_ = context.Operators.End(ad_);
-                    Period af_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.Start(ag_);
-                    CqlQuantity ai_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime aj_ = context.Operators.Subtract(ah_, ai_);
-                    CqlDateTime ak_ = context.Operators.End(ag_);
-                    CqlInterval<CqlDateTime> al_ = context.Operators.Interval(aj_, ak_, true, true);
-                    CqlBoolean am_ = context.Operators.In<CqlDateTime>(ae_, al_, "day");
-                    return am_;
-                }
-
-
-                CqlBoolean v_() {
-                    Code<Encounter.EncounterStatus> an_ = InpatientEncounter?.StatusElement;
-                    Encounter.EncounterStatus? ao_ = an_?.Value;
-                    Code<Encounter.EncounterStatus> ap_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ao_);
-                    CqlBoolean aq_ = context.Operators.Equal(ap_, "finished");
-                    return aq_;
-                }
-
-                return (s_
-                    /* CQL 'or' (127:15-129:9) */ || t_())
-                    /* CQL 'and' (127:15-130:87) */ && u_()
-                    /* CQL 'and' (127:9-131:52) */ && v_();
+                Encounter.HospitalizationComponent ak_ = InpatientEncounter?.Hospitalization;
+                CodeableConcept al_ = ak_?.DischargeDisposition;
+                CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, al_);
+                CqlCode an_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
+                CqlConcept ao_ = context.Operators.ConvertCodeToConcept(an_);
+                CqlBoolean ap_ = context.Operators.Equivalent(am_, ao_);
+                CqlCode aq_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
+                CqlConcept ar_ = context.Operators.ConvertCodeToConcept(aq_);
+                CqlBoolean as_ = context.Operators.Equivalent(am_, ar_);
+                CqlBoolean at_ = as_;
+                Period au_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
+                CqlDateTime aw_ = context.Operators.End(av_);
+                Period ax_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+                CqlQuantity ba_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime bb_ = context.Operators.Subtract(az_, ba_);
+                CqlDateTime bc_ = context.Operators.End(ay_);
+                CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(bb_, bc_, true, true);
+                CqlBoolean be_ = context.Operators.In<CqlDateTime>(aw_, bd_, "day");
+                CqlBoolean bf_ = be_;
+                Code<Encounter.EncounterStatus> bg_ = InpatientEncounter?.StatusElement;
+                Encounter.EncounterStatus? bh_ = bg_?.Value;
+                Code<Encounter.EncounterStatus> bi_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bh_);
+                CqlBoolean bj_ = context.Operators.Equal(bi_, "finished");
+                CqlBoolean bk_ = bj_;
+                return (ap_
+                    /* CQL 'or' (127:15-129:9) */ || at_)
+                    /* CQL 'and' (127:15-130:87) */ && bf_
+                    /* CQL 'and' (127:9-131:52) */ && bk_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Encounter>(e_, f_);
+            CqlValueSet h_ = this.Hospice_Encounter(context);
+            IEnumerable<Encounter> i_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-            CqlBoolean h_() {
-                CqlValueSet ar_ = this.Hospice_Encounter(context);
-                IEnumerable<Encounter> as_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ar_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                bool? at_(Encounter HospiceEncounter) {
-                    Period av_ = HospiceEncounter?.Period;
-                    CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
-                    Period ax_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
-                    CqlDateTime az_ = context.Operators.Start(ay_);
-                    CqlQuantity ba_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime bb_ = context.Operators.Subtract(az_, ba_);
-                    CqlDateTime bc_ = context.Operators.End(ay_);
-                    CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(bb_, bc_, true, true);
-                    CqlBoolean be_ = context.Operators.Overlaps(aw_, bd_, "day");
-                    return be_;
-                }
-
-                CqlBoolean au_ = context.Operators.WhereAny<Encounter>(as_, at_);
-                return au_;
+            bool? j_(Encounter HospiceEncounter) {
+                Period bl_ = HospiceEncounter?.Period;
+                CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
+                Period bn_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> bo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bn_);
+                CqlDateTime bp_ = context.Operators.Start(bo_);
+                CqlQuantity bq_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime br_ = context.Operators.Subtract(bp_, bq_);
+                CqlDateTime bs_ = context.Operators.End(bo_);
+                CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(br_, bs_, true, true);
+                CqlBoolean bu_ = context.Operators.Overlaps(bm_, bt_, "day");
+                return bu_;
             }
 
+            CqlBoolean k_ = context.Operators.WhereAny<Encounter>(i_, j_);
+            CqlBoolean l_ = k_;
+            CqlCode m_ = this.Hospice_care__Minimum_Data_Set_(context);
+            IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
+            IEnumerable<Observation> o_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, n_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
-            CqlBoolean i_() {
-                CqlCode bf_ = this.Hospice_care__Minimum_Data_Set_(context);
-                IEnumerable<CqlCode> bg_ = context.Operators.ToList<CqlCode>(bf_);
-                IEnumerable<Observation> bh_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, bg_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
-
-                bool? bi_(Observation HospiceAssessment) {
-                    DataType bk_ = HospiceAssessment?.Value;
-                    object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
-                    CqlCode bm_ = this.Yes__qualifier_value_(context);
-                    CqlConcept bn_ = context.Operators.ConvertCodeToConcept(bm_);
-                    CqlBoolean bo_ = context.Operators.Equivalent(bl_ as CqlConcept, bn_);
-
-                    CqlBoolean bp_() {
-                        DataType bq_ = HospiceAssessment?.Effective;
-                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                        CqlInterval<CqlDateTime> bs_ = QICoreCommon_4_0_000.Instance.toInterval(context, br_);
-                        Period bt_ = QualifiedVTEEncounter?.Period;
-                        CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bt_);
-                        CqlDateTime bv_ = context.Operators.Start(bu_);
-                        CqlQuantity bw_ = context.Operators.Quantity(90m, "days");
-                        CqlDateTime bx_ = context.Operators.Subtract(bv_, bw_);
-                        CqlDateTime by_ = context.Operators.End(bu_);
-                        CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bx_, by_, true, true);
-                        CqlBoolean ca_ = context.Operators.Overlaps(bs_, bz_, "day");
-                        return ca_;
-                    }
-
-                    return bo_
-                        /* CQL 'and' (137:11-138:103) */ && bp_();
-                }
-
-                CqlBoolean bj_ = context.Operators.WhereAny<Observation>(bh_, bi_);
-                return bj_;
+            bool? p_(Observation HospiceAssessment) {
+                DataType bv_ = HospiceAssessment?.Value;
+                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                CqlCode bx_ = this.Yes__qualifier_value_(context);
+                CqlConcept by_ = context.Operators.ConvertCodeToConcept(bx_);
+                CqlBoolean bz_ = context.Operators.Equivalent(bw_ as CqlConcept, by_);
+                DataType ca_ = HospiceAssessment?.Effective;
+                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
+                Period cd_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> ce_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cd_);
+                CqlDateTime cf_ = context.Operators.Start(ce_);
+                CqlQuantity cg_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime ch_ = context.Operators.Subtract(cf_, cg_);
+                CqlDateTime ci_ = context.Operators.End(ce_);
+                CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(ch_, ci_, true, true);
+                CqlBoolean ck_ = context.Operators.Overlaps(cc_, cj_, "day");
+                CqlBoolean cl_ = ck_;
+                return bz_
+                    /* CQL 'and' (137:11-138:103) */ && cl_;
             }
 
+            CqlBoolean q_ = context.Operators.WhereAny<Observation>(o_, p_);
+            CqlBoolean r_ = q_;
+            CqlValueSet s_ = this.Hospice_Care_Ambulatory(context);
+            IEnumerable<ServiceRequest> t_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, s_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
-            CqlBoolean j_() {
-                CqlValueSet cb_ = this.Hospice_Care_Ambulatory(context);
-                IEnumerable<ServiceRequest> cc_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, cb_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
-
-                bool? cd_(ServiceRequest HospiceOrder) {
-                    FhirDateTime cf_ = HospiceOrder?.AuthoredOnElement;
-                    CqlDateTime cg_ = context.Operators.Convert<CqlDateTime>(cf_);
-                    Period ch_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> ci_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ch_);
-                    CqlDateTime cj_ = context.Operators.Start(ci_);
-                    CqlQuantity ck_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime cl_ = context.Operators.Subtract(cj_, ck_);
-                    CqlDateTime cm_ = context.Operators.End(ci_);
-                    CqlInterval<CqlDateTime> cn_ = context.Operators.Interval(cl_, cm_, true, true);
-                    CqlBoolean co_ = context.Operators.In<CqlDateTime>(cg_, cn_, "day");
-
-                    CqlBoolean cp_() {
-                        Code<RequestStatus> cq_ = HospiceOrder?.StatusElement;
-                        RequestStatus? cr_ = cq_?.Value;
-                        Code<RequestStatus> cs_ = context.Operators.Convert<Code<RequestStatus>>(cr_);
-                        string ct_ = context.Operators.Convert<string>(cs_);
-                        string[] cu_ = [
-                            "active",
-                            "completed",
-                        ];
-                        CqlBoolean cv_ = context.Operators.In<string>(ct_, (IEnumerable<string>)cu_);
-                        return cv_;
-                    }
-
-                    return co_
-                        /* CQL 'and' (141:11-142:64) */ && cp_();
-                }
-
-                CqlBoolean ce_ = context.Operators.WhereAny<ServiceRequest>(cc_, cd_);
-                return ce_;
+            bool? u_(ServiceRequest HospiceOrder) {
+                FhirDateTime cm_ = HospiceOrder?.AuthoredOnElement;
+                CqlDateTime cn_ = context.Operators.Convert<CqlDateTime>(cm_);
+                Period co_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
+                CqlDateTime cq_ = context.Operators.Start(cp_);
+                CqlQuantity cr_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime cs_ = context.Operators.Subtract(cq_, cr_);
+                CqlDateTime ct_ = context.Operators.End(cp_);
+                CqlInterval<CqlDateTime> cu_ = context.Operators.Interval(cs_, ct_, true, true);
+                CqlBoolean cv_ = context.Operators.In<CqlDateTime>(cn_, cu_, "day");
+                Code<RequestStatus> cw_ = HospiceOrder?.StatusElement;
+                RequestStatus? cx_ = cw_?.Value;
+                Code<RequestStatus> cy_ = context.Operators.Convert<Code<RequestStatus>>(cx_);
+                string cz_ = context.Operators.Convert<string>(cy_);
+                string[] da_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean db_ = context.Operators.In<string>(cz_, (IEnumerable<string>)da_);
+                CqlBoolean dc_ = db_;
+                return cv_
+                    /* CQL 'and' (141:11-142:64) */ && dc_;
             }
 
+            CqlBoolean v_ = context.Operators.WhereAny<ServiceRequest>(t_, u_);
+            CqlBoolean w_ = v_;
+            IEnumerable<Procedure> x_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, s_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-            CqlBoolean k_() {
-                CqlValueSet cw_ = this.Hospice_Care_Ambulatory(context);
-                IEnumerable<Procedure> cx_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, cw_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-                bool? cy_(Procedure HospicePerformed) {
-                    object da_;
-                    DataType dk_ = HospicePerformed?.Performed;
-                    object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
-                    bool dm_ = dl_ is CqlDateTime;
-                    if (dm_)
+            bool? y_(Procedure HospicePerformed) {
+                object dd_;
+                DataType dn_ = HospicePerformed?.Performed;
+                object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+                bool dp_ = do_ is CqlDateTime;
+                if (dp_)
+                {
+                    dd_ = do_ as CqlDateTime;
+                }
+                else
+                {
+                    bool dq_ = do_ is CqlQuantity;
+                    if (dq_)
                     {
-                        da_ = dl_ as CqlDateTime;
+                        dd_ = do_ as CqlQuantity;
                     }
                     else
                     {
-                        bool dn_ = dl_ is CqlQuantity;
-                        if (dn_)
+                        bool dr_ = do_ is CqlInterval<CqlDateTime>;
+                        if (dr_)
                         {
-                            da_ = dl_ as CqlQuantity;
+                            dd_ = do_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool do_ = dl_ is CqlInterval<CqlDateTime>;
-                            if (do_)
+                            bool ds_ = do_ is CqlInterval<CqlQuantity>;
+                            if (ds_)
                             {
-                                da_ = dl_ as CqlInterval<CqlDateTime>;
+                                dd_ = do_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool dp_ = dl_ is CqlInterval<CqlQuantity>;
-                                if (dp_)
-                                {
-                                    da_ = dl_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    da_ = null;
-                                }
+                                dd_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> db_ = QICoreCommon_4_0_000.Instance.toInterval(context, da_);
-                    Period dc_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> dd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dc_);
-                    CqlDateTime de_ = context.Operators.Start(dd_);
-                    CqlQuantity df_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime dg_ = context.Operators.Subtract(de_, df_);
-                    CqlDateTime dh_ = context.Operators.End(dd_);
-                    CqlInterval<CqlDateTime> di_ = context.Operators.Interval(dg_, dh_, true, true);
-                    CqlBoolean dj_ = context.Operators.Overlaps(db_, di_, "day");
-                    return dj_;
                 }
-
-                CqlBoolean cz_ = context.Operators.WhereAny<Procedure>(cx_, cy_);
-                return cz_;
+                CqlInterval<CqlDateTime> de_ = QICoreCommon_4_0_000.Instance.toInterval(context, dd_);
+                Period df_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> dg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, df_);
+                CqlDateTime dh_ = context.Operators.Start(dg_);
+                CqlQuantity di_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime dj_ = context.Operators.Subtract(dh_, di_);
+                CqlDateTime dk_ = context.Operators.End(dg_);
+                CqlInterval<CqlDateTime> dl_ = context.Operators.Interval(dj_, dk_, true, true);
+                CqlBoolean dm_ = context.Operators.Overlaps(de_, dl_, "day");
+                return dm_;
             }
 
+            CqlBoolean z_ = context.Operators.WhereAny<Procedure>(x_, y_);
+            CqlBoolean aa_ = z_;
+            CqlValueSet ab_ = this.Hospice_Diagnosis(context);
+            IEnumerable<Condition> ac_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ab_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
-            CqlBoolean l_() {
-                CqlValueSet dq_ = this.Hospice_Diagnosis(context);
-                IEnumerable<Condition> dr_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, dq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-
-                bool? ds_(Condition HospiceCareDiagnosis) {
-                    CqlInterval<CqlDateTime> du_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis as Condition);
-                    Period dv_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
-                    CqlDateTime dx_ = context.Operators.Start(dw_);
-                    CqlQuantity dy_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime dz_ = context.Operators.Subtract(dx_, dy_);
-                    CqlDateTime ea_ = context.Operators.End(dw_);
-                    CqlInterval<CqlDateTime> eb_ = context.Operators.Interval(dz_, ea_, true, true);
-                    CqlBoolean ec_ = context.Operators.Overlaps(du_, eb_, "day");
-                    return ec_
-                        /* CQL 'and' (148:11-149:51) */ && this.isVerified(context, HospiceCareDiagnosis as Condition);
-                }
-
-                CqlBoolean dt_ = context.Operators.WhereAny<Condition>(dr_, ds_);
-                return dt_;
+            bool? ad_(Condition HospiceCareDiagnosis) {
+                CqlInterval<CqlDateTime> dt_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis as Condition);
+                Period du_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> dv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, du_);
+                CqlDateTime dw_ = context.Operators.Start(dv_);
+                CqlQuantity dx_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime dy_ = context.Operators.Subtract(dw_, dx_);
+                CqlDateTime dz_ = context.Operators.End(dv_);
+                CqlInterval<CqlDateTime> ea_ = context.Operators.Interval(dy_, dz_, true, true);
+                CqlBoolean eb_ = context.Operators.Overlaps(dt_, ea_, "day");
+                return eb_
+                    /* CQL 'and' (148:11-149:51) */ && this.isVerified(context, HospiceCareDiagnosis as Condition);
             }
 
+            CqlBoolean ae_ = context.Operators.WhereAny<Condition>(ac_, ad_);
+            CqlBoolean af_ = ae_;
+            IEnumerable<Condition> ag_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ab_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            CqlBoolean m_() {
-                CqlValueSet ed_ = this.Hospice_Diagnosis(context);
-                IEnumerable<Condition> ee_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ed_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-
-                bool? ef_(Condition HospiceCareConcern) {
-                    CqlInterval<CqlDateTime> eh_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareConcern as Condition);
-                    Period ei_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> ej_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ei_);
-                    CqlDateTime ek_ = context.Operators.Start(ej_);
-                    CqlQuantity el_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime em_ = context.Operators.Subtract(ek_, el_);
-                    CqlDateTime en_ = context.Operators.End(ej_);
-                    CqlInterval<CqlDateTime> eo_ = context.Operators.Interval(em_, en_, true, true);
-                    CqlBoolean ep_ = context.Operators.Overlaps(eh_, eo_, "day");
-                    return ep_
-                        /* CQL 'and' (152:11-153:49) */ && this.isVerified(context, HospiceCareConcern as Condition);
-                }
-
-                CqlBoolean eg_ = context.Operators.WhereAny<Condition>(ee_, ef_);
-                return eg_;
+            bool? ah_(Condition HospiceCareConcern) {
+                CqlInterval<CqlDateTime> ec_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareConcern as Condition);
+                Period ed_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ed_);
+                CqlDateTime ef_ = context.Operators.Start(ee_);
+                CqlQuantity eg_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime eh_ = context.Operators.Subtract(ef_, eg_);
+                CqlDateTime ei_ = context.Operators.End(ee_);
+                CqlInterval<CqlDateTime> ej_ = context.Operators.Interval(eh_, ei_, true, true);
+                CqlBoolean ek_ = context.Operators.Overlaps(ec_, ej_, "day");
+                return ek_
+                    /* CQL 'and' (152:11-153:49) */ && this.isVerified(context, HospiceCareConcern as Condition);
             }
 
+            CqlBoolean ai_ = context.Operators.WhereAny<Condition>(ag_, ah_);
+            CqlBoolean aj_ = ai_;
             return g_
-                /* CQL 'or' (126:11-135:7) */ || h_()
-                /* CQL 'or' (126:11-139:7) */ || i_()
-                /* CQL 'or' (126:11-143:7) */ || j_()
-                /* CQL 'or' (126:11-146:7) */ || k_()
-                /* CQL 'or' (126:11-150:7) */ || l_()
-                /* CQL 'or' (126:5-154:7) */ || m_();
+                /* CQL 'or' (126:11-135:7) */ || l_
+                /* CQL 'or' (126:11-139:7) */ || r_
+                /* CQL 'or' (126:11-143:7) */ || w_
+                /* CQL 'or' (126:11-146:7) */ || aa_
+                /* CQL 'or' (126:11-150:7) */ || af_
+                /* CQL 'or' (126:5-154:7) */ || aj_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -978,168 +830,147 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
             bool? g_(Observation PalliativeAssessment) {
-                DataType m_ = PalliativeAssessment?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                Period p_ = QualifiedVTEEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(90m, "days");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-                CqlDateTime u_ = context.Operators.End(q_);
-                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(t_, u_, true, true);
-                CqlBoolean w_ = context.Operators.Overlaps(o_, v_, "day");
-
-                CqlBoolean x_() {
-                    Code<ObservationStatus> y_ = PalliativeAssessment?.StatusElement;
-                    ObservationStatus? z_ = y_?.Value;
-                    string aa_ = context.Operators.Convert<string>(z_);
-                    string[] ab_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                    return ac_;
-                }
-
-                return w_
-                    /* CQL 'and' (161:9-162:80) */ && x_();
+                DataType ab_ = PalliativeAssessment?.Effective;
+                object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+                Period ae_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
+                CqlDateTime ag_ = context.Operators.Start(af_);
+                CqlQuantity ah_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime ai_ = context.Operators.Subtract(ag_, ah_);
+                CqlDateTime aj_ = context.Operators.End(af_);
+                CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ai_, aj_, true, true);
+                CqlBoolean al_ = context.Operators.Overlaps(ad_, ak_, "day");
+                Code<ObservationStatus> am_ = PalliativeAssessment?.StatusElement;
+                ObservationStatus? an_ = am_?.Value;
+                string ao_ = context.Operators.Convert<string>(an_);
+                string[] ap_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean aq_ = context.Operators.In<string>(ao_, (IEnumerable<string>)ap_);
+                CqlBoolean ar_ = aq_;
+                return al_
+                    /* CQL 'and' (161:9-162:80) */ && ar_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Observation>(f_, g_);
+            CqlValueSet i_ = this.Palliative_Care_Diagnosis(context);
+            IEnumerable<Condition> j_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
-            CqlBoolean i_() {
-                CqlValueSet ad_ = this.Palliative_Care_Diagnosis(context);
-                IEnumerable<Condition> ae_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ad_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-
-                bool? af_(Condition PalliativeCareDiagnosis) {
-                    CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeCareDiagnosis as Condition);
-                    Period ai_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
-                    CqlDateTime ak_ = context.Operators.Start(aj_);
-                    CqlQuantity al_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime am_ = context.Operators.Subtract(ak_, al_);
-                    CqlDateTime an_ = context.Operators.End(aj_);
-                    CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(am_, an_, true, true);
-                    CqlBoolean ap_ = context.Operators.Overlaps(ah_, ao_, "day");
-                    return ap_
-                        /* CQL 'and' (165:11-166:54) */ && this.isVerified(context, PalliativeCareDiagnosis as Condition);
-                }
-
-                CqlBoolean ag_ = context.Operators.WhereAny<Condition>(ae_, af_);
-                return ag_;
+            bool? k_(Condition PalliativeCareDiagnosis) {
+                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeCareDiagnosis as Condition);
+                Period at_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, at_);
+                CqlDateTime av_ = context.Operators.Start(au_);
+                CqlQuantity aw_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime ax_ = context.Operators.Subtract(av_, aw_);
+                CqlDateTime ay_ = context.Operators.End(au_);
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(ax_, ay_, true, true);
+                CqlBoolean ba_ = context.Operators.Overlaps(as_, az_, "day");
+                return ba_
+                    /* CQL 'and' (165:11-166:54) */ && this.isVerified(context, PalliativeCareDiagnosis as Condition);
             }
 
+            CqlBoolean l_ = context.Operators.WhereAny<Condition>(j_, k_);
+            CqlBoolean m_ = l_;
+            IEnumerable<Condition> n_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            CqlBoolean j_() {
-                CqlValueSet aq_ = this.Palliative_Care_Diagnosis(context);
-                IEnumerable<Condition> ar_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-
-                bool? as_(Condition PalliativeCareConcern) {
-                    CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeCareConcern as Condition);
-                    Period av_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
-                    CqlDateTime ax_ = context.Operators.Start(aw_);
-                    CqlQuantity ay_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime az_ = context.Operators.Subtract(ax_, ay_);
-                    CqlDateTime ba_ = context.Operators.End(aw_);
-                    CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(az_, ba_, true, true);
-                    CqlBoolean bc_ = context.Operators.Overlaps(au_, bb_, "day");
-                    return bc_
-                        /* CQL 'and' (169:11-170:52) */ && this.isVerified(context, PalliativeCareConcern as Condition);
-                }
-
-                CqlBoolean at_ = context.Operators.WhereAny<Condition>(ar_, as_);
-                return at_;
+            bool? o_(Condition PalliativeCareConcern) {
+                CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeCareConcern as Condition);
+                Period bc_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> bd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bc_);
+                CqlDateTime be_ = context.Operators.Start(bd_);
+                CqlQuantity bf_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime bg_ = context.Operators.Subtract(be_, bf_);
+                CqlDateTime bh_ = context.Operators.End(bd_);
+                CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(bg_, bh_, true, true);
+                CqlBoolean bj_ = context.Operators.Overlaps(bb_, bi_, "day");
+                return bj_
+                    /* CQL 'and' (169:11-170:52) */ && this.isVerified(context, PalliativeCareConcern as Condition);
             }
 
+            CqlBoolean p_ = context.Operators.WhereAny<Condition>(n_, o_);
+            CqlBoolean q_ = p_;
+            CqlValueSet r_ = this.Palliative_Care_Encounter(context);
+            IEnumerable<Encounter> s_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, r_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-            CqlBoolean k_() {
-                CqlValueSet bd_ = this.Palliative_Care_Encounter(context);
-                IEnumerable<Encounter> be_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, bd_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                bool? bf_(Encounter PalliativeEncounter) {
-                    Period bh_ = PalliativeEncounter?.Period;
-                    CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bh_);
-                    Period bj_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bj_);
-                    CqlDateTime bl_ = context.Operators.Start(bk_);
-                    CqlQuantity bm_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime bn_ = context.Operators.Subtract(bl_, bm_);
-                    CqlDateTime bo_ = context.Operators.End(bk_);
-                    CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bn_, bo_, true, true);
-                    CqlBoolean bq_ = context.Operators.Overlaps(bi_, bp_, "day");
-                    return bq_;
-                }
-
-                CqlBoolean bg_ = context.Operators.WhereAny<Encounter>(be_, bf_);
-                return bg_;
+            bool? t_(Encounter PalliativeEncounter) {
+                Period bk_ = PalliativeEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                Period bm_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
+                CqlDateTime bo_ = context.Operators.Start(bn_);
+                CqlQuantity bp_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime bq_ = context.Operators.Subtract(bo_, bp_);
+                CqlDateTime br_ = context.Operators.End(bn_);
+                CqlInterval<CqlDateTime> bs_ = context.Operators.Interval(bq_, br_, true, true);
+                CqlBoolean bt_ = context.Operators.Overlaps(bl_, bs_, "day");
+                return bt_;
             }
 
+            CqlBoolean u_ = context.Operators.WhereAny<Encounter>(s_, t_);
+            CqlBoolean v_ = u_;
+            CqlValueSet w_ = this.Palliative_Care_Intervention(context);
+            IEnumerable<Procedure> x_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, w_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-            CqlBoolean l_() {
-                CqlValueSet br_ = this.Palliative_Care_Intervention(context);
-                IEnumerable<Procedure> bs_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, br_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-                bool? bt_(Procedure PalliativeIntervention) {
-                    object bv_;
-                    DataType cf_ = PalliativeIntervention?.Performed;
-                    object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                    bool ch_ = cg_ is CqlDateTime;
+            bool? y_(Procedure PalliativeIntervention) {
+                object bu_;
+                DataType ce_ = PalliativeIntervention?.Performed;
+                object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                bool cg_ = cf_ is CqlDateTime;
+                if (cg_)
+                {
+                    bu_ = cf_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ch_ = cf_ is CqlQuantity;
                     if (ch_)
                     {
-                        bv_ = cg_ as CqlDateTime;
+                        bu_ = cf_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ci_ = cg_ is CqlQuantity;
+                        bool ci_ = cf_ is CqlInterval<CqlDateTime>;
                         if (ci_)
                         {
-                            bv_ = cg_ as CqlQuantity;
+                            bu_ = cf_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool cj_ = cg_ is CqlInterval<CqlDateTime>;
+                            bool cj_ = cf_ is CqlInterval<CqlQuantity>;
                             if (cj_)
                             {
-                                bv_ = cg_ as CqlInterval<CqlDateTime>;
+                                bu_ = cf_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ck_ = cg_ is CqlInterval<CqlQuantity>;
-                                if (ck_)
-                                {
-                                    bv_ = cg_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    bv_ = null;
-                                }
+                                bu_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> bw_ = QICoreCommon_4_0_000.Instance.toInterval(context, bv_);
-                    Period bx_ = QualifiedVTEEncounter?.Period;
-                    CqlInterval<CqlDateTime> by_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bx_);
-                    CqlDateTime bz_ = context.Operators.Start(by_);
-                    CqlQuantity ca_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime cb_ = context.Operators.Subtract(bz_, ca_);
-                    CqlDateTime cc_ = context.Operators.End(by_);
-                    CqlInterval<CqlDateTime> cd_ = context.Operators.Interval(cb_, cc_, true, true);
-                    CqlBoolean ce_ = context.Operators.Overlaps(bw_, cd_, "day");
-                    return ce_;
                 }
-
-                CqlBoolean bu_ = context.Operators.WhereAny<Procedure>(bs_, bt_);
-                return bu_;
+                CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_);
+                Period bw_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bw_);
+                CqlDateTime by_ = context.Operators.Start(bx_);
+                CqlQuantity bz_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime ca_ = context.Operators.Subtract(by_, bz_);
+                CqlDateTime cb_ = context.Operators.End(bx_);
+                CqlInterval<CqlDateTime> cc_ = context.Operators.Interval(ca_, cb_, true, true);
+                CqlBoolean cd_ = context.Operators.Overlaps(bv_, cc_, "day");
+                return cd_;
             }
 
+            CqlBoolean z_ = context.Operators.WhereAny<Procedure>(x_, y_);
+            CqlBoolean aa_ = z_;
             return h_
-                /* CQL 'or' (160:11-167:7) */ || i_()
-                /* CQL 'or' (160:11-171:7) */ || j_()
-                /* CQL 'or' (160:11-174:7) */ || k_()
-                /* CQL 'or' (160:5-177:7) */ || l_();
+                /* CQL 'or' (160:11-167:7) */ || m_
+                /* CQL 'or' (160:11-171:7) */ || q_
+                /* CQL 'or' (160:11-174:7) */ || v_
+                /* CQL 'or' (160:5-177:7) */ || aa_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1171,16 +1002,9 @@ public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleto
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlInterval<CqlDateTime> o_ = context.Operators.Interval(n_, l_, true, false);
                 CqlBoolean p_ = context.Operators.In<CqlDateTime>(i_, o_, (string)default);
-
-                CqlBoolean q_() {
-                    Period r_ = CurrentQualifiedVTE?.Period;
-                    CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.Start(s_);
-                    return t_ is not null;
-                }
-
+                CqlBoolean q_ = (CqlBoolean)(l_ is not null);
                 return p_
-                    /* CQL 'and' (182:17-182:110) */ && q_();
+                    /* CQL 'and' (182:17-182:110) */ && q_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter>(d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS117FHIRChildImmunStatus-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS117FHIRChildImmunStatus-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS117FHIRChildImmunStatus", "1.0.000")]
 public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<CMS117FHIRChildImmunStatus_1_0_000>
 {
@@ -402,15 +402,11 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.Equal(h_, 2);
-
-        CqlBoolean j_() {
-            IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
-            CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
-            return l_;
-        }
-
+        IEnumerable<Encounter> j_ = this.Qualifying_Encounters(context);
+        CqlBoolean k_ = context.Operators.Exists<Encounter>(j_);
+        CqlBoolean l_ = k_;
         return i_
-            /* CQL 'and' (80:3-83:42) */ && j_();
+            /* CQL 'and' (80:3-83:42) */ && l_;
     }
 
 
@@ -737,37 +733,23 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity o_ = context.Operators.Quantity(1m, "day");
             CqlDate p_ = context.Operators.Add(n_, o_);
             CqlBoolean q_ = context.Operators.SameOrAfter(k_, p_, "day");
-
-            CqlBoolean r_() {
-                CqlDateTime t_ = context.Operators.ConvertDateToDateTime(tuple_emdhflcfhwveravvnflazyxji?.DTaPVaccination3 as CqlDate);
-                CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
-                CqlDate v_ = context.Operators.DateFrom(u_);
-                CqlDateTime w_ = context.Operators.ConvertDateToDateTime(v_);
-                CqlDateTime x_ = context.Operators.ConvertDateToDateTime(tuple_emdhflcfhwveravvnflazyxji?.DTaPVaccination2 as CqlDate);
-                CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
-                CqlQuantity z_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime aa_ = context.Operators.Add(y_, z_);
-                CqlBoolean ab_ = context.Operators.SameOrAfter(w_, aa_, "day");
-                return ab_;
-            }
-
-
-            CqlBoolean s_() {
-                CqlDateTime ac_ = context.Operators.ConvertDateToDateTime(tuple_emdhflcfhwveravvnflazyxji?.DTaPVaccination4 as CqlDate);
-                CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.earliest(context, ac_);
-                CqlDate ae_ = context.Operators.DateFrom(ad_);
-                CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_emdhflcfhwveravvnflazyxji?.DTaPVaccination3 as CqlDate);
-                CqlDateTime ah_ = QICoreCommon_4_0_000.Instance.earliest(context, ag_);
-                CqlQuantity ai_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime aj_ = context.Operators.Add(ah_, ai_);
-                CqlBoolean ak_ = context.Operators.SameOrAfter(af_, aj_, "day");
-                return ak_;
-            }
-
+            CqlDateTime r_ = context.Operators.ConvertDateToDateTime(tuple_emdhflcfhwveravvnflazyxji?.DTaPVaccination3 as CqlDate);
+            CqlDateTime s_ = QICoreCommon_4_0_000.Instance.earliest(context, r_);
+            CqlDate t_ = context.Operators.DateFrom(s_);
+            CqlDateTime u_ = context.Operators.ConvertDateToDateTime(t_);
+            CqlDateTime v_ = context.Operators.Add(j_, o_);
+            CqlBoolean w_ = context.Operators.SameOrAfter(u_, v_, "day");
+            CqlBoolean x_ = w_;
+            CqlDateTime y_ = context.Operators.ConvertDateToDateTime(tuple_emdhflcfhwveravvnflazyxji?.DTaPVaccination4 as CqlDate);
+            CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, y_);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(aa_);
+            CqlDateTime ac_ = context.Operators.Add(s_, o_);
+            CqlBoolean ad_ = context.Operators.SameOrAfter(ab_, ac_, "day");
+            CqlBoolean ae_ = ad_;
             return q_
-                /* CQL 'and' (212:11-213:106) */ && r_()
-                /* CQL 'and' (212:5-214:106) */ && s_();
+                /* CQL 'and' (212:11-213:106) */ && x_
+                /* CQL 'and' (212:5-214:106) */ && ae_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate DTaPVaccination1, CqlDate DTaPVaccination2, CqlDate DTaPVaccination3, CqlDate DTaPVaccination4)?> e_ = context.Operators.SelectWhere<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>, (CqlTupleMetadata, CqlDate DTaPVaccination1, CqlDate DTaPVaccination2, CqlDate DTaPVaccination3, CqlDate DTaPVaccination4)?>(b_, c_, d_);
@@ -900,31 +882,23 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity o_ = context.Operators.Quantity(1m, "day");
             CqlDate p_ = context.Operators.Add(n_, o_);
             CqlBoolean q_ = context.Operators.SameOrAfter(k_, p_, (string)default);
-
-            CqlBoolean r_() {
-                CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_cnghazroxajthpiccbiajbrxv?.PolioVaccination3 as CqlDate);
-                CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
-                CqlDate u_ = context.Operators.DateFrom(t_);
-                CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_cnghazroxajthpiccbiajbrxv?.PolioVaccination2 as CqlDate);
-                CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
-                CqlDate x_ = context.Operators.DateFrom(w_);
-                CqlQuantity y_ = context.Operators.Quantity(1m, "day");
-                CqlDate z_ = context.Operators.Add(x_, y_);
-                CqlBoolean aa_ = context.Operators.SameOrAfter(u_, z_, (string)default);
-                return aa_;
-            }
-
+            CqlDateTime r_ = context.Operators.ConvertDateToDateTime(tuple_cnghazroxajthpiccbiajbrxv?.PolioVaccination3 as CqlDate);
+            CqlDateTime s_ = QICoreCommon_4_0_000.Instance.earliest(context, r_);
+            CqlDate t_ = context.Operators.DateFrom(s_);
+            CqlDate u_ = context.Operators.Add(k_, o_);
+            CqlBoolean v_ = context.Operators.SameOrAfter(t_, u_, (string)default);
+            CqlBoolean w_ = v_;
             return q_
-                /* CQL 'and' (253:5-254:111) */ && r_();
+                /* CQL 'and' (253:5-254:111) */ && w_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate PolioVaccination1, CqlDate PolioVaccination2, CqlDate PolioVaccination3)?> e_ = context.Operators.SelectWhere<ValueTuple<CqlDate, CqlDate, CqlDate>, (CqlTupleMetadata, CqlDate PolioVaccination1, CqlDate PolioVaccination2, CqlDate PolioVaccination3)?>(b_, c_, d_);
 
         CqlDate f_((CqlTupleMetadata, CqlDate PolioVaccination1, CqlDate PolioVaccination2, CqlDate PolioVaccination3)? tuple_cnghazroxajthpiccbiajbrxv) {
-            CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(tuple_cnghazroxajthpiccbiajbrxv?.PolioVaccination1 as CqlDate);
-            CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_);
-            CqlDate ad_ = context.Operators.DateFrom(ac_);
-            return ad_;
+            CqlDateTime x_ = context.Operators.ConvertDateToDateTime(tuple_cnghazroxajthpiccbiajbrxv?.PolioVaccination1 as CqlDate);
+            CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
+            CqlDate z_ = context.Operators.DateFrom(y_);
+            return z_;
         }
 
         IEnumerable<CqlDate> g_ = context.Operators.SelectDistinct<(CqlTupleMetadata, CqlDate PolioVaccination1, CqlDate PolioVaccination2, CqlDate PolioVaccination3)?, CqlDate>(e_, f_);
@@ -1328,54 +1302,38 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
             IEnumerable<CqlDate> d_ = this.Hib_4_Dose_Immunizations_or_Procedures(context);
             int? e_ = context.Operators.Count<CqlDate>(d_);
             CqlBoolean f_ = context.Operators.Greater(e_, 0);
+            IEnumerable<CqlDate> g_ = this.Hib_3_or_4_Dose_Immunizations(context);
 
-            CqlBoolean g_() {
-                IEnumerable<CqlDate> i_ = this.Hib_3_or_4_Dose_Immunizations(context);
-
-                CqlDate j_(CqlDate HibVaccinations) {
-                    CqlDateTime o_ = context.Operators.ConvertDateToDateTime(HibVaccinations as CqlDate);
-                    CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_);
-                    CqlDate q_ = context.Operators.DateFrom(p_);
-                    return q_;
-                }
-
-                IEnumerable<CqlDate> k_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(i_, j_);
-                IEnumerable<CqlDate> l_ = context.Operators.Distinct<CqlDate>(k_);
-                int? m_ = context.Operators.Count<CqlDate>(l_);
-                CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 4);
-                return n_;
+            CqlDate h_(CqlDate HibVaccinations) {
+                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(HibVaccinations as CqlDate);
+                CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
+                CqlDate w_ = context.Operators.DateFrom(v_);
+                return w_;
             }
 
+            IEnumerable<CqlDate> i_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(g_, h_);
+            IEnumerable<CqlDate> j_ = context.Operators.Distinct<CqlDate>(i_);
+            int? k_ = context.Operators.Count<CqlDate>(j_);
+            CqlBoolean l_ = context.Operators.GreaterOrEqual(k_, 4);
+            CqlBoolean m_ = l_;
 
-            CqlBoolean h_() {
-                IEnumerable<CqlDate> r_ = this.Hib_4_Dose_Immunizations_or_Procedures(context);
-                int? s_ = context.Operators.Count<CqlDate>(r_);
-                CqlBoolean t_ = context.Operators.Greater(s_, 0);
-
-                CqlBoolean u_() {
-                    IEnumerable<CqlDate> v_ = this.Hib_3_or_4_Dose_Immunizations(context);
-
-                    CqlDate w_(CqlDate HibVaccinations) {
-                        CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(HibVaccinations as CqlDate);
-                        CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_);
-                        CqlDate ad_ = context.Operators.DateFrom(ac_);
-                        return ad_;
-                    }
-
-                    IEnumerable<CqlDate> x_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(v_, w_);
-                    IEnumerable<CqlDate> y_ = context.Operators.Distinct<CqlDate>(x_);
-                    int? z_ = context.Operators.Count<CqlDate>(y_);
-                    CqlBoolean aa_ = context.Operators.GreaterOrEqual(z_, 3);
-                    return aa_;
-                }
-
-                return (CqlBoolean)(/* CQL 'is false' (315:14-315:33) */ t_.IsFalse)
-                    /* CQL 'and' (315:12-322:9) */ && u_();
+            CqlDate n_(CqlDate HibVaccinations) {
+                CqlDateTime x_ = context.Operators.ConvertDateToDateTime(HibVaccinations as CqlDate);
+                CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
+                CqlDate z_ = context.Operators.DateFrom(y_);
+                return z_;
             }
 
+            IEnumerable<CqlDate> o_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(g_, n_);
+            IEnumerable<CqlDate> p_ = context.Operators.Distinct<CqlDate>(o_);
+            int? q_ = context.Operators.Count<CqlDate>(p_);
+            CqlBoolean r_ = context.Operators.GreaterOrEqual(q_, 3);
+            CqlBoolean s_ = r_;
+            CqlBoolean t_ = (CqlBoolean)(/* CQL 'is false' (315:14-315:33) */ f_.IsFalse)
+                /* CQL 'and' (315:12-322:9) */ && s_;
             return (f_
-                /* CQL 'and' (307:13-314:7) */ && g_())
-                /* CQL 'or' (307:7-322:9) */ || h_();
+                /* CQL 'and' (307:13-314:7) */ && m_)
+                /* CQL 'or' (307:7-322:9) */ || t_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<CqlDate>(a_, b_);
@@ -1502,31 +1460,23 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity o_ = context.Operators.Quantity(1m, "day");
             CqlDate p_ = context.Operators.Add(n_, o_);
             CqlBoolean q_ = context.Operators.SameOrAfter(k_, p_, (string)default);
-
-            CqlBoolean r_() {
-                CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_eztgahauwggsdgadcgqnnipgw?.HepatitisBVaccination3 as CqlDate);
-                CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
-                CqlDate u_ = context.Operators.DateFrom(t_);
-                CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_eztgahauwggsdgadcgqnnipgw?.HepatitisBVaccination2 as CqlDate);
-                CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
-                CqlDate x_ = context.Operators.DateFrom(w_);
-                CqlQuantity y_ = context.Operators.Quantity(1m, "day");
-                CqlDate z_ = context.Operators.Add(x_, y_);
-                CqlBoolean aa_ = context.Operators.SameOrAfter(u_, z_, (string)default);
-                return aa_;
-            }
-
+            CqlDateTime r_ = context.Operators.ConvertDateToDateTime(tuple_eztgahauwggsdgadcgqnnipgw?.HepatitisBVaccination3 as CqlDate);
+            CqlDateTime s_ = QICoreCommon_4_0_000.Instance.earliest(context, r_);
+            CqlDate t_ = context.Operators.DateFrom(s_);
+            CqlDate u_ = context.Operators.Add(k_, o_);
+            CqlBoolean v_ = context.Operators.SameOrAfter(t_, u_, (string)default);
+            CqlBoolean w_ = v_;
             return q_
-                /* CQL 'and' (371:5-372:121) */ && r_();
+                /* CQL 'and' (371:5-372:121) */ && w_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate HepatitisBVaccination3)?> e_ = context.Operators.SelectWhere<ValueTuple<CqlDate, CqlDate, CqlDate>, (CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate HepatitisBVaccination3)?>(b_, c_, d_);
 
         CqlDate f_((CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate HepatitisBVaccination3)? tuple_eztgahauwggsdgadcgqnnipgw) {
-            CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(tuple_eztgahauwggsdgadcgqnnipgw?.HepatitisBVaccination1 as CqlDate);
-            CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_);
-            CqlDate ad_ = context.Operators.DateFrom(ac_);
-            return ad_;
+            CqlDateTime x_ = context.Operators.ConvertDateToDateTime(tuple_eztgahauwggsdgadcgqnnipgw?.HepatitisBVaccination1 as CqlDate);
+            CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
+            CqlDate z_ = context.Operators.DateFrom(y_);
+            return z_;
         }
 
         IEnumerable<CqlDate> g_ = context.Operators.SelectDistinct<(CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate HepatitisBVaccination3)?, CqlDate>(e_, f_);
@@ -1608,46 +1558,26 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity p_ = context.Operators.Quantity(1m, "day");
             CqlDate q_ = context.Operators.Add(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrAfter(l_, q_, (string)default);
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.HepatitisBVaccination1 as CqlDate);
-                CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
-                CqlDate w_ = context.Operators.DateFrom(v_);
-                CqlDateTime x_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.NewBornVaccine3 as CqlDate);
-                CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
-                CqlDate z_ = context.Operators.DateFrom(y_);
-                CqlQuantity aa_ = context.Operators.Quantity(1m, "day");
-                CqlDate ab_ = context.Operators.Add(z_, aa_);
-                CqlBoolean ac_ = context.Operators.SameOrAfter(w_, ab_, (string)default);
-                return ac_;
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.HepatitisBVaccination2 as CqlDate);
-                CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
-                CqlDate af_ = context.Operators.DateFrom(ae_);
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.NewBornVaccine3 as CqlDate);
-                CqlDateTime ah_ = QICoreCommon_4_0_000.Instance.earliest(context, ag_);
-                CqlDate ai_ = context.Operators.DateFrom(ah_);
-                CqlQuantity aj_ = context.Operators.Quantity(1m, "day");
-                CqlDate ak_ = context.Operators.Add(ai_, aj_);
-                CqlBoolean al_ = context.Operators.SameOrAfter(af_, ak_, (string)default);
-                return al_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.NewBornVaccine3 as CqlDate);
+            CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
+            CqlDate u_ = context.Operators.DateFrom(t_);
+            CqlDate v_ = context.Operators.Add(u_, p_);
+            CqlBoolean w_ = context.Operators.SameOrAfter(o_, v_, (string)default);
+            CqlBoolean x_ = w_;
+            CqlBoolean y_ = context.Operators.SameOrAfter(l_, v_, (string)default);
+            CqlBoolean z_ = y_;
             return r_
-                /* CQL 'and' (390:11-391:114) */ && s_()
-                /* CQL 'and' (390:5-392:114) */ && t_();
+                /* CQL 'and' (390:11-391:114) */ && x_
+                /* CQL 'and' (390:5-392:114) */ && z_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate NewBornVaccine3)?> f_ = context.Operators.SelectWhere<ValueTuple<CqlDate, CqlDate, CqlDate>, (CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate NewBornVaccine3)?>(c_, d_, e_);
 
         CqlDate g_((CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate NewBornVaccine3)? tuple_hdfambzgbwdpfetgqnfbceeeg) {
-            CqlDateTime am_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.HepatitisBVaccination1 as CqlDate);
-            CqlDateTime an_ = QICoreCommon_4_0_000.Instance.earliest(context, am_);
-            CqlDate ao_ = context.Operators.DateFrom(an_);
-            return ao_;
+            CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.HepatitisBVaccination1 as CqlDate);
+            CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_);
+            CqlDate ac_ = context.Operators.DateFrom(ab_);
+            return ac_;
         }
 
         IEnumerable<CqlDate> h_ = context.Operators.SelectDistinct<(CqlTupleMetadata, CqlDate HepatitisBVaccination1, CqlDate HepatitisBVaccination2, CqlDate NewBornVaccine3)?, CqlDate>(f_, g_);
@@ -1876,46 +1806,30 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity o_ = context.Operators.Quantity(1m, "day");
             CqlDate p_ = context.Operators.Add(n_, o_);
             CqlBoolean q_ = context.Operators.SameOrAfter(k_, p_, (string)default);
-
-            CqlBoolean r_() {
-                CqlDateTime t_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination3 as CqlDate);
-                CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
-                CqlDate v_ = context.Operators.DateFrom(u_);
-                CqlDateTime w_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination2 as CqlDate);
-                CqlDateTime x_ = QICoreCommon_4_0_000.Instance.earliest(context, w_);
-                CqlDate y_ = context.Operators.DateFrom(x_);
-                CqlQuantity z_ = context.Operators.Quantity(1m, "day");
-                CqlDate aa_ = context.Operators.Add(y_, z_);
-                CqlBoolean ab_ = context.Operators.SameOrAfter(v_, aa_, (string)default);
-                return ab_;
-            }
-
-
-            CqlBoolean s_() {
-                CqlDateTime ac_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination4 as CqlDate);
-                CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.earliest(context, ac_);
-                CqlDate ae_ = context.Operators.DateFrom(ad_);
-                CqlDateTime af_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination3 as CqlDate);
-                CqlDateTime ag_ = QICoreCommon_4_0_000.Instance.earliest(context, af_);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlQuantity ai_ = context.Operators.Quantity(1m, "day");
-                CqlDate aj_ = context.Operators.Add(ah_, ai_);
-                CqlBoolean ak_ = context.Operators.SameOrAfter(ae_, aj_, (string)default);
-                return ak_;
-            }
-
+            CqlDateTime r_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination3 as CqlDate);
+            CqlDateTime s_ = QICoreCommon_4_0_000.Instance.earliest(context, r_);
+            CqlDate t_ = context.Operators.DateFrom(s_);
+            CqlDate u_ = context.Operators.Add(k_, o_);
+            CqlBoolean v_ = context.Operators.SameOrAfter(t_, u_, (string)default);
+            CqlBoolean w_ = v_;
+            CqlDateTime x_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination4 as CqlDate);
+            CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
+            CqlDate z_ = context.Operators.DateFrom(y_);
+            CqlDate aa_ = context.Operators.Add(t_, o_);
+            CqlBoolean ab_ = context.Operators.SameOrAfter(z_, aa_, (string)default);
+            CqlBoolean ac_ = ab_;
             return q_
-                /* CQL 'and' (430:11-431:125) */ && r_()
-                /* CQL 'and' (430:5-432:125) */ && s_();
+                /* CQL 'and' (430:11-431:125) */ && w_
+                /* CQL 'and' (430:5-432:125) */ && ac_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate PneumococcalVaccination1, CqlDate PneumococcalVaccination2, CqlDate PneumococcalVaccination3, CqlDate PneumococcalVaccination4)?> e_ = context.Operators.SelectWhere<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>, (CqlTupleMetadata, CqlDate PneumococcalVaccination1, CqlDate PneumococcalVaccination2, CqlDate PneumococcalVaccination3, CqlDate PneumococcalVaccination4)?>(b_, c_, d_);
 
         CqlDate f_((CqlTupleMetadata, CqlDate PneumococcalVaccination1, CqlDate PneumococcalVaccination2, CqlDate PneumococcalVaccination3, CqlDate PneumococcalVaccination4)? tuple_ddpdeojhpyesfhgcocbnoippp) {
-            CqlDateTime al_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination1 as CqlDate);
-            CqlDateTime am_ = QICoreCommon_4_0_000.Instance.earliest(context, al_);
-            CqlDate an_ = context.Operators.DateFrom(am_);
-            return an_;
+            CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination1 as CqlDate);
+            CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
+            CqlDate af_ = context.Operators.DateFrom(ae_);
+            return af_;
         }
 
         IEnumerable<CqlDate> g_ = context.Operators.SelectDistinct<(CqlTupleMetadata, CqlDate PneumococcalVaccination1, CqlDate PneumococcalVaccination2, CqlDate PneumococcalVaccination3, CqlDate PneumococcalVaccination4)?, CqlDate>(e_, f_);
@@ -2205,54 +2119,38 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
             IEnumerable<CqlDate> d_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures(context);
             int? e_ = context.Operators.Count<CqlDate>(d_);
             CqlBoolean f_ = context.Operators.Greater(e_, 0);
+            IEnumerable<CqlDate> g_ = this.Rotavirus_2_or_3_Dose_Immunizations(context);
 
-            CqlBoolean g_() {
-                IEnumerable<CqlDate> i_ = this.Rotavirus_2_or_3_Dose_Immunizations(context);
-
-                CqlDate j_(CqlDate RotavirusVaccinations) {
-                    CqlDateTime o_ = context.Operators.ConvertDateToDateTime(RotavirusVaccinations as CqlDate);
-                    CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_);
-                    CqlDate q_ = context.Operators.DateFrom(p_);
-                    return q_;
-                }
-
-                IEnumerable<CqlDate> k_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(i_, j_);
-                IEnumerable<CqlDate> l_ = context.Operators.Distinct<CqlDate>(k_);
-                int? m_ = context.Operators.Count<CqlDate>(l_);
-                CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 3);
-                return n_;
+            CqlDate h_(CqlDate RotavirusVaccinations) {
+                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(RotavirusVaccinations as CqlDate);
+                CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
+                CqlDate w_ = context.Operators.DateFrom(v_);
+                return w_;
             }
 
+            IEnumerable<CqlDate> i_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(g_, h_);
+            IEnumerable<CqlDate> j_ = context.Operators.Distinct<CqlDate>(i_);
+            int? k_ = context.Operators.Count<CqlDate>(j_);
+            CqlBoolean l_ = context.Operators.GreaterOrEqual(k_, 3);
+            CqlBoolean m_ = l_;
 
-            CqlBoolean h_() {
-                IEnumerable<CqlDate> r_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures(context);
-                int? s_ = context.Operators.Count<CqlDate>(r_);
-                CqlBoolean t_ = context.Operators.Greater(s_, 0);
-
-                CqlBoolean u_() {
-                    IEnumerable<CqlDate> v_ = this.Rotavirus_2_or_3_Dose_Immunizations(context);
-
-                    CqlDate w_(CqlDate RotavirusVaccinations) {
-                        CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(RotavirusVaccinations as CqlDate);
-                        CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_);
-                        CqlDate ad_ = context.Operators.DateFrom(ac_);
-                        return ad_;
-                    }
-
-                    IEnumerable<CqlDate> x_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(v_, w_);
-                    IEnumerable<CqlDate> y_ = context.Operators.Distinct<CqlDate>(x_);
-                    int? z_ = context.Operators.Count<CqlDate>(y_);
-                    CqlBoolean aa_ = context.Operators.GreaterOrEqual(z_, 2);
-                    return aa_;
-                }
-
-                return (CqlBoolean)(/* CQL 'is false' (484:14-484:34) */ t_.IsFalse)
-                    /* CQL 'and' (484:12-489:9) */ && u_();
+            CqlDate n_(CqlDate RotavirusVaccinations) {
+                CqlDateTime x_ = context.Operators.ConvertDateToDateTime(RotavirusVaccinations as CqlDate);
+                CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
+                CqlDate z_ = context.Operators.DateFrom(y_);
+                return z_;
             }
 
+            IEnumerable<CqlDate> o_ = context.Operators.SelectDistinct<CqlDate, CqlDate>(g_, n_);
+            IEnumerable<CqlDate> p_ = context.Operators.Distinct<CqlDate>(o_);
+            int? q_ = context.Operators.Count<CqlDate>(p_);
+            CqlBoolean r_ = context.Operators.GreaterOrEqual(q_, 2);
+            CqlBoolean s_ = r_;
+            CqlBoolean t_ = (CqlBoolean)(/* CQL 'is false' (484:14-484:34) */ f_.IsFalse)
+                /* CQL 'and' (484:12-489:9) */ && s_;
             return (f_
-                /* CQL 'and' (478:13-483:7) */ && g_())
-                /* CQL 'or' (478:7-489:9) */ || h_();
+                /* CQL 'and' (478:13-483:7) */ && m_)
+                /* CQL 'or' (478:7-489:9) */ || t_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<CqlDate>(a_, b_);
@@ -2493,15 +2391,11 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<CqlDate> a_ = this.LAIV_Vaccinations(context);
         CqlBoolean b_ = context.Operators.Exists<CqlDate>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<CqlDate> d_ = this.Influenza_Immunizations_or_Procedures(context);
-            CqlBoolean e_ = context.Operators.Exists<CqlDate>(d_);
-            return e_;
-        }
-
+        IEnumerable<CqlDate> c_ = this.Influenza_Immunizations_or_Procedures(context);
+        CqlBoolean d_ = context.Operators.Exists<CqlDate>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'and' (549:3-550:54) */ && c_();
+            /* CQL 'and' (549:3-550:54) */ && e_;
     }
 
 
@@ -2544,190 +2438,98 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
     {
         IEnumerable<CqlDate> a_ = this.Four_DTaP_Vaccinations(context);
         CqlBoolean b_ = context.Operators.Exists<CqlDate>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Condition> m_ = this.DTaP_Numerator_Inclusion_Conditions(context);
-            CqlBoolean n_ = context.Operators.Exists<Condition>(m_);
-            return n_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<CqlDate> o_ = this.Three_Polio_Vaccinations(context);
-            CqlBoolean p_ = context.Operators.Exists<CqlDate>(o_);
-
-            CqlBoolean q_() {
-                IEnumerable<Condition> r_ = this.Polio_Numerator_Inclusion_Conditions(context);
-                CqlBoolean s_ = context.Operators.Exists<Condition>(r_);
-                return s_;
-            }
-
-            return p_
-                /* CQL 'or' (150:9-152:5) */ || q_();
-        }
-
-
-        CqlBoolean e_() {
-            IEnumerable<CqlDate> t_ = this.One_MMR_Vaccination(context);
-            CqlBoolean u_ = context.Operators.Exists<CqlDate>(t_);
-
-            CqlBoolean v_() {
-                IEnumerable<Condition> x_ = this.MMR_Numerator_Inclusion_Conditions(context);
-                CqlBoolean y_ = context.Operators.Exists<Condition>(x_);
-                return y_;
-            }
-
-
-            CqlBoolean w_() {
-                IEnumerable<Condition> z_ = this.Measles_Indicators(context);
-                CqlBoolean aa_ = context.Operators.Exists<Condition>(z_);
-
-                CqlBoolean ab_() {
-                    IEnumerable<Condition> ad_ = this.Mumps_Indicators(context);
-                    CqlBoolean ae_ = context.Operators.Exists<Condition>(ad_);
-                    return ae_;
-                }
-
-
-                CqlBoolean ac_() {
-                    IEnumerable<Condition> af_ = this.Rubella_Indicators(context);
-                    CqlBoolean ag_ = context.Operators.Exists<Condition>(af_);
-                    return ag_;
-                }
-
-                return aa_
-                    /* CQL 'and' (155:14-156:45) */ && ab_()
-                    /* CQL 'and' (155:12-158:9) */ && ac_();
-            }
-
-            return u_
-                /* CQL 'or' (153:11-154:58) */ || v_()
-                /* CQL 'or' (153:9-159:5) */ || w_();
-        }
-
-
-        CqlBoolean f_() {
-            CqlBoolean ah_ = this.Has_Appropriate_Number_of_Hib_Immunizations(context);
-
-            CqlBoolean ai_() {
-                IEnumerable<Condition> aj_ = this.Hib_Numerator_Inclusion_Conditions(context);
-                CqlBoolean ak_ = context.Operators.Exists<Condition>(aj_);
-                return ak_;
-            }
-
-            return ah_
-                /* CQL 'or' (160:9-162:5) */ || ai_();
-        }
-
-
-        CqlBoolean g_() {
-            IEnumerable<CqlDate> al_ = this.Three_Hepatitis_B_Vaccinations(context);
-            CqlBoolean am_ = context.Operators.Exists<CqlDate>(al_);
-
-            CqlBoolean an_() {
-                IEnumerable<CqlDate> ao_ = this.Meets_HepB_Vaccination_Requirement(context);
-                CqlBoolean ap_ = context.Operators.Exists<CqlDate>(ao_);
-
-                CqlBoolean aq_() {
-                    IEnumerable<Condition> ar_ = this.Hepatitis_B_Numerator_Inclusion_Conditions(context);
-                    CqlBoolean as_ = context.Operators.Exists<Condition>(ar_);
-                    return as_;
-                }
-
-                return ap_
-                    /* CQL 'or' (164:12-166:9) */ || aq_();
-            }
-
-            return am_
-                /* CQL 'or' (163:9-167:5) */ || an_();
-        }
-
-
-        CqlBoolean h_() {
-            IEnumerable<CqlDate> at_ = this.One_Chicken_Pox_Vaccination(context);
-            CqlBoolean au_ = context.Operators.Exists<CqlDate>(at_);
-
-            CqlBoolean av_() {
-                IEnumerable<Condition> aw_ = this.Varicella_Zoster_Numerator_Inclusion_Conditions(context);
-                CqlBoolean ax_ = context.Operators.Exists<Condition>(aw_);
-                return ax_;
-            }
-
-            return au_
-                /* CQL 'or' (168:9-170:5) */ || av_();
-        }
-
-
-        CqlBoolean i_() {
-            IEnumerable<CqlDate> ay_ = this.Four_Pneumococcal_Conjugate_Vaccinations(context);
-            CqlBoolean az_ = context.Operators.Exists<CqlDate>(ay_);
-
-            CqlBoolean ba_() {
-                IEnumerable<Condition> bb_ = this.Pneumococcal_Conjugate_Numerator_Inclusion_Conditions(context);
-                CqlBoolean bc_ = context.Operators.Exists<Condition>(bb_);
-                return bc_;
-            }
-
-            return az_
-                /* CQL 'or' (171:9-173:5) */ || ba_();
-        }
-
-
-        CqlBoolean j_() {
-            IEnumerable<CqlDate> bd_ = this.One_Hepatitis_A_Vaccinations(context);
-            CqlBoolean be_ = context.Operators.Exists<CqlDate>(bd_);
-
-            CqlBoolean bf_() {
-                IEnumerable<Condition> bg_ = this.Hepatitis_A_Numerator_Inclusion_Conditions(context);
-                CqlBoolean bh_ = context.Operators.Exists<Condition>(bg_);
-                return bh_;
-            }
-
-            return be_
-                /* CQL 'or' (174:9-176:5) */ || bf_();
-        }
-
-
-        CqlBoolean k_() {
-            CqlBoolean bi_ = this.Has_Appropriate_Number_of_Rotavirus_Immunizations(context);
-
-            CqlBoolean bj_() {
-                IEnumerable<Condition> bk_ = this.Rotavirus_Numerator_Inclusion_Conditions(context);
-                CqlBoolean bl_ = context.Operators.Exists<Condition>(bk_);
-                return bl_;
-            }
-
-            return bi_
-                /* CQL 'or' (177:9-179:5) */ || bj_();
-        }
-
-
-        CqlBoolean l_() {
-            IEnumerable<CqlDate> bm_ = this.Two_Influenza_Vaccinations(context);
-            CqlBoolean bn_ = context.Operators.Exists<CqlDate>(bm_);
-
-            CqlBoolean bo_() {
-                IEnumerable<Condition> bp_ = this.Influenza_Numerator_Inclusion_Conditions(context);
-                CqlBoolean bq_ = context.Operators.Exists<Condition>(bp_);
-                return bq_;
-            }
-
-            return bn_
-                /* CQL 'or' (180:11-181:74) */ || this.Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination(context)
-                /* CQL 'or' (180:9-183:5) */ || bo_();
-        }
-
+        IEnumerable<Condition> c_ = this.DTaP_Numerator_Inclusion_Conditions(context);
+        CqlBoolean d_ = context.Operators.Exists<Condition>(c_);
+        CqlBoolean e_ = d_;
+        IEnumerable<CqlDate> f_ = this.Three_Polio_Vaccinations(context);
+        CqlBoolean g_ = context.Operators.Exists<CqlDate>(f_);
+        IEnumerable<Condition> h_ = this.Polio_Numerator_Inclusion_Conditions(context);
+        CqlBoolean i_ = context.Operators.Exists<Condition>(h_);
+        CqlBoolean j_ = i_;
+        CqlBoolean k_ = g_
+            /* CQL 'or' (150:9-152:5) */ || j_;
+        IEnumerable<CqlDate> l_ = this.One_MMR_Vaccination(context);
+        CqlBoolean m_ = context.Operators.Exists<CqlDate>(l_);
+        IEnumerable<Condition> n_ = this.MMR_Numerator_Inclusion_Conditions(context);
+        CqlBoolean o_ = context.Operators.Exists<Condition>(n_);
+        CqlBoolean p_ = o_;
+        IEnumerable<Condition> q_ = this.Measles_Indicators(context);
+        CqlBoolean r_ = context.Operators.Exists<Condition>(q_);
+        IEnumerable<Condition> s_ = this.Mumps_Indicators(context);
+        CqlBoolean t_ = context.Operators.Exists<Condition>(s_);
+        CqlBoolean u_ = t_;
+        IEnumerable<Condition> v_ = this.Rubella_Indicators(context);
+        CqlBoolean w_ = context.Operators.Exists<Condition>(v_);
+        CqlBoolean x_ = w_;
+        CqlBoolean y_ = r_
+            /* CQL 'and' (155:14-156:45) */ && u_
+            /* CQL 'and' (155:12-158:9) */ && x_;
+        CqlBoolean z_ = m_
+            /* CQL 'or' (153:11-154:58) */ || p_
+            /* CQL 'or' (153:9-159:5) */ || y_;
+        CqlBoolean aa_ = this.Has_Appropriate_Number_of_Hib_Immunizations(context);
+        IEnumerable<Condition> ab_ = this.Hib_Numerator_Inclusion_Conditions(context);
+        CqlBoolean ac_ = context.Operators.Exists<Condition>(ab_);
+        CqlBoolean ad_ = ac_;
+        CqlBoolean ae_ = aa_
+            /* CQL 'or' (160:9-162:5) */ || ad_;
+        IEnumerable<CqlDate> af_ = this.Three_Hepatitis_B_Vaccinations(context);
+        CqlBoolean ag_ = context.Operators.Exists<CqlDate>(af_);
+        IEnumerable<CqlDate> ah_ = this.Meets_HepB_Vaccination_Requirement(context);
+        CqlBoolean ai_ = context.Operators.Exists<CqlDate>(ah_);
+        IEnumerable<Condition> aj_ = this.Hepatitis_B_Numerator_Inclusion_Conditions(context);
+        CqlBoolean ak_ = context.Operators.Exists<Condition>(aj_);
+        CqlBoolean al_ = ak_;
+        CqlBoolean am_ = ai_
+            /* CQL 'or' (164:12-166:9) */ || al_;
+        CqlBoolean an_ = ag_
+            /* CQL 'or' (163:9-167:5) */ || am_;
+        IEnumerable<CqlDate> ao_ = this.One_Chicken_Pox_Vaccination(context);
+        CqlBoolean ap_ = context.Operators.Exists<CqlDate>(ao_);
+        IEnumerable<Condition> aq_ = this.Varicella_Zoster_Numerator_Inclusion_Conditions(context);
+        CqlBoolean ar_ = context.Operators.Exists<Condition>(aq_);
+        CqlBoolean as_ = ar_;
+        CqlBoolean at_ = ap_
+            /* CQL 'or' (168:9-170:5) */ || as_;
+        IEnumerable<CqlDate> au_ = this.Four_Pneumococcal_Conjugate_Vaccinations(context);
+        CqlBoolean av_ = context.Operators.Exists<CqlDate>(au_);
+        IEnumerable<Condition> aw_ = this.Pneumococcal_Conjugate_Numerator_Inclusion_Conditions(context);
+        CqlBoolean ax_ = context.Operators.Exists<Condition>(aw_);
+        CqlBoolean ay_ = ax_;
+        CqlBoolean az_ = av_
+            /* CQL 'or' (171:9-173:5) */ || ay_;
+        IEnumerable<CqlDate> ba_ = this.One_Hepatitis_A_Vaccinations(context);
+        CqlBoolean bb_ = context.Operators.Exists<CqlDate>(ba_);
+        IEnumerable<Condition> bc_ = this.Hepatitis_A_Numerator_Inclusion_Conditions(context);
+        CqlBoolean bd_ = context.Operators.Exists<Condition>(bc_);
+        CqlBoolean be_ = bd_;
+        CqlBoolean bf_ = bb_
+            /* CQL 'or' (174:9-176:5) */ || be_;
+        CqlBoolean bg_ = this.Has_Appropriate_Number_of_Rotavirus_Immunizations(context);
+        IEnumerable<Condition> bh_ = this.Rotavirus_Numerator_Inclusion_Conditions(context);
+        CqlBoolean bi_ = context.Operators.Exists<Condition>(bh_);
+        CqlBoolean bj_ = bi_;
+        CqlBoolean bk_ = bg_
+            /* CQL 'or' (177:9-179:5) */ || bj_;
+        IEnumerable<CqlDate> bl_ = this.Two_Influenza_Vaccinations(context);
+        CqlBoolean bm_ = context.Operators.Exists<CqlDate>(bl_);
+        IEnumerable<Condition> bn_ = this.Influenza_Numerator_Inclusion_Conditions(context);
+        CqlBoolean bo_ = context.Operators.Exists<Condition>(bn_);
+        CqlBoolean bp_ = bo_;
+        CqlBoolean bq_ = bm_
+            /* CQL 'or' (180:11-181:74) */ || this.Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination(context)
+            /* CQL 'or' (180:9-183:5) */ || bp_;
         return (b_
-            /* CQL 'or' (147:3-149:3) */ || c_())
-            /* CQL 'and' (147:3-152:5) */ && d_()
-            /* CQL 'and' (147:3-159:5) */ && e_()
-            /* CQL 'and' (147:3-162:5) */ && f_()
-            /* CQL 'and' (147:3-167:5) */ && g_()
-            /* CQL 'and' (147:3-170:5) */ && h_()
-            /* CQL 'and' (147:3-173:5) */ && i_()
-            /* CQL 'and' (147:3-176:5) */ && j_()
-            /* CQL 'and' (147:3-179:5) */ && k_()
-            /* CQL 'and' (147:3-183:5) */ && l_();
+            /* CQL 'or' (147:3-149:3) */ || e_)
+            /* CQL 'and' (147:3-152:5) */ && k_
+            /* CQL 'and' (147:3-159:5) */ && z_
+            /* CQL 'and' (147:3-162:5) */ && ae_
+            /* CQL 'and' (147:3-167:5) */ && an_
+            /* CQL 'and' (147:3-170:5) */ && at_
+            /* CQL 'and' (147:3-173:5) */ && az_
+            /* CQL 'and' (147:3-176:5) */ && bf_
+            /* CQL 'and' (147:3-179:5) */ && bk_
+            /* CQL 'and' (147:3-183:5) */ && bq_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1188FHIRHIVSTITesting-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1188FHIRHIVSTITesting-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1188FHIRHIVSTITesting", "1.0.000")]
 public partial class CMS1188FHIRHIVSTITesting_1_0_000 : ILibrary, ISingleton<CMS1188FHIRHIVSTITesting_1_0_000>
 {
@@ -162,17 +162,13 @@ public partial class CMS1188FHIRHIVSTITesting_1_0_000 : ILibrary, ISingleton<CMS
             Period aj_ = QualifyingEncounter?.Period;
             CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
             CqlBoolean al_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ai_, ak_, "day");
-
-            CqlBoolean am_() {
-                Code<Encounter.EncounterStatus> an_ = QualifyingEncounter?.StatusElement;
-                Encounter.EncounterStatus? ao_ = an_?.Value;
-                Code<Encounter.EncounterStatus> ap_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ao_);
-                CqlBoolean aq_ = context.Operators.Equal(ap_, "finished");
-                return aq_;
-            }
-
+            Code<Encounter.EncounterStatus> am_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? an_ = am_?.Value;
+            Code<Encounter.EncounterStatus> ao_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(an_);
+            CqlBoolean ap_ = context.Operators.Equal(ao_, "finished");
+            CqlBoolean aq_ = ap_;
             return al_
-                /* CQL 'and' (55:7-56:51) */ && am_();
+                /* CQL 'and' (55:7-56:51) */ && aq_;
         }
 
         CqlBoolean ah_ = context.Operators.WhereAny<Encounter>(af_, ag_);
@@ -185,51 +181,27 @@ public partial class CMS1188FHIRHIVSTITesting_1_0_000 : ILibrary, ISingleton<CMS
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (84:54-85:66) */ || i_()
-                /* CQL 'or' (84:54-86:66) */ || j_()
-                /* CQL 'or' (84:52-88:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (84:54-85:66) */ || i_
+            /* CQL 'or' (84:54-86:66) */ || m_
+            /* CQL 'or' (84:52-88:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (84:3-88:3) */ || c_();
+            /* CQL 'implies' (84:3-88:3) */ || r_;
     }
 
 
@@ -311,58 +283,50 @@ public partial class CMS1188FHIRHIVSTITesting_1_0_000 : ILibrary, ISingleton<CMS
         bool? c_(Observation ChlamydiaTest) {
             DataType e_ = ChlamydiaTest?.Value;
             object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
-
-            CqlBoolean g_() {
-                Code<ObservationStatus> i_ = ChlamydiaTest?.StatusElement;
-                ObservationStatus? j_ = i_?.Value;
-                string k_ = context.Operators.Convert<string>(j_);
-                string[] l_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-                return m_;
+            Code<ObservationStatus> g_ = ChlamydiaTest?.StatusElement;
+            ObservationStatus? h_ = g_?.Value;
+            string i_ = context.Operators.Convert<string>(h_);
+            string[] j_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
+            CqlBoolean l_ = k_;
+            object m_;
+            DataType r_ = ChlamydiaTest?.Effective;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
+            {
+                m_ = s_ as CqlDateTime;
             }
-
-
-            CqlBoolean h_() {
-                object n_;
-                DataType r_ = ChlamydiaTest?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
+            else
+            {
                 if (t_)
                 {
-                    n_ = s_ as CqlDateTime;
+                    m_ = s_ as CqlDateTime;
                 }
                 else
                 {
-                    if (t_)
+                    bool u_ = s_ is CqlInterval<CqlDateTime>;
+                    if (u_)
                     {
-                        n_ = s_ as CqlDateTime;
+                        m_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlInterval<CqlDateTime>;
-                        if (u_)
-                        {
-                            n_ = s_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            n_ = null;
-                        }
+                        m_ = null;
                     }
                 }
-                CqlDateTime o_ = QICoreCommon_4_0_000.Instance.latest(context, n_);
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
-                return q_;
             }
-
+            CqlDateTime n_ = QICoreCommon_4_0_000.Instance.latest(context, m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+            CqlBoolean q_ = p_;
             return (CqlBoolean)(f_ is not null)
-                /* CQL 'and' (67:11-68:69) */ && g_()
-                /* CQL 'and' (67:5-69:79) */ && h_();
+                /* CQL 'and' (67:11-68:69) */ && l_
+                /* CQL 'and' (67:5-69:79) */ && q_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Observation>(b_, c_);
@@ -384,58 +348,50 @@ public partial class CMS1188FHIRHIVSTITesting_1_0_000 : ILibrary, ISingleton<CMS
         bool? c_(Observation GonorrheaTest) {
             DataType e_ = GonorrheaTest?.Value;
             object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
-
-            CqlBoolean g_() {
-                Code<ObservationStatus> i_ = GonorrheaTest?.StatusElement;
-                ObservationStatus? j_ = i_?.Value;
-                string k_ = context.Operators.Convert<string>(j_);
-                string[] l_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-                return m_;
+            Code<ObservationStatus> g_ = GonorrheaTest?.StatusElement;
+            ObservationStatus? h_ = g_?.Value;
+            string i_ = context.Operators.Convert<string>(h_);
+            string[] j_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
+            CqlBoolean l_ = k_;
+            object m_;
+            DataType r_ = GonorrheaTest?.Effective;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
+            {
+                m_ = s_ as CqlDateTime;
             }
-
-
-            CqlBoolean h_() {
-                object n_;
-                DataType r_ = GonorrheaTest?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
+            else
+            {
                 if (t_)
                 {
-                    n_ = s_ as CqlDateTime;
+                    m_ = s_ as CqlDateTime;
                 }
                 else
                 {
-                    if (t_)
+                    bool u_ = s_ is CqlInterval<CqlDateTime>;
+                    if (u_)
                     {
-                        n_ = s_ as CqlDateTime;
+                        m_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlInterval<CqlDateTime>;
-                        if (u_)
-                        {
-                            n_ = s_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            n_ = null;
-                        }
+                        m_ = null;
                     }
                 }
-                CqlDateTime o_ = QICoreCommon_4_0_000.Instance.latest(context, n_);
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
-                return q_;
             }
-
+            CqlDateTime n_ = QICoreCommon_4_0_000.Instance.latest(context, m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+            CqlBoolean q_ = p_;
             return (CqlBoolean)(f_ is not null)
-                /* CQL 'and' (73:11-74:69) */ && g_()
-                /* CQL 'and' (73:5-75:79) */ && h_();
+                /* CQL 'and' (73:11-74:69) */ && l_
+                /* CQL 'and' (73:5-75:79) */ && q_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Observation>(b_, c_);
@@ -457,58 +413,50 @@ public partial class CMS1188FHIRHIVSTITesting_1_0_000 : ILibrary, ISingleton<CMS
         bool? c_(Observation SyphilisTest) {
             DataType e_ = SyphilisTest?.Value;
             object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
-
-            CqlBoolean g_() {
-                Code<ObservationStatus> i_ = SyphilisTest?.StatusElement;
-                ObservationStatus? j_ = i_?.Value;
-                string k_ = context.Operators.Convert<string>(j_);
-                string[] l_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-                return m_;
+            Code<ObservationStatus> g_ = SyphilisTest?.StatusElement;
+            ObservationStatus? h_ = g_?.Value;
+            string i_ = context.Operators.Convert<string>(h_);
+            string[] j_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
+            CqlBoolean l_ = k_;
+            object m_;
+            DataType r_ = SyphilisTest?.Effective;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
+            {
+                m_ = s_ as CqlDateTime;
             }
-
-
-            CqlBoolean h_() {
-                object n_;
-                DataType r_ = SyphilisTest?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
+            else
+            {
                 if (t_)
                 {
-                    n_ = s_ as CqlDateTime;
+                    m_ = s_ as CqlDateTime;
                 }
                 else
                 {
-                    if (t_)
+                    bool u_ = s_ is CqlInterval<CqlDateTime>;
+                    if (u_)
                     {
-                        n_ = s_ as CqlDateTime;
+                        m_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlInterval<CqlDateTime>;
-                        if (u_)
-                        {
-                            n_ = s_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            n_ = null;
-                        }
+                        m_ = null;
                     }
                 }
-                CqlDateTime o_ = QICoreCommon_4_0_000.Instance.latest(context, n_);
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
-                return q_;
             }
-
+            CqlDateTime n_ = QICoreCommon_4_0_000.Instance.latest(context, m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+            CqlBoolean q_ = p_;
             return (CqlBoolean)(f_ is not null)
-                /* CQL 'and' (79:11-80:68) */ && g_()
-                /* CQL 'and' (79:5-81:78) */ && h_();
+                /* CQL 'and' (79:11-80:68) */ && l_
+                /* CQL 'and' (79:5-81:78) */ && q_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Observation>(b_, c_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1206FHIRCTOQR", "1.0.000")]
 public partial class CMS1206FHIRCTOQR_1_0_000 : ILibrary, ISingleton<CMS1206FHIRCTOQR_1_0_000>
 {
@@ -105,34 +105,25 @@ public partial class CMS1206FHIRCTOQR_1_0_000 : ILibrary, ISingleton<CMS1206FHIR
                 "corrected",
             ];
             CqlBoolean j_ = context.Operators.In<string>(h_, (IEnumerable<string>)i_);
-
-            CqlBoolean k_() {
-                DataType m_ = CTScanResult?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlDateTime p_ = context.Operators.End(o_);
-                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                CqlBoolean r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
-                return r_;
-            }
-
-
-            CqlBoolean l_() {
-                Patient s_ = this.Patient(context);
-                Date t_ = s_?.BirthDateElement;
-                string u_ = t_?.Value;
-                CqlDate v_ = context.Operators.ConvertStringToDate(u_);
-                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                CqlDate y_ = context.Operators.DateFrom(x_);
-                int? z_ = context.Operators.CalculateAgeAt(v_, y_, "year");
-                CqlBoolean aa_ = context.Operators.GreaterOrEqual(z_, 18);
-                return aa_;
-            }
-
+            DataType k_ = CTScanResult?.Effective;
+            object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+            CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+            CqlDateTime n_ = context.Operators.End(m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+            CqlBoolean q_ = p_;
+            Patient r_ = this.Patient(context);
+            Date s_ = r_?.BirthDateElement;
+            string t_ = s_?.Value;
+            CqlDate u_ = context.Operators.ConvertStringToDate(t_);
+            CqlDateTime v_ = context.Operators.Start(o_);
+            CqlDate w_ = context.Operators.DateFrom(v_);
+            int? x_ = context.Operators.CalculateAgeAt(u_, w_, "year");
+            CqlBoolean y_ = context.Operators.GreaterOrEqual(x_, 18);
+            CqlBoolean z_ = y_;
             return j_
-                /* CQL 'and' (52:11-53:87) */ && k_()
-                /* CQL 'and' (52:5-54:69) */ && l_();
+                /* CQL 'and' (52:11-53:87) */ && q_
+                /* CQL 'and' (52:5-54:69) */ && z_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -159,31 +150,21 @@ public partial class CMS1206FHIRCTOQR_1_0_000 : ILibrary, ISingleton<CMS1206FHIR
                 Encounter.EncounterStatus? i_ = h_?.Value;
                 Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
                 CqlBoolean k_ = context.Operators.Equivalent(j_, "finished");
-
-                CqlBoolean l_() {
-                    Period n_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                    CqlDateTime p_ = context.Operators.End(o_);
-                    CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                    CqlBoolean r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
-                    return r_;
-                }
-
-
-                CqlBoolean m_() {
-                    DataType s_ = QualifiedCTScan?.Effective;
-                    object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                    CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
-                    CqlDateTime v_ = context.Operators.Start(u_);
-                    Period w_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
-                    CqlBoolean y_ = context.Operators.In<CqlDateTime>(v_, x_, (string)default);
-                    return y_;
-                }
-
+                Period l_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.End(m_);
+                CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+                CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+                CqlBoolean q_ = p_;
+                DataType r_ = QualifiedCTScan?.Effective;
+                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
+                CqlDateTime u_ = context.Operators.Start(t_);
+                CqlBoolean v_ = context.Operators.In<CqlDateTime>(u_, m_, (string)default);
+                CqlBoolean w_ = v_;
                 return k_
-                    /* CQL 'and' (46:17-47:77) */ && l_()
-                    /* CQL 'and' (46:17-48:92) */ && m_();
+                    /* CQL 'and' (46:17-47:77) */ && q_
+                    /* CQL 'and' (46:17-48:92) */ && w_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Encounter>(e_, f_);
@@ -207,16 +188,12 @@ public partial class CMS1206FHIRCTOQR_1_0_000 : ILibrary, ISingleton<CMS1206FHIR
 
         bool? b_(Observation CTScan) {
             decimal? d_ = AlaraCommonFunctions_1_10_000.Instance.globalNoiseValue(context, CTScan);
-
-            CqlBoolean e_() {
-                DataType f_ = CTScan?.Value;
-                object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
-                return g_ is not null;
-            }
-
+            DataType e_ = CTScan?.Value;
+            object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
+            CqlBoolean g_ = (CqlBoolean)(f_ is not null);
             return (CqlBoolean)(d_ is not null)
                 /* CQL 'and' (39:11-40:50) */ && ((AlaraCommonFunctions_1_10_000.Instance.sizeAdjustedValue(context, CTScan)) is not null)
-                /* CQL 'and' (39:5-41:34) */ && e_();
+                /* CQL 'and' (39:5-41:34) */ && g_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1218FHIRHHRF", "1.0.000")]
 public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRHHRF_1_0_000>
 {
@@ -271,96 +271,61 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             Encounter.EncounterStatus? f_ = e_?.Value;
             Code<Encounter.EncounterStatus> g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
             CqlBoolean h_ = context.Operators.Equal(g_, "finished");
+            Period i_ = ElectiveEncounter?.Period;
+            CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+            CqlDateTime k_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+            CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+            CqlBoolean n_ = m_;
+            CodeableConcept o_ = ElectiveEncounter?.Priority;
+            CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
+            CqlBoolean q_ = (CqlBoolean)(p_ is not null);
+            CqlCode r_ = this.Elective__qualifier_value_(context);
+            CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+            CqlBoolean t_ = context.Operators.Equivalent(p_, s_);
+            Patient u_ = this.Patient(context);
+            Date v_ = u_?.BirthDateElement;
+            string w_ = v_?.Value;
+            CqlDate x_ = context.Operators.ConvertStringToDate(w_);
+            CqlDateTime y_ = context.Operators.Start(j_);
+            CqlDate z_ = context.Operators.DateFrom(y_);
+            int? aa_ = context.Operators.CalculateAgeAt(x_, z_, "year");
+            CqlBoolean ab_ = context.Operators.GreaterOrEqual(aa_, 18);
+            CqlBoolean ac_ = ab_;
+            CqlValueSet ad_ = this.Emergency_Department_Visit(context);
+            IEnumerable<Encounter> ae_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ad_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-            CqlBoolean i_() {
-                Period l_ = ElectiveEncounter?.Period;
-                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                CqlDateTime n_ = context.Operators.End(m_);
-                CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
-                CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
-                return p_;
+            bool? af_(Encounter EDVisit) {
+                Code<Encounter.EncounterStatus> aj_ = EDVisit?.StatusElement;
+                Encounter.EncounterStatus? ak_ = aj_?.Value;
+                Code<Encounter.EncounterStatus> al_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ak_);
+                CqlBoolean am_ = context.Operators.Equal(al_, "finished");
+                Period an_ = EDVisit?.Period;
+                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlDateTime ap_ = context.Operators.End(ao_);
+                Period aq_ = ElectiveEncounter?.Period;
+                CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aq_);
+                CqlDateTime as_ = context.Operators.Start(ar_);
+                CqlQuantity at_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime au_ = context.Operators.Subtract(as_, at_);
+                CqlInterval<CqlDateTime> av_ = context.Operators.Interval(au_, as_, true, true);
+                CqlBoolean aw_ = context.Operators.In<CqlDateTime>(ap_, av_, (string)default);
+                CqlBoolean ax_ = (CqlBoolean)(as_ is not null);
+                CqlBoolean ay_ = aw_
+                    /* CQL 'and' (209:17-209:97) */ && ax_;
+                return am_
+                    /* CQL 'and' (208:11-209:97) */ && ay_;
             }
 
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = ElectiveEncounter?.Priority;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                return r_ is not null;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept s_ = ElectiveEncounter?.Priority;
-                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                CqlCode u_ = this.Elective__qualifier_value_(context);
-                CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                CqlBoolean w_ = context.Operators.Equivalent(t_, v_);
-
-                CqlBoolean x_() {
-                    Patient z_ = this.Patient(context);
-                    Date aa_ = z_?.BirthDateElement;
-                    string ab_ = aa_?.Value;
-                    CqlDate ac_ = context.Operators.ConvertStringToDate(ab_);
-                    Period ad_ = ElectiveEncounter?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.Start(ae_);
-                    CqlDate ag_ = context.Operators.DateFrom(af_);
-                    int? ah_ = context.Operators.CalculateAgeAt(ac_, ag_, "year");
-                    CqlBoolean ai_ = context.Operators.GreaterOrEqual(ah_, 18);
-                    return ai_;
-                }
-
-
-                CqlBoolean y_() {
-                    CqlValueSet aj_ = this.Emergency_Department_Visit(context);
-                    IEnumerable<Encounter> ak_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                    bool? al_(Encounter EDVisit) {
-                        Code<Encounter.EncounterStatus> an_ = EDVisit?.StatusElement;
-                        Encounter.EncounterStatus? ao_ = an_?.Value;
-                        Code<Encounter.EncounterStatus> ap_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ao_);
-                        CqlBoolean aq_ = context.Operators.Equal(ap_, "finished");
-
-                        CqlBoolean ar_() {
-                            Period as_ = EDVisit?.Period;
-                            CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
-                            CqlDateTime au_ = context.Operators.End(at_);
-                            Period av_ = ElectiveEncounter?.Period;
-                            CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
-                            CqlDateTime ax_ = context.Operators.Start(aw_);
-                            CqlQuantity ay_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime az_ = context.Operators.Subtract(ax_, ay_);
-                            CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(az_, ax_, true, true);
-                            CqlBoolean bb_ = context.Operators.In<CqlDateTime>(au_, ba_, (string)default);
-
-                            CqlBoolean bc_() {
-                                Period bd_ = ElectiveEncounter?.Period;
-                                CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bd_);
-                                CqlDateTime bf_ = context.Operators.Start(be_);
-                                return bf_ is not null;
-                            }
-
-                            return bb_
-                                /* CQL 'and' (209:17-209:97) */ && bc_();
-                        }
-
-                        return aq_
-                            /* CQL 'and' (208:11-209:97) */ && ar_();
-                    }
-
-                    CqlBoolean am_ = context.Operators.WhereAny<Encounter>(ak_, al_);
-                    return !am_;
-                }
-
-                return w_
-                    /* CQL 'and' (205:58-206:73) */ && x_()
-                    /* CQL 'and' (205:58-210:7) */ && y_();
-            }
-
+            CqlBoolean ag_ = context.Operators.WhereAny<Encounter>(ae_, af_);
+            CqlBoolean ah_ = (CqlBoolean)!ag_;
+            CqlBoolean ai_ = t_
+                /* CQL 'and' (205:58-206:73) */ && ac_
+                /* CQL 'and' (205:58-210:7) */ && ah_;
             return (CqlBoolean)(!((bool?)(h_
-                /* CQL 'and' (203:11-204:74) */ && i_()
-                /* CQL 'and' (203:11-205:48) */ && j_())))
-                /* CQL 'implies' (203:5-210:7) */ || k_();
+                /* CQL 'and' (203:11-204:74) */ && n_
+                /* CQL 'and' (203:11-205:48) */ && q_)))
+                /* CQL 'implies' (203:5-210:7) */ || ai_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -409,38 +374,33 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             List<CodeableConcept> d_ = ElectiveEncounter?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Obstetrical_Or_Pregnancy_Related_Conditions(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = this.encounterReason(context, ElectiveEncounter);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = this.encounterReason(context, ElectiveEncounter);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.Obstetrical_Or_Pregnancy_Related_Conditions(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return !((bool?)(h_
-                /* CQL 'or' (214:15-216:5) */ || i_()));
+                /* CQL 'or' (214:15-216:5) */ || n_));
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -467,41 +427,23 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    DataType n_ = SurgeryWithAnesthesia?.Performed;
-                    object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                    CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_);
-                    CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, ElectiveEncounter);
-                    CqlBoolean r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
-                    return r_;
-                }
-
-
-                CqlBoolean m_() {
-                    DataType s_ = SurgeryWithAnesthesia?.Performed;
-                    object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                    CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
-                    CqlInterval<CqlDateTime> v_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, ElectiveEncounter);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    CqlQuantity x_ = context.Operators.Quantity(3m, "days");
-                    CqlDateTime y_ = context.Operators.Add(w_, x_);
-                    CqlInterval<CqlDateTime> z_ = context.Operators.Interval(w_, y_, false, true);
-                    CqlBoolean aa_ = context.Operators.In<CqlDateTime>(u_, z_, (string)default);
-
-                    CqlBoolean ab_() {
-                        CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, ElectiveEncounter);
-                        CqlDateTime ad_ = context.Operators.Start(ac_);
-                        return ad_ is not null;
-                    }
-
-                    return aa_
-                        /* CQL 'and' (92:13-92:166) */ && ab_();
-                }
-
+                DataType l_ = SurgeryWithAnesthesia?.Performed;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlDateTime n_ = QICoreCommon_4_0_000.Instance.earliest(context, m_);
+                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, ElectiveEncounter);
+                CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                CqlBoolean q_ = p_;
+                CqlDateTime r_ = context.Operators.Start(o_);
+                CqlQuantity s_ = context.Operators.Quantity(3m, "days");
+                CqlDateTime t_ = context.Operators.Add(r_, s_);
+                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, false, true);
+                CqlBoolean v_ = context.Operators.In<CqlDateTime>(n_, u_, (string)default);
+                CqlBoolean w_ = (CqlBoolean)(r_ is not null);
+                CqlBoolean x_ = v_
+                    /* CQL 'and' (92:13-92:166) */ && w_;
                 return k_
-                    /* CQL 'and' (90:17-91:143) */ && l_()
-                    /* CQL 'and' (90:17-92:166) */ && m_();
+                    /* CQL 'and' (90:17-91:143) */ && q_
+                    /* CQL 'and' (90:17-92:166) */ && x_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -553,38 +495,33 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             List<CodeableConcept> d_ = EncounterWithSurgery?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Degenerative_Neurological_Disorder(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = this.encounterReason(context, EncounterWithSurgery);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = this.encounterReason(context, EncounterWithSurgery);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.Degenerative_Neurological_Disorder(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'or' (96:5-97:94) */ || i_();
+                /* CQL 'or' (96:5-97:94) */ || n_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -806,93 +743,89 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    object m_;
-                    DataType v_ = Ventilation?.Performed;
-                    object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                    bool x_ = w_ is CqlDateTime;
-                    if (x_)
-                    {
-                        m_ = w_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool y_ = w_ is CqlQuantity;
-                        if (y_)
-                        {
-                            m_ = w_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool z_ = w_ is CqlInterval<CqlDateTime>;
-                            if (z_)
-                            {
-                                m_ = w_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool aa_ = w_ is CqlInterval<CqlQuantity>;
-                                if (aa_)
-                                {
-                                    m_ = w_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    m_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                    CqlDateTime o_ = context.Operators.Start(n_);
-                    object p_;
-                    Procedure ab_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType ac_ = ab_?.Performed;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    bool ae_ = ad_ is CqlDateTime;
-                    if (ae_)
-                    {
-                        p_ = ad_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool af_ = ad_ is CqlQuantity;
-                        if (af_)
-                        {
-                            p_ = ad_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                            if (ag_)
-                            {
-                                p_ = ad_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                                if (ah_)
-                                {
-                                    p_ = ad_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    p_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                    CqlDateTime r_ = context.Operators.Start(q_);
-                    CqlQuantity s_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-                    CqlBoolean u_ = context.Operators.Before(o_, t_, (string)default);
-                    return u_;
+                object l_;
+                DataType v_ = Ventilation?.Performed;
+                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                bool x_ = w_ is CqlDateTime;
+                if (x_)
+                {
+                    l_ = w_ as CqlDateTime;
                 }
-
+                else
+                {
+                    bool y_ = w_ is CqlQuantity;
+                    if (y_)
+                    {
+                        l_ = w_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool z_ = w_ is CqlInterval<CqlDateTime>;
+                        if (z_)
+                        {
+                            l_ = w_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool aa_ = w_ is CqlInterval<CqlQuantity>;
+                            if (aa_)
+                            {
+                                l_ = w_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                l_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                object o_;
+                Procedure ab_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType ac_ = ab_?.Performed;
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                bool ae_ = ad_ is CqlDateTime;
+                if (ae_)
+                {
+                    o_ = ad_ as CqlDateTime;
+                }
+                else
+                {
+                    bool af_ = ad_ is CqlQuantity;
+                    if (af_)
+                    {
+                        o_ = ad_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
+                        if (ag_)
+                        {
+                            o_ = ad_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
+                            if (ah_)
+                            {
+                                o_ = ad_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                o_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlQuantity r_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlBoolean t_ = context.Operators.Before(n_, s_, (string)default);
+                CqlBoolean u_ = t_;
                 return k_
-                    /* CQL 'and' (108:17-109:175) */ && l_()
+                    /* CQL 'and' (108:17-109:175) */ && u_
                     /* CQL 'and' (108:17-110:76) */ && this.startsDuringHospitalization(context, Ventilation, EncounterWithSurgery);
             }
 
@@ -919,38 +852,33 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             List<CodeableConcept> d_ = EncounterWithSurgery?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Neuromuscular_Disorder(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = this.encounterReason(context, EncounterWithSurgery);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = this.encounterReason(context, EncounterWithSurgery);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.Neuromuscular_Disorder(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'or' (114:5-115:82) */ || i_();
+                /* CQL 'or' (114:5-115:82) */ || n_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -982,154 +910,142 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "corrected",
                 ];
                 CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-
-                CqlBoolean o_() {
-                    DataType q_ = CarbonDioxide?.Effective;
-                    object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.Start(s_);
-                    object u_;
-                    Procedure af_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType ag_ = af_?.Performed;
-                    object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                    bool ai_ = ah_ is CqlDateTime;
-                    if (ai_)
+                DataType o_ = CarbonDioxide?.Effective;
+                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                object s_;
+                Procedure am_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType an_ = am_?.Performed;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                bool ap_ = ao_ is CqlDateTime;
+                if (ap_)
+                {
+                    s_ = ao_ as CqlDateTime;
+                }
+                else
+                {
+                    bool aq_ = ao_ is CqlQuantity;
+                    if (aq_)
                     {
-                        u_ = ah_ as CqlDateTime;
+                        s_ = ao_ as CqlQuantity;
                     }
                     else
                     {
-                        bool aj_ = ah_ is CqlQuantity;
-                        if (aj_)
+                        bool ar_ = ao_ is CqlInterval<CqlDateTime>;
+                        if (ar_)
                         {
-                            u_ = ah_ as CqlQuantity;
+                            s_ = ao_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ak_ = ah_ is CqlInterval<CqlDateTime>;
-                            if (ak_)
+                            bool as_ = ao_ is CqlInterval<CqlQuantity>;
+                            if (as_)
                             {
-                                u_ = ah_ as CqlInterval<CqlDateTime>;
+                                s_ = ao_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool al_ = ah_ is CqlInterval<CqlQuantity>;
-                                if (al_)
-                                {
-                                    u_ = ah_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    u_ = null;
-                                }
+                                s_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    CqlQuantity x_ = context.Operators.Quantity(48m, "hours");
-                    CqlDateTime y_ = context.Operators.Subtract(w_, x_);
-                    object z_;
-                    Procedure am_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType an_ = am_?.Performed;
-                    object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                    bool ap_ = ao_ is CqlDateTime;
-                    if (ap_)
+                }
+                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
+                CqlDateTime u_ = context.Operators.Start(t_);
+                CqlQuantity v_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime w_ = context.Operators.Subtract(u_, v_);
+                object x_;
+                Procedure at_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType au_ = at_?.Performed;
+                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                bool aw_ = av_ is CqlDateTime;
+                if (aw_)
+                {
+                    x_ = av_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ax_ = av_ is CqlQuantity;
+                    if (ax_)
                     {
-                        z_ = ao_ as CqlDateTime;
+                        x_ = av_ as CqlQuantity;
                     }
                     else
                     {
-                        bool aq_ = ao_ is CqlQuantity;
-                        if (aq_)
+                        bool ay_ = av_ is CqlInterval<CqlDateTime>;
+                        if (ay_)
                         {
-                            z_ = ao_ as CqlQuantity;
+                            x_ = av_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ar_ = ao_ is CqlInterval<CqlDateTime>;
-                            if (ar_)
+                            bool az_ = av_ is CqlInterval<CqlQuantity>;
+                            if (az_)
                             {
-                                z_ = ao_ as CqlInterval<CqlDateTime>;
+                                x_ = av_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool as_ = ao_ is CqlInterval<CqlQuantity>;
-                                if (as_)
-                                {
-                                    z_ = ao_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    z_ = null;
-                                }
+                                x_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
-                    CqlDateTime ab_ = context.Operators.Start(aa_);
-                    CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, false);
-                    CqlBoolean ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
-
-                    CqlBoolean ae_() {
-                        object at_;
-                        Procedure aw_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType ax_ = aw_?.Performed;
-                        object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                        bool az_ = ay_ is CqlDateTime;
-                        if (az_)
+                }
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, false);
+                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(r_, aa_, (string)default);
+                object ac_;
+                Procedure ba_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType bb_ = ba_?.Performed;
+                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                bool bd_ = bc_ is CqlDateTime;
+                if (bd_)
+                {
+                    ac_ = bc_ as CqlDateTime;
+                }
+                else
+                {
+                    bool be_ = bc_ is CqlQuantity;
+                    if (be_)
+                    {
+                        ac_ = bc_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool bf_ = bc_ is CqlInterval<CqlDateTime>;
+                        if (bf_)
                         {
-                            at_ = ay_ as CqlDateTime;
+                            ac_ = bc_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ba_ = ay_ is CqlQuantity;
-                            if (ba_)
+                            bool bg_ = bc_ is CqlInterval<CqlQuantity>;
+                            if (bg_)
                             {
-                                at_ = ay_ as CqlQuantity;
+                                ac_ = bc_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool bb_ = ay_ is CqlInterval<CqlDateTime>;
-                                if (bb_)
-                                {
-                                    at_ = ay_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool bc_ = ay_ is CqlInterval<CqlQuantity>;
-                                    if (bc_)
-                                    {
-                                        at_ = ay_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        at_ = null;
-                                    }
-                                }
+                                ac_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
-                        CqlDateTime av_ = context.Operators.Start(au_);
-                        return av_ is not null;
                     }
-
-                    return ad_
-                        /* CQL 'and' (122:13-122:109) */ && ae_();
                 }
-
-
-                CqlBoolean p_() {
-                    DataType bd_ = CarbonDioxide?.Value;
-                    object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                    CqlQuantity bf_ = context.Operators.Quantity(50m, "mm[Hg]");
-                    CqlBoolean bg_ = context.Operators.Greater(be_ as CqlQuantity, bf_);
-                    return bg_;
-                }
-
+                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+                CqlDateTime ae_ = context.Operators.Start(ad_);
+                CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
+                CqlBoolean ag_ = ab_
+                    /* CQL 'and' (122:13-122:109) */ && af_;
+                DataType ah_ = CarbonDioxide?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlQuantity aj_ = context.Operators.Quantity(50m, "mm[Hg]");
+                CqlBoolean ak_ = context.Operators.Greater(ai_ as CqlQuantity, aj_);
+                CqlBoolean al_ = ak_;
                 return n_
-                    /* CQL 'and' (121:17-122:109) */ && o_()
-                    /* CQL 'and' (121:17-123:57) */ && p_();
+                    /* CQL 'and' (121:17-122:109) */ && ag_
+                    /* CQL 'and' (121:17-123:57) */ && al_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<Observation>(g_, h_);
@@ -1152,154 +1068,142 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "corrected",
                 ];
                 CqlBoolean bp_ = context.Operators.In<string>(bn_, (IEnumerable<string>)bo_);
-
-                CqlBoolean bq_() {
-                    DataType bs_ = BloodpH?.Effective;
-                    object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                    CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, bt_);
-                    CqlDateTime bv_ = context.Operators.Start(bu_);
-                    object bw_;
-                    Procedure ch_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType ci_ = ch_?.Performed;
-                    object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                    bool ck_ = cj_ is CqlDateTime;
-                    if (ck_)
+                DataType bq_ = BloodpH?.Effective;
+                object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                CqlInterval<CqlDateTime> bs_ = QICoreCommon_4_0_000.Instance.toInterval(context, br_);
+                CqlDateTime bt_ = context.Operators.Start(bs_);
+                object bu_;
+                Procedure co_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType cp_ = co_?.Performed;
+                object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+                bool cr_ = cq_ is CqlDateTime;
+                if (cr_)
+                {
+                    bu_ = cq_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cs_ = cq_ is CqlQuantity;
+                    if (cs_)
                     {
-                        bw_ = cj_ as CqlDateTime;
+                        bu_ = cq_ as CqlQuantity;
                     }
                     else
                     {
-                        bool cl_ = cj_ is CqlQuantity;
-                        if (cl_)
+                        bool ct_ = cq_ is CqlInterval<CqlDateTime>;
+                        if (ct_)
                         {
-                            bw_ = cj_ as CqlQuantity;
+                            bu_ = cq_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool cm_ = cj_ is CqlInterval<CqlDateTime>;
-                            if (cm_)
+                            bool cu_ = cq_ is CqlInterval<CqlQuantity>;
+                            if (cu_)
                             {
-                                bw_ = cj_ as CqlInterval<CqlDateTime>;
+                                bu_ = cq_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool cn_ = cj_ is CqlInterval<CqlQuantity>;
-                                if (cn_)
-                                {
-                                    bw_ = cj_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    bw_ = null;
-                                }
+                                bu_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> bx_ = QICoreCommon_4_0_000.Instance.toInterval(context, bw_);
-                    CqlDateTime by_ = context.Operators.Start(bx_);
-                    CqlQuantity bz_ = context.Operators.Quantity(48m, "hours");
-                    CqlDateTime ca_ = context.Operators.Subtract(by_, bz_);
-                    object cb_;
-                    Procedure co_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType cp_ = co_?.Performed;
-                    object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
-                    bool cr_ = cq_ is CqlDateTime;
-                    if (cr_)
+                }
+                CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_);
+                CqlDateTime bw_ = context.Operators.Start(bv_);
+                CqlQuantity bx_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime by_ = context.Operators.Subtract(bw_, bx_);
+                object bz_;
+                Procedure cv_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType cw_ = cv_?.Performed;
+                object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                bool cy_ = cx_ is CqlDateTime;
+                if (cy_)
+                {
+                    bz_ = cx_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cz_ = cx_ is CqlQuantity;
+                    if (cz_)
                     {
-                        cb_ = cq_ as CqlDateTime;
+                        bz_ = cx_ as CqlQuantity;
                     }
                     else
                     {
-                        bool cs_ = cq_ is CqlQuantity;
-                        if (cs_)
+                        bool da_ = cx_ is CqlInterval<CqlDateTime>;
+                        if (da_)
                         {
-                            cb_ = cq_ as CqlQuantity;
+                            bz_ = cx_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ct_ = cq_ is CqlInterval<CqlDateTime>;
-                            if (ct_)
+                            bool db_ = cx_ is CqlInterval<CqlQuantity>;
+                            if (db_)
                             {
-                                cb_ = cq_ as CqlInterval<CqlDateTime>;
+                                bz_ = cx_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool cu_ = cq_ is CqlInterval<CqlQuantity>;
-                                if (cu_)
-                                {
-                                    cb_ = cq_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    cb_ = null;
-                                }
+                                bz_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
-                    CqlDateTime cd_ = context.Operators.Start(cc_);
-                    CqlInterval<CqlDateTime> ce_ = context.Operators.Interval(ca_, cd_, true, false);
-                    CqlBoolean cf_ = context.Operators.In<CqlDateTime>(bv_, ce_, (string)default);
-
-                    CqlBoolean cg_() {
-                        object cv_;
-                        Procedure cy_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType cz_ = cy_?.Performed;
-                        object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
-                        bool db_ = da_ is CqlDateTime;
-                        if (db_)
+                }
+                CqlInterval<CqlDateTime> ca_ = QICoreCommon_4_0_000.Instance.toInterval(context, bz_);
+                CqlDateTime cb_ = context.Operators.Start(ca_);
+                CqlInterval<CqlDateTime> cc_ = context.Operators.Interval(by_, cb_, true, false);
+                CqlBoolean cd_ = context.Operators.In<CqlDateTime>(bt_, cc_, (string)default);
+                object ce_;
+                Procedure dc_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType dd_ = dc_?.Performed;
+                object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
+                bool df_ = de_ is CqlDateTime;
+                if (df_)
+                {
+                    ce_ = de_ as CqlDateTime;
+                }
+                else
+                {
+                    bool dg_ = de_ is CqlQuantity;
+                    if (dg_)
+                    {
+                        ce_ = de_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool dh_ = de_ is CqlInterval<CqlDateTime>;
+                        if (dh_)
                         {
-                            cv_ = da_ as CqlDateTime;
+                            ce_ = de_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool dc_ = da_ is CqlQuantity;
-                            if (dc_)
+                            bool di_ = de_ is CqlInterval<CqlQuantity>;
+                            if (di_)
                             {
-                                cv_ = da_ as CqlQuantity;
+                                ce_ = de_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool dd_ = da_ is CqlInterval<CqlDateTime>;
-                                if (dd_)
-                                {
-                                    cv_ = da_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool de_ = da_ is CqlInterval<CqlQuantity>;
-                                    if (de_)
-                                    {
-                                        cv_ = da_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        cv_ = null;
-                                    }
-                                }
+                                ce_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> cw_ = QICoreCommon_4_0_000.Instance.toInterval(context, cv_);
-                        CqlDateTime cx_ = context.Operators.Start(cw_);
-                        return cx_ is not null;
                     }
-
-                    return cf_
-                        /* CQL 'and' (126:13-126:103) */ && cg_();
                 }
-
-
-                CqlBoolean br_() {
-                    DataType df_ = BloodpH?.Value;
-                    object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-                    CqlQuantity dh_ = context.Operators.Quantity(7.30m, "[pH]");
-                    CqlBoolean di_ = context.Operators.Less(dg_ as CqlQuantity, dh_);
-                    return di_;
-                }
-
+                CqlInterval<CqlDateTime> cf_ = QICoreCommon_4_0_000.Instance.toInterval(context, ce_);
+                CqlDateTime cg_ = context.Operators.Start(cf_);
+                CqlBoolean ch_ = (CqlBoolean)(cg_ is not null);
+                CqlBoolean ci_ = cd_
+                    /* CQL 'and' (126:13-126:103) */ && ch_;
+                DataType cj_ = BloodpH?.Value;
+                object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                CqlQuantity cl_ = context.Operators.Quantity(7.30m, "[pH]");
+                CqlBoolean cm_ = context.Operators.Less(ck_ as CqlQuantity, cl_);
+                CqlBoolean cn_ = cm_;
                 return bp_
-                    /* CQL 'and' (125:17-126:103) */ && bq_()
-                    /* CQL 'and' (125:17-127:51) */ && br_();
+                    /* CQL 'and' (125:17-126:103) */ && ci_
+                    /* CQL 'and' (125:17-127:51) */ && cn_;
             }
 
             CqlBoolean bk_ = context.Operators.WhereAny<Observation>(bi_, bj_);
@@ -1335,154 +1239,142 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "corrected",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    DataType o_ = Oxygen?.Effective;
-                    object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                    CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                    CqlDateTime r_ = context.Operators.Start(q_);
-                    object s_;
-                    Procedure ad_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType ae_ = ad_?.Performed;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    bool ag_ = af_ is CqlDateTime;
-                    if (ag_)
+                DataType m_ = Oxygen?.Effective;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                object q_;
+                Procedure ak_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType al_ = ak_?.Performed;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                bool an_ = am_ is CqlDateTime;
+                if (an_)
+                {
+                    q_ = am_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ao_ = am_ is CqlQuantity;
+                    if (ao_)
                     {
-                        s_ = af_ as CqlDateTime;
+                        q_ = am_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ah_ = af_ is CqlQuantity;
-                        if (ah_)
+                        bool ap_ = am_ is CqlInterval<CqlDateTime>;
+                        if (ap_)
                         {
-                            s_ = af_ as CqlQuantity;
+                            q_ = am_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                            if (ai_)
+                            bool aq_ = am_ is CqlInterval<CqlQuantity>;
+                            if (aq_)
                             {
-                                s_ = af_ as CqlInterval<CqlDateTime>;
+                                q_ = am_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                                if (aj_)
-                                {
-                                    s_ = af_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    s_ = null;
-                                }
+                                q_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
-                    CqlDateTime u_ = context.Operators.Start(t_);
-                    CqlQuantity v_ = context.Operators.Quantity(48m, "hours");
-                    CqlDateTime w_ = context.Operators.Subtract(u_, v_);
-                    object x_;
-                    Procedure ak_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType al_ = ak_?.Performed;
-                    object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                    bool an_ = am_ is CqlDateTime;
-                    if (an_)
+                }
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlQuantity t_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime u_ = context.Operators.Subtract(s_, t_);
+                object v_;
+                Procedure ar_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType as_ = ar_?.Performed;
+                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                bool au_ = at_ is CqlDateTime;
+                if (au_)
+                {
+                    v_ = at_ as CqlDateTime;
+                }
+                else
+                {
+                    bool av_ = at_ is CqlQuantity;
+                    if (av_)
                     {
-                        x_ = am_ as CqlDateTime;
+                        v_ = at_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ao_ = am_ is CqlQuantity;
-                        if (ao_)
+                        bool aw_ = at_ is CqlInterval<CqlDateTime>;
+                        if (aw_)
                         {
-                            x_ = am_ as CqlQuantity;
+                            v_ = at_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ap_ = am_ is CqlInterval<CqlDateTime>;
-                            if (ap_)
+                            bool ax_ = at_ is CqlInterval<CqlQuantity>;
+                            if (ax_)
                             {
-                                x_ = am_ as CqlInterval<CqlDateTime>;
+                                v_ = at_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aq_ = am_ is CqlInterval<CqlQuantity>;
-                                if (aq_)
-                                {
-                                    x_ = am_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    x_ = null;
-                                }
+                                v_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
-                    CqlDateTime z_ = context.Operators.Start(y_);
-                    CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, false);
-                    CqlBoolean ab_ = context.Operators.In<CqlDateTime>(r_, aa_, (string)default);
-
-                    CqlBoolean ac_() {
-                        object ar_;
-                        Procedure au_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                        DataType av_ = au_?.Performed;
-                        object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                        bool ax_ = aw_ is CqlDateTime;
-                        if (ax_)
+                }
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                CqlInterval<CqlDateTime> y_ = context.Operators.Interval(u_, x_, true, false);
+                CqlBoolean z_ = context.Operators.In<CqlDateTime>(p_, y_, (string)default);
+                object aa_;
+                Procedure ay_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType az_ = ay_?.Performed;
+                object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                bool bb_ = ba_ is CqlDateTime;
+                if (bb_)
+                {
+                    aa_ = ba_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bc_ = ba_ is CqlQuantity;
+                    if (bc_)
+                    {
+                        aa_ = ba_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool bd_ = ba_ is CqlInterval<CqlDateTime>;
+                        if (bd_)
                         {
-                            ar_ = aw_ as CqlDateTime;
+                            aa_ = ba_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ay_ = aw_ is CqlQuantity;
-                            if (ay_)
+                            bool be_ = ba_ is CqlInterval<CqlQuantity>;
+                            if (be_)
                             {
-                                ar_ = aw_ as CqlQuantity;
+                                aa_ = ba_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool az_ = aw_ is CqlInterval<CqlDateTime>;
-                                if (az_)
-                                {
-                                    ar_ = aw_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool ba_ = aw_ is CqlInterval<CqlQuantity>;
-                                    if (ba_)
-                                    {
-                                        ar_ = aw_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        ar_ = null;
-                                    }
-                                }
+                                aa_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                        CqlDateTime at_ = context.Operators.Start(as_);
-                        return at_ is not null;
                     }
-
-                    return ab_
-                        /* CQL 'and' (134:13-134:123) */ && ac_();
                 }
-
-
-                CqlBoolean n_() {
-                    DataType bb_ = Oxygen?.Value;
-                    object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                    CqlQuantity bd_ = context.Operators.Quantity(50m, "mm[Hg]");
-                    CqlBoolean be_ = context.Operators.Less(bc_ as CqlQuantity, bd_);
-                    return be_;
-                }
-
+                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
+                CqlDateTime ac_ = context.Operators.Start(ab_);
+                CqlBoolean ad_ = (CqlBoolean)(ac_ is not null);
+                CqlBoolean ae_ = z_
+                    /* CQL 'and' (134:13-134:123) */ && ad_;
+                DataType af_ = Oxygen?.Value;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                CqlQuantity ah_ = context.Operators.Quantity(50m, "mm[Hg]");
+                CqlBoolean ai_ = context.Operators.Less(ag_ as CqlQuantity, ah_);
+                CqlBoolean aj_ = ai_;
                 return l_
-                    /* CQL 'and' (133:17-134:123) */ && m_()
-                    /* CQL 'and' (133:17-135:50) */ && n_();
+                    /* CQL 'and' (133:17-134:123) */ && ae_
+                    /* CQL 'and' (133:17-135:50) */ && aj_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);
@@ -1578,177 +1470,173 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    CqlInterval<CqlDateTime> m_;
-                    object q_;
-                    DataType t_ = TracheostomySurgery?.Performed;
-                    object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                    bool v_ = u_ is CqlDateTime;
-                    if (v_)
-                    {
-                        q_ = u_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool w_ = u_ is CqlQuantity;
-                        if (w_)
-                        {
-                            q_ = u_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool x_ = u_ is CqlInterval<CqlDateTime>;
-                            if (x_)
-                            {
-                                q_ = u_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool y_ = u_ is CqlInterval<CqlQuantity>;
-                                if (y_)
-                                {
-                                    q_ = u_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    q_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    CqlDateTime s_ = context.Operators.Start(r_);
-                    if (s_ is null)
-                    {
-                        m_ = default;
-                    }
-                    else
-                    {
-                        object z_;
-                        DataType ag_ = TracheostomySurgery?.Performed;
-                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                        bool ai_ = ah_ is CqlDateTime;
-                        if (ai_)
-                        {
-                            z_ = ah_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool aj_ = ah_ is CqlQuantity;
-                            if (aj_)
-                            {
-                                z_ = ah_ as CqlQuantity;
-                            }
-                            else
-                            {
-                                bool ak_ = ah_ is CqlInterval<CqlDateTime>;
-                                if (ak_)
-                                {
-                                    z_ = ah_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool al_ = ah_ is CqlInterval<CqlQuantity>;
-                                    if (al_)
-                                    {
-                                        z_ = ah_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        z_ = null;
-                                    }
-                                }
-                            }
-                        }
-                        CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
-                        CqlDateTime ab_ = context.Operators.Start(aa_);
-                        object ac_;
-                        DataType am_ = TracheostomySurgery?.Performed;
-                        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                        bool ao_ = an_ is CqlDateTime;
-                        if (ao_)
-                        {
-                            ac_ = an_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool ap_ = an_ is CqlQuantity;
-                            if (ap_)
-                            {
-                                ac_ = an_ as CqlQuantity;
-                            }
-                            else
-                            {
-                                bool aq_ = an_ is CqlInterval<CqlDateTime>;
-                                if (aq_)
-                                {
-                                    ac_ = an_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool ar_ = an_ is CqlInterval<CqlQuantity>;
-                                    if (ar_)
-                                    {
-                                        ac_ = an_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        ac_ = null;
-                                    }
-                                }
-                            }
-                        }
-                        CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
-                        CqlDateTime ae_ = context.Operators.Start(ad_);
-                        CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ab_, ae_, true, true);
-                        m_ = af_;
-                    }
-                    object n_;
-                    Procedure as_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType at_ = as_?.Performed;
-                    object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                    bool av_ = au_ is CqlDateTime;
-                    if (av_)
-                    {
-                        n_ = au_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool aw_ = au_ is CqlQuantity;
-                        if (aw_)
-                        {
-                            n_ = au_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool ax_ = au_ is CqlInterval<CqlDateTime>;
-                            if (ax_)
-                            {
-                                n_ = au_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool ay_ = au_ is CqlInterval<CqlQuantity>;
-                                if (ay_)
-                                {
-                                    n_ = au_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    n_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                    CqlBoolean p_ = context.Operators.Before(m_, o_, "day");
-                    return p_;
+                CqlInterval<CqlDateTime> l_;
+                object q_;
+                DataType t_ = TracheostomySurgery?.Performed;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                bool v_ = u_ is CqlDateTime;
+                if (v_)
+                {
+                    q_ = u_ as CqlDateTime;
                 }
-
+                else
+                {
+                    bool w_ = u_ is CqlQuantity;
+                    if (w_)
+                    {
+                        q_ = u_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool x_ = u_ is CqlInterval<CqlDateTime>;
+                        if (x_)
+                        {
+                            q_ = u_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool y_ = u_ is CqlInterval<CqlQuantity>;
+                            if (y_)
+                            {
+                                q_ = u_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                q_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                if (s_ is null)
+                {
+                    l_ = default;
+                }
+                else
+                {
+                    object z_;
+                    DataType ag_ = TracheostomySurgery?.Performed;
+                    object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                    bool ai_ = ah_ is CqlDateTime;
+                    if (ai_)
+                    {
+                        z_ = ah_ as CqlDateTime;
+                    }
+                    else
+                    {
+                        bool aj_ = ah_ is CqlQuantity;
+                        if (aj_)
+                        {
+                            z_ = ah_ as CqlQuantity;
+                        }
+                        else
+                        {
+                            bool ak_ = ah_ is CqlInterval<CqlDateTime>;
+                            if (ak_)
+                            {
+                                z_ = ah_ as CqlInterval<CqlDateTime>;
+                            }
+                            else
+                            {
+                                bool al_ = ah_ is CqlInterval<CqlQuantity>;
+                                if (al_)
+                                {
+                                    z_ = ah_ as CqlInterval<CqlQuantity>;
+                                }
+                                else
+                                {
+                                    z_ = null;
+                                }
+                            }
+                        }
+                    }
+                    CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
+                    CqlDateTime ab_ = context.Operators.Start(aa_);
+                    object ac_;
+                    DataType am_ = TracheostomySurgery?.Performed;
+                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                    bool ao_ = an_ is CqlDateTime;
+                    if (ao_)
+                    {
+                        ac_ = an_ as CqlDateTime;
+                    }
+                    else
+                    {
+                        bool ap_ = an_ is CqlQuantity;
+                        if (ap_)
+                        {
+                            ac_ = an_ as CqlQuantity;
+                        }
+                        else
+                        {
+                            bool aq_ = an_ is CqlInterval<CqlDateTime>;
+                            if (aq_)
+                            {
+                                ac_ = an_ as CqlInterval<CqlDateTime>;
+                            }
+                            else
+                            {
+                                bool ar_ = an_ is CqlInterval<CqlQuantity>;
+                                if (ar_)
+                                {
+                                    ac_ = an_ as CqlInterval<CqlQuantity>;
+                                }
+                                else
+                                {
+                                    ac_ = null;
+                                }
+                            }
+                        }
+                    }
+                    CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+                    CqlDateTime ae_ = context.Operators.Start(ad_);
+                    CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ab_, ae_, true, true);
+                    l_ = af_;
+                }
+                object m_;
+                Procedure as_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType at_ = as_?.Performed;
+                object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                bool av_ = au_ is CqlDateTime;
+                if (av_)
+                {
+                    m_ = au_ as CqlDateTime;
+                }
+                else
+                {
+                    bool aw_ = au_ is CqlQuantity;
+                    if (aw_)
+                    {
+                        m_ = au_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ax_ = au_ is CqlInterval<CqlDateTime>;
+                        if (ax_)
+                        {
+                            m_ = au_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool ay_ = au_ is CqlInterval<CqlQuantity>;
+                            if (ay_)
+                            {
+                                m_ = au_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                m_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+                CqlBoolean o_ = context.Operators.Before(l_, n_, "day");
+                CqlBoolean p_ = o_;
                 return k_
                     /* CQL 'and' (222:17-223:84) */ && this.startsDuringHospitalization(context, TracheostomySurgery, EncounterWithSurgery)
-                    /* CQL 'and' (222:17-224:117) */ && l_();
+                    /* CQL 'and' (222:17-224:117) */ && p_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -1779,91 +1667,87 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    object m_;
-                    DataType s_ = TracheostomySurgery?.Performed;
-                    object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                    bool u_ = t_ is CqlDateTime;
-                    if (u_)
-                    {
-                        m_ = t_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool v_ = t_ is CqlQuantity;
-                        if (v_)
-                        {
-                            m_ = t_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool w_ = t_ is CqlInterval<CqlDateTime>;
-                            if (w_)
-                            {
-                                m_ = t_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool x_ = t_ is CqlInterval<CqlQuantity>;
-                                if (x_)
-                                {
-                                    m_ = t_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    m_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                    CqlDateTime o_ = context.Operators.Start(n_);
-                    object p_;
-                    Procedure y_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
-                    DataType z_ = y_?.Performed;
-                    object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                    bool ab_ = aa_ is CqlDateTime;
-                    if (ab_)
-                    {
-                        p_ = aa_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool ac_ = aa_ is CqlQuantity;
-                        if (ac_)
-                        {
-                            p_ = aa_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                            if (ad_)
-                            {
-                                p_ = aa_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                                if (ae_)
-                                {
-                                    p_ = aa_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    p_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                    CqlBoolean r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
-                    return r_;
+                object l_;
+                DataType s_ = TracheostomySurgery?.Performed;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                bool u_ = t_ is CqlDateTime;
+                if (u_)
+                {
+                    l_ = t_ as CqlDateTime;
                 }
-
+                else
+                {
+                    bool v_ = t_ is CqlQuantity;
+                    if (v_)
+                    {
+                        l_ = t_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool w_ = t_ is CqlInterval<CqlDateTime>;
+                        if (w_)
+                        {
+                            l_ = t_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool x_ = t_ is CqlInterval<CqlQuantity>;
+                            if (x_)
+                            {
+                                l_ = t_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                l_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                object o_;
+                Procedure y_ = this.firstAnesthesiaDuringHospitalization(context, EncounterWithSurgery);
+                DataType z_ = y_?.Performed;
+                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                bool ab_ = aa_ is CqlDateTime;
+                if (ab_)
+                {
+                    o_ = aa_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ac_ = aa_ is CqlQuantity;
+                    if (ac_)
+                    {
+                        o_ = aa_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
+                        if (ad_)
+                        {
+                            o_ = aa_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
+                            if (ae_)
+                            {
+                                o_ = aa_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                o_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+                CqlBoolean r_ = q_;
                 return k_
                     /* CQL 'and' (230:17-231:84) */ && this.startsDuringHospitalization(context, TracheostomySurgery, EncounterWithSurgery)
-                    /* CQL 'and' (230:17-232:117) */ && l_();
+                    /* CQL 'and' (230:17-232:117) */ && r_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -1925,33 +1809,33 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     public bool? starts30DaysOrLessAfterFirstAnesthesia(CqlContext context, Procedure procedure, Encounter encounter)
     {
         object a_;
-        DataType o_ = procedure?.Performed;
-        object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-        bool q_ = p_ is CqlDateTime;
-        if (q_)
+        DataType r_ = procedure?.Performed;
+        object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+        bool t_ = s_ is CqlDateTime;
+        if (t_)
         {
-            a_ = p_ as CqlDateTime;
+            a_ = s_ as CqlDateTime;
         }
         else
         {
-            bool r_ = p_ is CqlQuantity;
-            if (r_)
+            bool u_ = s_ is CqlQuantity;
+            if (u_)
             {
-                a_ = p_ as CqlQuantity;
+                a_ = s_ as CqlQuantity;
             }
             else
             {
-                bool s_ = p_ is CqlInterval<CqlDateTime>;
-                if (s_)
+                bool v_ = s_ is CqlInterval<CqlDateTime>;
+                if (v_)
                 {
-                    a_ = p_ as CqlInterval<CqlDateTime>;
+                    a_ = s_ as CqlInterval<CqlDateTime>;
                 }
                 else
                 {
-                    bool t_ = p_ is CqlInterval<CqlQuantity>;
-                    if (t_)
+                    bool w_ = s_ is CqlInterval<CqlQuantity>;
+                    if (w_)
                     {
-                        a_ = p_ as CqlInterval<CqlQuantity>;
+                        a_ = s_ as CqlInterval<CqlQuantity>;
                     }
                     else
                     {
@@ -1963,34 +1847,34 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
         CqlInterval<CqlDateTime> b_ = QICoreCommon_4_0_000.Instance.toInterval(context, a_);
         CqlDateTime c_ = context.Operators.Start(b_);
         object d_;
-        Procedure u_ = this.firstAnesthesiaDuringHospitalization(context, encounter);
-        DataType v_ = u_?.Performed;
-        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-        bool x_ = w_ is CqlDateTime;
-        if (x_)
+        Procedure x_ = this.firstAnesthesiaDuringHospitalization(context, encounter);
+        DataType y_ = x_?.Performed;
+        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+        bool aa_ = z_ is CqlDateTime;
+        if (aa_)
         {
-            d_ = w_ as CqlDateTime;
+            d_ = z_ as CqlDateTime;
         }
         else
         {
-            bool y_ = w_ is CqlQuantity;
-            if (y_)
+            bool ab_ = z_ is CqlQuantity;
+            if (ab_)
             {
-                d_ = w_ as CqlQuantity;
+                d_ = z_ as CqlQuantity;
             }
             else
             {
-                bool z_ = w_ is CqlInterval<CqlDateTime>;
-                if (z_)
+                bool ac_ = z_ is CqlInterval<CqlDateTime>;
+                if (ac_)
                 {
-                    d_ = w_ as CqlInterval<CqlDateTime>;
+                    d_ = z_ as CqlInterval<CqlDateTime>;
                 }
                 else
                 {
-                    bool aa_ = w_ is CqlInterval<CqlQuantity>;
-                    if (aa_)
+                    bool ad_ = z_ is CqlInterval<CqlQuantity>;
+                    if (ad_)
                     {
-                        d_ = w_ as CqlInterval<CqlQuantity>;
+                        d_ = z_ as CqlInterval<CqlQuantity>;
                     }
                     else
                     {
@@ -2002,34 +1886,34 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
         CqlInterval<CqlDateTime> e_ = QICoreCommon_4_0_000.Instance.toInterval(context, d_);
         CqlDateTime f_ = context.Operators.End(e_);
         object g_;
-        Procedure ab_ = this.firstAnesthesiaDuringHospitalization(context, encounter);
-        DataType ac_ = ab_?.Performed;
-        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-        bool ae_ = ad_ is CqlDateTime;
-        if (ae_)
+        Procedure ae_ = this.firstAnesthesiaDuringHospitalization(context, encounter);
+        DataType af_ = ae_?.Performed;
+        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+        bool ah_ = ag_ is CqlDateTime;
+        if (ah_)
         {
-            g_ = ad_ as CqlDateTime;
+            g_ = ag_ as CqlDateTime;
         }
         else
         {
-            bool af_ = ad_ is CqlQuantity;
-            if (af_)
+            bool ai_ = ag_ is CqlQuantity;
+            if (ai_)
             {
-                g_ = ad_ as CqlQuantity;
+                g_ = ag_ as CqlQuantity;
             }
             else
             {
-                bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                if (ag_)
+                bool aj_ = ag_ is CqlInterval<CqlDateTime>;
+                if (aj_)
                 {
-                    g_ = ad_ as CqlInterval<CqlDateTime>;
+                    g_ = ag_ as CqlInterval<CqlDateTime>;
                 }
                 else
                 {
-                    bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                    if (ah_)
+                    bool ak_ = ag_ is CqlInterval<CqlQuantity>;
+                    if (ak_)
                     {
-                        g_ = ad_ as CqlInterval<CqlQuantity>;
+                        g_ = ag_ as CqlInterval<CqlQuantity>;
                     }
                     else
                     {
@@ -2044,52 +1928,48 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
         CqlDateTime k_ = context.Operators.Add(i_, j_);
         CqlInterval<CqlDateTime> l_ = context.Operators.Interval(f_, k_, false, true);
         CqlBoolean m_ = context.Operators.In<CqlDateTime>(c_, l_, (string)default);
-
-        CqlBoolean n_() {
-            object ai_;
-            Procedure al_ = this.firstAnesthesiaDuringHospitalization(context, encounter);
-            DataType am_ = al_?.Performed;
-            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-            bool ao_ = an_ is CqlDateTime;
-            if (ao_)
+        object n_;
+        Procedure al_ = this.firstAnesthesiaDuringHospitalization(context, encounter);
+        DataType am_ = al_?.Performed;
+        object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+        bool ao_ = an_ is CqlDateTime;
+        if (ao_)
+        {
+            n_ = an_ as CqlDateTime;
+        }
+        else
+        {
+            bool ap_ = an_ is CqlQuantity;
+            if (ap_)
             {
-                ai_ = an_ as CqlDateTime;
+                n_ = an_ as CqlQuantity;
             }
             else
             {
-                bool ap_ = an_ is CqlQuantity;
-                if (ap_)
+                bool aq_ = an_ is CqlInterval<CqlDateTime>;
+                if (aq_)
                 {
-                    ai_ = an_ as CqlQuantity;
+                    n_ = an_ as CqlInterval<CqlDateTime>;
                 }
                 else
                 {
-                    bool aq_ = an_ is CqlInterval<CqlDateTime>;
-                    if (aq_)
+                    bool ar_ = an_ is CqlInterval<CqlQuantity>;
+                    if (ar_)
                     {
-                        ai_ = an_ as CqlInterval<CqlDateTime>;
+                        n_ = an_ as CqlInterval<CqlQuantity>;
                     }
                     else
                     {
-                        bool ar_ = an_ is CqlInterval<CqlQuantity>;
-                        if (ar_)
-                        {
-                            ai_ = an_ as CqlInterval<CqlQuantity>;
-                        }
-                        else
-                        {
-                            ai_ = null;
-                        }
+                        n_ = null;
                     }
                 }
             }
-            CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-            CqlDateTime ak_ = context.Operators.End(aj_);
-            return ak_ is not null;
         }
-
+        CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+        CqlDateTime p_ = context.Operators.End(o_);
+        CqlBoolean q_ = (CqlBoolean)(p_ is not null);
         return m_
-            /* CQL 'and' (676:3-676:148) */ && n_();
+            /* CQL 'and' (676:3-676:148) */ && q_;
     }
 
 
@@ -2103,90 +1983,86 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             EventStatus? h_ = g_?.Value;
             string i_ = context.Operators.Convert<string>(h_);
             CqlBoolean j_ = context.Operators.Equal(i_, "completed");
-
-            CqlBoolean k_() {
-                object l_;
-                DataType s_ = ProcedureList?.Performed;
-                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                bool u_ = t_ is CqlDateTime;
-                if (u_)
-                {
-                    l_ = t_ as CqlDateTime;
-                }
-                else
-                {
-                    bool v_ = t_ is CqlQuantity;
-                    if (v_)
-                    {
-                        l_ = t_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool w_ = t_ is CqlInterval<CqlDateTime>;
-                        if (w_)
-                        {
-                            l_ = t_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool x_ = t_ is CqlInterval<CqlQuantity>;
-                            if (x_)
-                            {
-                                l_ = t_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                l_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
-                CqlDateTime n_ = context.Operators.End(m_);
-                object o_;
-                DataType y_ = @event?.Performed;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
-                {
-                    o_ = z_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ab_ = z_ is CqlQuantity;
-                    if (ab_)
-                    {
-                        o_ = z_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ac_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ac_)
-                        {
-                            o_ = z_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ad_ = z_ is CqlInterval<CqlQuantity>;
-                            if (ad_)
-                            {
-                                o_ = z_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                o_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                CqlDateTime q_ = context.Operators.Start(p_);
-                CqlBoolean r_ = context.Operators.Before(n_, q_, (string)default);
-                return r_;
+            object k_;
+            DataType s_ = ProcedureList?.Performed;
+            object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+            bool u_ = t_ is CqlDateTime;
+            if (u_)
+            {
+                k_ = t_ as CqlDateTime;
             }
-
+            else
+            {
+                bool v_ = t_ is CqlQuantity;
+                if (v_)
+                {
+                    k_ = t_ as CqlQuantity;
+                }
+                else
+                {
+                    bool w_ = t_ is CqlInterval<CqlDateTime>;
+                    if (w_)
+                    {
+                        k_ = t_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool x_ = t_ is CqlInterval<CqlQuantity>;
+                        if (x_)
+                        {
+                            k_ = t_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            k_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
+            CqlDateTime m_ = context.Operators.End(l_);
+            object n_;
+            DataType y_ = @event?.Performed;
+            object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+            bool aa_ = z_ is CqlDateTime;
+            if (aa_)
+            {
+                n_ = z_ as CqlDateTime;
+            }
+            else
+            {
+                bool ab_ = z_ is CqlQuantity;
+                if (ab_)
+                {
+                    n_ = z_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ac_ = z_ is CqlInterval<CqlDateTime>;
+                    if (ac_)
+                    {
+                        n_ = z_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ad_ = z_ is CqlInterval<CqlQuantity>;
+                        if (ad_)
+                        {
+                            n_ = z_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            n_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+            CqlDateTime p_ = context.Operators.Start(o_);
+            CqlBoolean q_ = context.Operators.Before(m_, p_, (string)default);
+            CqlBoolean r_ = q_;
             return j_
-                /* CQL 'and' (653:7-654:98) */ && k_();
+                /* CQL 'and' (653:7-654:98) */ && r_;
         }
 
         IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
@@ -2267,33 +2143,25 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             bool? e_(Location Location) {
                 ResourceReference g_ = EncounterLocation?.Location;
                 CqlBoolean h_ = QICoreCommon_4_0_000.Instance.references(context, g_, Location);
+                List<CodeableConcept> i_ = Location?.Type;
 
-                CqlBoolean i_() {
-                    List<CodeableConcept> k_ = Location?.Type;
-
-                    CqlConcept l_(CodeableConcept @this) {
-                        CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return p_;
-                    }
-
-                    IEnumerable<CqlConcept> m_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)k_, l_);
-                    CqlCode n_ = this.ER(context);
-                    CqlBoolean o_ = QICoreCommon_4_0_000.Instance.includesCode(context, m_, n_);
-                    return o_;
-                }
-
-
-                CqlBoolean j_() {
-                    Period q_ = EncounterLocation?.Period;
-                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                    CqlDateTime s_ = context.Operators.Start(r_);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(s_, intrvl, (string)default);
+                CqlConcept j_(CodeableConcept @this) {
+                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                     return t_;
                 }
 
+                IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+                CqlCode l_ = this.ER(context);
+                CqlBoolean m_ = QICoreCommon_4_0_000.Instance.includesCode(context, k_, l_);
+                CqlBoolean n_ = m_;
+                Period o_ = EncounterLocation?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlBoolean r_ = context.Operators.In<CqlDateTime>(q_, intrvl, (string)default);
+                CqlBoolean s_ = r_;
                 return h_
-                    /* CQL 'and' (688:19-689:49) */ && i_()
-                    /* CQL 'and' (688:19-690:59) */ && j_();
+                    /* CQL 'and' (688:19-689:49) */ && n_
+                    /* CQL 'and' (688:19-690:59) */ && s_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Location>(d_, e_);
@@ -2330,90 +2198,86 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object q_;
-                DataType w_ = tuple_fccbecjtombnskgdhjbefdudj?.ProceduralIntubation?.Performed;
-                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                bool y_ = x_ is CqlDateTime;
-                if (y_)
-                {
-                    q_ = x_ as CqlDateTime;
-                }
-                else
-                {
-                    bool z_ = x_ is CqlQuantity;
-                    if (z_)
-                    {
-                        q_ = x_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool aa_ = x_ is CqlInterval<CqlDateTime>;
-                        if (aa_)
-                        {
-                            q_ = x_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ab_ = x_ is CqlInterval<CqlQuantity>;
-                            if (ab_)
-                            {
-                                q_ = x_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                q_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                object t_;
-                DataType ac_ = tuple_fccbecjtombnskgdhjbefdudj?.Anesthesia?.Performed;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                bool ae_ = ad_ is CqlDateTime;
-                if (ae_)
-                {
-                    t_ = ad_ as CqlDateTime;
-                }
-                else
-                {
-                    bool af_ = ad_ is CqlQuantity;
-                    if (af_)
-                    {
-                        t_ = ad_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
-                        {
-                            t_ = ad_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                            if (ah_)
-                            {
-                                t_ = ad_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                t_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
-                CqlBoolean v_ = context.Operators.In<CqlDateTime>(s_, u_, (string)default);
-                return v_;
+            object p_;
+            DataType w_ = tuple_fccbecjtombnskgdhjbefdudj?.ProceduralIntubation?.Performed;
+            object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+            bool y_ = x_ is CqlDateTime;
+            if (y_)
+            {
+                p_ = x_ as CqlDateTime;
             }
-
+            else
+            {
+                bool z_ = x_ is CqlQuantity;
+                if (z_)
+                {
+                    p_ = x_ as CqlQuantity;
+                }
+                else
+                {
+                    bool aa_ = x_ is CqlInterval<CqlDateTime>;
+                    if (aa_)
+                    {
+                        p_ = x_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ab_ = x_ is CqlInterval<CqlQuantity>;
+                        if (ab_)
+                        {
+                            p_ = x_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            p_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.Start(q_);
+            object s_;
+            DataType ac_ = tuple_fccbecjtombnskgdhjbefdudj?.Anesthesia?.Performed;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            bool ae_ = ad_ is CqlDateTime;
+            if (ae_)
+            {
+                s_ = ad_ as CqlDateTime;
+            }
+            else
+            {
+                bool af_ = ad_ is CqlQuantity;
+                if (af_)
+                {
+                    s_ = ad_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ag_ = ad_ is CqlInterval<CqlDateTime>;
+                    if (ag_)
+                    {
+                        s_ = ad_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ah_ = ad_ is CqlInterval<CqlQuantity>;
+                        if (ah_)
+                        {
+                            s_ = ad_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            s_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
+            CqlBoolean u_ = context.Operators.In<CqlDateTime>(r_, t_, (string)default);
+            CqlBoolean v_ = u_;
             return o_
                 /* CQL 'and' (251:11-252:83) */ && this.startsDuringHospitalization(context, tuple_fccbecjtombnskgdhjbefdudj?.ProceduralIntubation, tuple_fccbecjtombnskgdhjbefdudj?.EncounterWithSurgery)
-                /* CQL 'and' (251:5-253:105) */ && p_();
+                /* CQL 'and' (251:5-253:105) */ && v_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure ProceduralIntubation, Procedure Anesthesia)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, Procedure>, (CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure ProceduralIntubation, Procedure Anesthesia)?>(e_, f_, g_);
@@ -2442,164 +2306,152 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    object o_;
-                    DataType v_ = EndotrachealTubeIn?.Performed;
-                    object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                    bool x_ = w_ is CqlDateTime;
-                    if (x_)
+                object l_;
+                DataType af_ = EndotrachealTubeIn?.Performed;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                bool ah_ = ag_ is CqlDateTime;
+                if (ah_)
+                {
+                    l_ = ag_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ai_ = ag_ is CqlQuantity;
+                    if (ai_)
                     {
-                        o_ = w_ as CqlDateTime;
+                        l_ = ag_ as CqlQuantity;
                     }
                     else
                     {
-                        bool y_ = w_ is CqlQuantity;
-                        if (y_)
+                        bool aj_ = ag_ is CqlInterval<CqlDateTime>;
+                        if (aj_)
                         {
-                            o_ = w_ as CqlQuantity;
+                            l_ = ag_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool z_ = w_ is CqlInterval<CqlDateTime>;
-                            if (z_)
+                            bool ak_ = ag_ is CqlInterval<CqlQuantity>;
+                            if (ak_)
                             {
-                                o_ = w_ as CqlInterval<CqlDateTime>;
+                                l_ = ag_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aa_ = w_ is CqlInterval<CqlQuantity>;
-                                if (aa_)
-                                {
-                                    o_ = w_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    o_ = null;
-                                }
+                                l_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                    CqlDateTime q_ = context.Operators.Start(p_);
-                    object r_;
-                    Procedure ab_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
-                    DataType ac_ = ab_?.Performed;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    bool ae_ = ad_ is CqlDateTime;
-                    if (ae_)
+                }
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                object o_;
+                Procedure al_ = this.latestGeneralAnesthesiaOrMAC(context, EndotrachealTubeIn);
+                DataType am_ = al_?.Performed;
+                object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                bool ao_ = an_ is CqlDateTime;
+                if (ao_)
+                {
+                    o_ = an_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ap_ = an_ is CqlQuantity;
+                    if (ap_)
                     {
-                        r_ = ad_ as CqlDateTime;
+                        o_ = an_ as CqlQuantity;
                     }
                     else
                     {
-                        bool af_ = ad_ is CqlQuantity;
-                        if (af_)
+                        bool aq_ = an_ is CqlInterval<CqlDateTime>;
+                        if (aq_)
                         {
-                            r_ = ad_ as CqlQuantity;
+                            o_ = an_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                            if (ag_)
+                            bool ar_ = an_ is CqlInterval<CqlQuantity>;
+                            if (ar_)
                             {
-                                r_ = ad_ as CqlInterval<CqlDateTime>;
+                                o_ = an_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                                if (ah_)
-                                {
-                                    r_ = ad_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    r_ = null;
-                                }
+                                o_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.End(s_);
-                    CqlBoolean u_ = context.Operators.After(q_, t_, (string)default);
-                    return u_;
                 }
-
-
-                CqlBoolean m_() {
-                    object ai_;
-                    DataType al_ = EndotrachealTubeIn?.Performed;
-                    object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                    bool an_ = am_ is CqlDateTime;
-                    if (an_)
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                CqlBoolean r_ = context.Operators.After(n_, q_, (string)default);
+                CqlBoolean s_ = r_;
+                object t_;
+                DataType as_ = EndotrachealTubeIn?.Performed;
+                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                bool au_ = at_ is CqlDateTime;
+                if (au_)
+                {
+                    t_ = at_ as CqlDateTime;
+                }
+                else
+                {
+                    bool av_ = at_ is CqlQuantity;
+                    if (av_)
                     {
-                        ai_ = am_ as CqlDateTime;
+                        t_ = at_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ao_ = am_ is CqlQuantity;
-                        if (ao_)
+                        bool aw_ = at_ is CqlInterval<CqlDateTime>;
+                        if (aw_)
                         {
-                            ai_ = am_ as CqlQuantity;
+                            t_ = at_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ap_ = am_ is CqlInterval<CqlDateTime>;
-                            if (ap_)
+                            bool ax_ = at_ is CqlInterval<CqlQuantity>;
+                            if (ax_)
                             {
-                                ai_ = am_ as CqlInterval<CqlDateTime>;
+                                t_ = at_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aq_ = am_ is CqlInterval<CqlQuantity>;
-                                if (aq_)
-                                {
-                                    ai_ = am_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    ai_ = null;
-                                }
+                                t_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                    CqlBoolean ak_ = this.isNotAtProceduralHospitalLocationDuring(context, EncounterWithSurgery, aj_);
-                    return ak_;
+                }
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+                CqlBoolean v_ = this.isNotAtProceduralHospitalLocationDuring(context, EncounterWithSurgery, u_);
+                CqlBoolean w_ = v_;
+                IEnumerable<Procedure> x_ = this.Intubation_During_General_Anesthesia_And_MAC(context);
+
+                bool? y_(Procedure @this) {
+                    string ay_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return ay_ is not null;
                 }
 
 
-                CqlBoolean n_() {
-                    IEnumerable<Procedure> ar_ = this.Intubation_During_General_Anesthesia_And_MAC(context);
-
-                    bool? as_(Procedure @this) {
-                        string ay_ = (@this is Resource
-                            ? (@this as Resource).IdElement
-                            : default)?.Value;
-                        return ay_ is not null;
-                    }
-
-
-                    string at_(Procedure @this) {
-                        string az_ = (@this is Resource
-                            ? (@this as Resource).IdElement
-                            : default)?.Value;
-                        return az_;
-                    }
-
-                    IEnumerable<string> au_ = context.Operators.WhereSelect<Procedure, string>(ar_, as_, at_);
-                    Id av_ = EndotrachealTubeIn?.IdElement;
-                    string aw_ = av_?.Value;
-                    CqlBoolean ax_ = context.Operators.Contains<string>(au_, aw_);
-                    return !ax_;
+                string z_(Procedure @this) {
+                    string az_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return az_;
                 }
 
+                IEnumerable<string> aa_ = context.Operators.WhereSelect<Procedure, string>(x_, y_, z_);
+                Id ab_ = EndotrachealTubeIn?.IdElement;
+                string ac_ = ab_?.Value;
+                CqlBoolean ad_ = context.Operators.Contains<string>(aa_, ac_);
+                CqlBoolean ae_ = (CqlBoolean)!ad_;
                 return k_
                     /* CQL 'and' (156:17-157:94) */ && this.starts30DaysOrLessAfterFirstAnesthesia(context, EndotrachealTubeIn, EncounterWithSurgery)
                     /* CQL 'and' (156:17-158:83) */ && this.startsDuringHospitalization(context, EndotrachealTubeIn, EncounterWithSurgery)
-                    /* CQL 'and' (156:17-159:152) */ && l_()
-                    /* CQL 'and' (156:17-160:120) */ && m_()
-                    /* CQL 'and' (156:17-161:100) */ && n_();
+                    /* CQL 'and' (156:17-159:152) */ && s_
+                    /* CQL 'and' (156:17-160:120) */ && w_
+                    /* CQL 'and' (156:17-161:100) */ && ae_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -2743,224 +2595,212 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object s_;
-                DataType z_ = tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation?.Performed;
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                bool ab_ = aa_ is CqlDateTime;
-                if (ab_)
-                {
-                    s_ = aa_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ac_ = aa_ is CqlQuantity;
-                    if (ac_)
-                    {
-                        s_ = aa_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
-                        {
-                            s_ = aa_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                            if (ae_)
-                            {
-                                s_ = aa_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                s_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
-                CqlDateTime u_ = context.Operators.Start(t_);
-                object v_;
-                Procedure af_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation);
-                DataType ag_ = af_?.Performed;
-                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                bool ai_ = ah_ is CqlDateTime;
-                if (ai_)
-                {
-                    v_ = ah_ as CqlDateTime;
-                }
-                else
-                {
-                    bool aj_ = ah_ is CqlQuantity;
-                    if (aj_)
-                    {
-                        v_ = ah_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ak_ = ah_ is CqlInterval<CqlDateTime>;
-                        if (ak_)
-                        {
-                            v_ = ah_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool al_ = ah_ is CqlInterval<CqlQuantity>;
-                            if (al_)
-                            {
-                                v_ = ah_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                v_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlBoolean y_ = context.Operators.After(u_, x_, (string)default);
-                return y_;
+            object p_;
+            DataType am_ = tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation?.Performed;
+            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            bool ao_ = an_ is CqlDateTime;
+            if (ao_)
+            {
+                p_ = an_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                CqlInterval<CqlDateTime> am_ = this.interval(context, tuple_qajmwefzjrlyudjfgicwdhsi?.OxygenSupport);
-                CqlDateTime an_ = context.Operators.Start(am_);
-                object ao_;
-                Procedure aw_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation);
-                DataType ax_ = aw_?.Performed;
-                object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                bool az_ = ay_ is CqlDateTime;
-                if (az_)
+            else
+            {
+                bool ap_ = an_ is CqlQuantity;
+                if (ap_)
                 {
-                    ao_ = ay_ as CqlDateTime;
+                    p_ = an_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ba_ = ay_ is CqlQuantity;
-                    if (ba_)
+                    bool aq_ = an_ is CqlInterval<CqlDateTime>;
+                    if (aq_)
                     {
-                        ao_ = ay_ as CqlQuantity;
+                        p_ = an_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bb_ = ay_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool ar_ = an_ is CqlInterval<CqlQuantity>;
+                        if (ar_)
                         {
-                            ao_ = ay_ as CqlInterval<CqlDateTime>;
+                            p_ = an_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bc_ = ay_ is CqlInterval<CqlQuantity>;
-                            if (bc_)
-                            {
-                                ao_ = ay_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ao_ = null;
-                            }
+                            p_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
-                CqlDateTime aq_ = context.Operators.End(ap_);
-                object ar_;
-                DataType bd_ = tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation?.Performed;
-                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                bool bf_ = be_ is CqlDateTime;
-                if (bf_)
-                {
-                    ar_ = be_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bg_ = be_ is CqlQuantity;
-                    if (bg_)
-                    {
-                        ar_ = be_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bh_ = be_ is CqlInterval<CqlDateTime>;
-                        if (bh_)
-                        {
-                            ar_ = be_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bi_ = be_ is CqlInterval<CqlQuantity>;
-                            if (bi_)
-                            {
-                                ar_ = be_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ar_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.Start(as_);
-                CqlInterval<CqlDateTime> au_ = context.Operators.Interval(aq_, at_, true, true);
-                CqlBoolean av_ = context.Operators.In<CqlDateTime>(an_, au_, (string)default);
-                return av_;
             }
-
-
-            CqlBoolean r_() {
-                object bj_;
-                DataType bm_ = tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation?.Performed;
-                object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                bool bo_ = bn_ is CqlDateTime;
-                if (bo_)
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.Start(q_);
+            object s_;
+            Procedure as_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation);
+            DataType at_ = as_?.Performed;
+            object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+            bool av_ = au_ is CqlDateTime;
+            if (av_)
+            {
+                s_ = au_ as CqlDateTime;
+            }
+            else
+            {
+                bool aw_ = au_ is CqlQuantity;
+                if (aw_)
                 {
-                    bj_ = bn_ as CqlDateTime;
+                    s_ = au_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bp_ = bn_ is CqlQuantity;
-                    if (bp_)
+                    bool ax_ = au_ is CqlInterval<CqlDateTime>;
+                    if (ax_)
                     {
-                        bj_ = bn_ as CqlQuantity;
+                        s_ = au_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bq_ = bn_ is CqlInterval<CqlDateTime>;
-                        if (bq_)
+                        bool ay_ = au_ is CqlInterval<CqlQuantity>;
+                        if (ay_)
                         {
-                            bj_ = bn_ as CqlInterval<CqlDateTime>;
+                            s_ = au_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool br_ = bn_ is CqlInterval<CqlQuantity>;
-                            if (br_)
-                            {
-                                bj_ = bn_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bj_ = null;
-                            }
+                            s_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
-                CqlBoolean bl_ = this.isNotAtProceduralHospitalLocationDuring(context, tuple_qajmwefzjrlyudjfgicwdhsi?.EncounterWithSurgery, bk_);
-                return bl_;
             }
-
+            CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
+            CqlDateTime u_ = context.Operators.End(t_);
+            CqlBoolean v_ = context.Operators.After(r_, u_, (string)default);
+            CqlBoolean w_ = v_;
+            CqlInterval<CqlDateTime> x_ = this.interval(context, tuple_qajmwefzjrlyudjfgicwdhsi?.OxygenSupport);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            object z_;
+            Procedure az_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation);
+            DataType ba_ = az_?.Performed;
+            object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+            bool bc_ = bb_ is CqlDateTime;
+            if (bc_)
+            {
+                z_ = bb_ as CqlDateTime;
+            }
+            else
+            {
+                bool bd_ = bb_ is CqlQuantity;
+                if (bd_)
+                {
+                    z_ = bb_ as CqlQuantity;
+                }
+                else
+                {
+                    bool be_ = bb_ is CqlInterval<CqlDateTime>;
+                    if (be_)
+                    {
+                        z_ = bb_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bf_ = bb_ is CqlInterval<CqlQuantity>;
+                        if (bf_)
+                        {
+                            z_ = bb_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            z_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
+            CqlDateTime ab_ = context.Operators.End(aa_);
+            object ac_;
+            DataType bg_ = tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation?.Performed;
+            object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+            bool bi_ = bh_ is CqlDateTime;
+            if (bi_)
+            {
+                ac_ = bh_ as CqlDateTime;
+            }
+            else
+            {
+                bool bj_ = bh_ is CqlQuantity;
+                if (bj_)
+                {
+                    ac_ = bh_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bk_ = bh_ is CqlInterval<CqlDateTime>;
+                    if (bk_)
+                    {
+                        ac_ = bh_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bl_ = bh_ is CqlInterval<CqlQuantity>;
+                        if (bl_)
+                        {
+                            ac_ = bh_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ac_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+            CqlDateTime ae_ = context.Operators.Start(ad_);
+            CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ab_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDateTime>(y_, af_, (string)default);
+            CqlBoolean ah_ = ag_;
+            object ai_;
+            DataType bm_ = tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation?.Performed;
+            object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+            bool bo_ = bn_ is CqlDateTime;
+            if (bo_)
+            {
+                ai_ = bn_ as CqlDateTime;
+            }
+            else
+            {
+                bool bp_ = bn_ is CqlQuantity;
+                if (bp_)
+                {
+                    ai_ = bn_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bq_ = bn_ is CqlInterval<CqlDateTime>;
+                    if (bq_)
+                    {
+                        ai_ = bn_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool br_ = bn_ is CqlInterval<CqlQuantity>;
+                        if (br_)
+                        {
+                            ai_ = bn_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ai_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+            CqlBoolean ak_ = this.isNotAtProceduralHospitalLocationDuring(context, tuple_qajmwefzjrlyudjfgicwdhsi?.EncounterWithSurgery, aj_);
+            CqlBoolean al_ = ak_;
             return o_
                 /* CQL 'and' (170:11-171:85) */ && this.starts30DaysOrLessAfterFirstAnesthesia(context, tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation, tuple_qajmwefzjrlyudjfgicwdhsi?.EncounterWithSurgery)
                 /* CQL 'and' (170:11-172:74) */ && this.startsDuringHospitalization(context, tuple_qajmwefzjrlyudjfgicwdhsi?.Ventilation, tuple_qajmwefzjrlyudjfgicwdhsi?.EncounterWithSurgery)
-                /* CQL 'and' (170:11-173:74) */ && p_()
-                /* CQL 'and' (170:11-174:122) */ && q_()
-                /* CQL 'and' (170:5-175:94) */ && r_();
+                /* CQL 'and' (170:11-173:74) */ && w_
+                /* CQL 'and' (170:11-174:122) */ && ah_
+                /* CQL 'and' (170:5-175:94) */ && al_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure Ventilation, object OxygenSupport)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure Ventilation, object OxygenSupport)?>(e_, f_, g_);
@@ -3058,264 +2898,256 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             EventStatus? n_ = m_?.Value;
             string o_ = context.Operators.Convert<string>(n_);
             CqlBoolean p_ = context.Operators.Equal(o_, "completed");
-
-            CqlBoolean q_() {
-                CqlInterval<CqlDateTime> s_;
-                object w_;
-                DataType z_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                bool ab_ = aa_ is CqlDateTime;
-                if (ab_)
-                {
-                    w_ = aa_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ac_ = aa_ is CqlQuantity;
-                    if (ac_)
-                    {
-                        w_ = aa_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
-                        {
-                            w_ = aa_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                            if (ae_)
-                            {
-                                w_ = aa_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                w_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                if (y_ is null)
-                {
-                    s_ = default;
-                }
-                else
-                {
-                    object af_;
-                    DataType am_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    bool ao_ = an_ is CqlDateTime;
-                    if (ao_)
-                    {
-                        af_ = an_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool ap_ = an_ is CqlQuantity;
-                        if (ap_)
-                        {
-                            af_ = an_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool aq_ = an_ is CqlInterval<CqlDateTime>;
-                            if (aq_)
-                            {
-                                af_ = an_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool ar_ = an_ is CqlInterval<CqlQuantity>;
-                                if (ar_)
-                                {
-                                    af_ = an_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    af_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.Start(ag_);
-                    object ai_;
-                    DataType as_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
-                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                    bool au_ = at_ is CqlDateTime;
-                    if (au_)
-                    {
-                        ai_ = at_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool av_ = at_ is CqlQuantity;
-                        if (av_)
-                        {
-                            ai_ = at_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool aw_ = at_ is CqlInterval<CqlDateTime>;
-                            if (aw_)
-                            {
-                                ai_ = at_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool ax_ = at_ is CqlInterval<CqlQuantity>;
-                                if (ax_)
-                                {
-                                    ai_ = at_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    ai_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                    CqlDateTime ak_ = context.Operators.Start(aj_);
-                    CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ah_, ak_, true, true);
-                    s_ = al_;
-                }
-                object t_;
-                Procedure ay_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_bmexejitjfqtagoadebdecoag?.Extubation);
-                DataType az_ = ay_?.Performed;
-                object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                bool bb_ = ba_ is CqlDateTime;
-                if (bb_)
-                {
-                    t_ = ba_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bc_ = ba_ is CqlQuantity;
-                    if (bc_)
-                    {
-                        t_ = ba_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bd_ = ba_ is CqlInterval<CqlDateTime>;
-                        if (bd_)
-                        {
-                            t_ = ba_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool be_ = ba_ is CqlInterval<CqlQuantity>;
-                            if (be_)
-                            {
-                                t_ = ba_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                t_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
-                CqlBoolean v_ = context.Operators.After(s_, u_, (string)default);
-                return v_;
+            CqlInterval<CqlDateTime> q_;
+            object ag_;
+            DataType aj_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
+            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+            bool al_ = ak_ is CqlDateTime;
+            if (al_)
+            {
+                ag_ = ak_ as CqlDateTime;
             }
-
-
-            CqlBoolean r_() {
-                CqlInterval<CqlDateTime> bf_ = this.interval(context, tuple_bmexejitjfqtagoadebdecoag?.OxygenSupport);
-                CqlDateTime bg_ = context.Operators.Start(bf_);
-                object bh_;
-                Procedure bp_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_bmexejitjfqtagoadebdecoag?.Extubation);
-                DataType bq_ = bp_?.Performed;
-                object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                bool bs_ = br_ is CqlDateTime;
-                if (bs_)
+            else
+            {
+                bool am_ = ak_ is CqlQuantity;
+                if (am_)
                 {
-                    bh_ = br_ as CqlDateTime;
+                    ag_ = ak_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bt_ = br_ is CqlQuantity;
-                    if (bt_)
+                    bool an_ = ak_ is CqlInterval<CqlDateTime>;
+                    if (an_)
                     {
-                        bh_ = br_ as CqlQuantity;
+                        ag_ = ak_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bu_ = br_ is CqlInterval<CqlDateTime>;
-                        if (bu_)
+                        bool ao_ = ak_ is CqlInterval<CqlQuantity>;
+                        if (ao_)
                         {
-                            bh_ = br_ as CqlInterval<CqlDateTime>;
+                            ag_ = ak_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bv_ = br_ is CqlInterval<CqlQuantity>;
-                            if (bv_)
-                            {
-                                bh_ = br_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bh_ = null;
-                            }
+                            ag_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
-                CqlDateTime bj_ = context.Operators.End(bi_);
-                object bk_;
-                DataType bw_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
-                object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                bool by_ = bx_ is CqlDateTime;
-                if (by_)
-                {
-                    bk_ = bx_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bz_ = bx_ is CqlQuantity;
-                    if (bz_)
-                    {
-                        bk_ = bx_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ca_ = bx_ is CqlInterval<CqlDateTime>;
-                        if (ca_)
-                        {
-                            bk_ = bx_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cb_ = bx_ is CqlInterval<CqlQuantity>;
-                            if (cb_)
-                            {
-                                bk_ = bx_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bk_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bl_ = QICoreCommon_4_0_000.Instance.toInterval(context, bk_);
-                CqlDateTime bm_ = context.Operators.Start(bl_);
-                CqlInterval<CqlDateTime> bn_ = context.Operators.Interval(bj_, bm_, true, true);
-                CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bg_, bn_, (string)default);
-                return bo_;
             }
-
+            CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
+            CqlDateTime ai_ = context.Operators.Start(ah_);
+            if (ai_ is null)
+            {
+                q_ = default;
+            }
+            else
+            {
+                object ap_;
+                DataType aw_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
+                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                bool ay_ = ax_ is CqlDateTime;
+                if (ay_)
+                {
+                    ap_ = ax_ as CqlDateTime;
+                }
+                else
+                {
+                    bool az_ = ax_ is CqlQuantity;
+                    if (az_)
+                    {
+                        ap_ = ax_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ba_ = ax_ is CqlInterval<CqlDateTime>;
+                        if (ba_)
+                        {
+                            ap_ = ax_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool bb_ = ax_ is CqlInterval<CqlQuantity>;
+                            if (bb_)
+                            {
+                                ap_ = ax_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                ap_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
+                CqlDateTime ar_ = context.Operators.Start(aq_);
+                object as_;
+                DataType bc_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                bool be_ = bd_ is CqlDateTime;
+                if (be_)
+                {
+                    as_ = bd_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bf_ = bd_ is CqlQuantity;
+                    if (bf_)
+                    {
+                        as_ = bd_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool bg_ = bd_ is CqlInterval<CqlDateTime>;
+                        if (bg_)
+                        {
+                            as_ = bd_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool bh_ = bd_ is CqlInterval<CqlQuantity>;
+                            if (bh_)
+                            {
+                                as_ = bd_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                as_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
+                CqlDateTime au_ = context.Operators.Start(at_);
+                CqlInterval<CqlDateTime> av_ = context.Operators.Interval(ar_, au_, true, true);
+                q_ = av_;
+            }
+            object r_;
+            Procedure bi_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_bmexejitjfqtagoadebdecoag?.Extubation);
+            DataType bj_ = bi_?.Performed;
+            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+            bool bl_ = bk_ is CqlDateTime;
+            if (bl_)
+            {
+                r_ = bk_ as CqlDateTime;
+            }
+            else
+            {
+                bool bm_ = bk_ is CqlQuantity;
+                if (bm_)
+                {
+                    r_ = bk_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bn_ = bk_ is CqlInterval<CqlDateTime>;
+                    if (bn_)
+                    {
+                        r_ = bk_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bo_ = bk_ is CqlInterval<CqlQuantity>;
+                        if (bo_)
+                        {
+                            r_ = bk_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            r_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
+            CqlBoolean t_ = context.Operators.After(q_, s_, (string)default);
+            CqlBoolean u_ = t_;
+            CqlInterval<CqlDateTime> v_ = this.interval(context, tuple_bmexejitjfqtagoadebdecoag?.OxygenSupport);
+            CqlDateTime w_ = context.Operators.Start(v_);
+            object x_;
+            Procedure bp_ = this.latestGeneralAnesthesiaOrMAC(context, tuple_bmexejitjfqtagoadebdecoag?.Extubation);
+            DataType bq_ = bp_?.Performed;
+            object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+            bool bs_ = br_ is CqlDateTime;
+            if (bs_)
+            {
+                x_ = br_ as CqlDateTime;
+            }
+            else
+            {
+                bool bt_ = br_ is CqlQuantity;
+                if (bt_)
+                {
+                    x_ = br_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bu_ = br_ is CqlInterval<CqlDateTime>;
+                    if (bu_)
+                    {
+                        x_ = br_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bv_ = br_ is CqlInterval<CqlQuantity>;
+                        if (bv_)
+                        {
+                            x_ = br_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            x_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+            CqlDateTime z_ = context.Operators.End(y_);
+            object aa_;
+            DataType bw_ = tuple_bmexejitjfqtagoadebdecoag?.Extubation?.Performed;
+            object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+            bool by_ = bx_ is CqlDateTime;
+            if (by_)
+            {
+                aa_ = bx_ as CqlDateTime;
+            }
+            else
+            {
+                bool bz_ = bx_ is CqlQuantity;
+                if (bz_)
+                {
+                    aa_ = bx_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ca_ = bx_ is CqlInterval<CqlDateTime>;
+                    if (ca_)
+                    {
+                        aa_ = bx_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cb_ = bx_ is CqlInterval<CqlQuantity>;
+                        if (cb_)
+                        {
+                            aa_ = bx_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            aa_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
+            CqlDateTime ac_ = context.Operators.Start(ab_);
+            CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(z_, ac_, true, true);
+            CqlBoolean ae_ = context.Operators.In<CqlDateTime>(w_, ad_, (string)default);
+            CqlBoolean af_ = ae_;
             return p_
                 /* CQL 'and' (272:11-273:73) */ && this.startsDuringHospitalization(context, tuple_bmexejitjfqtagoadebdecoag?.Extubation, tuple_bmexejitjfqtagoadebdecoag?.EncounterWithSurgery)
-                /* CQL 'and' (272:11-274:100) */ && q_()
-                /* CQL 'and' (272:5-275:155) */ && r_();
+                /* CQL 'and' (272:11-274:100) */ && u_
+                /* CQL 'and' (272:5-275:155) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure Extubation, object OxygenSupport)?> i_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure Extubation, object OxygenSupport)?>(f_, g_, h_);
@@ -3351,90 +3183,86 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             EventStatus? n_ = m_?.Value;
             string o_ = context.Operators.Convert<string>(n_);
             CqlBoolean p_ = context.Operators.Equal(o_, "completed");
-
-            CqlBoolean q_() {
-                object r_;
-                DataType x_ = tuple_ekminbgfrptfmgtchtshrgjuc?.Extubation?.Performed;
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                bool z_ = y_ is CqlDateTime;
-                if (z_)
-                {
-                    r_ = y_ as CqlDateTime;
-                }
-                else
-                {
-                    bool aa_ = y_ is CqlQuantity;
-                    if (aa_)
-                    {
-                        r_ = y_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ab_ = y_ is CqlInterval<CqlDateTime>;
-                        if (ab_)
-                        {
-                            r_ = y_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ac_ = y_ is CqlInterval<CqlQuantity>;
-                            if (ac_)
-                            {
-                                r_ = y_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                r_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.Start(s_);
-                object u_;
-                DataType ad_ = tuple_ekminbgfrptfmgtchtshrgjuc?.Anesthesia?.Performed;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
-                {
-                    u_ = ae_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ag_ = ae_ is CqlQuantity;
-                    if (ag_)
-                    {
-                        u_ = ae_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ah_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ah_)
-                        {
-                            u_ = ae_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ai_ = ae_ is CqlInterval<CqlQuantity>;
-                            if (ai_)
-                            {
-                                u_ = ae_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                u_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                CqlBoolean w_ = context.Operators.In<CqlDateTime>(t_, v_, (string)default);
-                return w_;
+            object q_;
+            DataType x_ = tuple_ekminbgfrptfmgtchtshrgjuc?.Extubation?.Performed;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            bool z_ = y_ is CqlDateTime;
+            if (z_)
+            {
+                q_ = y_ as CqlDateTime;
             }
-
+            else
+            {
+                bool aa_ = y_ is CqlQuantity;
+                if (aa_)
+                {
+                    q_ = y_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ab_ = y_ is CqlInterval<CqlDateTime>;
+                    if (ab_)
+                    {
+                        q_ = y_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ac_ = y_ is CqlInterval<CqlQuantity>;
+                        if (ac_)
+                        {
+                            q_ = y_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            q_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+            CqlDateTime s_ = context.Operators.Start(r_);
+            object t_;
+            DataType ad_ = tuple_ekminbgfrptfmgtchtshrgjuc?.Anesthesia?.Performed;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            bool af_ = ae_ is CqlDateTime;
+            if (af_)
+            {
+                t_ = ae_ as CqlDateTime;
+            }
+            else
+            {
+                bool ag_ = ae_ is CqlQuantity;
+                if (ag_)
+                {
+                    t_ = ae_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ah_ = ae_ is CqlInterval<CqlDateTime>;
+                    if (ah_)
+                    {
+                        t_ = ae_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ai_ = ae_ is CqlInterval<CqlQuantity>;
+                        if (ai_)
+                        {
+                            t_ = ae_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            t_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+            CqlBoolean v_ = context.Operators.In<CqlDateTime>(s_, u_, (string)default);
+            CqlBoolean w_ = v_;
             return p_
                 /* CQL 'and' (261:11-262:73) */ && this.startsDuringHospitalization(context, tuple_ekminbgfrptfmgtchtshrgjuc?.Extubation, tuple_ekminbgfrptfmgtchtshrgjuc?.EncounterWithSurgery)
-                /* CQL 'and' (261:5-263:95) */ && q_();
+                /* CQL 'and' (261:5-263:95) */ && w_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure Extubation, Procedure Anesthesia)?> i_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, Procedure>, (CqlTupleMetadata, Encounter EncounterWithSurgery, Procedure Extubation, Procedure Anesthesia)?>(f_, g_, h_);
@@ -3455,23 +3283,19 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             bool? e_(Location Location) {
                 ResourceReference g_ = EncounterLocation?.Location;
                 CqlBoolean h_ = QICoreCommon_4_0_000.Instance.references(context, g_, Location);
+                List<CodeableConcept> i_ = Location?.Type;
 
-                CqlBoolean i_() {
-                    List<CodeableConcept> j_ = Location?.Type;
-
-                    CqlConcept k_(CodeableConcept @this) {
-                        CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return o_;
-                    }
-
-                    IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
-                    CqlCode m_ = this.ER(context);
-                    CqlBoolean n_ = QICoreCommon_4_0_000.Instance.includesCode(context, l_, m_);
-                    return n_;
+                CqlConcept j_(CodeableConcept @this) {
+                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return o_;
                 }
 
+                IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+                CqlCode l_ = this.ER(context);
+                CqlBoolean m_ = QICoreCommon_4_0_000.Instance.includesCode(context, k_, l_);
+                CqlBoolean n_ = m_;
                 return h_
-                    /* CQL 'and' (681:19-682:49) */ && i_();
+                    /* CQL 'and' (681:19-682:49) */ && n_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Location>(d_, e_);
@@ -3503,149 +3327,135 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 EventStatus? j_ = i_?.Value;
                 string k_ = context.Operators.Convert<string>(j_);
                 CqlBoolean l_ = context.Operators.Equal(k_, "completed");
-
-                CqlBoolean m_() {
-                    object o_;
-                    DataType x_ = Extubation?.Performed;
-                    object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                    bool z_ = y_ is CqlDateTime;
-                    if (z_)
+                object m_;
+                DataType ak_ = Extubation?.Performed;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
+                {
+                    m_ = al_ as CqlDateTime;
+                }
+                else
+                {
+                    bool an_ = al_ is CqlQuantity;
+                    if (an_)
                     {
-                        o_ = y_ as CqlDateTime;
+                        m_ = al_ as CqlQuantity;
                     }
                     else
                     {
-                        bool aa_ = y_ is CqlQuantity;
-                        if (aa_)
+                        bool ao_ = al_ is CqlInterval<CqlDateTime>;
+                        if (ao_)
                         {
-                            o_ = y_ as CqlQuantity;
+                            m_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ab_ = y_ is CqlInterval<CqlDateTime>;
-                            if (ab_)
+                            bool ap_ = al_ is CqlInterval<CqlQuantity>;
+                            if (ap_)
                             {
-                                o_ = y_ as CqlInterval<CqlDateTime>;
+                                m_ = al_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ac_ = y_ is CqlInterval<CqlQuantity>;
-                                if (ac_)
-                                {
-                                    o_ = y_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    o_ = null;
-                                }
+                                m_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                    CqlDateTime q_ = context.Operators.Start(p_);
-                    object r_;
-                    Procedure ad_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
-                    DataType ae_ = ad_?.Performed;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    bool ag_ = af_ is CqlDateTime;
-                    if (ag_)
+                }
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.Start(n_);
+                object p_;
+                Procedure aq_ = this.latestGeneralAnesthesiaOrMAC(context, Extubation);
+                DataType ar_ = aq_?.Performed;
+                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                bool at_ = as_ is CqlDateTime;
+                if (at_)
+                {
+                    p_ = as_ as CqlDateTime;
+                }
+                else
+                {
+                    bool au_ = as_ is CqlQuantity;
+                    if (au_)
                     {
-                        r_ = af_ as CqlDateTime;
+                        p_ = as_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ah_ = af_ is CqlQuantity;
-                        if (ah_)
+                        bool av_ = as_ is CqlInterval<CqlDateTime>;
+                        if (av_)
                         {
-                            r_ = af_ as CqlQuantity;
+                            p_ = as_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                            if (ai_)
+                            bool aw_ = as_ is CqlInterval<CqlQuantity>;
+                            if (aw_)
                             {
-                                r_ = af_ as CqlInterval<CqlDateTime>;
+                                p_ = as_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                                if (aj_)
-                                {
-                                    r_ = af_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    r_ = null;
-                                }
+                                p_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.End(s_);
-                    CqlQuantity u_ = context.Operators.Quantity(48m, "hours");
-                    CqlDateTime v_ = context.Operators.Add(t_, u_);
-                    CqlBoolean w_ = context.Operators.After(q_, v_, (string)default);
-                    return w_;
+                }
+                CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+                CqlDateTime r_ = context.Operators.End(q_);
+                CqlQuantity s_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime t_ = context.Operators.Add(r_, s_);
+                CqlBoolean u_ = context.Operators.After(o_, t_, (string)default);
+                CqlBoolean v_ = u_;
+                IEnumerable<Procedure> w_ = this.Extubation_With_Preceding_Noninvasive_Oxygen(context);
+
+                bool? x_(Procedure @this) {
+                    string ax_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return ax_ is not null;
                 }
 
 
-                CqlBoolean n_() {
-                    IEnumerable<Procedure> ak_ = this.Extubation_With_Preceding_Noninvasive_Oxygen(context);
-
-                    bool? al_(Procedure @this) {
-                        string as_ = (@this is Resource
-                            ? (@this as Resource).IdElement
-                            : default)?.Value;
-                        return as_ is not null;
-                    }
-
-
-                    string am_(Procedure @this) {
-                        string at_ = (@this is Resource
-                            ? (@this as Resource).IdElement
-                            : default)?.Value;
-                        return at_;
-                    }
-
-                    IEnumerable<string> an_ = context.Operators.WhereSelect<Procedure, string>(ak_, al_, am_);
-                    Id ao_ = Extubation?.IdElement;
-                    string ap_ = ao_?.Value;
-                    CqlBoolean aq_ = context.Operators.Contains<string>(an_, ap_);
-
-                    CqlBoolean ar_() {
-                        IEnumerable<Procedure> au_ = this.Extubation_During_General_Anesthesia(context);
-
-                        bool? av_(Procedure @this) {
-                            string bb_ = (@this is Resource
-                                ? (@this as Resource).IdElement
-                                : default)?.Value;
-                            return bb_ is not null;
-                        }
-
-
-                        string aw_(Procedure @this) {
-                            string bc_ = (@this is Resource
-                                ? (@this as Resource).IdElement
-                                : default)?.Value;
-                            return bc_;
-                        }
-
-                        IEnumerable<string> ax_ = context.Operators.WhereSelect<Procedure, string>(au_, av_, aw_);
-                        Id ay_ = Extubation?.IdElement;
-                        string az_ = ay_?.Value;
-                        CqlBoolean ba_ = context.Operators.Contains<string>(ax_, az_);
-                        return !ba_;
-                    }
-
-                    return !((bool?)(aq_
-                        /* CQL 'and' (185:17-187:9) */ && ar_()));
+                string y_(Procedure @this) {
+                    string ay_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return ay_;
                 }
 
+                IEnumerable<string> z_ = context.Operators.WhereSelect<Procedure, string>(w_, x_, y_);
+                Id aa_ = Extubation?.IdElement;
+                string ab_ = aa_?.Value;
+                CqlBoolean ac_ = context.Operators.Contains<string>(z_, ab_);
+                IEnumerable<Procedure> ad_ = this.Extubation_During_General_Anesthesia(context);
+
+                bool? ae_(Procedure @this) {
+                    string az_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return az_ is not null;
+                }
+
+
+                string af_(Procedure @this) {
+                    string ba_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return ba_;
+                }
+
+                IEnumerable<string> ag_ = context.Operators.WhereSelect<Procedure, string>(ad_, ae_, af_);
+                CqlBoolean ah_ = context.Operators.Contains<string>(ag_, ab_);
+                CqlBoolean ai_ = (CqlBoolean)!ah_;
+                CqlBoolean aj_ = (CqlBoolean)(!((bool?)(ac_
+                    /* CQL 'and' (185:17-187:9) */ && ai_)));
                 return l_
                     /* CQL 'and' (181:17-182:71) */ && this.isDuringHospitalization(context, Extubation, EncounterWithSurgery)
                     /* CQL 'and' (181:17-183:86) */ && this.starts30DaysOrLessAfterFirstAnesthesia(context, Extubation, EncounterWithSurgery)
-                    /* CQL 'and' (181:17-184:155) */ && m_()
-                    /* CQL 'and' (181:17-187:9) */ && n_()
+                    /* CQL 'and' (181:17-184:155) */ && v_
+                    /* CQL 'and' (181:17-187:9) */ && aj_
                     /* CQL 'and' (181:17-188:70) */ && this.isNotAtProceduralHospitalLocation(context, EncounterWithSurgery);
             }
 
@@ -3677,293 +3487,277 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
+                object l_;
+                DataType av_ = Ventilation?.Performed;
+                object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                bool ax_ = aw_ is CqlDateTime;
+                if (ax_)
+                {
+                    l_ = aw_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ay_ = aw_ is CqlQuantity;
+                    if (ay_)
+                    {
+                        l_ = aw_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool az_ = aw_ is CqlInterval<CqlDateTime>;
+                        if (az_)
+                        {
+                            l_ = aw_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool ba_ = aw_ is CqlInterval<CqlQuantity>;
+                            if (ba_)
+                            {
+                                l_ = aw_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                l_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                object o_;
+                Procedure bb_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                DataType bc_ = bb_?.Performed;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                bool be_ = bd_ is CqlDateTime;
+                if (be_)
+                {
+                    o_ = bd_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bf_ = bd_ is CqlQuantity;
+                    if (bf_)
+                    {
+                        o_ = bd_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool bg_ = bd_ is CqlInterval<CqlDateTime>;
+                        if (bg_)
+                        {
+                            o_ = bd_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool bh_ = bd_ is CqlInterval<CqlQuantity>;
+                            if (bh_)
+                            {
+                                o_ = bd_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                o_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                CqlQuantity r_ = context.Operators.Quantity(48m, "hours");
+                CqlDateTime s_ = context.Operators.Add(q_, r_);
+                CqlBoolean t_ = context.Operators.SameOrAfter(n_, s_, (string)default);
+                CqlBoolean u_ = t_;
+                object v_;
+                DataType bi_ = Ventilation?.Performed;
+                object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                bool bk_ = bj_ is CqlDateTime;
+                if (bk_)
+                {
+                    v_ = bj_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bl_ = bj_ is CqlQuantity;
+                    if (bl_)
+                    {
+                        v_ = bj_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool bm_ = bj_ is CqlInterval<CqlDateTime>;
+                        if (bm_)
+                        {
+                            v_ = bj_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool bn_ = bj_ is CqlInterval<CqlQuantity>;
+                            if (bn_)
+                            {
+                                v_ = bj_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                v_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                object y_;
+                Procedure bo_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                DataType bp_ = bo_?.Performed;
+                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+                bool br_ = bq_ is CqlDateTime;
+                if (br_)
+                {
+                    y_ = bq_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bs_ = bq_ is CqlQuantity;
+                    if (bs_)
+                    {
+                        y_ = bq_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
+                        if (bt_)
+                        {
+                            y_ = bq_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
+                            if (bu_)
+                            {
+                                y_ = bq_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                y_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+                CqlDateTime aa_ = context.Operators.End(z_);
+                object ab_;
+                Procedure bv_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                DataType bw_ = bv_?.Performed;
+                object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+                bool by_ = bx_ is CqlDateTime;
+                if (by_)
+                {
+                    ab_ = bx_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bz_ = bx_ is CqlQuantity;
+                    if (bz_)
+                    {
+                        ab_ = bx_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ca_ = bx_ is CqlInterval<CqlDateTime>;
+                        if (ca_)
+                        {
+                            ab_ = bx_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool cb_ = bx_ is CqlInterval<CqlQuantity>;
+                            if (cb_)
+                            {
+                                ab_ = bx_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                ab_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+                CqlDateTime ad_ = context.Operators.End(ac_);
+                CqlQuantity ae_ = context.Operators.Quantity(72m, "hours");
+                CqlDateTime af_ = context.Operators.Add(ad_, ae_);
+                CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(aa_, af_, false, true);
+                CqlBoolean ah_ = context.Operators.In<CqlDateTime>(x_, ag_, (string)default);
+                object ai_;
+                Procedure cc_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
+                DataType cd_ = cc_?.Performed;
+                object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                bool cf_ = ce_ is CqlDateTime;
+                if (cf_)
+                {
+                    ai_ = ce_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cg_ = ce_ is CqlQuantity;
+                    if (cg_)
+                    {
+                        ai_ = ce_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ch_ = ce_ is CqlInterval<CqlDateTime>;
+                        if (ch_)
+                        {
+                            ai_ = ce_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool ci_ = ce_ is CqlInterval<CqlQuantity>;
+                            if (ci_)
+                            {
+                                ai_ = ce_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                ai_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+                CqlDateTime ak_ = context.Operators.End(aj_);
+                CqlBoolean al_ = (CqlBoolean)(ak_ is not null);
+                CqlBoolean am_ = ah_
+                    /* CQL 'and' (195:13-195:155) */ && al_;
+                IEnumerable<Encounter> an_ = this.Encounter_With_Mechanical_Ventilation_Outside_Of_Procedural_Area_Within_30_Days_Of_End_Of_First_OR_Procedure_And_Preceded_By_Non_Invasive_Oxygen_Therapy(context);
 
-                CqlBoolean l_() {
-                    object o_;
-                    DataType x_ = Ventilation?.Performed;
-                    object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                    bool z_ = y_ is CqlDateTime;
-                    if (z_)
-                    {
-                        o_ = y_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool aa_ = y_ is CqlQuantity;
-                        if (aa_)
-                        {
-                            o_ = y_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool ab_ = y_ is CqlInterval<CqlDateTime>;
-                            if (ab_)
-                            {
-                                o_ = y_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool ac_ = y_ is CqlInterval<CqlQuantity>;
-                                if (ac_)
-                                {
-                                    o_ = y_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    o_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                    CqlDateTime q_ = context.Operators.Start(p_);
-                    object r_;
-                    Procedure ad_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                    DataType ae_ = ad_?.Performed;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    bool ag_ = af_ is CqlDateTime;
-                    if (ag_)
-                    {
-                        r_ = af_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool ah_ = af_ is CqlQuantity;
-                        if (ah_)
-                        {
-                            r_ = af_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                            if (ai_)
-                            {
-                                r_ = af_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                                if (aj_)
-                                {
-                                    r_ = af_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    r_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.End(s_);
-                    CqlQuantity u_ = context.Operators.Quantity(48m, "hours");
-                    CqlDateTime v_ = context.Operators.Add(t_, u_);
-                    CqlBoolean w_ = context.Operators.SameOrAfter(q_, v_, (string)default);
-                    return w_;
+                bool? ao_(Encounter @this) {
+                    string cj_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return cj_ is not null;
                 }
 
 
-                CqlBoolean m_() {
-                    object ak_;
-                    DataType ay_ = Ventilation?.Performed;
-                    object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                    bool ba_ = az_ is CqlDateTime;
-                    if (ba_)
-                    {
-                        ak_ = az_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bb_ = az_ is CqlQuantity;
-                        if (bb_)
-                        {
-                            ak_ = az_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool bc_ = az_ is CqlInterval<CqlDateTime>;
-                            if (bc_)
-                            {
-                                ak_ = az_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool bd_ = az_ is CqlInterval<CqlQuantity>;
-                                if (bd_)
-                                {
-                                    ak_ = az_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    ak_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
-                    CqlDateTime am_ = context.Operators.Start(al_);
-                    object an_;
-                    Procedure be_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                    DataType bf_ = be_?.Performed;
-                    object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                    bool bh_ = bg_ is CqlDateTime;
-                    if (bh_)
-                    {
-                        an_ = bg_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bi_ = bg_ is CqlQuantity;
-                        if (bi_)
-                        {
-                            an_ = bg_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool bj_ = bg_ is CqlInterval<CqlDateTime>;
-                            if (bj_)
-                            {
-                                an_ = bg_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool bk_ = bg_ is CqlInterval<CqlQuantity>;
-                                if (bk_)
-                                {
-                                    an_ = bg_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    an_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_);
-                    CqlDateTime ap_ = context.Operators.End(ao_);
-                    object aq_;
-                    Procedure bl_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                    DataType bm_ = bl_?.Performed;
-                    object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                    bool bo_ = bn_ is CqlDateTime;
-                    if (bo_)
-                    {
-                        aq_ = bn_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bp_ = bn_ is CqlQuantity;
-                        if (bp_)
-                        {
-                            aq_ = bn_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool bq_ = bn_ is CqlInterval<CqlDateTime>;
-                            if (bq_)
-                            {
-                                aq_ = bn_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool br_ = bn_ is CqlInterval<CqlQuantity>;
-                                if (br_)
-                                {
-                                    aq_ = bn_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    aq_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
-                    CqlDateTime as_ = context.Operators.End(ar_);
-                    CqlQuantity at_ = context.Operators.Quantity(72m, "hours");
-                    CqlDateTime au_ = context.Operators.Add(as_, at_);
-                    CqlInterval<CqlDateTime> av_ = context.Operators.Interval(ap_, au_, false, true);
-                    CqlBoolean aw_ = context.Operators.In<CqlDateTime>(am_, av_, (string)default);
-
-                    CqlBoolean ax_() {
-                        object bs_;
-                        Procedure bv_ = this.latestGeneralAnesthesiaOrMAC(context, Ventilation);
-                        DataType bw_ = bv_?.Performed;
-                        object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                        bool by_ = bx_ is CqlDateTime;
-                        if (by_)
-                        {
-                            bs_ = bx_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool bz_ = bx_ is CqlQuantity;
-                            if (bz_)
-                            {
-                                bs_ = bx_ as CqlQuantity;
-                            }
-                            else
-                            {
-                                bool ca_ = bx_ is CqlInterval<CqlDateTime>;
-                                if (ca_)
-                                {
-                                    bs_ = bx_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool cb_ = bx_ is CqlInterval<CqlQuantity>;
-                                    if (cb_)
-                                    {
-                                        bs_ = bx_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        bs_ = null;
-                                    }
-                                }
-                            }
-                        }
-                        CqlInterval<CqlDateTime> bt_ = QICoreCommon_4_0_000.Instance.toInterval(context, bs_);
-                        CqlDateTime bu_ = context.Operators.End(bt_);
-                        return bu_ is not null;
-                    }
-
-                    return aw_
-                        /* CQL 'and' (195:13-195:155) */ && ax_();
+                string ap_(Encounter @this) {
+                    string ck_ = (@this is Resource
+                        ? (@this as Resource).IdElement
+                        : default)?.Value;
+                    return ck_;
                 }
 
-
-                CqlBoolean n_() {
-                    IEnumerable<Encounter> cc_ = this.Encounter_With_Mechanical_Ventilation_Outside_Of_Procedural_Area_Within_30_Days_Of_End_Of_First_OR_Procedure_And_Preceded_By_Non_Invasive_Oxygen_Therapy(context);
-
-                    bool? cd_(Encounter @this) {
-                        string cj_ = (@this is Resource
-                            ? (@this as Resource).IdElement
-                            : default)?.Value;
-                        return cj_ is not null;
-                    }
-
-
-                    string ce_(Encounter @this) {
-                        string ck_ = (@this is Resource
-                            ? (@this as Resource).IdElement
-                            : default)?.Value;
-                        return ck_;
-                    }
-
-                    IEnumerable<string> cf_ = context.Operators.WhereSelect<Encounter, string>(cc_, cd_, ce_);
-                    Id cg_ = EncounterWithSurgery?.IdElement;
-                    string ch_ = cg_?.Value;
-                    CqlBoolean ci_ = context.Operators.Contains<string>(cf_, ch_);
-                    return !ci_;
-                }
-
+                IEnumerable<string> aq_ = context.Operators.WhereSelect<Encounter, string>(an_, ao_, ap_);
+                Id ar_ = EncounterWithSurgery?.IdElement;
+                string as_ = ar_?.Value;
+                CqlBoolean at_ = context.Operators.Contains<string>(aq_, as_);
+                CqlBoolean au_ = (CqlBoolean)!at_;
                 return k_
-                    /* CQL 'and' (193:17-194:155) */ && l_()
-                    /* CQL 'and' (193:17-195:155) */ && m_()
+                    /* CQL 'and' (193:17-194:155) */ && u_
+                    /* CQL 'and' (193:17-195:155) */ && am_
                     /* CQL 'and' (193:17-196:87) */ && this.starts30DaysOrLessAfterFirstAnesthesia(context, Ventilation, EncounterWithSurgery)
                     /* CQL 'and' (193:17-197:76) */ && this.startsDuringHospitalization(context, Ventilation, EncounterWithSurgery)
-                    /* CQL 'and' (193:17-198:210) */ && n_()
+                    /* CQL 'and' (193:17-198:210) */ && au_
                     /* CQL 'and' (193:17-199:70) */ && this.isNotAtProceduralHospitalLocation(context, EncounterWithSurgery);
             }
 
@@ -4010,32 +3804,24 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 FinancialResourceStatusCodes? o_ = n_?.Value;
                 Code<FinancialResourceStatusCodes> p_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(o_);
                 CqlBoolean q_ = context.Operators.Equal(p_, "active");
+                Code<ClaimUseCode> r_ = C?.UseElement;
+                ClaimUseCode? s_ = r_?.Value;
+                Code<ClaimUseCode> t_ = context.Operators.Convert<Code<ClaimUseCode>>(s_);
+                CqlBoolean u_ = context.Operators.Equal(t_, "claim");
+                CqlBoolean v_ = u_;
+                List<Claim.ItemComponent> w_ = C?.Item;
 
-                CqlBoolean r_() {
-                    Code<ClaimUseCode> t_ = C?.UseElement;
-                    ClaimUseCode? u_ = t_?.Value;
-                    Code<ClaimUseCode> v_ = context.Operators.Convert<Code<ClaimUseCode>>(u_);
-                    CqlBoolean w_ = context.Operators.Equal(v_, "claim");
-                    return w_;
+                bool? x_(Claim.ItemComponent I) {
+                    List<ResourceReference> aa_ = I?.Encounter;
+                    CqlBoolean ab_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)aa_, E);
+                    return ab_;
                 }
 
-
-                CqlBoolean s_() {
-                    List<Claim.ItemComponent> x_ = C?.Item;
-
-                    bool? y_(Claim.ItemComponent I) {
-                        List<ResourceReference> aa_ = I?.Encounter;
-                        CqlBoolean ab_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)aa_, E);
-                        return ab_;
-                    }
-
-                    CqlBoolean z_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)x_, y_);
-                    return z_;
-                }
-
+                CqlBoolean y_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)w_, x_);
+                CqlBoolean z_ = y_;
                 return q_
-                    /* CQL 'and' (738:15-739:29) */ && r_()
-                    /* CQL 'and' (738:9-742:11) */ && s_();
+                    /* CQL 'and' (738:15-739:29) */ && v_
+                    /* CQL 'and' (738:9-742:11) */ && z_;
             }
 
             IEnumerable<Claim> g_ = context.Operators.Where<Claim>(e_, f_);
@@ -4060,99 +3846,87 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 IEnumerable<Claim> ag_ = context.Operators.Retrieve<Claim>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim"));
 
                 bool? ah_(Claim C) {
-                    Code<FinancialResourceStatusCodes> av_ = C?.StatusElement;
-                    FinancialResourceStatusCodes? aw_ = av_?.Value;
-                    Code<FinancialResourceStatusCodes> ax_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(aw_);
-                    CqlBoolean ay_ = context.Operators.Equal(ax_, "active");
+                    Code<FinancialResourceStatusCodes> ax_ = C?.StatusElement;
+                    FinancialResourceStatusCodes? ay_ = ax_?.Value;
+                    Code<FinancialResourceStatusCodes> az_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(ay_);
+                    CqlBoolean ba_ = context.Operators.Equal(az_, "active");
+                    Code<ClaimUseCode> bb_ = C?.UseElement;
+                    ClaimUseCode? bc_ = bb_?.Value;
+                    Code<ClaimUseCode> bd_ = context.Operators.Convert<Code<ClaimUseCode>>(bc_);
+                    CqlBoolean be_ = context.Operators.Equal(bd_, "claim");
+                    CqlBoolean bf_ = be_;
+                    List<Claim.ItemComponent> bg_ = C?.Item;
 
-                    CqlBoolean az_() {
-                        Code<ClaimUseCode> bb_ = C?.UseElement;
-                        ClaimUseCode? bc_ = bb_?.Value;
-                        Code<ClaimUseCode> bd_ = context.Operators.Convert<Code<ClaimUseCode>>(bc_);
-                        CqlBoolean be_ = context.Operators.Equal(bd_, "claim");
-                        return be_;
+                    bool? bh_(Claim.ItemComponent I) {
+                        List<ResourceReference> bk_ = I?.Encounter;
+                        CqlBoolean bl_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bk_, E);
+                        return bl_;
                     }
 
-
-                    CqlBoolean ba_() {
-                        List<Claim.ItemComponent> bf_ = C?.Item;
-
-                        bool? bg_(Claim.ItemComponent I) {
-                            List<ResourceReference> bi_ = I?.Encounter;
-                            CqlBoolean bj_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bi_, E);
-                            return bj_;
-                        }
-
-                        CqlBoolean bh_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)bf_, bg_);
-                        return bh_;
-                    }
-
-                    return ay_
-                        /* CQL 'and' (738:15-739:29) */ && az_()
-                        /* CQL 'and' (738:9-742:11) */ && ba_();
+                    CqlBoolean bi_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)bg_, bh_);
+                    CqlBoolean bj_ = bi_;
+                    return ba_
+                        /* CQL 'and' (738:15-739:29) */ && bf_
+                        /* CQL 'and' (738:9-742:11) */ && bj_;
                 }
 
                 IEnumerable<Claim> ai_ = context.Operators.Where<Claim>(ag_, ah_);
 
                 bool? aj_(Claim @this) {
-                    List<Claim.ItemComponent> bk_ = @this?.Item;
-                    return bk_ is not null;
+                    List<Claim.ItemComponent> bm_ = @this?.Item;
+                    return bm_ is not null;
                 }
 
 
                 List<Claim.ItemComponent> ak_(Claim @this) {
-                    List<Claim.ItemComponent> bl_ = @this?.Item;
-                    return bl_;
+                    List<Claim.ItemComponent> bn_ = @this?.Item;
+                    return bn_;
                 }
 
                 IEnumerable<List<Claim.ItemComponent>> al_ = context.Operators.WhereSelect<Claim, List<Claim.ItemComponent>>(ai_, aj_, ak_);
                 IEnumerable<Claim.ItemComponent> am_ = context.Operators.Flatten<Claim.ItemComponent>((IEnumerable<IEnumerable<Claim.ItemComponent>>)al_);
 
                 bool? an_(Claim.ItemComponent I) {
-                    List<ResourceReference> bm_ = I?.Encounter;
-                    CqlBoolean bn_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bm_, E);
-                    return bn_;
+                    List<ResourceReference> bo_ = I?.Encounter;
+                    CqlBoolean bp_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bo_, E);
+                    return bp_;
                 }
 
                 IEnumerable<Claim.ItemComponent> ao_ = context.Operators.Where<Claim.ItemComponent>(am_, an_);
 
                 bool? ap_(Claim.ItemComponent @this) {
-                    List<PositiveInt> bo_ = @this?.DiagnosisSequenceElement;
+                    List<PositiveInt> bq_ = @this?.DiagnosisSequenceElement;
 
-                    int? bp_(PositiveInt @this) {
-                        int? br_ = @this?.Value;
-                        return br_;
+                    int? br_(PositiveInt @this) {
+                        int? bt_ = @this?.Value;
+                        return bt_;
                     }
 
-                    IEnumerable<int?> bq_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)bo_, bp_);
-                    return bq_ is not null;
+                    IEnumerable<int?> bs_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)bq_, br_);
+                    return bs_ is not null;
                 }
 
 
                 IEnumerable<int?> aq_(Claim.ItemComponent @this) {
-                    List<PositiveInt> bs_ = @this?.DiagnosisSequenceElement;
+                    List<PositiveInt> bu_ = @this?.DiagnosisSequenceElement;
 
-                    int? bt_(PositiveInt @this) {
-                        int? bv_ = @this?.Value;
-                        return bv_;
+                    int? bv_(PositiveInt @this) {
+                        int? bx_ = @this?.Value;
+                        return bx_;
                     }
 
-                    IEnumerable<int?> bu_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)bs_, bt_);
-                    return bu_;
+                    IEnumerable<int?> bw_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)bu_, bv_);
+                    return bw_;
                 }
 
                 IEnumerable<IEnumerable<int?>> ar_ = context.Operators.WhereSelect<Claim.ItemComponent, IEnumerable<int?>>(ao_, ap_, aq_);
                 IEnumerable<int?> as_ = context.Operators.Flatten<int?>(ar_);
                 CqlBoolean at_ = context.Operators.In<int?>(af_, as_);
-
-                CqlBoolean au_() {
-                    CodeableConcept bw_ = D?.OnAdmission;
-                    CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
-                    return bx_ is not null;
-                }
-
+                CodeableConcept au_ = D?.OnAdmission;
+                CqlConcept av_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, au_);
+                CqlBoolean aw_ = (CqlBoolean)(av_ is not null);
                 return at_
-                    /* CQL 'and' (748:7-749:37) */ && au_();
+                    /* CQL 'and' (748:7-749:37) */ && aw_;
             }
 
             IEnumerable<Claim.DiagnosisComponent> m_ = context.Operators.Where<Claim.DiagnosisComponent>(k_, l_);
@@ -4213,18 +3987,14 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "corrected",
                 ];
                 CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-
-                CqlBoolean p_() {
-                    DataType q_ = ASAclass?.Value;
-                    object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                    CqlValueSet s_ = this.ASA_Physical_Status_Class(context);
-                    CqlBoolean t_ = context.Operators.ConceptInValueSet(r_ as CqlConcept, s_);
-                    return t_;
-                }
-
+                DataType p_ = ASAclass?.Value;
+                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+                CqlValueSet r_ = this.ASA_Physical_Status_Class(context);
+                CqlBoolean s_ = context.Operators.ConceptInValueSet(q_ as CqlConcept, r_);
+                CqlBoolean t_ = s_;
                 return o_
                     /* CQL 'and' (288:17-289:72) */ && this.startsDuringHospitalization(context, ASAclass, QualifyingEncounter)
-                    /* CQL 'and' (288:17-290:68) */ && p_();
+                    /* CQL 'and' (288:17-290:68) */ && t_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Encounter>(h_, i_);
@@ -4264,30 +4034,22 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 CqlDateTime l_ = context.Operators.Start(k_);
                 CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
                 CqlBoolean n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
-
-                CqlBoolean o_() {
-                    DataType q_ = BMI?.Value;
-                    CqlQuantity r_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, q_ as Quantity);
-                    return r_ is not null;
-                }
-
-
-                CqlBoolean p_() {
-                    Code<ObservationStatus> s_ = BMI?.StatusElement;
-                    ObservationStatus? t_ = s_?.Value;
-                    string u_ = context.Operators.Convert<string>(t_);
-                    string[] v_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
-                    return w_;
-                }
-
+                DataType o_ = BMI?.Value;
+                CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_ as Quantity);
+                CqlBoolean q_ = (CqlBoolean)(p_ is not null);
+                Code<ObservationStatus> r_ = BMI?.StatusElement;
+                ObservationStatus? s_ = r_?.Value;
+                string t_ = context.Operators.Convert<string>(s_);
+                string[] u_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+                CqlBoolean w_ = v_;
                 return n_
-                    /* CQL 'and' (296:17-297:33) */ && o_()
-                    /* CQL 'and' (296:17-298:61) */ && p_();
+                    /* CQL 'and' (296:17-297:33) */ && q_
+                    /* CQL 'and' (296:17-298:61) */ && w_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Encounter>(f_, g_);
@@ -4322,32 +4084,24 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 FinancialResourceStatusCodes? s_ = r_?.Value;
                 Code<FinancialResourceStatusCodes> t_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(s_);
                 CqlBoolean u_ = context.Operators.Equal(t_, "active");
+                Code<ClaimUseCode> v_ = C?.UseElement;
+                ClaimUseCode? w_ = v_?.Value;
+                Code<ClaimUseCode> x_ = context.Operators.Convert<Code<ClaimUseCode>>(w_);
+                CqlBoolean y_ = context.Operators.Equal(x_, "claim");
+                CqlBoolean z_ = y_;
+                List<Claim.ItemComponent> aa_ = C?.Item;
 
-                CqlBoolean v_() {
-                    Code<ClaimUseCode> x_ = C?.UseElement;
-                    ClaimUseCode? y_ = x_?.Value;
-                    Code<ClaimUseCode> z_ = context.Operators.Convert<Code<ClaimUseCode>>(y_);
-                    CqlBoolean aa_ = context.Operators.Equal(z_, "claim");
-                    return aa_;
+                bool? ab_(Claim.ItemComponent I) {
+                    List<ResourceReference> ae_ = I?.Encounter;
+                    CqlBoolean af_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)ae_, parentEncounter);
+                    return af_;
                 }
 
-
-                CqlBoolean w_() {
-                    List<Claim.ItemComponent> ab_ = C?.Item;
-
-                    bool? ac_(Claim.ItemComponent I) {
-                        List<ResourceReference> ae_ = I?.Encounter;
-                        CqlBoolean af_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)ae_, parentEncounter);
-                        return af_;
-                    }
-
-                    CqlBoolean ad_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)ab_, ac_);
-                    return ad_;
-                }
-
+                CqlBoolean ac_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)aa_, ab_);
+                CqlBoolean ad_ = ac_;
                 return u_
-                    /* CQL 'and' (723:17-724:31) */ && v_()
-                    /* CQL 'and' (723:11-727:13) */ && w_();
+                    /* CQL 'and' (723:17-724:31) */ && z_
+                    /* CQL 'and' (723:11-727:13) */ && ad_;
             }
 
             IEnumerable<Claim> h_ = context.Operators.Where<Claim>(f_, g_);
@@ -4581,25 +4335,25 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
     public bool? earliestOccursDuringHospitalization(CqlContext context, Observation observation, Encounter encounter)
     {
         object a_;
-        DataType f_ = observation?.Effective;
-        object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
-        bool h_ = g_ is CqlDateTime;
-        if (h_)
+        DataType h_ = observation?.Effective;
+        object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+        bool j_ = i_ is CqlDateTime;
+        if (j_)
         {
-            a_ = g_ as CqlDateTime;
+            a_ = i_ as CqlDateTime;
         }
         else
         {
-            if (h_)
+            if (j_)
             {
-                a_ = g_ as CqlDateTime;
+                a_ = i_ as CqlDateTime;
             }
             else
             {
-                bool i_ = g_ is CqlInterval<CqlDateTime>;
-                if (i_)
+                bool k_ = i_ is CqlInterval<CqlDateTime>;
+                if (k_)
                 {
-                    a_ = g_ as CqlInterval<CqlDateTime>;
+                    a_ = i_ as CqlInterval<CqlDateTime>;
                 }
                 else
                 {
@@ -4610,15 +4364,11 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
         CqlDateTime b_ = QICoreCommon_4_0_000.Instance.earliest(context, a_);
         CqlInterval<CqlDateTime> c_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, encounter);
         CqlBoolean d_ = context.Operators.In<CqlDateTime>(b_, c_, (string)default);
-
-        CqlBoolean e_() {
-            DataType j_ = observation?.Value;
-            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-            return k_ is not null;
-        }
-
+        DataType e_ = observation?.Value;
+        object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
+        CqlBoolean g_ = (CqlBoolean)(f_ is not null);
         return d_
-            /* CQL 'and' (700:3-701:37) */ && e_();
+            /* CQL 'and' (700:3-701:37) */ && g_;
     }
 
 
@@ -5085,27 +4835,19 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "corrected",
             ];
             CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-
-            CqlBoolean n_() {
-                DataType p_ = FirstBodyMass?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlInterval<CqlDateTime> t_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, (string)default);
-                return u_;
-            }
-
-
-            CqlBoolean o_() {
-                DataType v_ = FirstBodyMass?.Value;
-                CqlQuantity w_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, v_ as Quantity);
-                return w_ is not null;
-            }
-
+            DataType n_ = FirstBodyMass?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlInterval<CqlDateTime> r_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlBoolean s_ = context.Operators.In<CqlDateTime>(q_, r_, (string)default);
+            CqlBoolean t_ = s_;
+            DataType u_ = FirstBodyMass?.Value;
+            CqlQuantity v_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, u_ as Quantity);
+            CqlBoolean w_ = (CqlBoolean)(v_ is not null);
             return m_
-                /* CQL 'and' (526:13-527:115) */ && n_()
-                /* CQL 'and' (526:7-528:43) */ && o_();
+                /* CQL 'and' (526:13-527:115) */ && t_
+                /* CQL 'and' (526:7-528:43) */ && w_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
@@ -5165,26 +4907,18 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "corrected",
             ];
             CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-
-            CqlBoolean p_() {
-                DataType r_ = FirstTemperature?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
-                CqlInterval<CqlDateTime> u_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlBoolean v_ = context.Operators.In<CqlDateTime>(t_, u_, (string)default);
-                return v_;
-            }
-
-
-            CqlBoolean q_() {
-                DataType w_ = FirstTemperature?.Value;
-                CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_ as Quantity);
-                return x_ is not null;
-            }
-
+            DataType p_ = FirstTemperature?.Effective;
+            object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+            CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
+            CqlInterval<CqlDateTime> s_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
+            CqlBoolean u_ = t_;
+            DataType v_ = FirstTemperature?.Value;
+            CqlQuantity w_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, v_ as Quantity);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
             return o_
-                /* CQL 'and' (534:13-535:109) */ && p_()
-                /* CQL 'and' (534:7-536:46) */ && q_();
+                /* CQL 'and' (534:13-535:109) */ && u_
+                /* CQL 'and' (534:7-536:46) */ && x_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -5414,26 +5148,18 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "corrected",
             ];
             CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-
-            CqlBoolean p_() {
-                DataType r_ = FirstHeartBeats?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
-                CqlInterval<CqlDateTime> u_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlBoolean v_ = context.Operators.In<CqlDateTime>(t_, u_, (string)default);
-                return v_;
-            }
-
-
-            CqlBoolean q_() {
-                DataType w_ = FirstHeartBeats?.Value;
-                CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_ as Quantity);
-                return x_ is not null;
-            }
-
+            DataType p_ = FirstHeartBeats?.Effective;
+            object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+            CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
+            CqlInterval<CqlDateTime> s_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
+            CqlBoolean u_ = t_;
+            DataType v_ = FirstHeartBeats?.Value;
+            CqlQuantity w_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, v_ as Quantity);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
             return o_
-                /* CQL 'and' (556:13-557:108) */ && p_()
-                /* CQL 'and' (556:7-558:45) */ && q_();
+                /* CQL 'and' (556:13-557:108) */ && u_
+                /* CQL 'and' (556:7-558:45) */ && x_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -5918,26 +5644,18 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "corrected",
             ];
             CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-
-            CqlBoolean p_() {
-                DataType r_ = FirstRespiration?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, s_);
-                CqlInterval<CqlDateTime> u_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlBoolean v_ = context.Operators.In<CqlDateTime>(t_, u_, (string)default);
-                return v_;
-            }
-
-
-            CqlBoolean q_() {
-                DataType w_ = FirstRespiration?.Value;
-                CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_ as Quantity);
-                return x_ is not null;
-            }
-
+            DataType p_ = FirstRespiration?.Effective;
+            object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+            CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
+            CqlInterval<CqlDateTime> s_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
+            CqlBoolean u_ = t_;
+            DataType v_ = FirstRespiration?.Value;
+            CqlQuantity w_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, v_ as Quantity);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
             return o_
-                /* CQL 'and' (599:13-600:109) */ && p_()
-                /* CQL 'and' (599:7-601:46) */ && q_();
+                /* CQL 'and' (599:13-600:109) */ && u_
+                /* CQL 'and' (599:7-601:46) */ && x_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -6080,18 +5798,14 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "corrected",
             ];
             CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
-
-            CqlBoolean l_() {
-                DataType m_ = SBPReading?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_);
-                CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                return q_;
-            }
-
+            DataType l_ = SBPReading?.Effective;
+            object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+            CqlDateTime n_ = QICoreCommon_4_0_000.Instance.earliest(context, m_);
+            CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+            CqlBoolean q_ = p_;
             return k_
-                /* CQL 'and' (618:7-619:103) */ && l_();
+                /* CQL 'and' (618:7-619:103) */ && q_;
         }
 
 
@@ -6358,41 +6072,24 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "corrected",
             ];
             CqlBoolean k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
-
-            CqlBoolean l_() {
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, QualifyingEncounter);
-                DataType o_ = SMStatus?.Effective;
-                CqlDateTime p_ = context.Operators.LateBoundProperty<CqlDateTime>(o_, "value");
-                CqlDateTime q_ = QICoreCommon_4_0_000.Instance.latest(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, r_, (string)default);
-
-                CqlBoolean t_() {
-                    DataType u_ = SMStatus?.Effective;
-                    CqlDateTime v_ = context.Operators.LateBoundProperty<CqlDateTime>(u_, "value");
-                    CqlDateTime w_ = QICoreCommon_4_0_000.Instance.latest(context, v_);
-                    CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                    CqlInterval<CqlDateTime> y_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, QualifyingEncounter);
-                    CqlBoolean z_ = context.Operators.Before(x_, y_, (string)default);
-                    return z_;
-                }
-
-                return s_
-                    /* CQL 'or' (662:12-664:9) */ || t_();
-            }
-
-
-            CqlBoolean m_() {
-                DataType aa_ = SMStatus?.Value;
-                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                CqlValueSet ac_ = this.Smoking_Status(context);
-                CqlBoolean ad_ = context.Operators.ConceptInValueSet(ab_ as CqlConcept, ac_);
-                return ad_;
-            }
-
+            CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, QualifyingEncounter);
+            DataType m_ = SMStatus?.Effective;
+            CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+            CqlDateTime o_ = QICoreCommon_4_0_000.Instance.latest(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, p_, (string)default);
+            CqlBoolean r_ = context.Operators.Before(p_, l_, (string)default);
+            CqlBoolean s_ = r_;
+            CqlBoolean t_ = q_
+                /* CQL 'or' (662:12-664:9) */ || s_;
+            DataType u_ = SMStatus?.Value;
+            object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+            CqlValueSet w_ = this.Smoking_Status(context);
+            CqlBoolean x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
+            CqlBoolean y_ = x_;
             return k_
-                /* CQL 'and' (661:13-664:9) */ && l_()
-                /* CQL 'and' (661:7-665:57) */ && m_();
+                /* CQL 'and' (661:13-664:9) */ && t_
+                /* CQL 'and' (661:7-665:57) */ && y_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS122FHIRDiabetesAssessGT9Pct-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS122FHIRDiabetesAssessGT9Pct-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS122FHIRDiabetesAssessGT9Pct", "1.0.000")]
 public partial class CMS122FHIRDiabetesAssessGT9Pct_1_0_000 : ILibrary, ISingleton<CMS122FHIRDiabetesAssessGT9Pct_1_0_000>
 {
@@ -379,35 +379,27 @@ public partial class CMS122FHIRDiabetesAssessGT9Pct_1_0_000 : ILibrary, ISinglet
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
+        IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
+        CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
+        CqlBoolean m_ = l_;
+        CqlValueSet n_ = this.Diabetes(context);
+        IEnumerable<Condition> o_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        Condition p_(Condition X) => X as Condition;
+        IEnumerable<Condition> q_ = context.Operators.Select<Condition, Condition>(o_, p_);
+        IEnumerable<Condition> r_ = Status_1_15_000.Instance.verified(context, q_);
 
-        CqlBoolean k_() {
-            IEnumerable<Encounter> m_ = this.Qualifying_Encounters(context);
-            CqlBoolean n_ = context.Operators.Exists<Encounter>(m_);
-            return n_;
+        bool? s_(Condition DiabetesDiagnosis) {
+            CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesDiagnosis);
+            CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
+            CqlBoolean x_ = context.Operators.Overlaps(v_, w_, "day");
+            return x_;
         }
 
-
-        CqlBoolean l_() {
-            CqlValueSet o_ = this.Diabetes(context);
-            IEnumerable<Condition> p_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            Condition q_(Condition X) => X as Condition;
-            IEnumerable<Condition> r_ = context.Operators.Select<Condition, Condition>(p_, q_);
-            IEnumerable<Condition> s_ = Status_1_15_000.Instance.verified(context, r_);
-
-            bool? t_(Condition DiabetesDiagnosis) {
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesDiagnosis);
-                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                CqlBoolean x_ = context.Operators.Overlaps(v_, w_, "day");
-                return x_;
-            }
-
-            CqlBoolean u_ = context.Operators.WhereAny<Condition>(s_, t_);
-            return u_;
-        }
-
+        CqlBoolean t_ = context.Operators.WhereAny<Condition>(r_, s_);
+        CqlBoolean u_ = t_;
         return j_
-            /* CQL 'and' (52:3-55:38) */ && k_()
-            /* CQL 'and' (52:3-58:5) */ && l_();
+            /* CQL 'and' (52:3-55:38) */ && m_
+            /* CQL 'and' (52:3-58:5) */ && u_;
     }
 
 
@@ -622,16 +614,11 @@ public partial class CMS122FHIRDiabetesAssessGT9Pct_1_0_000 : ILibrary, ISinglet
     private bool? Has_Most_Recent_Glycemic_Status_Assessment_Without_Result_Compute(CqlContext context)
     {
         Observation a_ = this.Lowest_Glycemic_Status_Assessment_Reading_on_Most_Recent_Day(context);
-
-        CqlBoolean b_() {
-            Observation c_ = this.Lowest_Glycemic_Status_Assessment_Reading_on_Most_Recent_Day(context);
-            DataType d_ = c_?.Value;
-            object e_ = FHIRHelpers_4_4_000.Instance.ToValue(context, d_);
-            return e_ is null;
-        }
-
+        DataType b_ = a_?.Value;
+        object c_ = FHIRHelpers_4_4_000.Instance.ToValue(context, b_);
+        CqlBoolean d_ = (CqlBoolean)(c_ is null);
         return (CqlBoolean)(a_ is not null)
-            /* CQL 'and' (133:3-134:84) */ && b_();
+            /* CQL 'and' (133:3-134:84) */ && d_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1244FHIRECATHOQR", "1.0.000")]
 public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244FHIRECATHOQR_1_0_000>
 {
@@ -151,17 +151,13 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> k_ = EDEvalManagementVisit?.StatusElement;
-                Encounter.EncounterStatus? l_ = k_?.Value;
-                Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
-                CqlBoolean n_ = context.Operators.Equal(m_, "finished");
-                return n_;
-            }
-
+            Code<Encounter.EncounterStatus> j_ = EDEvalManagementVisit?.StatusElement;
+            Encounter.EncounterStatus? k_ = j_?.Value;
+            Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
+            CqlBoolean m_ = context.Operators.Equal(l_, "finished");
+            CqlBoolean n_ = m_;
             return i_
-                /* CQL 'and' (113:5-114:51) */ && j_();
+                /* CQL 'and' (113:5-114:51) */ && n_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -186,22 +182,18 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> k_ = EDTriage?.StatusElement;
-                Encounter.EncounterStatus? l_ = k_?.Value;
-                Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
-                string n_ = context.Operators.Convert<string>(m_);
-                string[] o_ = [
-                    "finished",
-                    "triaged",
-                ];
-                CqlBoolean p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
-                return p_;
-            }
-
+            Code<Encounter.EncounterStatus> j_ = EDTriage?.StatusElement;
+            Encounter.EncounterStatus? k_ = j_?.Value;
+            Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
+            string m_ = context.Operators.Convert<string>(l_);
+            string[] n_ = [
+                "finished",
+                "triaged",
+            ];
+            CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
+            CqlBoolean p_ = o_;
             return i_
-                /* CQL 'and' (143:7-144:56) */ && j_();
+                /* CQL 'and' (143:7-144:56) */ && p_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -228,54 +220,23 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                 Period i_ = EDEvalManagementInMP?.Period;
                 CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                 CqlBoolean k_ = context.Operators.OverlapsBefore(h_, j_, (string)default);
-
-                CqlBoolean l_() {
-                    Period o_ = EDEvalManagementInMP?.Period;
-                    CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                    Period q_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, r_, (string)default);
-                    return s_;
-                }
-
-
-                CqlBoolean m_() {
-                    Period t_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                    Period v_ = EDEvalManagementInMP?.Period;
-                    CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                    CqlBoolean x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
-                    return x_;
-                }
-
-
-                CqlBoolean n_() {
-                    Period y_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.End(z_);
-                    Period ab_ = EDEvalManagementInMP?.Period;
-                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                    CqlDateTime ad_ = context.Operators.Start(ac_);
-                    CqlQuantity ae_ = context.Operators.Quantity(120m, "minutes");
-                    CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
-                    CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(af_, ad_, true, false);
-                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, (string)default);
-
-                    CqlBoolean ai_() {
-                        Period aj_ = EDEvalManagementInMP?.Period;
-                        CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
-                        CqlDateTime al_ = context.Operators.Start(ak_);
-                        return al_ is not null;
-                    }
-
-                    return ah_
-                        /* CQL 'and' (153:16-153:107) */ && ai_();
-                }
-
+                CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, h_, (string)default);
+                CqlBoolean m_ = l_;
+                CqlBoolean n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, (string)default);
+                CqlBoolean o_ = n_;
+                CqlDateTime p_ = context.Operators.End(h_);
+                CqlDateTime q_ = context.Operators.Start(j_);
+                CqlQuantity r_ = context.Operators.Quantity(120m, "minutes");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, q_, true, false);
+                CqlBoolean u_ = context.Operators.In<CqlDateTime>(p_, t_, (string)default);
+                CqlBoolean v_ = (CqlBoolean)(q_ is not null);
+                CqlBoolean w_ = u_
+                    /* CQL 'and' (153:16-153:107) */ && v_;
                 return k_
-                    /* CQL 'or' (150:17-151:73) */ || l_()
-                    /* CQL 'or' (150:17-152:73) */ || m_()
-                    /* CQL 'or' (150:9-154:9) */ || n_();
+                    /* CQL 'or' (150:17-151:73) */ || m_
+                    /* CQL 'or' (150:17-152:73) */ || o_
+                    /* CQL 'or' (150:9-154:9) */ || w_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter>(d_, e_);
@@ -340,115 +301,64 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             List<CodeableConcept> p_ = o_?.Type;
 
             CqlConcept q_(CodeableConcept @this) {
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return w_;
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ao_;
             }
 
 
             bool? r_(CqlConcept LocationType) {
-                CqlValueSet x_ = this.Emergency_Department_Location(context);
-                CqlBoolean y_ = context.Operators.ConceptInValueSet(LocationType, x_);
-
-                CqlBoolean z_() {
-                    CqlCode ab_ = this.Emergency_room(context);
-                    CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
-                    CqlBoolean ad_ = context.Operators.Equivalent(LocationType, ac_);
-                    return ad_;
-                }
-
-
-                CqlBoolean aa_() {
-                    CqlCode ae_ = this.Emergency_trauma_unit(context);
-                    CqlConcept af_ = context.Operators.ConvertCodeToConcept(ae_);
-                    CqlBoolean ag_ = context.Operators.Equivalent(LocationType, af_);
-                    return ag_;
-                }
-
-                return y_
-                    /* CQL 'or' (222:17-223:48) */ || z_()
-                    /* CQL 'or' (222:11-225:11) */ || aa_();
+                CqlValueSet ap_ = this.Emergency_Department_Location(context);
+                CqlBoolean aq_ = context.Operators.ConceptInValueSet(LocationType, ap_);
+                CqlCode ar_ = this.Emergency_room(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(LocationType, as_);
+                CqlBoolean au_ = at_;
+                CqlCode av_ = this.Emergency_trauma_unit(context);
+                CqlConcept aw_ = context.Operators.ConvertCodeToConcept(av_);
+                CqlBoolean ax_ = context.Operators.Equivalent(LocationType, aw_);
+                CqlBoolean ay_ = ax_;
+                return aq_
+                    /* CQL 'or' (222:17-223:48) */ || au_
+                    /* CQL 'or' (222:11-225:11) */ || ay_;
             }
 
             IEnumerable<CqlConcept> s_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)p_, q_, r_);
             CqlBoolean t_ = context.Operators.Exists<CqlConcept>(s_);
-
-            CqlBoolean u_() {
-                Period ah_ = Location?.Period;
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.Start(ai_);
-                return aj_ is not null;
-            }
-
-
-            CqlBoolean v_() {
-                Period ak_ = Location?.Period;
-                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
-                CqlDateTime am_ = context.Operators.End(al_);
-                Period an_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
-                CqlDateTime ap_ = context.Operators.Start(ao_);
-                CqlQuantity aq_ = context.Operators.Quantity(120m, "minutes");
-                CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
-                CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ar_, ap_, true, false);
-                CqlBoolean at_ = context.Operators.In<CqlDateTime>(am_, as_, (string)default);
-
-                CqlBoolean au_() {
-                    Period ay_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
-                    CqlDateTime ba_ = context.Operators.Start(az_);
-                    return ba_ is not null;
-                }
-
-
-                CqlBoolean av_() {
-                    Period bb_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
-                    Period bd_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bd_);
-                    CqlBoolean bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
-                    return bf_;
-                }
-
-
-                CqlBoolean aw_() {
-                    Period bg_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    Period bi_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bi_);
-                    CqlBoolean bk_ = context.Operators.OverlapsBefore(bh_, bj_, (string)default);
-                    return bk_;
-                }
-
-
-                CqlBoolean ax_() {
-                    Period bl_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
-                    CqlDateTime bn_ = context.Operators.Start(bm_);
-                    Period bo_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
-                    CqlDateTime bq_ = context.Operators.Start(bp_);
-                    CqlBoolean br_ = context.Operators.SameAs(bn_, bq_, (string)default);
-                    return br_;
-                }
-
-                return (at_
-                    /* CQL 'and' (228:13-228:87) */ && au_())
-                    /* CQL 'or' (228:13-229:65) */ || av_()
-                    /* CQL 'or' (228:13-230:65) */ || aw_()
-                    /* CQL 'or' (228:12-232:9) */ || ax_();
-            }
-
+            Period u_ = Location?.Period;
+            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+            CqlDateTime w_ = context.Operators.Start(v_);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
+            CqlDateTime y_ = context.Operators.End(v_);
+            Period z_ = EDEncounter?.Period;
+            CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
+            CqlDateTime ab_ = context.Operators.Start(aa_);
+            CqlQuantity ac_ = context.Operators.Quantity(120m, "minutes");
+            CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
+            CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ad_, ab_, true, false);
+            CqlBoolean af_ = context.Operators.In<CqlDateTime>(y_, ae_, (string)default);
+            CqlBoolean ag_ = (CqlBoolean)(ab_ is not null);
+            CqlBoolean ah_ = context.Operators.OverlapsBefore(v_, aa_, (string)default);
+            CqlBoolean ai_ = ah_;
+            CqlBoolean aj_ = context.Operators.OverlapsBefore(aa_, v_, (string)default);
+            CqlBoolean ak_ = aj_;
+            CqlBoolean al_ = context.Operators.SameAs(w_, ab_, (string)default);
+            CqlBoolean am_ = al_;
+            CqlBoolean an_ = (af_
+                /* CQL 'and' (228:13-228:87) */ && ag_)
+                /* CQL 'or' (228:13-229:65) */ || ai_
+                /* CQL 'or' (228:13-230:65) */ || ak_
+                /* CQL 'or' (228:12-232:9) */ || am_;
             return t_
-                /* CQL 'and' (221:13-227:48) */ && u_()
-                /* CQL 'and' (221:7-232:9) */ && v_();
+                /* CQL 'and' (221:13-227:48) */ && x_
+                /* CQL 'and' (221:7-232:9) */ && an_;
         }
 
 
         CqlDateTime g_(Encounter.LocationComponent Location) {
-            Period bs_ = Location?.Period;
-            CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
-            CqlDateTime bu_ = context.Operators.Start(bt_);
-            return bu_;
+            Period az_ = Location?.Period;
+            CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, az_);
+            CqlDateTime bb_ = context.Operators.Start(ba_);
+            return bb_;
         }
 
         IEnumerable<CqlDateTime> h_ = context.Operators.WhereSelect<Encounter.LocationComponent, CqlDateTime>(e_, f_, g_);
@@ -478,54 +388,23 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                 Period i_ = EDEncounter?.Period;
                 CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                 CqlBoolean k_ = context.Operators.OverlapsBefore(h_, j_, (string)default);
-
-                CqlBoolean l_() {
-                    Period o_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                    Period q_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, r_, (string)default);
-                    return s_;
-                }
-
-
-                CqlBoolean m_() {
-                    Period t_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                    Period v_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                    CqlBoolean x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
-                    return x_;
-                }
-
-
-                CqlBoolean n_() {
-                    Period y_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.End(z_);
-                    Period ab_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                    CqlDateTime ad_ = context.Operators.Start(ac_);
-                    CqlQuantity ae_ = context.Operators.Quantity(120m, "minutes");
-                    CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
-                    CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(af_, ad_, true, false);
-                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, (string)default);
-
-                    CqlBoolean ai_() {
-                        Period aj_ = EDEncounter?.Period;
-                        CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
-                        CqlDateTime al_ = context.Operators.Start(ak_);
-                        return al_ is not null;
-                    }
-
-                    return ah_
-                        /* CQL 'and' (163:14-163:96) */ && ai_();
-                }
-
+                CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, h_, (string)default);
+                CqlBoolean m_ = l_;
+                CqlBoolean n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, (string)default);
+                CqlBoolean o_ = n_;
+                CqlDateTime p_ = context.Operators.End(h_);
+                CqlDateTime q_ = context.Operators.Start(j_);
+                CqlQuantity r_ = context.Operators.Quantity(120m, "minutes");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, q_, true, false);
+                CqlBoolean u_ = context.Operators.In<CqlDateTime>(p_, t_, (string)default);
+                CqlBoolean v_ = (CqlBoolean)(q_ is not null);
+                CqlBoolean w_ = u_
+                    /* CQL 'and' (163:14-163:96) */ && v_;
                 return k_
-                    /* CQL 'or' (160:19-161:62) */ || l_()
-                    /* CQL 'or' (160:19-162:62) */ || m_()
-                    /* CQL 'or' (160:17-164:7) */ || n_();
+                    /* CQL 'or' (160:19-161:62) */ || m_
+                    /* CQL 'or' (160:19-162:62) */ || o_
+                    /* CQL 'or' (160:17-164:7) */ || w_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter>(d_, e_);
@@ -563,23 +442,19 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             List<CodeableConcept> j_ = i_?.Type;
 
             CqlConcept k_(CodeableConcept @this) {
-                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return p_;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return s_;
             }
 
             IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
             CqlValueSet m_ = this.Emergency_Department_Treatment_Location(context);
             CqlBoolean n_ = context.Operators.ConceptsInValueSet(l_, m_);
-
-            CqlBoolean o_() {
-                Period q_ = Location?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                return s_ is not null;
-            }
-
+            Period o_ = Location?.Period;
+            CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlBoolean r_ = (CqlBoolean)(q_ is not null);
             return n_
-                /* CQL 'and' (259:7-260:48) */ && o_();
+                /* CQL 'and' (259:7-260:48) */ && r_;
         }
 
 
@@ -659,17 +534,13 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             Period k_ = j_?.Period;
             CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
             CqlBoolean m_ = context.Operators.In<CqlDateTime>(i_, l_, (string)default);
-
-            CqlBoolean n_() {
-                Code<RequestIntent> o_ = AdmitOrder?.IntentElement;
-                RequestIntent? p_ = o_?.Value;
-                Code<RequestIntent> q_ = context.Operators.Convert<Code<RequestIntent>>(p_);
-                CqlBoolean r_ = context.Operators.Equivalent(q_, "order");
-                return r_;
-            }
-
+            Code<RequestIntent> n_ = AdmitOrder?.IntentElement;
+            RequestIntent? o_ = n_?.Value;
+            Code<RequestIntent> p_ = context.Operators.Convert<Code<RequestIntent>>(o_);
+            CqlBoolean q_ = context.Operators.Equivalent(p_, "order");
+            CqlBoolean r_ = q_;
             return m_
-                /* CQL 'and' (200:7-201:39) */ && n_();
+                /* CQL 'and' (200:7-201:39) */ && r_;
         }
 
 
@@ -732,58 +603,31 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             CqlDateTime n_ = context.Operators.Subtract(l_, m_);
             CqlInterval<CqlDateTime> o_ = context.Operators.Interval(n_, l_, true, true);
             CqlBoolean p_ = context.Operators.In<CqlDateTime>(i_, o_, (string)default);
-
-            CqlBoolean q_() {
-                Period u_ = EncounterInpatient?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                return w_ is not null;
-            }
-
-
-            CqlBoolean r_() {
-                Period x_ = EDEvalManagementInMP?.Period;
-                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
-                CqlDateTime z_ = context.Operators.Start(y_);
-                Period aa_ = EncounterInpatient?.Period;
-                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                CqlDateTime ac_ = context.Operators.Start(ab_);
-                CqlBoolean ad_ = context.Operators.Before(z_, ac_, (string)default);
-                return ad_;
-            }
-
-
-            CqlBoolean s_() {
-                CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
-                Period af_ = EDEvalManagementInMP?.Period;
-                CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                CqlBoolean ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ag_, "day");
-                return ah_;
-            }
-
-
-            CqlBoolean t_() {
-                Code<Encounter.EncounterStatus> ai_ = EDEvalManagementInMP?.StatusElement;
-                Encounter.EncounterStatus? aj_ = ai_?.Value;
-                Code<Encounter.EncounterStatus> ak_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aj_);
-                CqlBoolean al_ = context.Operators.Equal(ak_, "finished");
-                return al_;
-            }
-
+            CqlBoolean q_ = (CqlBoolean)(l_ is not null);
+            CqlBoolean r_ = context.Operators.Before(i_, l_, (string)default);
+            CqlBoolean s_ = r_;
+            CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
+            CqlBoolean u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, h_, "day");
+            CqlBoolean v_ = u_;
+            Code<Encounter.EncounterStatus> w_ = EDEvalManagementInMP?.StatusElement;
+            Encounter.EncounterStatus? x_ = w_?.Value;
+            Code<Encounter.EncounterStatus> y_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(x_);
+            CqlBoolean z_ = context.Operators.Equal(y_, "finished");
+            CqlBoolean aa_ = z_;
             return p_
-                /* CQL 'and' (275:13-275:108) */ && q_()
-                /* CQL 'and' (275:13-276:88) */ && r_()
-                /* CQL 'and' (275:13-277:74) */ && s_()
-                /* CQL 'and' (275:7-278:52) */ && t_();
+                /* CQL 'and' (275:13-275:108) */ && q_
+                /* CQL 'and' (275:13-276:88) */ && s_
+                /* CQL 'and' (275:13-277:74) */ && v_
+                /* CQL 'and' (275:7-278:52) */ && aa_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         object d_(Encounter @this) {
-            Period am_ = @this?.Period;
-            CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
-            CqlDateTime ao_ = context.Operators.End(an_);
-            return ao_;
+            Period ab_ = @this?.Period;
+            CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+            CqlDateTime ad_ = context.Operators.End(ac_);
+            return ad_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.SortBy<Encounter>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
@@ -817,115 +661,64 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             List<CodeableConcept> p_ = o_?.Type;
 
             CqlConcept q_(CodeableConcept @this) {
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return w_;
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ao_;
             }
 
 
             bool? r_(CqlConcept LocationType) {
-                CqlValueSet x_ = this.Emergency_Department_Location(context);
-                CqlBoolean y_ = context.Operators.ConceptInValueSet(LocationType, x_);
-
-                CqlBoolean z_() {
-                    CqlCode ab_ = this.Emergency_room(context);
-                    CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
-                    CqlBoolean ad_ = context.Operators.Equivalent(LocationType, ac_);
-                    return ad_;
-                }
-
-
-                CqlBoolean aa_() {
-                    CqlCode ae_ = this.Emergency_trauma_unit(context);
-                    CqlConcept af_ = context.Operators.ConvertCodeToConcept(ae_);
-                    CqlBoolean ag_ = context.Operators.Equivalent(LocationType, af_);
-                    return ag_;
-                }
-
-                return y_
-                    /* CQL 'or' (240:17-241:48) */ || z_()
-                    /* CQL 'or' (240:11-243:11) */ || aa_();
+                CqlValueSet ap_ = this.Emergency_Department_Location(context);
+                CqlBoolean aq_ = context.Operators.ConceptInValueSet(LocationType, ap_);
+                CqlCode ar_ = this.Emergency_room(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(LocationType, as_);
+                CqlBoolean au_ = at_;
+                CqlCode av_ = this.Emergency_trauma_unit(context);
+                CqlConcept aw_ = context.Operators.ConvertCodeToConcept(av_);
+                CqlBoolean ax_ = context.Operators.Equivalent(LocationType, aw_);
+                CqlBoolean ay_ = ax_;
+                return aq_
+                    /* CQL 'or' (240:17-241:48) */ || au_
+                    /* CQL 'or' (240:11-243:11) */ || ay_;
             }
 
             IEnumerable<CqlConcept> s_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)p_, q_, r_);
             CqlBoolean t_ = context.Operators.Exists<CqlConcept>(s_);
-
-            CqlBoolean u_() {
-                Period ah_ = Location?.Period;
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.End(ai_);
-                return aj_ is not null;
-            }
-
-
-            CqlBoolean v_() {
-                Period ak_ = Location?.Period;
-                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
-                CqlDateTime am_ = context.Operators.End(al_);
-                Period an_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
-                CqlDateTime ap_ = context.Operators.Start(ao_);
-                CqlQuantity aq_ = context.Operators.Quantity(120m, "minutes");
-                CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
-                CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ar_, ap_, true, false);
-                CqlBoolean at_ = context.Operators.In<CqlDateTime>(am_, as_, (string)default);
-
-                CqlBoolean au_() {
-                    Period ay_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
-                    CqlDateTime ba_ = context.Operators.Start(az_);
-                    return ba_ is not null;
-                }
-
-
-                CqlBoolean av_() {
-                    Period bb_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
-                    Period bd_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bd_);
-                    CqlBoolean bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
-                    return bf_;
-                }
-
-
-                CqlBoolean aw_() {
-                    Period bg_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    Period bi_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bi_);
-                    CqlBoolean bk_ = context.Operators.OverlapsBefore(bh_, bj_, (string)default);
-                    return bk_;
-                }
-
-
-                CqlBoolean ax_() {
-                    Period bl_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
-                    CqlDateTime bn_ = context.Operators.Start(bm_);
-                    Period bo_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
-                    CqlDateTime bq_ = context.Operators.Start(bp_);
-                    CqlBoolean br_ = context.Operators.SameAs(bn_, bq_, (string)default);
-                    return br_;
-                }
-
-                return (at_
-                    /* CQL 'and' (247:13-247:87) */ && au_())
-                    /* CQL 'or' (247:13-248:65) */ || av_()
-                    /* CQL 'or' (247:13-249:65) */ || aw_()
-                    /* CQL 'or' (247:12-251:9) */ || ax_();
-            }
-
+            Period u_ = Location?.Period;
+            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+            CqlDateTime w_ = context.Operators.End(v_);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
+            Period y_ = EDEncounter?.Period;
+            CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+            CqlDateTime aa_ = context.Operators.Start(z_);
+            CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
+            CqlDateTime ac_ = context.Operators.Subtract(aa_, ab_);
+            CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(ac_, aa_, true, false);
+            CqlBoolean ae_ = context.Operators.In<CqlDateTime>(w_, ad_, (string)default);
+            CqlBoolean af_ = (CqlBoolean)(aa_ is not null);
+            CqlBoolean ag_ = context.Operators.OverlapsBefore(v_, z_, (string)default);
+            CqlBoolean ah_ = ag_;
+            CqlBoolean ai_ = context.Operators.OverlapsBefore(z_, v_, (string)default);
+            CqlBoolean aj_ = ai_;
+            CqlDateTime ak_ = context.Operators.Start(v_);
+            CqlBoolean al_ = context.Operators.SameAs(ak_, aa_, (string)default);
+            CqlBoolean am_ = al_;
+            CqlBoolean an_ = (ae_
+                /* CQL 'and' (247:13-247:87) */ && af_)
+                /* CQL 'or' (247:13-248:65) */ || ah_
+                /* CQL 'or' (247:13-249:65) */ || aj_
+                /* CQL 'or' (247:12-251:9) */ || am_;
             return t_
-                /* CQL 'and' (239:13-246:42) */ && u_()
-                /* CQL 'and' (239:7-251:9) */ && v_();
+                /* CQL 'and' (239:13-246:42) */ && x_
+                /* CQL 'and' (239:7-251:9) */ && an_;
         }
 
 
         CqlDateTime g_(Encounter.LocationComponent Location) {
-            Period bs_ = Location?.Period;
-            CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
-            CqlDateTime bu_ = context.Operators.End(bt_);
-            return bu_;
+            Period az_ = Location?.Period;
+            CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, az_);
+            CqlDateTime bb_ = context.Operators.End(ba_);
+            return bb_;
         }
 
         IEnumerable<CqlDateTime> h_ = context.Operators.WhereSelect<Encounter.LocationComponent, CqlDateTime>(e_, f_, g_);
@@ -981,22 +774,18 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             Period m_ = l_?.Period;
             CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
             CqlBoolean o_ = context.Operators.In<CqlDateTime>(k_, n_, (string)default);
-
-            CqlBoolean p_() {
-                Code<ObservationStatus> q_ = EDEvaluation?.StatusElement;
-                ObservationStatus? r_ = q_?.Value;
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                return u_;
-            }
-
+            Code<ObservationStatus> p_ = EDEvaluation?.StatusElement;
+            ObservationStatus? q_ = p_?.Value;
+            string r_ = context.Operators.Convert<string>(q_);
+            string[] s_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
+            CqlBoolean u_ = t_;
             return o_
-                /* CQL 'and' (187:7-188:70) */ && p_();
+                /* CQL 'and' (187:7-188:70) */ && u_;
         }
 
 
@@ -1269,17 +1058,13 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                 Period j_ = EDObsEncounter?.Period;
                 CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
                 CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, k_, (string)default);
-
-                CqlBoolean m_() {
-                    Code<Encounter.EncounterStatus> n_ = EDObsEncounter?.StatusElement;
-                    Encounter.EncounterStatus? o_ = n_?.Value;
-                    Code<Encounter.EncounterStatus> p_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(o_);
-                    CqlBoolean q_ = context.Operators.Equal(p_, "finished");
-                    return q_;
-                }
-
+                Code<Encounter.EncounterStatus> m_ = EDObsEncounter?.StatusElement;
+                Encounter.EncounterStatus? n_ = m_?.Value;
+                Code<Encounter.EncounterStatus> o_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(n_);
+                CqlBoolean p_ = context.Operators.Equal(o_, "finished");
+                CqlBoolean q_ = p_;
                 return l_
-                    /* CQL 'and' (138:17-139:46) */ && m_();
+                    /* CQL 'and' (138:17-139:46) */ && q_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Encounter>(e_, f_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS124FHIRCervicalCancerScreen-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS124FHIRCervicalCancerScreen-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS124FHIRCervicalCancerScreen", "1.0.000")]
 public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISingleton<CMS124FHIRCervicalCancerScreen_1_0_000>
 {
@@ -172,49 +172,40 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(24, 64, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
+        List<Extension> k_;
+        bool u_ = a_ is DomainResource;
+        if (u_)
+        {
+            k_ = (a_ as DomainResource).Extension;
+        }
+        else
+        {
+            k_ = default;
+        }
 
-        CqlBoolean k_() {
-            List<Extension> m_;
-            Patient s_ = this.Patient(context);
-            bool t_ = s_ is DomainResource;
-            if (t_)
-            {
-                m_ = (s_ as DomainResource).Extension;
-            }
-            else
-            {
-                m_ = default;
-            }
-
-            bool? n_(Extension @this) {
-                FhirUri u_ = @this?.UrlElement;
-                string v_ = FHIRHelpers_4_4_000.Instance.ToString(context, u_);
-                CqlBoolean w_ = context.Operators.Equal(v_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
-                return w_;
-            }
-
-
-            DataType o_(Extension @this) {
-                DataType x_ = @this?.Value;
-                return x_;
-            }
-
-            IEnumerable<DataType> p_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)m_, n_, o_);
-            DataType q_ = context.Operators.SingletonFrom<DataType>(p_);
-            CqlBoolean r_ = context.Operators.Equal(q_, "248152002");
-            return r_;
+        bool? l_(Extension @this) {
+            FhirUri v_ = @this?.UrlElement;
+            string w_ = FHIRHelpers_4_4_000.Instance.ToString(context, v_);
+            CqlBoolean x_ = context.Operators.Equal(w_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+            return x_;
         }
 
 
-        CqlBoolean l_() {
-            IEnumerable<Encounter> y_ = this.Qualifying_Encounters(context);
-            CqlBoolean z_ = context.Operators.Exists<Encounter>(y_);
-            return z_;
+        DataType m_(Extension @this) {
+            DataType y_ = @this?.Value;
+            return y_;
         }
 
+        IEnumerable<DataType> n_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)k_, l_, m_);
+        DataType o_ = context.Operators.SingletonFrom<DataType>(n_);
+        CqlBoolean p_ = context.Operators.Equal(o_, "248152002");
+        CqlBoolean q_ = p_;
+        IEnumerable<Encounter> r_ = this.Qualifying_Encounters(context);
+        CqlBoolean s_ = context.Operators.Exists<Encounter>(r_);
+        CqlBoolean t_ = s_;
         return j_
-            /* CQL 'and' (33:3-36:33) */ && k_()
-            /* CQL 'and' (33:3-37:38) */ && l_();
+            /* CQL 'and' (33:3-36:33) */ && q_
+            /* CQL 'and' (33:3-37:38) */ && t_;
     }
 
 
@@ -319,15 +310,11 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
-
-        CqlBoolean b_() {
-            IEnumerable<object> c_ = this.Absence_of_Cervix(context);
-            CqlBoolean d_ = context.Operators.Exists<object>(c_);
-            return d_;
-        }
-
+        IEnumerable<object> b_ = this.Absence_of_Cervix(context);
+        CqlBoolean c_ = context.Operators.Exists<object>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'or' (53:3-54:33) */ || b_()
+            /* CQL 'or' (53:3-54:33) */ || d_
             /* CQL 'or' (53:3-55:69) */ || PalliativeCare_1_18_000.Instance.Has_Palliative_Care_in_the_Measurement_Period(context);
     }
 
@@ -346,25 +333,25 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
 
         bool? d_(Observation CervicalCytology) {
             object f_;
-            DataType p_ = CervicalCytology?.Effective;
-            object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-            bool r_ = q_ is CqlDateTime;
-            if (r_)
+            DataType r_ = CervicalCytology?.Effective;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
             {
-                f_ = q_ as CqlDateTime;
+                f_ = s_ as CqlDateTime;
             }
             else
             {
-                if (r_)
+                if (t_)
                 {
-                    f_ = q_ as CqlDateTime;
+                    f_ = s_ as CqlDateTime;
                 }
                 else
                 {
-                    bool s_ = q_ is CqlInterval<CqlDateTime>;
-                    if (s_)
+                    bool u_ = s_ is CqlInterval<CqlDateTime>;
+                    if (u_)
                     {
-                        f_ = q_ as CqlInterval<CqlDateTime>;
+                        f_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -380,15 +367,11 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
             CqlDateTime l_ = context.Operators.End(h_);
             CqlInterval<CqlDateTime> m_ = context.Operators.Interval(k_, l_, true, true);
             CqlBoolean n_ = context.Operators.In<CqlDateTime>(g_, m_, "day");
-
-            CqlBoolean o_() {
-                DataType t_ = CervicalCytology?.Value;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                return u_ is not null;
-            }
-
+            DataType o_ = CervicalCytology?.Value;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlBoolean q_ = (CqlBoolean)(p_ is not null);
             return n_
-                /* CQL 'and' (73:5-74:44) */ && o_();
+                /* CQL 'and' (73:5-74:44) */ && q_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -414,25 +397,25 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
             string h_ = g_?.Value;
             CqlDate i_ = context.Operators.ConvertStringToDate(h_);
             object j_;
-            DataType q_ = HPVTest?.Effective;
-            object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-            bool s_ = r_ is CqlDateTime;
-            if (s_)
+            DataType ab_ = HPVTest?.Effective;
+            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            bool ad_ = ac_ is CqlDateTime;
+            if (ad_)
             {
-                j_ = r_ as CqlDateTime;
+                j_ = ac_ as CqlDateTime;
             }
             else
             {
-                if (s_)
+                if (ad_)
                 {
-                    j_ = r_ as CqlDateTime;
+                    j_ = ac_ as CqlDateTime;
                 }
                 else
                 {
-                    bool t_ = r_ is CqlInterval<CqlDateTime>;
-                    if (t_)
+                    bool ae_ = ac_ is CqlInterval<CqlDateTime>;
+                    if (ae_)
                     {
-                        j_ = r_ as CqlInterval<CqlDateTime>;
+                        j_ = ac_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -444,56 +427,48 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
             CqlDate l_ = context.Operators.DateFrom(k_);
             int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
             CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 30);
-
-            CqlBoolean o_() {
-                object u_;
-                DataType ad_ = HPVTest?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+            object o_;
+            DataType af_ = HPVTest?.Effective;
+            object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+            bool ah_ = ag_ is CqlDateTime;
+            if (ah_)
+            {
+                o_ = ag_ as CqlDateTime;
+            }
+            else
+            {
+                if (ah_)
                 {
-                    u_ = ae_ as CqlDateTime;
+                    o_ = ag_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    bool ai_ = ag_ is CqlInterval<CqlDateTime>;
+                    if (ai_)
                     {
-                        u_ = ae_ as CqlDateTime;
+                        o_ = ag_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
-                        {
-                            u_ = ae_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            u_ = null;
-                        }
+                        o_ = null;
                     }
                 }
-                CqlDateTime v_ = QICoreCommon_4_0_000.Instance.latest(context, u_);
-                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                CqlQuantity y_ = context.Operators.Quantity(4m, "years");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlDateTime aa_ = context.Operators.End(w_);
-                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(z_, aa_, true, true);
-                CqlBoolean ac_ = context.Operators.In<CqlDateTime>(v_, ab_, "day");
-                return ac_;
             }
-
-
-            CqlBoolean p_() {
-                DataType ah_ = HPVTest?.Value;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                return ai_ is not null;
-            }
-
+            CqlDateTime p_ = QICoreCommon_4_0_000.Instance.latest(context, o_);
+            CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
+            CqlDateTime r_ = context.Operators.Start(q_);
+            CqlQuantity s_ = context.Operators.Quantity(4m, "years");
+            CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+            CqlDateTime u_ = context.Operators.End(q_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(t_, u_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(p_, v_, "day");
+            CqlBoolean x_ = w_;
+            DataType y_ = HPVTest?.Value;
+            object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+            CqlBoolean aa_ = (CqlBoolean)(z_ is not null);
             return n_
-                /* CQL 'and' (78:11-79:131) */ && o_()
-                /* CQL 'and' (78:5-80:35) */ && p_();
+                /* CQL 'and' (78:11-79:131) */ && x_
+                /* CQL 'and' (78:5-80:35) */ && aa_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -511,15 +486,11 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Observation> a_ = this.Cervical_Cytology_Within_3_Years(context);
         CqlBoolean b_ = context.Operators.Exists<Observation>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> d_ = this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older(context);
-            CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
-            return e_;
-        }
-
+        IEnumerable<Observation> c_ = this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'or' (58:3-59:66) */ || c_();
+            /* CQL 'or' (58:3-59:66) */ || e_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS125FHIRBreastCancerScreen-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS125FHIRBreastCancerScreen-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS125FHIRBreastCancerScreen", "1.0.000")]
 public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton<CMS125FHIRBreastCancerScreen_1_0_000>
 {
@@ -129,49 +129,40 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(42, 74, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
+        List<Extension> k_;
+        bool u_ = a_ is DomainResource;
+        if (u_)
+        {
+            k_ = (a_ as DomainResource).Extension;
+        }
+        else
+        {
+            k_ = default;
+        }
 
-        CqlBoolean k_() {
-            List<Extension> m_;
-            Patient s_ = this.Patient(context);
-            bool t_ = s_ is DomainResource;
-            if (t_)
-            {
-                m_ = (s_ as DomainResource).Extension;
-            }
-            else
-            {
-                m_ = default;
-            }
-
-            bool? n_(Extension @this) {
-                FhirUri u_ = @this?.UrlElement;
-                string v_ = FHIRHelpers_4_4_000.Instance.ToString(context, u_);
-                CqlBoolean w_ = context.Operators.Equal(v_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
-                return w_;
-            }
-
-
-            DataType o_(Extension @this) {
-                DataType x_ = @this?.Value;
-                return x_;
-            }
-
-            IEnumerable<DataType> p_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)m_, n_, o_);
-            DataType q_ = context.Operators.SingletonFrom<DataType>(p_);
-            CqlBoolean r_ = context.Operators.Equal(q_, "248152002");
-            return r_;
+        bool? l_(Extension @this) {
+            FhirUri v_ = @this?.UrlElement;
+            string w_ = FHIRHelpers_4_4_000.Instance.ToString(context, v_);
+            CqlBoolean x_ = context.Operators.Equal(w_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+            return x_;
         }
 
 
-        CqlBoolean l_() {
-            IEnumerable<Encounter> y_ = AdultOutpatientEncounters_4_19_000.Instance.Qualifying_Encounters(context);
-            CqlBoolean z_ = context.Operators.Exists<Encounter>(y_);
-            return z_;
+        DataType m_(Extension @this) {
+            DataType y_ = @this?.Value;
+            return y_;
         }
 
+        IEnumerable<DataType> n_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)k_, l_, m_);
+        DataType o_ = context.Operators.SingletonFrom<DataType>(n_);
+        CqlBoolean p_ = context.Operators.Equal(o_, "248152002");
+        CqlBoolean q_ = p_;
+        IEnumerable<Encounter> r_ = AdultOutpatientEncounters_4_19_000.Instance.Qualifying_Encounters(context);
+        CqlBoolean s_ = context.Operators.Exists<Encounter>(r_);
+        CqlBoolean t_ = s_;
         return j_
-            /* CQL 'and' (34:3-37:33) */ && k_()
-            /* CQL 'and' (34:3-38:64) */ && l_();
+            /* CQL 'and' (34:3-37:33) */ && q_
+            /* CQL 'and' (34:3-38:64) */ && t_;
     }
 
 
@@ -523,55 +514,31 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Condition> e_ = this.Right_Mastectomy_Diagnosis(context);
-            CqlBoolean f_ = context.Operators.Exists<Condition>(e_);
-
-            CqlBoolean g_() {
-                IEnumerable<Procedure> i_ = this.Right_Mastectomy_Procedure(context);
-                CqlBoolean j_ = context.Operators.Exists<Procedure>(i_);
-                return j_;
-            }
-
-
-            CqlBoolean h_() {
-                IEnumerable<Condition> k_ = this.Left_Mastectomy_Diagnosis(context);
-                CqlBoolean l_ = context.Operators.Exists<Condition>(k_);
-
-                CqlBoolean m_() {
-                    IEnumerable<Procedure> n_ = this.Left_Mastectomy_Procedure(context);
-                    CqlBoolean o_ = context.Operators.Exists<Procedure>(n_);
-                    return o_;
-                }
-
-                return l_
-                    /* CQL 'or' (48:13-50:9) */ || m_();
-            }
-
-            return (f_
-                /* CQL 'or' (45:10-47:7) */ || g_())
-                /* CQL 'and' (45:8-51:5) */ && h_();
-        }
-
-
-        CqlBoolean c_() {
-            IEnumerable<Condition> p_ = this.Bilateral_Mastectomy_Diagnosis(context);
-            CqlBoolean q_ = context.Operators.Exists<Condition>(p_);
-            return q_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Procedure> r_ = this.Bilateral_Mastectomy_Procedure(context);
-            CqlBoolean s_ = context.Operators.Exists<Procedure>(r_);
-            return s_;
-        }
-
+        IEnumerable<Condition> b_ = this.Right_Mastectomy_Diagnosis(context);
+        CqlBoolean c_ = context.Operators.Exists<Condition>(b_);
+        IEnumerable<Procedure> d_ = this.Right_Mastectomy_Procedure(context);
+        CqlBoolean e_ = context.Operators.Exists<Procedure>(d_);
+        CqlBoolean f_ = e_;
+        IEnumerable<Condition> g_ = this.Left_Mastectomy_Diagnosis(context);
+        CqlBoolean h_ = context.Operators.Exists<Condition>(g_);
+        IEnumerable<Procedure> i_ = this.Left_Mastectomy_Procedure(context);
+        CqlBoolean j_ = context.Operators.Exists<Procedure>(i_);
+        CqlBoolean k_ = j_;
+        CqlBoolean l_ = h_
+            /* CQL 'or' (48:13-50:9) */ || k_;
+        CqlBoolean m_ = (c_
+            /* CQL 'or' (45:10-47:7) */ || f_)
+            /* CQL 'and' (45:8-51:5) */ && l_;
+        IEnumerable<Condition> n_ = this.Bilateral_Mastectomy_Diagnosis(context);
+        CqlBoolean o_ = context.Operators.Exists<Condition>(n_);
+        CqlBoolean p_ = o_;
+        IEnumerable<Procedure> q_ = this.Bilateral_Mastectomy_Procedure(context);
+        CqlBoolean r_ = context.Operators.Exists<Procedure>(q_);
+        CqlBoolean s_ = r_;
         return a_
-            /* CQL 'or' (44:3-51:5) */ || b_()
-            /* CQL 'or' (44:3-52:46) */ || c_()
-            /* CQL 'or' (44:3-53:46) */ || d_()
+            /* CQL 'or' (44:3-51:5) */ || m_
+            /* CQL 'or' (44:3-52:46) */ || p_
+            /* CQL 'or' (44:3-53:46) */ || s_
             /* CQL 'or' (44:3-54:73) */ || AdvancedIllnessandFrailty_1_27_000.Instance.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty(context)
             /* CQL 'or' (44:3-55:74) */ || AdvancedIllnessandFrailty_1_27_000.Instance.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home(context)
             /* CQL 'or' (44:3-56:69) */ || PalliativeCare_1_18_000.Instance.Has_Palliative_Care_in_the_Measurement_Period(context);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS1264FHIRECATREHQR", "1.0.000")]
 public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264FHIRECATREHQR_1_0_000>
 {
@@ -134,17 +134,13 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> k_ = EDEvalManagementVisit?.StatusElement;
-                Encounter.EncounterStatus? l_ = k_?.Value;
-                Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
-                CqlBoolean n_ = context.Operators.Equal(m_, "finished");
-                return n_;
-            }
-
+            Code<Encounter.EncounterStatus> j_ = EDEvalManagementVisit?.StatusElement;
+            Encounter.EncounterStatus? k_ = j_?.Value;
+            Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
+            CqlBoolean m_ = context.Operators.Equal(l_, "finished");
+            CqlBoolean n_ = m_;
             return i_
-                /* CQL 'and' (92:5-93:51) */ && j_();
+                /* CQL 'and' (92:5-93:51) */ && n_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -169,22 +165,18 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> k_ = EDTriage?.StatusElement;
-                Encounter.EncounterStatus? l_ = k_?.Value;
-                Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
-                string n_ = context.Operators.Convert<string>(m_);
-                string[] o_ = [
-                    "finished",
-                    "triaged",
-                ];
-                CqlBoolean p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
-                return p_;
-            }
-
+            Code<Encounter.EncounterStatus> j_ = EDTriage?.StatusElement;
+            Encounter.EncounterStatus? k_ = j_?.Value;
+            Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
+            string m_ = context.Operators.Convert<string>(l_);
+            string[] n_ = [
+                "finished",
+                "triaged",
+            ];
+            CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
+            CqlBoolean p_ = o_;
             return i_
-                /* CQL 'and' (122:5-123:54) */ && j_();
+                /* CQL 'and' (122:5-123:54) */ && p_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -211,54 +203,23 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                 Period i_ = EDEvalManagementinMP?.Period;
                 CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                 CqlBoolean k_ = context.Operators.OverlapsBefore(h_, j_, (string)default);
-
-                CqlBoolean l_() {
-                    Period o_ = EDEvalManagementinMP?.Period;
-                    CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                    Period q_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, r_, (string)default);
-                    return s_;
-                }
-
-
-                CqlBoolean m_() {
-                    Period t_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                    Period v_ = EDEvalManagementinMP?.Period;
-                    CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                    CqlBoolean x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
-                    return x_;
-                }
-
-
-                CqlBoolean n_() {
-                    Period y_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.End(z_);
-                    Period ab_ = EDEvalManagementinMP?.Period;
-                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                    CqlDateTime ad_ = context.Operators.Start(ac_);
-                    CqlQuantity ae_ = context.Operators.Quantity(120m, "minutes");
-                    CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
-                    CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(af_, ad_, true, false);
-                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, (string)default);
-
-                    CqlBoolean ai_() {
-                        Period aj_ = EDEvalManagementinMP?.Period;
-                        CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
-                        CqlDateTime al_ = context.Operators.Start(ak_);
-                        return al_ is not null;
-                    }
-
-                    return ah_
-                        /* CQL 'and' (131:16-131:107) */ && ai_();
-                }
-
+                CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, h_, (string)default);
+                CqlBoolean m_ = l_;
+                CqlBoolean n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, (string)default);
+                CqlBoolean o_ = n_;
+                CqlDateTime p_ = context.Operators.End(h_);
+                CqlDateTime q_ = context.Operators.Start(j_);
+                CqlQuantity r_ = context.Operators.Quantity(120m, "minutes");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, q_, true, false);
+                CqlBoolean u_ = context.Operators.In<CqlDateTime>(p_, t_, (string)default);
+                CqlBoolean v_ = (CqlBoolean)(q_ is not null);
+                CqlBoolean w_ = u_
+                    /* CQL 'and' (131:16-131:107) */ && v_;
                 return k_
-                    /* CQL 'or' (128:17-129:73) */ || l_()
-                    /* CQL 'or' (128:17-130:73) */ || m_()
-                    /* CQL 'or' (128:9-132:9) */ || n_();
+                    /* CQL 'or' (128:17-129:73) */ || m_
+                    /* CQL 'or' (128:17-130:73) */ || o_
+                    /* CQL 'or' (128:9-132:9) */ || w_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter>(d_, e_);
@@ -323,115 +284,64 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             List<CodeableConcept> p_ = o_?.Type;
 
             CqlConcept q_(CodeableConcept @this) {
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return w_;
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ao_;
             }
 
 
             bool? r_(CqlConcept LocationType) {
-                CqlValueSet x_ = this.Emergency_Department_Location(context);
-                CqlBoolean y_ = context.Operators.ConceptInValueSet(LocationType, x_);
-
-                CqlBoolean z_() {
-                    CqlCode ab_ = this.Emergency_room(context);
-                    CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
-                    CqlBoolean ad_ = context.Operators.Equivalent(LocationType, ac_);
-                    return ad_;
-                }
-
-
-                CqlBoolean aa_() {
-                    CqlCode ae_ = this.Emergency_trauma_unit(context);
-                    CqlConcept af_ = context.Operators.ConvertCodeToConcept(ae_);
-                    CqlBoolean ag_ = context.Operators.Equivalent(LocationType, af_);
-                    return ag_;
-                }
-
-                return y_
-                    /* CQL 'or' (155:17-156:48) */ || z_()
-                    /* CQL 'or' (155:11-158:11) */ || aa_();
+                CqlValueSet ap_ = this.Emergency_Department_Location(context);
+                CqlBoolean aq_ = context.Operators.ConceptInValueSet(LocationType, ap_);
+                CqlCode ar_ = this.Emergency_room(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(LocationType, as_);
+                CqlBoolean au_ = at_;
+                CqlCode av_ = this.Emergency_trauma_unit(context);
+                CqlConcept aw_ = context.Operators.ConvertCodeToConcept(av_);
+                CqlBoolean ax_ = context.Operators.Equivalent(LocationType, aw_);
+                CqlBoolean ay_ = ax_;
+                return aq_
+                    /* CQL 'or' (155:17-156:48) */ || au_
+                    /* CQL 'or' (155:11-158:11) */ || ay_;
             }
 
             IEnumerable<CqlConcept> s_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)p_, q_, r_);
             CqlBoolean t_ = context.Operators.Exists<CqlConcept>(s_);
-
-            CqlBoolean u_() {
-                Period ah_ = Location?.Period;
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.Start(ai_);
-                return aj_ is not null;
-            }
-
-
-            CqlBoolean v_() {
-                Period ak_ = Location?.Period;
-                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
-                CqlDateTime am_ = context.Operators.End(al_);
-                Period an_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
-                CqlDateTime ap_ = context.Operators.Start(ao_);
-                CqlQuantity aq_ = context.Operators.Quantity(120m, "minutes");
-                CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
-                CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ar_, ap_, true, false);
-                CqlBoolean at_ = context.Operators.In<CqlDateTime>(am_, as_, (string)default);
-
-                CqlBoolean au_() {
-                    Period ay_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
-                    CqlDateTime ba_ = context.Operators.Start(az_);
-                    return ba_ is not null;
-                }
-
-
-                CqlBoolean av_() {
-                    Period bb_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
-                    Period bd_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bd_);
-                    CqlBoolean bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
-                    return bf_;
-                }
-
-
-                CqlBoolean aw_() {
-                    Period bg_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    Period bi_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bi_);
-                    CqlBoolean bk_ = context.Operators.OverlapsBefore(bh_, bj_, (string)default);
-                    return bk_;
-                }
-
-
-                CqlBoolean ax_() {
-                    Period bl_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
-                    CqlDateTime bn_ = context.Operators.Start(bm_);
-                    Period bo_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
-                    CqlDateTime bq_ = context.Operators.Start(bp_);
-                    CqlBoolean br_ = context.Operators.SameAs(bn_, bq_, (string)default);
-                    return br_;
-                }
-
-                return (at_
-                    /* CQL 'and' (161:13-161:87) */ && au_())
-                    /* CQL 'or' (161:13-162:65) */ || av_()
-                    /* CQL 'or' (161:13-163:65) */ || aw_()
-                    /* CQL 'or' (161:12-165:9) */ || ax_();
-            }
-
+            Period u_ = Location?.Period;
+            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+            CqlDateTime w_ = context.Operators.Start(v_);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
+            CqlDateTime y_ = context.Operators.End(v_);
+            Period z_ = EDEncounter?.Period;
+            CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
+            CqlDateTime ab_ = context.Operators.Start(aa_);
+            CqlQuantity ac_ = context.Operators.Quantity(120m, "minutes");
+            CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
+            CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ad_, ab_, true, false);
+            CqlBoolean af_ = context.Operators.In<CqlDateTime>(y_, ae_, (string)default);
+            CqlBoolean ag_ = (CqlBoolean)(ab_ is not null);
+            CqlBoolean ah_ = context.Operators.OverlapsBefore(v_, aa_, (string)default);
+            CqlBoolean ai_ = ah_;
+            CqlBoolean aj_ = context.Operators.OverlapsBefore(aa_, v_, (string)default);
+            CqlBoolean ak_ = aj_;
+            CqlBoolean al_ = context.Operators.SameAs(w_, ab_, (string)default);
+            CqlBoolean am_ = al_;
+            CqlBoolean an_ = (af_
+                /* CQL 'and' (161:13-161:87) */ && ag_)
+                /* CQL 'or' (161:13-162:65) */ || ai_
+                /* CQL 'or' (161:13-163:65) */ || ak_
+                /* CQL 'or' (161:12-165:9) */ || am_;
             return t_
-                /* CQL 'and' (154:13-160:48) */ && u_()
-                /* CQL 'and' (154:7-165:9) */ && v_();
+                /* CQL 'and' (154:13-160:48) */ && x_
+                /* CQL 'and' (154:7-165:9) */ && an_;
         }
 
 
         CqlDateTime g_(Encounter.LocationComponent Location) {
-            Period bs_ = Location?.Period;
-            CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
-            CqlDateTime bu_ = context.Operators.Start(bt_);
-            return bu_;
+            Period az_ = Location?.Period;
+            CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, az_);
+            CqlDateTime bb_ = context.Operators.Start(ba_);
+            return bb_;
         }
 
         IEnumerable<CqlDateTime> h_ = context.Operators.WhereSelect<Encounter.LocationComponent, CqlDateTime>(e_, f_, g_);
@@ -461,54 +371,23 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                 Period i_ = EDEncounter?.Period;
                 CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                 CqlBoolean k_ = context.Operators.OverlapsBefore(h_, j_, (string)default);
-
-                CqlBoolean l_() {
-                    Period o_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
-                    Period q_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, r_, (string)default);
-                    return s_;
-                }
-
-
-                CqlBoolean m_() {
-                    Period t_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                    Period v_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                    CqlBoolean x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
-                    return x_;
-                }
-
-
-                CqlBoolean n_() {
-                    Period y_ = EDTriageinMP?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.End(z_);
-                    Period ab_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                    CqlDateTime ad_ = context.Operators.Start(ac_);
-                    CqlQuantity ae_ = context.Operators.Quantity(120m, "minutes");
-                    CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
-                    CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(af_, ad_, true, false);
-                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, (string)default);
-
-                    CqlBoolean ai_() {
-                        Period aj_ = EDEncounter?.Period;
-                        CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
-                        CqlDateTime al_ = context.Operators.Start(ak_);
-                        return al_ is not null;
-                    }
-
-                    return ah_
-                        /* CQL 'and' (141:14-141:96) */ && ai_();
-                }
-
+                CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, h_, (string)default);
+                CqlBoolean m_ = l_;
+                CqlBoolean n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, (string)default);
+                CqlBoolean o_ = n_;
+                CqlDateTime p_ = context.Operators.End(h_);
+                CqlDateTime q_ = context.Operators.Start(j_);
+                CqlQuantity r_ = context.Operators.Quantity(120m, "minutes");
+                CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, q_, true, false);
+                CqlBoolean u_ = context.Operators.In<CqlDateTime>(p_, t_, (string)default);
+                CqlBoolean v_ = (CqlBoolean)(q_ is not null);
+                CqlBoolean w_ = u_
+                    /* CQL 'and' (141:14-141:96) */ && v_;
                 return k_
-                    /* CQL 'or' (138:19-139:62) */ || l_()
-                    /* CQL 'or' (138:19-140:62) */ || m_()
-                    /* CQL 'or' (138:17-142:7) */ || n_();
+                    /* CQL 'or' (138:19-139:62) */ || m_
+                    /* CQL 'or' (138:19-140:62) */ || o_
+                    /* CQL 'or' (138:17-142:7) */ || w_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter>(d_, e_);
@@ -546,23 +425,19 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             List<CodeableConcept> j_ = i_?.Type;
 
             CqlConcept k_(CodeableConcept @this) {
-                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return p_;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return s_;
             }
 
             IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
             CqlValueSet m_ = this.Emergency_Department_Treatment_Location(context);
             CqlBoolean n_ = context.Operators.ConceptsInValueSet(l_, m_);
-
-            CqlBoolean o_() {
-                Period q_ = Location?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                return s_ is not null;
-            }
-
+            Period o_ = Location?.Period;
+            CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlBoolean r_ = (CqlBoolean)(q_ is not null);
             return n_
-                /* CQL 'and' (192:7-193:48) */ && o_();
+                /* CQL 'and' (192:7-193:48) */ && r_;
         }
 
 
@@ -642,32 +517,24 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             Period k_ = EDEncounter?.Period;
             CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
             CqlBoolean m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
-
-            CqlBoolean n_() {
-                Code<RequestIntent> p_ = TransferOrder?.IntentElement;
-                RequestIntent? q_ = p_?.Value;
-                Code<RequestIntent> r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
-                CqlBoolean s_ = context.Operators.Equal(r_, "order");
-                return s_;
-            }
-
-
-            CqlBoolean o_() {
-                Code<RequestStatus> t_ = TransferOrder?.StatusElement;
-                RequestStatus? u_ = t_?.Value;
-                Code<RequestStatus> v_ = context.Operators.Convert<Code<RequestStatus>>(u_);
-                string w_ = context.Operators.Convert<string>(v_);
-                string[] x_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-                return y_;
-            }
-
+            Code<RequestIntent> n_ = TransferOrder?.IntentElement;
+            RequestIntent? o_ = n_?.Value;
+            Code<RequestIntent> p_ = context.Operators.Convert<Code<RequestIntent>>(o_);
+            CqlBoolean q_ = context.Operators.Equal(p_, "order");
+            CqlBoolean r_ = q_;
+            Code<RequestStatus> s_ = TransferOrder?.StatusElement;
+            RequestStatus? t_ = s_?.Value;
+            Code<RequestStatus> u_ = context.Operators.Convert<Code<RequestStatus>>(t_);
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
             return m_
-                /* CQL 'and' (200:13-201:42) */ && n_()
-                /* CQL 'and' (200:7-202:61) */ && o_();
+                /* CQL 'and' (200:13-201:42) */ && r_
+                /* CQL 'and' (200:7-202:61) */ && y_;
         }
 
 
@@ -710,115 +577,64 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             List<CodeableConcept> p_ = o_?.Type;
 
             CqlConcept q_(CodeableConcept @this) {
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return w_;
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ao_;
             }
 
 
             bool? r_(CqlConcept LocationType) {
-                CqlValueSet x_ = this.Emergency_Department_Location(context);
-                CqlBoolean y_ = context.Operators.ConceptInValueSet(LocationType, x_);
-
-                CqlBoolean z_() {
-                    CqlCode ab_ = this.Emergency_room(context);
-                    CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
-                    CqlBoolean ad_ = context.Operators.Equivalent(LocationType, ac_);
-                    return ad_;
-                }
-
-
-                CqlBoolean aa_() {
-                    CqlCode ae_ = this.Emergency_trauma_unit(context);
-                    CqlConcept af_ = context.Operators.ConvertCodeToConcept(ae_);
-                    CqlBoolean ag_ = context.Operators.Equivalent(LocationType, af_);
-                    return ag_;
-                }
-
-                return y_
-                    /* CQL 'or' (173:17-174:48) */ || z_()
-                    /* CQL 'or' (173:11-176:11) */ || aa_();
+                CqlValueSet ap_ = this.Emergency_Department_Location(context);
+                CqlBoolean aq_ = context.Operators.ConceptInValueSet(LocationType, ap_);
+                CqlCode ar_ = this.Emergency_room(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(LocationType, as_);
+                CqlBoolean au_ = at_;
+                CqlCode av_ = this.Emergency_trauma_unit(context);
+                CqlConcept aw_ = context.Operators.ConvertCodeToConcept(av_);
+                CqlBoolean ax_ = context.Operators.Equivalent(LocationType, aw_);
+                CqlBoolean ay_ = ax_;
+                return aq_
+                    /* CQL 'or' (173:17-174:48) */ || au_
+                    /* CQL 'or' (173:11-176:11) */ || ay_;
             }
 
             IEnumerable<CqlConcept> s_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)p_, q_, r_);
             CqlBoolean t_ = context.Operators.Exists<CqlConcept>(s_);
-
-            CqlBoolean u_() {
-                Period ah_ = Location?.Period;
-                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                CqlDateTime aj_ = context.Operators.End(ai_);
-                return aj_ is not null;
-            }
-
-
-            CqlBoolean v_() {
-                Period ak_ = Location?.Period;
-                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
-                CqlDateTime am_ = context.Operators.End(al_);
-                Period an_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
-                CqlDateTime ap_ = context.Operators.Start(ao_);
-                CqlQuantity aq_ = context.Operators.Quantity(120m, "minutes");
-                CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
-                CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ar_, ap_, true, false);
-                CqlBoolean at_ = context.Operators.In<CqlDateTime>(am_, as_, (string)default);
-
-                CqlBoolean au_() {
-                    Period ay_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
-                    CqlDateTime ba_ = context.Operators.Start(az_);
-                    return ba_ is not null;
-                }
-
-
-                CqlBoolean av_() {
-                    Period bb_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
-                    Period bd_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bd_);
-                    CqlBoolean bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
-                    return bf_;
-                }
-
-
-                CqlBoolean aw_() {
-                    Period bg_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                    Period bi_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bi_);
-                    CqlBoolean bk_ = context.Operators.OverlapsBefore(bh_, bj_, (string)default);
-                    return bk_;
-                }
-
-
-                CqlBoolean ax_() {
-                    Period bl_ = Location?.Period;
-                    CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
-                    CqlDateTime bn_ = context.Operators.Start(bm_);
-                    Period bo_ = EDEncounter?.Period;
-                    CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
-                    CqlDateTime bq_ = context.Operators.Start(bp_);
-                    CqlBoolean br_ = context.Operators.SameAs(bn_, bq_, (string)default);
-                    return br_;
-                }
-
-                return (at_
-                    /* CQL 'and' (180:13-180:87) */ && au_())
-                    /* CQL 'or' (180:13-181:65) */ || av_()
-                    /* CQL 'or' (180:13-182:65) */ || aw_()
-                    /* CQL 'or' (180:12-184:9) */ || ax_();
-            }
-
+            Period u_ = Location?.Period;
+            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+            CqlDateTime w_ = context.Operators.End(v_);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
+            Period y_ = EDEncounter?.Period;
+            CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+            CqlDateTime aa_ = context.Operators.Start(z_);
+            CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
+            CqlDateTime ac_ = context.Operators.Subtract(aa_, ab_);
+            CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(ac_, aa_, true, false);
+            CqlBoolean ae_ = context.Operators.In<CqlDateTime>(w_, ad_, (string)default);
+            CqlBoolean af_ = (CqlBoolean)(aa_ is not null);
+            CqlBoolean ag_ = context.Operators.OverlapsBefore(v_, z_, (string)default);
+            CqlBoolean ah_ = ag_;
+            CqlBoolean ai_ = context.Operators.OverlapsBefore(z_, v_, (string)default);
+            CqlBoolean aj_ = ai_;
+            CqlDateTime ak_ = context.Operators.Start(v_);
+            CqlBoolean al_ = context.Operators.SameAs(ak_, aa_, (string)default);
+            CqlBoolean am_ = al_;
+            CqlBoolean an_ = (ae_
+                /* CQL 'and' (180:13-180:87) */ && af_)
+                /* CQL 'or' (180:13-181:65) */ || ah_
+                /* CQL 'or' (180:13-182:65) */ || aj_
+                /* CQL 'or' (180:12-184:9) */ || am_;
             return t_
-                /* CQL 'and' (172:13-179:42) */ && u_()
-                /* CQL 'and' (172:7-184:9) */ && v_();
+                /* CQL 'and' (172:13-179:42) */ && x_
+                /* CQL 'and' (172:7-184:9) */ && an_;
         }
 
 
         CqlDateTime g_(Encounter.LocationComponent Location) {
-            Period bs_ = Location?.Period;
-            CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bs_);
-            CqlDateTime bu_ = context.Operators.End(bt_);
-            return bu_;
+            Period az_ = Location?.Period;
+            CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, az_);
+            CqlDateTime bb_ = context.Operators.End(ba_);
+            return bb_;
         }
 
         IEnumerable<CqlDateTime> h_ = context.Operators.WhereSelect<Encounter.LocationComponent, CqlDateTime>(e_, f_, g_);
@@ -873,17 +689,13 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                 Period j_ = EDObsEncounter?.Period;
                 CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
                 CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, k_, (string)default);
-
-                CqlBoolean m_() {
-                    Code<Encounter.EncounterStatus> n_ = EDObsEncounter?.StatusElement;
-                    Encounter.EncounterStatus? o_ = n_?.Value;
-                    Code<Encounter.EncounterStatus> p_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(o_);
-                    CqlBoolean q_ = context.Operators.Equal(p_, "finished");
-                    return q_;
-                }
-
+                Code<Encounter.EncounterStatus> m_ = EDObsEncounter?.StatusElement;
+                Encounter.EncounterStatus? n_ = m_?.Value;
+                Code<Encounter.EncounterStatus> o_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(n_);
+                CqlBoolean p_ = context.Operators.Equal(o_, "finished");
+                CqlBoolean q_ = p_;
                 return l_
-                    /* CQL 'and' (117:17-118:46) */ && m_();
+                    /* CQL 'and' (117:17-118:46) */ && q_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Encounter>(e_, f_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS128FHIRAntidepressantMgmt", "1.0.000")]
 public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton<CMS128FHIRAntidepressantMgmt_1_0_000>
 {
@@ -173,17 +173,13 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
                 IEnumerable<string> u_ = context.Operators.Split((string)t_, "/");
                 string v_ = context.Operators.Last<string>(u_);
                 CqlBoolean w_ = context.Operators.Equal(s_, v_);
-
-                CqlBoolean x_() {
-                    CodeableConcept y_ = M?.Code;
-                    CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                    CqlValueSet aa_ = this.Antidepressant_Medication(context);
-                    CqlBoolean ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-                    return ab_;
-                }
-
+                CodeableConcept x_ = M?.Code;
+                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
+                CqlValueSet z_ = this.Antidepressant_Medication(context);
+                CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
+                CqlBoolean ab_ = aa_;
                 return w_
-                    /* CQL 'and' */ && x_();
+                    /* CQL 'and' */ && ab_;
             }
 
             CqlBoolean r_ = context.Operators.WhereAny<Medication>(p_, q_);
@@ -246,23 +242,18 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
 
         bool? f_(Condition MajorDepression) {
             CqlDate h_ = this.IPSD(context);
-
-            CqlBoolean i_() {
-                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MajorDepression);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                CqlDate l_ = context.Operators.DateFrom(k_);
-                CqlDate m_ = this.IPSD(context);
-                CqlQuantity n_ = context.Operators.Quantity(60m, "days");
-                CqlDate o_ = context.Operators.Subtract(m_, n_);
-                CqlDate p_ = context.Operators.Add(m_, n_);
-                CqlInterval<CqlDate> q_ = context.Operators.Interval(o_, p_, true, true);
-                CqlBoolean r_ = context.Operators.In<CqlDate>(l_, q_, (string)default);
-                return r_
-                    /* CQL 'and' (44:13-44:94) */ && ((this.IPSD(context)) is not null);
-            }
-
+            CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MajorDepression);
+            CqlDateTime j_ = context.Operators.Start(i_);
+            CqlDate k_ = context.Operators.DateFrom(j_);
+            CqlQuantity l_ = context.Operators.Quantity(60m, "days");
+            CqlDate m_ = context.Operators.Subtract(h_, l_);
+            CqlDate n_ = context.Operators.Add(h_, l_);
+            CqlInterval<CqlDate> o_ = context.Operators.Interval(m_, n_, true, true);
+            CqlBoolean p_ = context.Operators.In<CqlDate>(k_, o_, (string)default);
+            CqlBoolean q_ = p_
+                /* CQL 'and' (44:13-44:94) */ && ((this.IPSD(context)) is not null);
             return (CqlBoolean)(h_ is not null)
-                /* CQL 'and' (43:7-44:94) */ && i_();
+                /* CQL 'and' (43:7-44:94) */ && q_;
         }
 
         CqlBoolean g_ = context.Operators.WhereAny<Condition>(e_, f_);
@@ -346,16 +337,12 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 18);
-
-        CqlBoolean j_() {
-            IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
-            CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
-            return l_;
-        }
-
+        IEnumerable<Encounter> j_ = this.Qualifying_Encounters(context);
+        CqlBoolean k_ = context.Operators.Exists<Encounter>(j_);
+        CqlBoolean l_ = k_;
         return i_
             /* CQL 'and' (32:3-33:49) */ && this.Has_IPSD_and_Major_Depression_Diagnosis(context)
-            /* CQL 'and' (32:3-34:38) */ && j_();
+            /* CQL 'and' (32:3-34:38) */ && l_;
     }
 
 
@@ -381,73 +368,60 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-        CqlBoolean b_() {
-            IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? c_(MedicationRequest MR) {
+            IEnumerable<Medication> l_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? d_(MedicationRequest MR) {
-                IEnumerable<Medication> l_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-                bool? m_(Medication M) {
-                    object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
-                    string r_ = context.Operators.Last<string>(q_);
-                    CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Antidepressant_Medication(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
-                    return s_
-                        /* CQL 'and' */ && t_();
-                }
-
-                CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
-                return n_;
+            bool? m_(Medication M) {
+                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
+                string r_ = context.Operators.Last<string>(q_);
+                CqlBoolean s_ = context.Operators.Equal(o_, r_);
+                CodeableConcept t_ = M?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlValueSet v_ = this.Antidepressant_Medication(context);
+                CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                CqlBoolean x_ = w_;
+                return s_
+                    /* CQL 'and' */ && x_;
             }
 
-            IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
-            CqlValueSet f_ = this.Antidepressant_Medication(context);
-            IEnumerable<MedicationRequest> g_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
-            IEnumerable<MedicationRequest> i_ = Status_1_15_000.Instance.isMedicationActive(context, h_);
-
-            bool? j_(MedicationRequest ActiveAntidepressant) {
-                CqlDate y_ = this.IPSD(context);
-
-                CqlBoolean z_() {
-                    CqlInterval<CqlDate> aa_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveAntidepressant);
-                    CqlDate ab_ = aa_?.low;
-                    CqlDateTime ac_ = context.Operators.ConvertDateToDateTime(ab_);
-                    CqlDate ad_ = aa_?.high;
-                    CqlDateTime ae_ = context.Operators.ConvertDateToDateTime(ad_);
-                    CqlBoolean af_ = aa_?.lowClosed;
-                    CqlBoolean ag_ = aa_?.highClosed;
-                    CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ac_, ae_, af_, ag_);
-                    CqlInterval<CqlDate> ai_ = CQMCommon_4_1_000.Instance.ToDateInterval(context, ah_);
-                    CqlDate aj_ = this.IPSD(context);
-                    CqlQuantity ak_ = context.Operators.Quantity(105m, "days");
-                    CqlDate al_ = context.Operators.Subtract(aj_, ak_);
-                    CqlInterval<CqlDate> am_ = context.Operators.Interval(al_, aj_, true, false);
-                    CqlBoolean an_ = context.Operators.Overlaps(ai_, am_, (string)default);
-                    return an_;
-                }
-
-                return (CqlBoolean)(y_ is not null)
-                    /* CQL 'and' (82:9-83:137) */ && z_();
-            }
-
-            CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
-            return k_;
+            CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
+            return n_;
         }
 
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
+        CqlValueSet e_ = this.Antidepressant_Medication(context);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> g_ = context.Operators.Union<MedicationRequest>(d_, f_);
+        IEnumerable<MedicationRequest> h_ = Status_1_15_000.Instance.isMedicationActive(context, g_);
+
+        bool? i_(MedicationRequest ActiveAntidepressant) {
+            CqlDate y_ = this.IPSD(context);
+            CqlInterval<CqlDate> z_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, ActiveAntidepressant);
+            CqlDate aa_ = z_?.low;
+            CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(aa_);
+            CqlDate ac_ = z_?.high;
+            CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(ac_);
+            CqlBoolean ae_ = z_?.lowClosed;
+            CqlBoolean af_ = z_?.highClosed;
+            CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, ad_, ae_, af_);
+            CqlInterval<CqlDate> ah_ = CQMCommon_4_1_000.Instance.ToDateInterval(context, ag_);
+            CqlQuantity ai_ = context.Operators.Quantity(105m, "days");
+            CqlDate aj_ = context.Operators.Subtract(y_, ai_);
+            CqlInterval<CqlDate> ak_ = context.Operators.Interval(aj_, y_, true, false);
+            CqlBoolean al_ = context.Operators.Overlaps(ah_, ak_, (string)default);
+            CqlBoolean am_ = al_;
+            return (CqlBoolean)(y_ is not null)
+                /* CQL 'and' (82:9-83:137) */ && am_;
+        }
+
+        CqlBoolean j_ = context.Operators.WhereAny<MedicationRequest>(h_, i_);
+        CqlBoolean k_ = j_;
         return a_
-            /* CQL 'or' (80:3-84:5) */ || b_();
+            /* CQL 'or' (80:3-84:5) */ || k_;
     }
 
 
@@ -470,17 +444,13 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
                 IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
                 string p_ = context.Operators.Last<string>(o_);
                 CqlBoolean q_ = context.Operators.Equal(m_, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = M?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlValueSet u_ = this.Antidepressant_Medication(context);
-                    CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                    return v_;
-                }
-
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Antidepressant_Medication(context);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' */ && r_();
+                    /* CQL 'and' */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Medication>(j_, k_);
@@ -555,17 +525,13 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
                 IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
                 string p_ = context.Operators.Last<string>(o_);
                 CqlBoolean q_ = context.Operators.Equal(m_, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = M?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlValueSet u_ = this.Antidepressant_Medication(context);
-                    CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                    return v_;
-                }
-
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Antidepressant_Medication(context);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' */ && r_();
+                    /* CQL 'and' */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Medication>(j_, k_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS129FHIRProstCaBoneScanUse", "1.0.000")]
 public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton<CMS129FHIRProstCaBoneScanUse_1_0_000>
 {
@@ -197,51 +197,27 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (143:54-144:66) */ || i_()
-                /* CQL 'or' (143:54-145:66) */ || j_()
-                /* CQL 'or' (143:52-147:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (143:54-144:66) */ || i_
+            /* CQL 'or' (143:54-145:66) */ || m_
+            /* CQL 'or' (143:52-147:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (143:3-147:3) */ || c_();
+            /* CQL 'implies' (143:3-147:3) */ || r_;
     }
 
 
@@ -296,33 +272,33 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
 
         bool? c_(Procedure ProstateCancerTreatment) {
             object h_;
-            DataType n_ = ProstateCancerTreatment?.Performed;
-            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-            bool p_ = o_ is CqlDateTime;
-            if (p_)
+            DataType r_ = ProstateCancerTreatment?.Performed;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
             {
-                h_ = o_ as CqlDateTime;
+                h_ = s_ as CqlDateTime;
             }
             else
             {
-                bool q_ = o_ is CqlQuantity;
-                if (q_)
+                bool u_ = s_ is CqlQuantity;
+                if (u_)
                 {
-                    h_ = o_ as CqlQuantity;
+                    h_ = s_ as CqlQuantity;
                 }
                 else
                 {
-                    bool r_ = o_ is CqlInterval<CqlDateTime>;
-                    if (r_)
+                    bool v_ = s_ is CqlInterval<CqlDateTime>;
+                    if (v_)
                     {
-                        h_ = o_ as CqlInterval<CqlDateTime>;
+                        h_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool s_ = o_ is CqlInterval<CqlQuantity>;
-                        if (s_)
+                        bool w_ = s_ is CqlInterval<CqlQuantity>;
+                        if (w_)
                         {
-                            h_ = o_ as CqlInterval<CqlQuantity>;
+                            h_ = s_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
@@ -335,17 +311,13 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
             CqlDateTime j_ = context.Operators.End(i_);
             CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
             CqlBoolean l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
-
-            CqlBoolean m_() {
-                Code<EventStatus> t_ = ProstateCancerTreatment?.StatusElement;
-                EventStatus? u_ = t_?.Value;
-                string v_ = context.Operators.Convert<string>(u_);
-                CqlBoolean w_ = context.Operators.Equal(v_, "completed");
-                return w_;
-            }
-
+            Code<EventStatus> m_ = ProstateCancerTreatment?.StatusElement;
+            EventStatus? n_ = m_?.Value;
+            string o_ = context.Operators.Convert<string>(n_);
+            CqlBoolean p_ = context.Operators.Equal(o_, "completed");
+            CqlBoolean q_ = p_;
             return l_
-                /* CQL 'and' (84:7-85:56) */ && m_();
+                /* CQL 'and' (84:7-85:56) */ && q_;
         }
 
         IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
@@ -422,33 +394,33 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                 CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
                 CqlDateTime t_ = context.Operators.Start(s_);
                 object u_;
-                DataType z_ = FirstProstateCancerTreatment?.Performed;
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                bool ab_ = aa_ is CqlDateTime;
-                if (ab_)
+                DataType ae_ = FirstProstateCancerTreatment?.Performed;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool ag_ = af_ is CqlDateTime;
+                if (ag_)
                 {
-                    u_ = aa_ as CqlDateTime;
+                    u_ = af_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ac_ = aa_ is CqlQuantity;
-                    if (ac_)
+                    bool ah_ = af_ is CqlQuantity;
+                    if (ah_)
                     {
-                        u_ = aa_ as CqlQuantity;
+                        u_ = af_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
+                        bool ai_ = af_ is CqlInterval<CqlDateTime>;
+                        if (ai_)
                         {
-                            u_ = aa_ as CqlInterval<CqlDateTime>;
+                            u_ = af_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                            if (ae_)
+                            bool aj_ = af_ is CqlInterval<CqlQuantity>;
+                            if (aj_)
                             {
-                                u_ = aa_ as CqlInterval<CqlQuantity>;
+                                u_ = af_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -460,22 +432,18 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                 CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
                 CqlDateTime w_ = context.Operators.Start(v_);
                 CqlBoolean x_ = context.Operators.Before(t_, w_, (string)default);
-
-                CqlBoolean y_() {
-                    Code<ObservationStatus> af_ = ProstateCancerStaging?.StatusElement;
-                    ObservationStatus? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    string[] ai_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-                    return aj_;
-                }
-
+                Code<ObservationStatus> y_ = ProstateCancerStaging?.StatusElement;
+                ObservationStatus? z_ = y_?.Value;
+                string aa_ = context.Operators.Convert<string>(z_);
+                string[] ab_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
+                CqlBoolean ad_ = ac_;
                 return x_
-                    /* CQL 'and' (121:19-122:81) */ && y_();
+                    /* CQL 'and' (121:19-122:81) */ && ad_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)n_, o_);
@@ -504,40 +472,22 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
             CqlCode aq_ = this.American_Joint_Committee_on_Cancer_cT1a__qualifier_value_(context);
             CqlConcept ar_ = context.Operators.ConvertCodeToConcept(aq_);
             CqlBoolean as_ = context.Operators.Equivalent(ap_ as CqlConcept, ar_);
-
-            CqlBoolean at_() {
-                DataType aw_ = LastProstateCancerStaging?.Value;
-                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                CqlCode ay_ = this.American_Joint_Committee_on_Cancer_cT1b__qualifier_value_(context);
-                CqlConcept az_ = context.Operators.ConvertCodeToConcept(ay_);
-                CqlBoolean ba_ = context.Operators.Equivalent(ax_ as CqlConcept, az_);
-                return ba_;
-            }
-
-
-            CqlBoolean au_() {
-                DataType bb_ = LastProstateCancerStaging?.Value;
-                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                CqlCode bd_ = this.American_Joint_Committee_on_Cancer_cT1c__qualifier_value_(context);
-                CqlConcept be_ = context.Operators.ConvertCodeToConcept(bd_);
-                CqlBoolean bf_ = context.Operators.Equivalent(bc_ as CqlConcept, be_);
-                return bf_;
-            }
-
-
-            CqlBoolean av_() {
-                DataType bg_ = LastProstateCancerStaging?.Value;
-                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                CqlCode bi_ = this.American_Joint_Committee_on_Cancer_cT2a__qualifier_value_(context);
-                CqlConcept bj_ = context.Operators.ConvertCodeToConcept(bi_);
-                CqlBoolean bk_ = context.Operators.Equivalent(bh_ as CqlConcept, bj_);
-                return bk_;
-            }
-
+            CqlCode at_ = this.American_Joint_Committee_on_Cancer_cT1b__qualifier_value_(context);
+            CqlConcept au_ = context.Operators.ConvertCodeToConcept(at_);
+            CqlBoolean av_ = context.Operators.Equivalent(ap_ as CqlConcept, au_);
+            CqlBoolean aw_ = av_;
+            CqlCode ax_ = this.American_Joint_Committee_on_Cancer_cT1c__qualifier_value_(context);
+            CqlConcept ay_ = context.Operators.ConvertCodeToConcept(ax_);
+            CqlBoolean az_ = context.Operators.Equivalent(ap_ as CqlConcept, ay_);
+            CqlBoolean ba_ = az_;
+            CqlCode bb_ = this.American_Joint_Committee_on_Cancer_cT2a__qualifier_value_(context);
+            CqlConcept bc_ = context.Operators.ConvertCodeToConcept(bb_);
+            CqlBoolean bd_ = context.Operators.Equivalent(ap_ as CqlConcept, bc_);
+            CqlBoolean be_ = bd_;
             return as_
-                /* CQL 'or' (125:13-126:104) */ || at_()
-                /* CQL 'or' (125:13-127:104) */ || au_()
-                /* CQL 'or' (125:5-129:5) */ || av_();
+                /* CQL 'or' (125:13-126:104) */ || aw_
+                /* CQL 'or' (125:13-127:104) */ || ba_
+                /* CQL 'or' (125:5-129:5) */ || be_;
         }
 
         IEnumerable<Observation> k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
@@ -565,39 +515,35 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
 
             bool? n_(Observation MostRecentProstateCancerStaging) {
                 CqlInterval<CqlDateTime> p_;
-                DataType v_ = PSATest?.Effective;
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                if (y_ is null)
+                DataType aa_ = PSATest?.Effective;
+                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                if (ad_ is null)
                 {
                     p_ = default;
                 }
                 else
                 {
-                    CqlInterval<CqlDateTime> z_ = context.Operators.Interval(y_, y_, true, true);
-                    p_ = z_;
+                    CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ad_, ad_, true, true);
+                    p_ = ae_;
                 }
                 DataType q_ = MostRecentProstateCancerStaging?.Effective;
                 object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
                 CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
                 CqlBoolean t_ = context.Operators.Before(p_, s_, (string)default);
-
-                CqlBoolean u_() {
-                    Code<ObservationStatus> aa_ = PSATest?.StatusElement;
-                    ObservationStatus? ab_ = aa_?.Value;
-                    string ac_ = context.Operators.Convert<string>(ab_);
-                    string[] ad_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-                    return ae_;
-                }
-
+                Code<ObservationStatus> u_ = PSATest?.StatusElement;
+                ObservationStatus? v_ = u_?.Value;
+                string w_ = context.Operators.Convert<string>(v_);
+                string[] x_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
+                CqlBoolean z_ = y_;
                 return t_
-                    /* CQL 'and' (92:19-93:67) */ && u_();
+                    /* CQL 'and' (92:19-93:67) */ && z_;
             }
 
             CqlBoolean o_ = context.Operators.WhereAny<Observation>((IEnumerable<Observation>)m_, n_);
@@ -658,33 +604,33 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                 CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
                 CqlDateTime t_ = context.Operators.Start(s_);
                 object u_;
-                DataType z_ = FirstProstateCancerTreatment?.Performed;
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                bool ab_ = aa_ is CqlDateTime;
-                if (ab_)
+                DataType ae_ = FirstProstateCancerTreatment?.Performed;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool ag_ = af_ is CqlDateTime;
+                if (ag_)
                 {
-                    u_ = aa_ as CqlDateTime;
+                    u_ = af_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ac_ = aa_ is CqlQuantity;
-                    if (ac_)
+                    bool ah_ = af_ is CqlQuantity;
+                    if (ah_)
                     {
-                        u_ = aa_ as CqlQuantity;
+                        u_ = af_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
+                        bool ai_ = af_ is CqlInterval<CqlDateTime>;
+                        if (ai_)
                         {
-                            u_ = aa_ as CqlInterval<CqlDateTime>;
+                            u_ = af_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                            if (ae_)
+                            bool aj_ = af_ is CqlInterval<CqlQuantity>;
+                            if (aj_)
                             {
-                                u_ = aa_ as CqlInterval<CqlQuantity>;
+                                u_ = af_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -696,22 +642,18 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                 CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
                 CqlDateTime w_ = context.Operators.Start(v_);
                 CqlBoolean x_ = context.Operators.Before(t_, w_, (string)default);
-
-                CqlBoolean y_() {
-                    Code<ObservationStatus> af_ = GleasonScore?.StatusElement;
-                    ObservationStatus? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    string[] ai_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-                    return aj_;
-                }
-
+                Code<ObservationStatus> y_ = GleasonScore?.StatusElement;
+                ObservationStatus? z_ = y_?.Value;
+                string aa_ = context.Operators.Convert<string>(z_);
+                string[] ab_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
+                CqlBoolean ad_ = ac_;
                 return x_
-                    /* CQL 'and' (108:19-109:72) */ && y_();
+                    /* CQL 'and' (108:19-109:72) */ && ad_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)n_, o_);
@@ -802,22 +744,18 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
             CqlDateTime t_ = context.Operators.End(s_);
             CqlInterval<CqlDateTime> u_ = this.Measurement_Period(context);
             CqlBoolean v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
-
-            CqlBoolean w_() {
-                Code<ObservationStatus> x_ = BoneScan?.StatusElement;
-                ObservationStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                return ab_;
-            }
-
+            Code<ObservationStatus> w_ = BoneScan?.StatusElement;
+            ObservationStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
             return v_
-                /* CQL 'and' (67:5-68:64) */ && w_();
+                /* CQL 'and' (67:5-68:64) */ && ab_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
@@ -890,33 +828,33 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
 
             bool? f_(Condition ActiveProstateCancer) {
                 object h_;
-                DataType o_ = SalvageTherapy?.Performed;
-                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                bool q_ = p_ is CqlDateTime;
-                if (q_)
+                DataType s_ = SalvageTherapy?.Performed;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                bool u_ = t_ is CqlDateTime;
+                if (u_)
                 {
-                    h_ = p_ as CqlDateTime;
+                    h_ = t_ as CqlDateTime;
                 }
                 else
                 {
-                    bool r_ = p_ is CqlQuantity;
-                    if (r_)
+                    bool v_ = t_ is CqlQuantity;
+                    if (v_)
                     {
-                        h_ = p_ as CqlQuantity;
+                        h_ = t_ as CqlQuantity;
                     }
                     else
                     {
-                        bool s_ = p_ is CqlInterval<CqlDateTime>;
-                        if (s_)
+                        bool w_ = t_ is CqlInterval<CqlDateTime>;
+                        if (w_)
                         {
-                            h_ = p_ as CqlInterval<CqlDateTime>;
+                            h_ = t_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool t_ = p_ is CqlInterval<CqlQuantity>;
-                            if (t_)
+                            bool x_ = t_ is CqlInterval<CqlQuantity>;
+                            if (x_)
                             {
-                                h_ = p_ as CqlInterval<CqlQuantity>;
+                                h_ = t_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -930,17 +868,13 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                 CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as Condition);
                 CqlDateTime l_ = context.Operators.Start(k_);
                 CqlBoolean m_ = context.Operators.After(j_, l_, (string)default);
-
-                CqlBoolean n_() {
-                    Code<EventStatus> u_ = SalvageTherapy?.StatusElement;
-                    EventStatus? v_ = u_?.Value;
-                    string w_ = context.Operators.Convert<string>(v_);
-                    CqlBoolean x_ = context.Operators.Equal(w_, "completed");
-                    return x_;
-                }
-
+                Code<EventStatus> n_ = SalvageTherapy?.StatusElement;
+                EventStatus? o_ = n_?.Value;
+                string p_ = context.Operators.Convert<string>(o_);
+                CqlBoolean q_ = context.Operators.Equal(p_, "completed");
+                CqlBoolean r_ = q_;
                 return m_
-                    /* CQL 'and' (101:19-102:49) */ && n_();
+                    /* CQL 'and' (101:19-102:49) */ && r_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Condition>(e_, f_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS130FHIRColorectalCancerScrn-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS130FHIRColorectalCancerScrn-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS130FHIRColorectalCancerScrn", "1.0.000")]
 public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISingleton<CMS130FHIRColorectalCancerScrn_1_0_000>
 {
@@ -154,15 +154,11 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(46, 75, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> l_ = AdultOutpatientEncounters_4_19_000.Instance.Qualifying_Encounters(context);
-            CqlBoolean m_ = context.Operators.Exists<Encounter>(l_);
-            return m_;
-        }
-
+        IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_19_000.Instance.Qualifying_Encounters(context);
+        CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
+        CqlBoolean m_ = l_;
         return j_
-            /* CQL 'and' (40:3-43:64) */ && k_();
+            /* CQL 'and' (40:3-43:64) */ && m_;
     }
 
 
@@ -278,23 +274,15 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Condition> d_ = this.Malignant_Neoplasm(context);
-            CqlBoolean e_ = context.Operators.Exists<Condition>(d_);
-            return e_;
-        }
-
-
-        CqlBoolean c_() {
-            IEnumerable<Procedure> f_ = this.Total_Colectomy_Performed(context);
-            CqlBoolean g_ = context.Operators.Exists<Procedure>(f_);
-            return g_;
-        }
-
+        IEnumerable<Condition> b_ = this.Malignant_Neoplasm(context);
+        CqlBoolean c_ = context.Operators.Exists<Condition>(b_);
+        CqlBoolean d_ = c_;
+        IEnumerable<Procedure> e_ = this.Total_Colectomy_Performed(context);
+        CqlBoolean f_ = context.Operators.Exists<Procedure>(e_);
+        CqlBoolean g_ = f_;
         return a_
-            /* CQL 'or' (49:3-50:34) */ || b_()
-            /* CQL 'or' (49:3-51:41) */ || c_()
+            /* CQL 'or' (49:3-50:34) */ || d_
+            /* CQL 'or' (49:3-51:41) */ || g_
             /* CQL 'or' (49:3-52:73) */ || AdvancedIllnessandFrailty_1_27_000.Instance.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty(context)
             /* CQL 'or' (49:3-53:74) */ || AdvancedIllnessandFrailty_1_27_000.Instance.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home(context)
             /* CQL 'or' (49:3-54:69) */ || PalliativeCare_1_18_000.Instance.Has_Palliative_Care_in_the_Measurement_Period(context);
@@ -316,43 +304,39 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
         bool? d_(Observation FecalOccultResult) {
             DataType f_ = FecalOccultResult?.Value;
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
-
-            CqlBoolean h_() {
-                object i_;
-                DataType m_ = FecalOccultResult?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                bool o_ = n_ is CqlDateTime;
+            object h_;
+            DataType m_ = FecalOccultResult?.Effective;
+            object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+            bool o_ = n_ is CqlDateTime;
+            if (o_)
+            {
+                h_ = n_ as CqlDateTime;
+            }
+            else
+            {
                 if (o_)
                 {
-                    i_ = n_ as CqlDateTime;
+                    h_ = n_ as CqlDateTime;
                 }
                 else
                 {
-                    if (o_)
+                    bool p_ = n_ is CqlInterval<CqlDateTime>;
+                    if (p_)
                     {
-                        i_ = n_ as CqlDateTime;
+                        h_ = n_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool p_ = n_ is CqlInterval<CqlDateTime>;
-                        if (p_)
-                        {
-                            i_ = n_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            i_ = null;
-                        }
+                        h_ = null;
                     }
                 }
-                CqlDateTime j_ = QICoreCommon_4_0_000.Instance.latest(context, i_);
-                CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
-                CqlBoolean l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
-                return l_;
             }
-
+            CqlDateTime i_ = QICoreCommon_4_0_000.Instance.latest(context, h_);
+            CqlInterval<CqlDateTime> j_ = this.Measurement_Period(context);
+            CqlBoolean k_ = context.Operators.In<CqlDateTime>(i_, j_, "day");
+            CqlBoolean l_ = k_;
             return (CqlBoolean)(g_ is not null)
-                /* CQL 'and' (65:5-66:83) */ && h_();
+                /* CQL 'and' (65:5-66:83) */ && l_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -375,48 +359,44 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
         bool? d_(Observation sDNATest) {
             DataType f_ = sDNATest?.Value;
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
-
-            CqlBoolean h_() {
-                object i_;
-                DataType r_ = sDNATest?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
+            object h_;
+            DataType r_ = sDNATest?.Effective;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
+            {
+                h_ = s_ as CqlDateTime;
+            }
+            else
+            {
                 if (t_)
                 {
-                    i_ = s_ as CqlDateTime;
+                    h_ = s_ as CqlDateTime;
                 }
                 else
                 {
-                    if (t_)
+                    bool u_ = s_ is CqlInterval<CqlDateTime>;
+                    if (u_)
                     {
-                        i_ = s_ as CqlDateTime;
+                        h_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlInterval<CqlDateTime>;
-                        if (u_)
-                        {
-                            i_ = s_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            i_ = null;
-                        }
+                        h_ = null;
                     }
                 }
-                CqlDateTime j_ = QICoreCommon_4_0_000.Instance.latest(context, i_);
-                CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                CqlQuantity m_ = context.Operators.Quantity(2m, "years");
-                CqlDateTime n_ = context.Operators.Subtract(l_, m_);
-                CqlDateTime o_ = context.Operators.End(k_);
-                CqlInterval<CqlDateTime> p_ = context.Operators.Interval(n_, o_, true, true);
-                CqlBoolean q_ = context.Operators.In<CqlDateTime>(j_, p_, "day");
-                return q_;
             }
-
+            CqlDateTime i_ = QICoreCommon_4_0_000.Instance.latest(context, h_);
+            CqlInterval<CqlDateTime> j_ = this.Measurement_Period(context);
+            CqlDateTime k_ = context.Operators.Start(j_);
+            CqlQuantity l_ = context.Operators.Quantity(2m, "years");
+            CqlDateTime m_ = context.Operators.Subtract(k_, l_);
+            CqlDateTime n_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> o_ = context.Operators.Interval(m_, n_, true, true);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(i_, o_, "day");
+            CqlBoolean q_ = p_;
             return (CqlBoolean)(g_ is not null)
-                /* CQL 'and' (102:5-103:132) */ && h_();
+                /* CQL 'and' (102:5-103:132) */ && q_;
         }
 
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
@@ -598,39 +578,23 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Observation> a_ = this.Fecal_Occult_Blood_Test_Performed(context);
         CqlBoolean b_ = context.Operators.Exists<Observation>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> g_ = this.Stool_DNA_with_FIT_Test_Performed(context);
-            CqlBoolean h_ = context.Operators.Exists<Observation>(g_);
-            return h_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Procedure> i_ = this.Flexible_Sigmoidoscopy_Performed(context);
-            CqlBoolean j_ = context.Operators.Exists<Procedure>(i_);
-            return j_;
-        }
-
-
-        CqlBoolean e_() {
-            IEnumerable<Observation> k_ = this.CT_Colonography_Performed(context);
-            CqlBoolean l_ = context.Operators.Exists<Observation>(k_);
-            return l_;
-        }
-
-
-        CqlBoolean f_() {
-            IEnumerable<Procedure> m_ = this.Colonoscopy_Performed(context);
-            CqlBoolean n_ = context.Operators.Exists<Procedure>(m_);
-            return n_;
-        }
-
+        IEnumerable<Observation> c_ = this.Stool_DNA_with_FIT_Test_Performed(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
+        IEnumerable<Procedure> f_ = this.Flexible_Sigmoidoscopy_Performed(context);
+        CqlBoolean g_ = context.Operators.Exists<Procedure>(f_);
+        CqlBoolean h_ = g_;
+        IEnumerable<Observation> i_ = this.CT_Colonography_Performed(context);
+        CqlBoolean j_ = context.Operators.Exists<Observation>(i_);
+        CqlBoolean k_ = j_;
+        IEnumerable<Procedure> l_ = this.Colonoscopy_Performed(context);
+        CqlBoolean m_ = context.Operators.Exists<Procedure>(l_);
+        CqlBoolean n_ = m_;
         return b_
-            /* CQL 'or' (57:3-58:49) */ || c_()
-            /* CQL 'or' (57:3-59:48) */ || d_()
-            /* CQL 'or' (57:3-60:41) */ || e_()
-            /* CQL 'or' (57:3-61:37) */ || f_();
+            /* CQL 'or' (57:3-58:49) */ || e_
+            /* CQL 'or' (57:3-59:48) */ || h_
+            /* CQL 'or' (57:3-60:41) */ || k_
+            /* CQL 'or' (57:3-61:37) */ || n_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS131FHIRDiabetesEyeExam-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS131FHIRDiabetesEyeExam-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS131FHIRDiabetesEyeExam", "1.0.000")]
 public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CMS131FHIRDiabetesEyeExam_1_0_000>
 {
@@ -208,35 +208,27 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
+        IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
+        CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
+        CqlBoolean m_ = l_;
+        CqlValueSet n_ = this.Diabetes(context);
+        IEnumerable<Condition> o_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        Condition p_(Condition X) => X as Condition;
+        IEnumerable<Condition> q_ = context.Operators.Select<Condition, Condition>(o_, p_);
+        IEnumerable<Condition> r_ = Status_1_15_000.Instance.verified(context, q_);
 
-        CqlBoolean k_() {
-            IEnumerable<Encounter> m_ = this.Qualifying_Encounters(context);
-            CqlBoolean n_ = context.Operators.Exists<Encounter>(m_);
-            return n_;
+        bool? s_(Condition DiabetesDx) {
+            CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesDx);
+            CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
+            CqlBoolean x_ = context.Operators.Overlaps(v_, w_, "day");
+            return x_;
         }
 
-
-        CqlBoolean l_() {
-            CqlValueSet o_ = this.Diabetes(context);
-            IEnumerable<Condition> p_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            Condition q_(Condition X) => X as Condition;
-            IEnumerable<Condition> r_ = context.Operators.Select<Condition, Condition>(p_, q_);
-            IEnumerable<Condition> s_ = Status_1_15_000.Instance.verified(context, r_);
-
-            bool? t_(Condition DiabetesDx) {
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesDx);
-                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                CqlBoolean x_ = context.Operators.Overlaps(v_, w_, "day");
-                return x_;
-            }
-
-            CqlBoolean u_ = context.Operators.WhereAny<Condition>(s_, t_);
-            return u_;
-        }
-
+        CqlBoolean t_ = context.Operators.WhereAny<Condition>(r_, s_);
+        CqlBoolean u_ = t_;
         return j_
-            /* CQL 'and' (41:3-44:42) */ && k_()
-            /* CQL 'and' (41:3-47:5) */ && l_();
+            /* CQL 'and' (41:3-44:42) */ && m_
+            /* CQL 'and' (41:3-47:5) */ && u_;
     }
 
 
@@ -400,18 +392,14 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
             object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
             CqlValueSet i_ = this.Autonomous_Eye_Exam_Result_or_Finding(context);
             CqlBoolean j_ = context.Operators.ConceptInValueSet(h_ as CqlConcept, i_);
-
-            CqlBoolean k_() {
-                CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
-                DataType m_ = AutonomousEyeExam?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlBoolean p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
-                return p_;
-            }
-
+            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
+            DataType l_ = AutonomousEyeExam?.Effective;
+            object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+            CqlBoolean o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, "day");
+            CqlBoolean p_ = o_;
             return j_
-                /* CQL 'and' (83:5-84:87) */ && k_();
+                /* CQL 'and' (83:5-84:87) */ && p_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
@@ -437,18 +425,14 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
             object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
             CqlValueSet i_ = this.Diabetic_Retinopathy_Severity_Level(context);
             CqlBoolean j_ = context.Operators.ConceptInValueSet(h_ as CqlConcept, i_);
-
-            CqlBoolean k_() {
-                CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
-                DataType m_ = LeftEyeRetinopathy?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlBoolean p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
-                return p_;
-            }
-
+            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
+            DataType l_ = LeftEyeRetinopathy?.Effective;
+            object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+            CqlBoolean o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, "day");
+            CqlBoolean p_ = o_;
             return j_
-                /* CQL 'and' (113:5-114:88) */ && k_();
+                /* CQL 'and' (113:5-114:88) */ && p_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
@@ -474,18 +458,14 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
             object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
             CqlValueSet i_ = this.Diabetic_Retinopathy_Severity_Level(context);
             CqlBoolean j_ = context.Operators.ConceptInValueSet(h_ as CqlConcept, i_);
-
-            CqlBoolean k_() {
-                CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
-                DataType m_ = RightEyeRetinopathy?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlBoolean p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
-                return p_;
-            }
-
+            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
+            DataType l_ = RightEyeRetinopathy?.Effective;
+            object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+            CqlBoolean o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, "day");
+            CqlBoolean p_ = o_;
             return j_
-                /* CQL 'and' (123:5-124:89) */ && k_();
+                /* CQL 'and' (123:5-124:89) */ && p_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
@@ -512,24 +492,20 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
             CqlCode i_ = this.No_apparent_retinopathy(context);
             CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
             CqlBoolean k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
-
-            CqlBoolean l_() {
-                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(1m, "year");
-                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
-                CqlDateTime q_ = context.Operators.End(m_);
-                CqlDateTime r_ = context.Operators.Subtract(q_, o_);
-                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                DataType t_ = RightEyeNoRetinopathy?.Effective;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                CqlBoolean w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(s_, v_, "day");
-                return w_;
-            }
-
+            CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+            CqlDateTime m_ = context.Operators.Start(l_);
+            CqlQuantity n_ = context.Operators.Quantity(1m, "year");
+            CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+            CqlDateTime p_ = context.Operators.End(l_);
+            CqlDateTime q_ = context.Operators.Subtract(p_, n_);
+            CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
+            DataType s_ = RightEyeNoRetinopathy?.Effective;
+            object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+            CqlBoolean v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, "day");
+            CqlBoolean w_ = v_;
             return k_
-                /* CQL 'and' (118:5-119:157) */ && l_();
+                /* CQL 'and' (118:5-119:157) */ && w_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
@@ -556,24 +532,20 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
             CqlCode i_ = this.No_apparent_retinopathy(context);
             CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
             CqlBoolean k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
-
-            CqlBoolean l_() {
-                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(1m, "year");
-                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
-                CqlDateTime q_ = context.Operators.End(m_);
-                CqlDateTime r_ = context.Operators.Subtract(q_, o_);
-                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                DataType t_ = LeftEyeNoRetinopathy?.Effective;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                CqlBoolean w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(s_, v_, "day");
-                return w_;
-            }
-
+            CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+            CqlDateTime m_ = context.Operators.Start(l_);
+            CqlQuantity n_ = context.Operators.Quantity(1m, "year");
+            CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+            CqlDateTime p_ = context.Operators.End(l_);
+            CqlDateTime q_ = context.Operators.Subtract(p_, n_);
+            CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
+            DataType s_ = LeftEyeNoRetinopathy?.Effective;
+            object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+            CqlBoolean v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, "day");
+            CqlBoolean w_ = v_;
             return k_
-                /* CQL 'and' (108:5-109:156) */ && l_();
+                /* CQL 'and' (108:5-109:156) */ && w_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
@@ -590,24 +562,15 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
     private bool? Retinal_Exam_Finding_with_Retinopathy_Severity_Level_in_Measurement_Period_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Has_Left_Eye_Retinopathy(context);
-
-        CqlBoolean b_() {
-            CqlBoolean d_ = this.Has_Left_Eye_Retinopathy(context);
-            return d_
-                /* CQL 'and' (135:8-137:5) */ && this.Has_Right_Eye_No_Retinopathy_in_Year_Prior(context);
-        }
-
-
-        CqlBoolean c_() {
-            CqlBoolean e_ = this.Has_Right_Eye_Retinopathy(context);
-            return e_
-                /* CQL 'and' (138:8-140:5) */ && this.Has_Left_Eye_No_Retinopathy_in_Year_Prior(context);
-        }
-
+        CqlBoolean b_ = a_
+            /* CQL 'and' (135:8-137:5) */ && this.Has_Right_Eye_No_Retinopathy_in_Year_Prior(context);
+        CqlBoolean c_ = this.Has_Right_Eye_Retinopathy(context);
+        CqlBoolean d_ = c_
+            /* CQL 'and' (138:8-140:5) */ && this.Has_Left_Eye_No_Retinopathy_in_Year_Prior(context);
         return (a_
             /* CQL 'and' (132:3-134:3) */ && this.Has_Right_Eye_Retinopathy(context))
-            /* CQL 'or' (132:3-137:5) */ || b_()
-            /* CQL 'or' (132:3-140:5) */ || c_();
+            /* CQL 'or' (132:3-137:5) */ || b_
+            /* CQL 'or' (132:3-140:5) */ || d_;
     }
 
 
@@ -634,16 +597,11 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
     private bool? Numerator_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Diabetic_Retinopathy_Overlapping_Measurement_Period(context);
-
-        CqlBoolean b_() {
-            CqlBoolean c_ = this.Diabetic_Retinopathy_Overlapping_Measurement_Period(context);
-            return (CqlBoolean)!c_
-                /* CQL 'and' (74:8-76:5) */ && this.Retinal_Exam_in_Measurement_Period_or_Year_Prior(context);
-        }
-
+        CqlBoolean b_ = (CqlBoolean)!a_
+            /* CQL 'and' (74:8-76:5) */ && this.Retinal_Exam_in_Measurement_Period_or_Year_Prior(context);
         return (a_
             /* CQL 'and' (71:3-73:3) */ && this.Retinal_Exam_in_Measurement_Period(context))
-            /* CQL 'or' (71:3-76:5) */ || b_()
+            /* CQL 'or' (71:3-76:5) */ || b_
             /* CQL 'or' (71:3-77:50) */ || this.Autonomous_Eye_Exam_in_Measurement_Period(context)
             /* CQL 'or' (71:3-78:83) */ || this.Retinal_Exam_Finding_with_Retinopathy_Severity_Level_in_Measurement_Period(context)
             /* CQL 'or' (71:3-79:78) */ || this.Retinal_Exam_Finding_with_No_Retinopathy_Severity_Level_in_Year_Prior(context);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS133FHIRCataracts2040BCVA90Days-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS133FHIRCataracts2040BCVA90Days-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS133FHIRCataracts2040BCVA90Days", "1.0.000")]
 public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISingleton<CMS133FHIRCataracts2040BCVA90Days_1_0_000>
 {
@@ -320,33 +320,33 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
         bool? c_(Procedure CataractSurgery) {
             CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
             object f_;
-            DataType k_ = CataractSurgery?.Performed;
-            object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-            bool m_ = l_ is CqlDateTime;
-            if (m_)
+            DataType v_ = CataractSurgery?.Performed;
+            object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+            bool x_ = w_ is CqlDateTime;
+            if (x_)
             {
-                f_ = l_ as CqlDateTime;
+                f_ = w_ as CqlDateTime;
             }
             else
             {
-                bool n_ = l_ is CqlQuantity;
-                if (n_)
+                bool y_ = w_ is CqlQuantity;
+                if (y_)
                 {
-                    f_ = l_ as CqlQuantity;
+                    f_ = w_ as CqlQuantity;
                 }
                 else
                 {
-                    bool o_ = l_ is CqlInterval<CqlDateTime>;
-                    if (o_)
+                    bool z_ = w_ is CqlInterval<CqlDateTime>;
+                    if (z_)
                     {
-                        f_ = l_ as CqlInterval<CqlDateTime>;
+                        f_ = w_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool p_ = l_ is CqlInterval<CqlQuantity>;
-                        if (p_)
+                        bool aa_ = w_ is CqlInterval<CqlQuantity>;
+                        if (aa_)
                         {
-                            f_ = l_ as CqlInterval<CqlQuantity>;
+                            f_ = w_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
@@ -357,66 +357,57 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
             }
             CqlInterval<CqlDateTime> g_ = QICoreCommon_4_0_000.Instance.toInterval(context, f_);
             CqlBoolean h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
-
-            CqlBoolean i_() {
-                object q_;
-                DataType y_ = CataractSurgery?.Performed;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
+            object i_;
+            DataType ab_ = CataractSurgery?.Performed;
+            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            bool ad_ = ac_ is CqlDateTime;
+            if (ad_)
+            {
+                i_ = ac_ as CqlDateTime;
+            }
+            else
+            {
+                bool ae_ = ac_ is CqlQuantity;
+                if (ae_)
                 {
-                    q_ = z_ as CqlDateTime;
+                    i_ = ac_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ab_ = z_ is CqlQuantity;
-                    if (ab_)
+                    bool af_ = ac_ is CqlInterval<CqlDateTime>;
+                    if (af_)
                     {
-                        q_ = z_ as CqlQuantity;
+                        i_ = ac_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ac_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ac_)
+                        bool ag_ = ac_ is CqlInterval<CqlQuantity>;
+                        if (ag_)
                         {
-                            q_ = z_ as CqlInterval<CqlDateTime>;
+                            i_ = ac_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool ad_ = z_ is CqlInterval<CqlQuantity>;
-                            if (ad_)
-                            {
-                                q_ = z_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                q_ = null;
-                            }
+                            i_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlDateTime u_ = context.Operators.End(t_);
-                CqlQuantity v_ = context.Operators.Quantity(92m, "days");
-                CqlDateTime w_ = context.Operators.Subtract(u_, v_);
-                CqlBoolean x_ = context.Operators.SameOrBefore(s_, w_, "day");
-                return x_;
             }
-
-
-            CqlBoolean j_() {
-                Code<EventStatus> ae_ = CataractSurgery?.StatusElement;
-                EventStatus? af_ = ae_?.Value;
-                string ag_ = context.Operators.Convert<string>(af_);
-                CqlBoolean ah_ = context.Operators.Equal(ag_, "completed");
-                return ah_;
-            }
-
+            CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.toInterval(context, i_);
+            CqlDateTime k_ = context.Operators.Start(j_);
+            CqlDateTime l_ = context.Operators.End(e_);
+            CqlQuantity m_ = context.Operators.Quantity(92m, "days");
+            CqlDateTime n_ = context.Operators.Subtract(l_, m_);
+            CqlBoolean o_ = context.Operators.SameOrBefore(k_, n_, "day");
+            CqlBoolean p_ = o_;
+            Code<EventStatus> q_ = CataractSurgery?.StatusElement;
+            EventStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            CqlBoolean t_ = context.Operators.Equal(s_, "completed");
+            CqlBoolean u_ = t_;
             return h_
-                /* CQL 'and' (86:11-87:115) */ && i_()
-                /* CQL 'and' (86:5-88:46) */ && j_();
+                /* CQL 'and' (86:11-87:115) */ && p_
+                /* CQL 'and' (86:5-88:46) */ && u_;
         }
 
         IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
@@ -471,51 +462,27 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (277:54-278:66) */ || i_()
-                /* CQL 'or' (277:54-279:66) */ || j_()
-                /* CQL 'or' (277:52-281:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (277:54-278:66) */ || i_
+            /* CQL 'or' (277:54-279:66) */ || m_
+            /* CQL 'or' (277:52-281:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (277:3-281:3) */ || c_();
+            /* CQL 'implies' (277:3-281:3) */ || r_;
     }
 
 
@@ -895,33 +862,33 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
                 CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
                 CqlDateTime o_ = context.Operators.Start(n_);
                 object p_;
-                DataType ac_ = CataractSurgeryPerformed?.Performed;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                bool ae_ = ad_ is CqlDateTime;
-                if (ae_)
+                DataType ao_ = CataractSurgeryPerformed?.Performed;
+                object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                bool aq_ = ap_ is CqlDateTime;
+                if (aq_)
                 {
-                    p_ = ad_ as CqlDateTime;
+                    p_ = ap_ as CqlDateTime;
                 }
                 else
                 {
-                    bool af_ = ad_ is CqlQuantity;
-                    if (af_)
+                    bool ar_ = ap_ is CqlQuantity;
+                    if (ar_)
                     {
-                        p_ = ad_ as CqlQuantity;
+                        p_ = ap_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool as_ = ap_ is CqlInterval<CqlDateTime>;
+                        if (as_)
                         {
-                            p_ = ad_ as CqlInterval<CqlDateTime>;
+                            p_ = ap_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                            if (ah_)
+                            bool at_ = ap_ is CqlInterval<CqlQuantity>;
+                            if (at_)
                             {
-                                p_ = ad_ as CqlInterval<CqlQuantity>;
+                                p_ = ap_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -933,33 +900,33 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
                 CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
                 CqlDateTime r_ = context.Operators.End(q_);
                 object s_;
-                DataType ai_ = CataractSurgeryPerformed?.Performed;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                bool ak_ = aj_ is CqlDateTime;
-                if (ak_)
+                DataType au_ = CataractSurgeryPerformed?.Performed;
+                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                bool aw_ = av_ is CqlDateTime;
+                if (aw_)
                 {
-                    s_ = aj_ as CqlDateTime;
+                    s_ = av_ as CqlDateTime;
                 }
                 else
                 {
-                    bool al_ = aj_ is CqlQuantity;
-                    if (al_)
+                    bool ax_ = av_ is CqlQuantity;
+                    if (ax_)
                     {
-                        s_ = aj_ as CqlQuantity;
+                        s_ = av_ as CqlQuantity;
                     }
                     else
                     {
-                        bool am_ = aj_ is CqlInterval<CqlDateTime>;
-                        if (am_)
+                        bool ay_ = av_ is CqlInterval<CqlDateTime>;
+                        if (ay_)
                         {
-                            s_ = aj_ as CqlInterval<CqlDateTime>;
+                            s_ = av_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool an_ = aj_ is CqlInterval<CqlQuantity>;
-                            if (an_)
+                            bool az_ = av_ is CqlInterval<CqlQuantity>;
+                            if (az_)
                             {
-                                s_ = aj_ as CqlInterval<CqlQuantity>;
+                                s_ = av_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -974,76 +941,64 @@ public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISing
                 CqlDateTime w_ = context.Operators.Add(u_, v_);
                 CqlInterval<CqlDateTime> x_ = context.Operators.Interval(r_, w_, false, true);
                 CqlBoolean y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
-
-                CqlBoolean z_() {
-                    object ao_;
-                    DataType ar_ = CataractSurgeryPerformed?.Performed;
-                    object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                    bool at_ = as_ is CqlDateTime;
-                    if (at_)
+                object z_;
+                DataType ba_ = CataractSurgeryPerformed?.Performed;
+                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+                bool bc_ = bb_ is CqlDateTime;
+                if (bc_)
+                {
+                    z_ = bb_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bd_ = bb_ is CqlQuantity;
+                    if (bd_)
                     {
-                        ao_ = as_ as CqlDateTime;
+                        z_ = bb_ as CqlQuantity;
                     }
                     else
                     {
-                        bool au_ = as_ is CqlQuantity;
-                        if (au_)
+                        bool be_ = bb_ is CqlInterval<CqlDateTime>;
+                        if (be_)
                         {
-                            ao_ = as_ as CqlQuantity;
+                            z_ = bb_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool av_ = as_ is CqlInterval<CqlDateTime>;
-                            if (av_)
+                            bool bf_ = bb_ is CqlInterval<CqlQuantity>;
+                            if (bf_)
                             {
-                                ao_ = as_ as CqlInterval<CqlDateTime>;
+                                z_ = bb_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aw_ = as_ is CqlInterval<CqlQuantity>;
-                                if (aw_)
-                                {
-                                    ao_ = as_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    ao_ = null;
-                                }
+                                z_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
-                    CqlDateTime aq_ = context.Operators.End(ap_);
-                    return aq_ is not null;
                 }
-
-
-                CqlBoolean aa_() {
-                    Code<ObservationStatus> ax_ = VisualAcuityExamPerformed?.StatusElement;
-                    ObservationStatus? ay_ = ax_?.Value;
-                    string az_ = context.Operators.Convert<string>(ay_);
-                    string[] ba_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
-                    return bb_;
-                }
-
-
-                CqlBoolean ab_() {
-                    DataType bc_ = VisualAcuityExamPerformed?.Value;
-                    object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                    CqlValueSet be_ = this.Visual_Acuity_20_40_or_Better(context);
-                    CqlBoolean bf_ = context.Operators.ConceptInValueSet(bd_ as CqlConcept, be_);
-                    return bf_;
-                }
-
+                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
+                CqlDateTime ab_ = context.Operators.End(aa_);
+                CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+                Code<ObservationStatus> ad_ = VisualAcuityExamPerformed?.StatusElement;
+                ObservationStatus? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                string[] ag_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
+                CqlBoolean ai_ = ah_;
+                DataType aj_ = VisualAcuityExamPerformed?.Value;
+                object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                CqlValueSet al_ = this.Visual_Acuity_20_40_or_Better(context);
+                CqlBoolean am_ = context.Operators.ConceptInValueSet(ak_ as CqlConcept, al_);
+                CqlBoolean an_ = am_;
                 return y_
-                    /* CQL 'and' (267:17-267:152) */ && z_()
-                    /* CQL 'and' (267:17-268:83) */ && aa_()
-                    /* CQL 'and' (267:17-269:89) */ && ab_();
+                    /* CQL 'and' (267:17-267:152) */ && ac_
+                    /* CQL 'and' (267:17-268:83) */ && ai_
+                    /* CQL 'and' (267:17-269:89) */ && an_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Observation>(i_, j_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS135FHIRACEIorARBorARNIforHF", "1.0.000")]
 public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISingleton<CMS135FHIRACEIorARBorARNIforHF_1_0_000>
 {
@@ -143,15 +143,11 @@ public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISinglet
     private bool? Denominator_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Initial_Population(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (35:3-36:95) */ && b_();
+            /* CQL 'and' (35:3-36:95) */ && d_;
     }
 
 
@@ -240,55 +236,41 @@ public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISinglet
 
         bool? c_(MedicationRequest NoACEIOrARBOrARNIOrdered) {
             CqlBoolean e_ = AHAOverall_4_1_000.Instance.isMedicationNotRequestedOrderedDuringHeartFailureOutpatientEncounter(context, NoACEIOrARBOrARNIOrdered);
+            List<CodeableConcept> f_ = NoACEIOrARBOrARNIOrdered?.ReasonCode;
 
-            CqlBoolean f_() {
-                List<CodeableConcept> g_ = NoACEIOrARBOrARNIOrdered?.ReasonCode;
-
-                CqlConcept h_(CodeableConcept @this) {
-                    CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return n_;
-                }
-
-                IEnumerable<CqlConcept> i_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)g_, h_);
-                CqlValueSet j_ = this.Medical_Reason(context);
-                CqlBoolean k_ = context.Operators.ConceptsInValueSet(i_, j_);
-
-                CqlBoolean l_() {
-                    List<CodeableConcept> o_ = NoACEIOrARBOrARNIOrdered?.ReasonCode;
-
-                    CqlConcept p_(CodeableConcept @this) {
-                        CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return t_;
-                    }
-
-                    IEnumerable<CqlConcept> q_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)o_, p_);
-                    CqlValueSet r_ = this.Patient_Reason(context);
-                    CqlBoolean s_ = context.Operators.ConceptsInValueSet(q_, r_);
-                    return s_;
-                }
-
-
-                CqlBoolean m_() {
-                    List<CodeableConcept> u_ = NoACEIOrARBOrARNIOrdered?.ReasonCode;
-
-                    CqlConcept v_(CodeableConcept @this) {
-                        CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return z_;
-                    }
-
-                    IEnumerable<CqlConcept> w_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)u_, v_);
-                    CqlValueSet x_ = this.Patient_Reason_for_ACE_Inhibitor_or_ARB_Decline(context);
-                    CqlBoolean y_ = context.Operators.ConceptsInValueSet(w_, x_);
-                    return y_;
-                }
-
-                return k_
-                    /* CQL 'or' (113:15-114:70) */ || l_()
-                    /* CQL 'or' (113:13-116:9) */ || m_();
+            CqlConcept g_(CodeableConcept @this) {
+                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return v_;
             }
 
+            IEnumerable<CqlConcept> h_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)f_, g_);
+            CqlValueSet i_ = this.Medical_Reason(context);
+            CqlBoolean j_ = context.Operators.ConceptsInValueSet(h_, i_);
+
+            CqlConcept k_(CodeableConcept @this) {
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return w_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)f_, k_);
+            CqlValueSet m_ = this.Patient_Reason(context);
+            CqlBoolean n_ = context.Operators.ConceptsInValueSet(l_, m_);
+            CqlBoolean o_ = n_;
+
+            CqlConcept p_(CodeableConcept @this) {
+                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return x_;
+            }
+
+            IEnumerable<CqlConcept> q_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)f_, p_);
+            CqlValueSet r_ = this.Patient_Reason_for_ACE_Inhibitor_or_ARB_Decline(context);
+            CqlBoolean s_ = context.Operators.ConceptsInValueSet(q_, r_);
+            CqlBoolean t_ = s_;
+            CqlBoolean u_ = j_
+                /* CQL 'or' (113:15-114:70) */ || o_
+                /* CQL 'or' (113:13-116:9) */ || t_;
             return e_
-                /* CQL 'and' (112:7-116:9) */ && f_();
+                /* CQL 'and' (112:7-116:9) */ && u_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<MedicationRequest>(b_, c_);
@@ -371,103 +353,77 @@ public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISinglet
         IEnumerable<Condition> d_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, c_ as IEnumerable<Condition>);
 
         bool? e_(Condition PregnancyDiagnosis) {
-            IEnumerable<Encounter> h_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
+            IEnumerable<Encounter> k_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
-            bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyDiagnosis);
-                CqlDateTime l_ = context.Operators.Start(k_);
-                Period m_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+            bool? l_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyDiagnosis);
                 CqlDateTime o_ = context.Operators.Start(n_);
-                CqlQuantity p_ = context.Operators.Quantity(9m, "months");
-                CqlDateTime q_ = context.Operators.Subtract(o_, p_);
-                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(q_, o_, true, true);
-                CqlBoolean s_ = context.Operators.In<CqlDateTime>(l_, r_, (string)default);
-
-                CqlBoolean t_() {
-                    Period u_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    return w_ is not null;
-                }
-
-                return s_
-                    /* CQL 'and' (93:19-93:154) */ && t_()
+                Period p_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(t_, r_, true, true);
+                CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, (string)default);
+                CqlBoolean w_ = (CqlBoolean)(r_ is not null);
+                return v_
+                    /* CQL 'and' (93:19-93:154) */ && w_
                     /* CQL 'and' (93:19-94:47) */ && AHAOverall_4_1_000.Instance.isVerified(context, PregnancyDiagnosis);
             }
 
-            CqlBoolean j_ = context.Operators.WhereAny<Encounter>(h_, i_);
-            return j_;
+            CqlBoolean m_ = context.Operators.WhereAny<Encounter>(k_, l_);
+            return m_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Condition>(d_, e_);
+        IEnumerable<Observation> g_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancystatus"));
 
-        CqlBoolean g_() {
-            IEnumerable<Observation> x_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancystatus"));
+        bool? h_(Observation PregnantObservation) {
+            IEnumerable<Encounter> x_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
 
-            bool? y_(Observation PregnantObservation) {
-                IEnumerable<Encounter> aa_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
-
-                bool? ab_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
-                    DataType ad_ = PregnantObservation?.Effective;
-                    CqlDateTime ae_ = context.Operators.LateBoundProperty<CqlDateTime>(ad_, "value");
-                    CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
-                    CqlDateTime ag_ = context.Operators.Start(af_);
-                    Period ah_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                    CqlDateTime aj_ = context.Operators.Start(ai_);
-                    CqlQuantity ak_ = context.Operators.Quantity(9m, "months");
-                    CqlDateTime al_ = context.Operators.Subtract(aj_, ak_);
-                    CqlInterval<CqlDateTime> am_ = context.Operators.Interval(al_, aj_, true, true);
-                    CqlBoolean an_ = context.Operators.In<CqlDateTime>(ag_, am_, (string)default);
-
-                    CqlBoolean ao_() {
-                        Period aq_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                        CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aq_);
-                        CqlDateTime as_ = context.Operators.Start(ar_);
-                        return as_ is not null;
-                    }
-
-
-                    CqlBoolean ap_() {
-                        DataType at_ = PregnantObservation?.Value;
-                        CqlConcept au_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, at_ as CodeableConcept);
-                        CqlValueSet av_ = this.Pregnancy(context);
-                        CqlBoolean aw_ = context.Operators.ConceptInValueSet(au_, av_);
-
-                        CqlBoolean ax_() {
-                            Code<ObservationStatus> ay_ = PregnantObservation?.StatusElement;
-                            ObservationStatus? az_ = ay_?.Value;
-                            Code<ObservationStatus> ba_ = context.Operators.Convert<Code<ObservationStatus>>(az_);
-                            string bb_ = context.Operators.Convert<string>(ba_);
-                            string[] bc_ = [
-                                "final",
-                                "amended",
-                                "corrected",
-                            ];
-                            CqlBoolean bd_ = context.Operators.In<string>(bb_, (IEnumerable<string>)bc_);
-                            return bd_;
-                        }
-
-                        return aw_
-                            /* CQL 'and' (99:17-101:13) */ && ax_();
-                    }
-
-                    return an_
-                        /* CQL 'and' (98:21-98:159) */ && ao_()
-                        /* CQL 'and' (98:21-101:13) */ && ap_();
-                }
-
-                CqlBoolean ac_ = context.Operators.WhereAny<Encounter>(aa_, ab_);
-                return ac_;
+            bool? y_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) {
+                DataType aa_ = PregnantObservation?.Effective;
+                CqlDateTime ab_ = context.Operators.LateBoundProperty<CqlDateTime>(aa_, "value");
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                Period ae_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
+                CqlDateTime ag_ = context.Operators.Start(af_);
+                CqlQuantity ah_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime ai_ = context.Operators.Subtract(ag_, ah_);
+                CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ai_, ag_, true, true);
+                CqlBoolean ak_ = context.Operators.In<CqlDateTime>(ad_, aj_, (string)default);
+                CqlBoolean al_ = (CqlBoolean)(ag_ is not null);
+                DataType am_ = PregnantObservation?.Value;
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_ as CodeableConcept);
+                CqlValueSet ao_ = this.Pregnancy(context);
+                CqlBoolean ap_ = context.Operators.ConceptInValueSet(an_, ao_);
+                Code<ObservationStatus> aq_ = PregnantObservation?.StatusElement;
+                ObservationStatus? ar_ = aq_?.Value;
+                Code<ObservationStatus> as_ = context.Operators.Convert<Code<ObservationStatus>>(ar_);
+                string at_ = context.Operators.Convert<string>(as_);
+                string[] au_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+                CqlBoolean aw_ = av_;
+                CqlBoolean ax_ = ap_
+                    /* CQL 'and' (99:17-101:13) */ && aw_;
+                return ak_
+                    /* CQL 'and' (98:21-98:159) */ && al_
+                    /* CQL 'and' (98:21-101:13) */ && ax_;
             }
 
-            CqlBoolean z_ = context.Operators.WhereAny<Observation>(x_, y_);
+            CqlBoolean z_ = context.Operators.WhereAny<Encounter>(x_, y_);
             return z_;
         }
 
+        CqlBoolean i_ = context.Operators.WhereAny<Observation>(g_, h_);
+        CqlBoolean j_ = i_;
         return f_
-            /* CQL 'or' (90:3-102:5) */ || g_();
+            /* CQL 'or' (90:3-102:5) */ || j_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS136FHIRChildADHDMedFollowUp", "1.0.000")]
 public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISingleton<CMS136FHIRChildADHDMedFollowUp_1_0_000>
 {
@@ -245,17 +245,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> bq_ = context.Operators.Split((string)bp_, "/");
                 string br_ = context.Operators.Last<string>(bq_);
                 CqlBoolean bs_ = context.Operators.Equal(bo_, br_);
-
-                CqlBoolean bt_() {
-                    CodeableConcept bu_ = M?.Code;
-                    CqlConcept bv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bu_);
-                    CqlValueSet bw_ = this.Atomoxetine(context);
-                    CqlBoolean bx_ = context.Operators.ConceptInValueSet(bv_, bw_);
-                    return bx_;
-                }
-
+                CodeableConcept bt_ = M?.Code;
+                CqlConcept bu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bt_);
+                CqlValueSet bv_ = this.Atomoxetine(context);
+                CqlBoolean bw_ = context.Operators.ConceptInValueSet(bu_, bv_);
+                CqlBoolean bx_ = bw_;
                 return bs_
-                    /* CQL 'and' */ && bt_();
+                    /* CQL 'and' */ && bx_;
             }
 
             CqlBoolean bn_ = context.Operators.WhereAny<Medication>(bl_, bm_);
@@ -276,17 +272,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> cd_ = context.Operators.Split((string)cc_, "/");
                 string ce_ = context.Operators.Last<string>(cd_);
                 CqlBoolean cf_ = context.Operators.Equal(cb_, ce_);
-
-                CqlBoolean cg_() {
-                    CodeableConcept ch_ = M?.Code;
-                    CqlConcept ci_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ch_);
-                    CqlValueSet cj_ = this.Clonidine(context);
-                    CqlBoolean ck_ = context.Operators.ConceptInValueSet(ci_, cj_);
-                    return ck_;
-                }
-
+                CodeableConcept cg_ = M?.Code;
+                CqlConcept ch_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cg_);
+                CqlValueSet ci_ = this.Clonidine(context);
+                CqlBoolean cj_ = context.Operators.ConceptInValueSet(ch_, ci_);
+                CqlBoolean ck_ = cj_;
                 return cf_
-                    /* CQL 'and' */ && cg_();
+                    /* CQL 'and' */ && ck_;
             }
 
             CqlBoolean ca_ = context.Operators.WhereAny<Medication>(by_, bz_);
@@ -308,17 +300,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> cq_ = context.Operators.Split((string)cp_, "/");
                 string cr_ = context.Operators.Last<string>(cq_);
                 CqlBoolean cs_ = context.Operators.Equal(co_, cr_);
-
-                CqlBoolean ct_() {
-                    CodeableConcept cu_ = M?.Code;
-                    CqlConcept cv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cu_);
-                    CqlValueSet cw_ = this.Dexmethylphenidate(context);
-                    CqlBoolean cx_ = context.Operators.ConceptInValueSet(cv_, cw_);
-                    return cx_;
-                }
-
+                CodeableConcept ct_ = M?.Code;
+                CqlConcept cu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ct_);
+                CqlValueSet cv_ = this.Dexmethylphenidate(context);
+                CqlBoolean cw_ = context.Operators.ConceptInValueSet(cu_, cv_);
+                CqlBoolean cx_ = cw_;
                 return cs_
-                    /* CQL 'and' */ && ct_();
+                    /* CQL 'and' */ && cx_;
             }
 
             CqlBoolean cn_ = context.Operators.WhereAny<Medication>(cl_, cm_);
@@ -340,17 +328,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> dd_ = context.Operators.Split((string)dc_, "/");
                 string de_ = context.Operators.Last<string>(dd_);
                 CqlBoolean df_ = context.Operators.Equal(db_, de_);
-
-                CqlBoolean dg_() {
-                    CodeableConcept dh_ = M?.Code;
-                    CqlConcept di_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dh_);
-                    CqlValueSet dj_ = this.Dextroamphetamine(context);
-                    CqlBoolean dk_ = context.Operators.ConceptInValueSet(di_, dj_);
-                    return dk_;
-                }
-
+                CodeableConcept dg_ = M?.Code;
+                CqlConcept dh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dg_);
+                CqlValueSet di_ = this.Dextroamphetamine(context);
+                CqlBoolean dj_ = context.Operators.ConceptInValueSet(dh_, di_);
+                CqlBoolean dk_ = dj_;
                 return df_
-                    /* CQL 'and' */ && dg_();
+                    /* CQL 'and' */ && dk_;
             }
 
             CqlBoolean da_ = context.Operators.WhereAny<Medication>(cy_, cz_);
@@ -372,17 +356,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> dq_ = context.Operators.Split((string)dp_, "/");
                 string dr_ = context.Operators.Last<string>(dq_);
                 CqlBoolean ds_ = context.Operators.Equal(do_, dr_);
-
-                CqlBoolean dt_() {
-                    CodeableConcept du_ = M?.Code;
-                    CqlConcept dv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, du_);
-                    CqlValueSet dw_ = this.Lisdexamfetamine(context);
-                    CqlBoolean dx_ = context.Operators.ConceptInValueSet(dv_, dw_);
-                    return dx_;
-                }
-
+                CodeableConcept dt_ = M?.Code;
+                CqlConcept du_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dt_);
+                CqlValueSet dv_ = this.Lisdexamfetamine(context);
+                CqlBoolean dw_ = context.Operators.ConceptInValueSet(du_, dv_);
+                CqlBoolean dx_ = dw_;
                 return ds_
-                    /* CQL 'and' */ && dt_();
+                    /* CQL 'and' */ && dx_;
             }
 
             CqlBoolean dn_ = context.Operators.WhereAny<Medication>(dl_, dm_);
@@ -404,18 +384,14 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> ed_ = context.Operators.Split((string)ec_, "/");
                 string ee_ = context.Operators.Last<string>(ed_);
                 CqlBoolean ef_ = context.Operators.Equal(eb_, ee_);
-
-                CqlBoolean eg_() {
-                    CodeableConcept eh_ = M?.Code;
-                    CqlConcept ei_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eh_);
-                    CqlCode ej_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-                    CqlConcept ek_ = context.Operators.ConvertCodeToConcept(ej_);
-                    CqlBoolean el_ = context.Operators.Equivalent(ei_, ek_);
-                    return el_;
-                }
-
+                CodeableConcept eg_ = M?.Code;
+                CqlConcept eh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eg_);
+                CqlCode ei_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+                CqlConcept ej_ = context.Operators.ConvertCodeToConcept(ei_);
+                CqlBoolean ek_ = context.Operators.Equivalent(eh_, ej_);
+                CqlBoolean el_ = ek_;
                 return ef_
-                    /* CQL 'and' */ && eg_();
+                    /* CQL 'and' */ && el_;
             }
 
             CqlBoolean ea_ = context.Operators.WhereAny<Medication>(dy_, dz_);
@@ -438,17 +414,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> er_ = context.Operators.Split((string)eq_, "/");
                 string es_ = context.Operators.Last<string>(er_);
                 CqlBoolean et_ = context.Operators.Equal(ep_, es_);
-
-                CqlBoolean eu_() {
-                    CodeableConcept ev_ = M?.Code;
-                    CqlConcept ew_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ev_);
-                    CqlValueSet ex_ = this.Methylphenidate(context);
-                    CqlBoolean ey_ = context.Operators.ConceptInValueSet(ew_, ex_);
-                    return ey_;
-                }
-
+                CodeableConcept eu_ = M?.Code;
+                CqlConcept ev_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eu_);
+                CqlValueSet ew_ = this.Methylphenidate(context);
+                CqlBoolean ex_ = context.Operators.ConceptInValueSet(ev_, ew_);
+                CqlBoolean ey_ = ex_;
                 return et_
-                    /* CQL 'and' */ && eu_();
+                    /* CQL 'and' */ && ey_;
             }
 
             CqlBoolean eo_ = context.Operators.WhereAny<Medication>(em_, en_);
@@ -470,17 +442,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> fe_ = context.Operators.Split((string)fd_, "/");
                 string ff_ = context.Operators.Last<string>(fe_);
                 CqlBoolean fg_ = context.Operators.Equal(fc_, ff_);
-
-                CqlBoolean fh_() {
-                    CodeableConcept fi_ = M?.Code;
-                    CqlConcept fj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fi_);
-                    CqlValueSet fk_ = this.Guanfacine_Medications(context);
-                    CqlBoolean fl_ = context.Operators.ConceptInValueSet(fj_, fk_);
-                    return fl_;
-                }
-
+                CodeableConcept fh_ = M?.Code;
+                CqlConcept fi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fh_);
+                CqlValueSet fj_ = this.Guanfacine_Medications(context);
+                CqlBoolean fk_ = context.Operators.ConceptInValueSet(fi_, fj_);
+                CqlBoolean fl_ = fk_;
                 return fg_
-                    /* CQL 'and' */ && fh_();
+                    /* CQL 'and' */ && fl_;
             }
 
             CqlBoolean fb_ = context.Operators.WhereAny<Medication>(ez_, fa_);
@@ -502,17 +470,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> fr_ = context.Operators.Split((string)fq_, "/");
                 string fs_ = context.Operators.Last<string>(fr_);
                 CqlBoolean ft_ = context.Operators.Equal(fp_, fs_);
-
-                CqlBoolean fu_() {
-                    CodeableConcept fv_ = M?.Code;
-                    CqlConcept fw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fv_);
-                    CqlValueSet fx_ = this.Viloxazine(context);
-                    CqlBoolean fy_ = context.Operators.ConceptInValueSet(fw_, fx_);
-                    return fy_;
-                }
-
+                CodeableConcept fu_ = M?.Code;
+                CqlConcept fv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fu_);
+                CqlValueSet fw_ = this.Viloxazine(context);
+                CqlBoolean fx_ = context.Operators.ConceptInValueSet(fv_, fw_);
+                CqlBoolean fy_ = fx_;
                 return ft_
-                    /* CQL 'and' */ && fu_();
+                    /* CQL 'and' */ && fy_;
             }
 
             CqlBoolean fo_ = context.Operators.WhereAny<Medication>(fm_, fn_);
@@ -549,17 +513,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> ip_ = context.Operators.Split((string)io_, "/");
                     string iq_ = context.Operators.Last<string>(ip_);
                     CqlBoolean ir_ = context.Operators.Equal(in_, iq_);
-
-                    CqlBoolean is_() {
-                        CodeableConcept it_ = M?.Code;
-                        CqlConcept iu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, it_);
-                        CqlValueSet iv_ = this.Atomoxetine(context);
-                        CqlBoolean iw_ = context.Operators.ConceptInValueSet(iu_, iv_);
-                        return iw_;
-                    }
-
+                    CodeableConcept is_ = M?.Code;
+                    CqlConcept it_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, is_);
+                    CqlValueSet iu_ = this.Atomoxetine(context);
+                    CqlBoolean iv_ = context.Operators.ConceptInValueSet(it_, iu_);
+                    CqlBoolean iw_ = iv_;
                     return ir_
-                        /* CQL 'and' */ && is_();
+                        /* CQL 'and' */ && iw_;
                 }
 
                 CqlBoolean im_ = context.Operators.WhereAny<Medication>(ik_, il_);
@@ -580,17 +540,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> jc_ = context.Operators.Split((string)jb_, "/");
                     string jd_ = context.Operators.Last<string>(jc_);
                     CqlBoolean je_ = context.Operators.Equal(ja_, jd_);
-
-                    CqlBoolean jf_() {
-                        CodeableConcept jg_ = M?.Code;
-                        CqlConcept jh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jg_);
-                        CqlValueSet ji_ = this.Clonidine(context);
-                        CqlBoolean jj_ = context.Operators.ConceptInValueSet(jh_, ji_);
-                        return jj_;
-                    }
-
+                    CodeableConcept jf_ = M?.Code;
+                    CqlConcept jg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jf_);
+                    CqlValueSet jh_ = this.Clonidine(context);
+                    CqlBoolean ji_ = context.Operators.ConceptInValueSet(jg_, jh_);
+                    CqlBoolean jj_ = ji_;
                     return je_
-                        /* CQL 'and' */ && jf_();
+                        /* CQL 'and' */ && jj_;
                 }
 
                 CqlBoolean iz_ = context.Operators.WhereAny<Medication>(ix_, iy_);
@@ -612,17 +568,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> jp_ = context.Operators.Split((string)jo_, "/");
                     string jq_ = context.Operators.Last<string>(jp_);
                     CqlBoolean jr_ = context.Operators.Equal(jn_, jq_);
-
-                    CqlBoolean js_() {
-                        CodeableConcept jt_ = M?.Code;
-                        CqlConcept ju_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jt_);
-                        CqlValueSet jv_ = this.Dexmethylphenidate(context);
-                        CqlBoolean jw_ = context.Operators.ConceptInValueSet(ju_, jv_);
-                        return jw_;
-                    }
-
+                    CodeableConcept js_ = M?.Code;
+                    CqlConcept jt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, js_);
+                    CqlValueSet ju_ = this.Dexmethylphenidate(context);
+                    CqlBoolean jv_ = context.Operators.ConceptInValueSet(jt_, ju_);
+                    CqlBoolean jw_ = jv_;
                     return jr_
-                        /* CQL 'and' */ && js_();
+                        /* CQL 'and' */ && jw_;
                 }
 
                 CqlBoolean jm_ = context.Operators.WhereAny<Medication>(jk_, jl_);
@@ -644,17 +596,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> kc_ = context.Operators.Split((string)kb_, "/");
                     string kd_ = context.Operators.Last<string>(kc_);
                     CqlBoolean ke_ = context.Operators.Equal(ka_, kd_);
-
-                    CqlBoolean kf_() {
-                        CodeableConcept kg_ = M?.Code;
-                        CqlConcept kh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kg_);
-                        CqlValueSet ki_ = this.Dextroamphetamine(context);
-                        CqlBoolean kj_ = context.Operators.ConceptInValueSet(kh_, ki_);
-                        return kj_;
-                    }
-
+                    CodeableConcept kf_ = M?.Code;
+                    CqlConcept kg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kf_);
+                    CqlValueSet kh_ = this.Dextroamphetamine(context);
+                    CqlBoolean ki_ = context.Operators.ConceptInValueSet(kg_, kh_);
+                    CqlBoolean kj_ = ki_;
                     return ke_
-                        /* CQL 'and' */ && kf_();
+                        /* CQL 'and' */ && kj_;
                 }
 
                 CqlBoolean jz_ = context.Operators.WhereAny<Medication>(jx_, jy_);
@@ -676,17 +624,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> kp_ = context.Operators.Split((string)ko_, "/");
                     string kq_ = context.Operators.Last<string>(kp_);
                     CqlBoolean kr_ = context.Operators.Equal(kn_, kq_);
-
-                    CqlBoolean ks_() {
-                        CodeableConcept kt_ = M?.Code;
-                        CqlConcept ku_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kt_);
-                        CqlValueSet kv_ = this.Lisdexamfetamine(context);
-                        CqlBoolean kw_ = context.Operators.ConceptInValueSet(ku_, kv_);
-                        return kw_;
-                    }
-
+                    CodeableConcept ks_ = M?.Code;
+                    CqlConcept kt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ks_);
+                    CqlValueSet ku_ = this.Lisdexamfetamine(context);
+                    CqlBoolean kv_ = context.Operators.ConceptInValueSet(kt_, ku_);
+                    CqlBoolean kw_ = kv_;
                     return kr_
-                        /* CQL 'and' */ && ks_();
+                        /* CQL 'and' */ && kw_;
                 }
 
                 CqlBoolean km_ = context.Operators.WhereAny<Medication>(kk_, kl_);
@@ -708,18 +652,14 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> lc_ = context.Operators.Split((string)lb_, "/");
                     string ld_ = context.Operators.Last<string>(lc_);
                     CqlBoolean le_ = context.Operators.Equal(la_, ld_);
-
-                    CqlBoolean lf_() {
-                        CodeableConcept lg_ = M?.Code;
-                        CqlConcept lh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lg_);
-                        CqlCode li_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-                        CqlConcept lj_ = context.Operators.ConvertCodeToConcept(li_);
-                        CqlBoolean lk_ = context.Operators.Equivalent(lh_, lj_);
-                        return lk_;
-                    }
-
+                    CodeableConcept lf_ = M?.Code;
+                    CqlConcept lg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lf_);
+                    CqlCode lh_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+                    CqlConcept li_ = context.Operators.ConvertCodeToConcept(lh_);
+                    CqlBoolean lj_ = context.Operators.Equivalent(lg_, li_);
+                    CqlBoolean lk_ = lj_;
                     return le_
-                        /* CQL 'and' */ && lf_();
+                        /* CQL 'and' */ && lk_;
                 }
 
                 CqlBoolean kz_ = context.Operators.WhereAny<Medication>(kx_, ky_);
@@ -742,17 +682,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> lq_ = context.Operators.Split((string)lp_, "/");
                     string lr_ = context.Operators.Last<string>(lq_);
                     CqlBoolean ls_ = context.Operators.Equal(lo_, lr_);
-
-                    CqlBoolean lt_() {
-                        CodeableConcept lu_ = M?.Code;
-                        CqlConcept lv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lu_);
-                        CqlValueSet lw_ = this.Methylphenidate(context);
-                        CqlBoolean lx_ = context.Operators.ConceptInValueSet(lv_, lw_);
-                        return lx_;
-                    }
-
+                    CodeableConcept lt_ = M?.Code;
+                    CqlConcept lu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lt_);
+                    CqlValueSet lv_ = this.Methylphenidate(context);
+                    CqlBoolean lw_ = context.Operators.ConceptInValueSet(lu_, lv_);
+                    CqlBoolean lx_ = lw_;
                     return ls_
-                        /* CQL 'and' */ && lt_();
+                        /* CQL 'and' */ && lx_;
                 }
 
                 CqlBoolean ln_ = context.Operators.WhereAny<Medication>(ll_, lm_);
@@ -774,17 +710,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> md_ = context.Operators.Split((string)mc_, "/");
                     string me_ = context.Operators.Last<string>(md_);
                     CqlBoolean mf_ = context.Operators.Equal(mb_, me_);
-
-                    CqlBoolean mg_() {
-                        CodeableConcept mh_ = M?.Code;
-                        CqlConcept mi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mh_);
-                        CqlValueSet mj_ = this.Guanfacine_Medications(context);
-                        CqlBoolean mk_ = context.Operators.ConceptInValueSet(mi_, mj_);
-                        return mk_;
-                    }
-
+                    CodeableConcept mg_ = M?.Code;
+                    CqlConcept mh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mg_);
+                    CqlValueSet mi_ = this.Guanfacine_Medications(context);
+                    CqlBoolean mj_ = context.Operators.ConceptInValueSet(mh_, mi_);
+                    CqlBoolean mk_ = mj_;
                     return mf_
-                        /* CQL 'and' */ && mg_();
+                        /* CQL 'and' */ && mk_;
                 }
 
                 CqlBoolean ma_ = context.Operators.WhereAny<Medication>(ly_, lz_);
@@ -806,17 +738,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> mq_ = context.Operators.Split((string)mp_, "/");
                     string mr_ = context.Operators.Last<string>(mq_);
                     CqlBoolean ms_ = context.Operators.Equal(mo_, mr_);
-
-                    CqlBoolean mt_() {
-                        CodeableConcept mu_ = M?.Code;
-                        CqlConcept mv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mu_);
-                        CqlValueSet mw_ = this.Viloxazine(context);
-                        CqlBoolean mx_ = context.Operators.ConceptInValueSet(mv_, mw_);
-                        return mx_;
-                    }
-
+                    CodeableConcept mt_ = M?.Code;
+                    CqlConcept mu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mt_);
+                    CqlValueSet mv_ = this.Viloxazine(context);
+                    CqlBoolean mw_ = context.Operators.ConceptInValueSet(mu_, mv_);
+                    CqlBoolean mx_ = mw_;
                     return ms_
-                        /* CQL 'and' */ && mt_();
+                        /* CQL 'and' */ && mx_;
                 }
 
                 CqlBoolean mn_ = context.Operators.WhereAny<Medication>(ml_, mm_);
@@ -1014,39 +942,22 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 6);
-
-        CqlBoolean j_() {
-            Patient m_ = this.Patient(context);
-            Date n_ = m_?.BirthDateElement;
-            string o_ = n_?.Value;
-            CqlDate p_ = context.Operators.ConvertStringToDate(o_);
-            CqlInterval<CqlDateTime> q_ = this.Intake_Period(context);
-            CqlDateTime r_ = context.Operators.End(q_);
-            CqlDate s_ = context.Operators.DateFrom(r_);
-            int? t_ = context.Operators.CalculateAgeAt(p_, s_, "year");
-            CqlBoolean u_ = context.Operators.LessOrEqual(t_, 12);
-            return u_;
-        }
-
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> v_ = this.Qualifying_Encounter(context);
-            CqlBoolean w_ = context.Operators.Exists<Encounter>(v_);
-            return w_;
-        }
-
-
-        CqlBoolean l_() {
-            IEnumerable<Encounter> x_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase(context);
-            CqlBoolean y_ = context.Operators.Exists<Encounter>(x_);
-            return !y_;
-        }
-
+        CqlDateTime j_ = context.Operators.End(e_);
+        CqlDate k_ = context.Operators.DateFrom(j_);
+        int? l_ = context.Operators.CalculateAgeAt(d_, k_, "year");
+        CqlBoolean m_ = context.Operators.LessOrEqual(l_, 12);
+        CqlBoolean n_ = m_;
+        IEnumerable<Encounter> o_ = this.Qualifying_Encounter(context);
+        CqlBoolean p_ = context.Operators.Exists<Encounter>(o_);
+        CqlBoolean q_ = p_;
+        IEnumerable<Encounter> r_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase(context);
+        CqlBoolean s_ = context.Operators.Exists<Encounter>(r_);
+        CqlBoolean t_ = (CqlBoolean)!s_;
         return i_
-            /* CQL 'and' (49:3-52:11) */ && j_()
-            /* CQL 'and' (49:3-53:37) */ && k_()
+            /* CQL 'and' (49:3-52:11) */ && n_
+            /* CQL 'and' (49:3-53:37) */ && q_
             /* CQL 'and' (49:3-54:75) */ && ((this.First_ADHD_Medication_Prescribed_During_Intake_Period(context)) is not null)
-            /* CQL 'and' (49:3-55:85) */ && l_();
+            /* CQL 'and' (49:3-55:85) */ && t_;
     }
 
 
@@ -1100,15 +1011,11 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Condition> c_ = this.Narcolepsy_Exclusion(context);
-            CqlBoolean d_ = context.Operators.Exists<Condition>(c_);
-            return d_;
-        }
-
+        IEnumerable<Condition> b_ = this.Narcolepsy_Exclusion(context);
+        CqlBoolean c_ = context.Operators.Exists<Condition>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'or' (123:3-124:36) */ || b_();
+            /* CQL 'or' (123:3-124:36) */ || d_;
     }
 
 
@@ -1247,17 +1154,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> en_ = context.Operators.Split((string)em_, "/");
                 string eo_ = context.Operators.Last<string>(en_);
                 CqlBoolean ep_ = context.Operators.Equal(el_, eo_);
-
-                CqlBoolean eq_() {
-                    CodeableConcept er_ = M?.Code;
-                    CqlConcept es_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, er_);
-                    CqlValueSet et_ = this.Atomoxetine(context);
-                    CqlBoolean eu_ = context.Operators.ConceptInValueSet(es_, et_);
-                    return eu_;
-                }
-
+                CodeableConcept eq_ = M?.Code;
+                CqlConcept er_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eq_);
+                CqlValueSet es_ = this.Atomoxetine(context);
+                CqlBoolean et_ = context.Operators.ConceptInValueSet(er_, es_);
+                CqlBoolean eu_ = et_;
                 return ep_
-                    /* CQL 'and' */ && eq_();
+                    /* CQL 'and' */ && eu_;
             }
 
             CqlBoolean ek_ = context.Operators.WhereAny<Medication>(ei_, ej_);
@@ -1309,17 +1212,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> fg_ = context.Operators.Split((string)ff_, "/");
                 string fh_ = context.Operators.Last<string>(fg_);
                 CqlBoolean fi_ = context.Operators.Equal(fe_, fh_);
-
-                CqlBoolean fj_() {
-                    CodeableConcept fk_ = M?.Code;
-                    CqlConcept fl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fk_);
-                    CqlValueSet fm_ = this.Clonidine(context);
-                    CqlBoolean fn_ = context.Operators.ConceptInValueSet(fl_, fm_);
-                    return fn_;
-                }
-
+                CodeableConcept fj_ = M?.Code;
+                CqlConcept fk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fj_);
+                CqlValueSet fl_ = this.Clonidine(context);
+                CqlBoolean fm_ = context.Operators.ConceptInValueSet(fk_, fl_);
+                CqlBoolean fn_ = fm_;
                 return fi_
-                    /* CQL 'and' */ && fj_();
+                    /* CQL 'and' */ && fn_;
             }
 
             CqlBoolean fd_ = context.Operators.WhereAny<Medication>(fb_, fc_);
@@ -1372,17 +1271,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> fz_ = context.Operators.Split((string)fy_, "/");
                 string ga_ = context.Operators.Last<string>(fz_);
                 CqlBoolean gb_ = context.Operators.Equal(fx_, ga_);
-
-                CqlBoolean gc_() {
-                    CodeableConcept gd_ = M?.Code;
-                    CqlConcept ge_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gd_);
-                    CqlValueSet gf_ = this.Dexmethylphenidate(context);
-                    CqlBoolean gg_ = context.Operators.ConceptInValueSet(ge_, gf_);
-                    return gg_;
-                }
-
+                CodeableConcept gc_ = M?.Code;
+                CqlConcept gd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gc_);
+                CqlValueSet ge_ = this.Dexmethylphenidate(context);
+                CqlBoolean gf_ = context.Operators.ConceptInValueSet(gd_, ge_);
+                CqlBoolean gg_ = gf_;
                 return gb_
-                    /* CQL 'and' */ && gc_();
+                    /* CQL 'and' */ && gg_;
             }
 
             CqlBoolean fw_ = context.Operators.WhereAny<Medication>(fu_, fv_);
@@ -1434,17 +1329,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> gs_ = context.Operators.Split((string)gr_, "/");
                 string gt_ = context.Operators.Last<string>(gs_);
                 CqlBoolean gu_ = context.Operators.Equal(gq_, gt_);
-
-                CqlBoolean gv_() {
-                    CodeableConcept gw_ = M?.Code;
-                    CqlConcept gx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gw_);
-                    CqlValueSet gy_ = this.Dextroamphetamine(context);
-                    CqlBoolean gz_ = context.Operators.ConceptInValueSet(gx_, gy_);
-                    return gz_;
-                }
-
+                CodeableConcept gv_ = M?.Code;
+                CqlConcept gw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gv_);
+                CqlValueSet gx_ = this.Dextroamphetamine(context);
+                CqlBoolean gy_ = context.Operators.ConceptInValueSet(gw_, gx_);
+                CqlBoolean gz_ = gy_;
                 return gu_
-                    /* CQL 'and' */ && gv_();
+                    /* CQL 'and' */ && gz_;
             }
 
             CqlBoolean gp_ = context.Operators.WhereAny<Medication>(gn_, go_);
@@ -1498,17 +1389,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> hl_ = context.Operators.Split((string)hk_, "/");
                 string hm_ = context.Operators.Last<string>(hl_);
                 CqlBoolean hn_ = context.Operators.Equal(hj_, hm_);
-
-                CqlBoolean ho_() {
-                    CodeableConcept hp_ = M?.Code;
-                    CqlConcept hq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hp_);
-                    CqlValueSet hr_ = this.Lisdexamfetamine(context);
-                    CqlBoolean hs_ = context.Operators.ConceptInValueSet(hq_, hr_);
-                    return hs_;
-                }
-
+                CodeableConcept ho_ = M?.Code;
+                CqlConcept hp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ho_);
+                CqlValueSet hq_ = this.Lisdexamfetamine(context);
+                CqlBoolean hr_ = context.Operators.ConceptInValueSet(hp_, hq_);
+                CqlBoolean hs_ = hr_;
                 return hn_
-                    /* CQL 'and' */ && ho_();
+                    /* CQL 'and' */ && hs_;
             }
 
             CqlBoolean hi_ = context.Operators.WhereAny<Medication>(hg_, hh_);
@@ -1560,17 +1447,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> ie_ = context.Operators.Split((string)id_, "/");
                 string if_ = context.Operators.Last<string>(ie_);
                 CqlBoolean ig_ = context.Operators.Equal(ic_, if_);
-
-                CqlBoolean ih_() {
-                    CodeableConcept ii_ = M?.Code;
-                    CqlConcept ij_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ii_);
-                    CqlValueSet ik_ = this.Methylphenidate(context);
-                    CqlBoolean il_ = context.Operators.ConceptInValueSet(ij_, ik_);
-                    return il_;
-                }
-
+                CodeableConcept ih_ = M?.Code;
+                CqlConcept ii_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ih_);
+                CqlValueSet ij_ = this.Methylphenidate(context);
+                CqlBoolean ik_ = context.Operators.ConceptInValueSet(ii_, ij_);
+                CqlBoolean il_ = ik_;
                 return ig_
-                    /* CQL 'and' */ && ih_();
+                    /* CQL 'and' */ && il_;
             }
 
             CqlBoolean ib_ = context.Operators.WhereAny<Medication>(hz_, ia_);
@@ -1624,17 +1507,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> ix_ = context.Operators.Split((string)iw_, "/");
                 string iy_ = context.Operators.Last<string>(ix_);
                 CqlBoolean iz_ = context.Operators.Equal(iv_, iy_);
-
-                CqlBoolean ja_() {
-                    CodeableConcept jb_ = M?.Code;
-                    CqlConcept jc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jb_);
-                    CqlValueSet jd_ = this.Guanfacine_Medications(context);
-                    CqlBoolean je_ = context.Operators.ConceptInValueSet(jc_, jd_);
-                    return je_;
-                }
-
+                CodeableConcept ja_ = M?.Code;
+                CqlConcept jb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ja_);
+                CqlValueSet jc_ = this.Guanfacine_Medications(context);
+                CqlBoolean jd_ = context.Operators.ConceptInValueSet(jb_, jc_);
+                CqlBoolean je_ = jd_;
                 return iz_
-                    /* CQL 'and' */ && ja_();
+                    /* CQL 'and' */ && je_;
             }
 
             CqlBoolean iu_ = context.Operators.WhereAny<Medication>(is_, it_);
@@ -1686,18 +1565,14 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> jq_ = context.Operators.Split((string)jp_, "/");
                 string jr_ = context.Operators.Last<string>(jq_);
                 CqlBoolean js_ = context.Operators.Equal(jo_, jr_);
-
-                CqlBoolean jt_() {
-                    CodeableConcept ju_ = M?.Code;
-                    CqlConcept jv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ju_);
-                    CqlCode jw_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
-                    CqlConcept jx_ = context.Operators.ConvertCodeToConcept(jw_);
-                    CqlBoolean jy_ = context.Operators.Equivalent(jv_, jx_);
-                    return jy_;
-                }
-
+                CodeableConcept jt_ = M?.Code;
+                CqlConcept ju_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jt_);
+                CqlCode jv_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet(context);
+                CqlConcept jw_ = context.Operators.ConvertCodeToConcept(jv_);
+                CqlBoolean jx_ = context.Operators.Equivalent(ju_, jw_);
+                CqlBoolean jy_ = jx_;
                 return js_
-                    /* CQL 'and' */ && jt_();
+                    /* CQL 'and' */ && jy_;
             }
 
             CqlBoolean jn_ = context.Operators.WhereAny<Medication>(jl_, jm_);
@@ -1752,17 +1627,13 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> kk_ = context.Operators.Split((string)kj_, "/");
                 string kl_ = context.Operators.Last<string>(kk_);
                 CqlBoolean km_ = context.Operators.Equal(ki_, kl_);
-
-                CqlBoolean kn_() {
-                    CodeableConcept ko_ = M?.Code;
-                    CqlConcept kp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ko_);
-                    CqlValueSet kq_ = this.Viloxazine(context);
-                    CqlBoolean kr_ = context.Operators.ConceptInValueSet(kp_, kq_);
-                    return kr_;
-                }
-
+                CodeableConcept kn_ = M?.Code;
+                CqlConcept ko_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kn_);
+                CqlValueSet kp_ = this.Viloxazine(context);
+                CqlBoolean kq_ = context.Operators.ConceptInValueSet(ko_, kp_);
+                CqlBoolean kr_ = kq_;
                 return km_
-                    /* CQL 'and' */ && kn_();
+                    /* CQL 'and' */ && kr_;
             }
 
             CqlBoolean kh_ = context.Operators.WhereAny<Medication>(kf_, kg_);
@@ -1894,40 +1765,23 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 6);
-
-        CqlBoolean j_() {
-            Patient m_ = this.Patient(context);
-            Date n_ = m_?.BirthDateElement;
-            string o_ = n_?.Value;
-            CqlDate p_ = context.Operators.ConvertStringToDate(o_);
-            CqlInterval<CqlDateTime> q_ = this.Intake_Period(context);
-            CqlDateTime r_ = context.Operators.End(q_);
-            CqlDate s_ = context.Operators.DateFrom(r_);
-            int? t_ = context.Operators.CalculateAgeAt(p_, s_, "year");
-            CqlBoolean u_ = context.Operators.LessOrEqual(t_, 12);
-            return u_;
-        }
-
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> v_ = this.Qualifying_Encounter(context);
-            CqlBoolean w_ = context.Operators.Exists<Encounter>(v_);
-            return w_;
-        }
-
-
-        CqlBoolean l_() {
-            IEnumerable<Encounter> x_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase(context);
-            CqlBoolean y_ = context.Operators.Exists<Encounter>(x_);
-            return !y_;
-        }
-
+        CqlDateTime j_ = context.Operators.End(e_);
+        CqlDate k_ = context.Operators.DateFrom(j_);
+        int? l_ = context.Operators.CalculateAgeAt(d_, k_, "year");
+        CqlBoolean m_ = context.Operators.LessOrEqual(l_, 12);
+        CqlBoolean n_ = m_;
+        IEnumerable<Encounter> o_ = this.Qualifying_Encounter(context);
+        CqlBoolean p_ = context.Operators.Exists<Encounter>(o_);
+        CqlBoolean q_ = p_;
+        IEnumerable<Encounter> r_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase(context);
+        CqlBoolean s_ = context.Operators.Exists<Encounter>(r_);
+        CqlBoolean t_ = (CqlBoolean)!s_;
         return i_
-            /* CQL 'and' (158:3-161:11) */ && j_()
-            /* CQL 'and' (158:3-162:37) */ && k_()
+            /* CQL 'and' (158:3-161:11) */ && n_
+            /* CQL 'and' (158:3-162:37) */ && q_
             /* CQL 'and' (158:3-163:75) */ && ((this.First_ADHD_Medication_Prescribed_During_Intake_Period(context)) is not null)
             /* CQL 'and' (158:3-164:83) */ && this.Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days(context)
-            /* CQL 'and' (158:3-165:103) */ && l_();
+            /* CQL 'and' (158:3-165:103) */ && t_;
     }
 
 
@@ -2052,32 +1906,24 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<Encounter> a_ = this.Encounter_During_Initiation_Phase(context);
         CqlBoolean b_ = context.Operators.Exists<Encounter>(a_);
+        CqlBoolean c_ = this.Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
+        IEnumerable<CqlDate> d_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
 
-        CqlBoolean c_() {
-            CqlBoolean d_ = this.Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
-
-            CqlBoolean e_() {
-                IEnumerable<CqlDate> f_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
-
-                bool? g_(CqlDate Encounter1) {
-                    IEnumerable<CqlDate> i_ = this.Virtual_Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
-                    bool? j_(CqlDate Encounter2) => (CqlBoolean)(Encounter1 is not null)
-                        /* CQL 'and' (271:25-272:42) */ && (Encounter2 is not null)
-                        /* CQL 'and' (271:25-273:44) */ && !(context.Operators.Equivalent(Encounter1, Encounter2));
-                    CqlBoolean k_ = context.Operators.WhereAny<CqlDate>(i_, j_);
-                    return k_;
-                }
-
-                CqlBoolean h_ = context.Operators.WhereAny<CqlDate>(f_, g_);
-                return h_;
-            }
-
-            return d_
-                /* CQL 'or' (268:9-275:5) */ || e_();
+        bool? e_(CqlDate Encounter1) {
+            IEnumerable<CqlDate> i_ = this.Virtual_Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase(context);
+            bool? j_(CqlDate Encounter2) => (CqlBoolean)(Encounter1 is not null)
+                /* CQL 'and' (271:25-272:42) */ && (Encounter2 is not null)
+                /* CQL 'and' (271:25-273:44) */ && !(context.Operators.Equivalent(Encounter1, Encounter2));
+            CqlBoolean k_ = context.Operators.WhereAny<CqlDate>(i_, j_);
+            return k_;
         }
 
+        CqlBoolean f_ = context.Operators.WhereAny<CqlDate>(d_, e_);
+        CqlBoolean g_ = f_;
+        CqlBoolean h_ = c_
+            /* CQL 'or' (268:9-275:5) */ || g_;
         return b_
-            /* CQL 'and' (267:3-275:5) */ && c_();
+            /* CQL 'and' (267:3-275:5) */ && h_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS137FHIRSUDTxInitEngagement", "1.0.000")]
 public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleton<CMS137FHIRSUDTxInitEngagement_1_0_000>
 {
@@ -174,31 +174,18 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 Period r_ = ValidEncounters?.Period;
                 CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
                 CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, (string)default);
-
-                CqlBoolean u_() {
-                    CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SUDDiagnosis);
-                    CqlDateTime x_ = context.Operators.Start(w_);
-                    Period y_ = ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlBoolean aa_ = context.Operators.In<CqlDateTime>(x_, z_, (string)default);
-                    return aa_;
-                }
-
-
-                CqlBoolean v_() {
-                    CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SUDDiagnosis);
-                    CqlDateTime ac_ = context.Operators.Start(ab_);
-                    CqlInterval<CqlDateTime> ad_ = this.Measurement_Period(context);
-                    CqlDateTime ae_ = context.Operators.End(ad_);
-                    CqlQuantity af_ = context.Operators.Quantity(47m, "days");
-                    CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
-                    CqlBoolean ah_ = context.Operators.SameOrBefore(ac_, ag_, "day");
-                    return ah_;
-                }
-
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SUDDiagnosis);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlBoolean w_ = context.Operators.In<CqlDateTime>(v_, s_, (string)default);
+                CqlBoolean x_ = w_;
+                CqlDateTime y_ = context.Operators.End(q_);
+                CqlQuantity z_ = context.Operators.Quantity(47m, "days");
+                CqlDateTime aa_ = context.Operators.Subtract(y_, z_);
+                CqlBoolean ab_ = context.Operators.SameOrBefore(v_, aa_, "day");
+                CqlBoolean ac_ = ab_;
                 return t_
-                    /* CQL 'and' (41:19-42:84) */ && u_()
-                    /* CQL 'and' (41:19-44:37) */ && v_();
+                    /* CQL 'and' (41:19-42:84) */ && x_
+                    /* CQL 'and' (41:19-44:37) */ && ac_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Condition>(n_, o_);
@@ -207,20 +194,20 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
 
 
         (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? c_(Encounter ValidEncounters) {
-            Period ai_ = ValidEncounters?.Period;
-            CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
-            CqlDateTime ak_ = context.Operators.Start(aj_);
-            CqlDate al_ = context.Operators.DateFrom(ak_);
-            (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? am_ = (CqlTupleMetadata_GYLjjJGJTORTXhCHiKcLEBBaJ, al_, ValidEncounters);
-            return am_;
+            Period ad_ = ValidEncounters?.Period;
+            CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
+            CqlDateTime af_ = context.Operators.Start(ae_);
+            CqlDate ag_ = context.Operators.DateFrom(af_);
+            (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? ah_ = (CqlTupleMetadata_GYLjjJGJTORTXhCHiKcLEBBaJ, ag_, ValidEncounters);
+            return ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?> d_ = context.Operators.WhereSelect<Encounter, (CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?>(a_, b_, c_);
         IEnumerable<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?> e_ = context.Operators.Distinct<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?>(d_);
 
         object f_((CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)? @this) {
-            CqlDate an_ = @this?.ValidEncounterDate;
-            return an_;
+            CqlDate ai_ = @this?.ValidEncounterDate;
+            return ai_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?> g_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDate ValidEncounterDate, Encounter ValidEncounter)?>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
@@ -324,17 +311,9 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(aw_);
                 CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(az_, ba_, true, false);
                 CqlBoolean bc_ = context.Operators.In<CqlDateTime>(as_, bb_, "day");
-
-                CqlBoolean bd_() {
-                    Period bk_ = FirstSUDEpisode?.Period;
-                    CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
-                    CqlDateTime bm_ = context.Operators.Start(bl_);
-                    CqlDate bn_ = context.Operators.DateFrom(bm_);
-                    return bn_ is not null;
-                }
-
+                CqlBoolean bd_ = (CqlBoolean)(aw_ is not null);
                 return bc_
-                    /* CQL 'and' (70:19-70:135) */ && bd_();
+                    /* CQL 'and' (70:19-70:135) */ && bd_;
             }
 
             CqlBoolean ap_ = context.Operators.WhereAny<Encounter>((IEnumerable<Encounter>)an_, ao_);
@@ -347,64 +326,56 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<Encounter> q_ = context.Operators.Except<Encounter>(o_, p_);
 
         bool? r_(Encounter QualifyingEncounter) {
-            IEnumerable<Condition> bo_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
+            IEnumerable<Condition> bk_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
 
-            bool? bp_(Condition @this) {
-                CodeableConcept bu_ = @this?.Code;
-                CqlConcept bv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bu_);
-                return bv_ is not null;
+            bool? bl_(Condition @this) {
+                CodeableConcept bq_ = @this?.Code;
+                CqlConcept br_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bq_);
+                return br_ is not null;
             }
 
 
-            CqlConcept bq_(Condition @this) {
-                CodeableConcept bw_ = @this?.Code;
-                CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
-                return bx_;
+            CqlConcept bm_(Condition @this) {
+                CodeableConcept bs_ = @this?.Code;
+                CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bs_);
+                return bt_;
             }
 
-            IEnumerable<CqlConcept> br_ = context.Operators.WhereSelect<Condition, CqlConcept>(bo_, bp_, bq_);
-            CqlValueSet bs_ = this.Substance_Use_Disorder(context);
-            CqlBoolean bt_ = context.Operators.ConceptsInValueSet(br_, bs_);
-            return bt_;
+            IEnumerable<CqlConcept> bn_ = context.Operators.WhereSelect<Condition, CqlConcept>(bk_, bl_, bm_);
+            CqlValueSet bo_ = this.Substance_Use_Disorder(context);
+            CqlBoolean bp_ = context.Operators.ConceptsInValueSet(bn_, bo_);
+            return bp_;
         }
 
         IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
 
         bool? t_(Encounter SUDEncounterDx) {
-            Encounter by_ = this.First_SUD_Episode_During_Measurement_Period(context);
-            Encounter[] bz_ = [
-                by_,
+            Encounter bu_ = this.First_SUD_Episode_During_Measurement_Period(context);
+            Encounter[] bv_ = [
+                bu_,
             ];
 
-            bool? ca_(Encounter FirstSUDEpisode) {
-                Period cc_ = SUDEncounterDx?.Period;
-                CqlInterval<CqlDateTime> cd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cc_);
-                CqlDateTime ce_ = context.Operators.Start(cd_);
-                Period cf_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> cg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cf_);
-                CqlDateTime ch_ = context.Operators.Start(cg_);
-                CqlDate ci_ = context.Operators.DateFrom(ch_);
-                CqlQuantity cj_ = context.Operators.Quantity(60m, "days");
-                CqlDate ck_ = context.Operators.Subtract(ci_, cj_);
-                CqlDateTime cl_ = context.Operators.ConvertDateToDateTime(ck_);
-                CqlDateTime cm_ = context.Operators.ConvertDateToDateTime(ci_);
-                CqlInterval<CqlDateTime> cn_ = context.Operators.Interval(cl_, cm_, true, false);
-                CqlBoolean co_ = context.Operators.In<CqlDateTime>(ce_, cn_, "day");
-
-                CqlBoolean cp_() {
-                    Period cq_ = FirstSUDEpisode?.Period;
-                    CqlInterval<CqlDateTime> cr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
-                    CqlDateTime cs_ = context.Operators.Start(cr_);
-                    CqlDate ct_ = context.Operators.DateFrom(cs_);
-                    return ct_ is not null;
-                }
-
-                return co_
-                    /* CQL 'and' (76:21-76:120) */ && cp_();
+            bool? bw_(Encounter FirstSUDEpisode) {
+                Period by_ = SUDEncounterDx?.Period;
+                CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, by_);
+                CqlDateTime ca_ = context.Operators.Start(bz_);
+                Period cb_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cb_);
+                CqlDateTime cd_ = context.Operators.Start(cc_);
+                CqlDate ce_ = context.Operators.DateFrom(cd_);
+                CqlQuantity cf_ = context.Operators.Quantity(60m, "days");
+                CqlDate cg_ = context.Operators.Subtract(ce_, cf_);
+                CqlDateTime ch_ = context.Operators.ConvertDateToDateTime(cg_);
+                CqlDateTime ci_ = context.Operators.ConvertDateToDateTime(ce_);
+                CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(ch_, ci_, true, false);
+                CqlBoolean ck_ = context.Operators.In<CqlDateTime>(ca_, cj_, "day");
+                CqlBoolean cl_ = (CqlBoolean)(ce_ is not null);
+                return ck_
+                    /* CQL 'and' (76:21-76:120) */ && cl_;
             }
 
-            CqlBoolean cb_ = context.Operators.WhereAny<Encounter>((IEnumerable<Encounter>)bz_, ca_);
-            return cb_;
+            CqlBoolean bx_ = context.Operators.WhereAny<Encounter>((IEnumerable<Encounter>)bv_, bw_);
+            return bx_;
         }
 
         IEnumerable<Encounter> u_ = context.Operators.Where<Encounter>(s_, t_);
@@ -412,29 +383,25 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> w_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
         bool? x_(MedicationRequest MR) {
-            IEnumerable<Medication> cu_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            IEnumerable<Medication> cm_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? cv_(Medication M) {
-                object cx_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object cy_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> cz_ = context.Operators.Split((string)cy_, "/");
-                string da_ = context.Operators.Last<string>(cz_);
-                CqlBoolean db_ = context.Operators.Equal(cx_, da_);
-
-                CqlBoolean dc_() {
-                    CodeableConcept dd_ = M?.Code;
-                    CqlConcept de_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dd_);
-                    CqlValueSet df_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
-                    CqlBoolean dg_ = context.Operators.ConceptInValueSet(de_, df_);
-                    return dg_;
-                }
-
-                return db_
-                    /* CQL 'and' */ && dc_();
+            bool? cn_(Medication M) {
+                object cp_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object cq_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> cr_ = context.Operators.Split((string)cq_, "/");
+                string cs_ = context.Operators.Last<string>(cr_);
+                CqlBoolean ct_ = context.Operators.Equal(cp_, cs_);
+                CodeableConcept cu_ = M?.Code;
+                CqlConcept cv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cu_);
+                CqlValueSet cw_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
+                CqlBoolean cx_ = context.Operators.ConceptInValueSet(cv_, cw_);
+                CqlBoolean cy_ = cx_;
+                return ct_
+                    /* CQL 'and' */ && cy_;
             }
 
-            CqlBoolean cw_ = context.Operators.WhereAny<Medication>(cu_, cv_);
-            return cw_;
+            CqlBoolean co_ = context.Operators.WhereAny<Medication>(cm_, cn_);
+            return co_;
         }
 
         IEnumerable<MedicationRequest> y_ = context.Operators.Where<MedicationRequest>(w_, x_);
@@ -443,29 +410,25 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> ab_ = context.Operators.Union<MedicationRequest>(y_, aa_);
 
         bool? ac_(MedicationRequest MR) {
-            IEnumerable<Medication> dh_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            IEnumerable<Medication> cz_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? di_(Medication M) {
-                object dk_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object dl_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> dm_ = context.Operators.Split((string)dl_, "/");
-                string dn_ = context.Operators.Last<string>(dm_);
-                CqlBoolean do_ = context.Operators.Equal(dk_, dn_);
-
-                CqlBoolean dp_() {
-                    CodeableConcept dq_ = M?.Code;
-                    CqlConcept dr_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dq_);
-                    CqlValueSet ds_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
-                    CqlBoolean dt_ = context.Operators.ConceptInValueSet(dr_, ds_);
-                    return dt_;
-                }
-
-                return do_
-                    /* CQL 'and' */ && dp_();
+            bool? da_(Medication M) {
+                object dc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object dd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> de_ = context.Operators.Split((string)dd_, "/");
+                string df_ = context.Operators.Last<string>(de_);
+                CqlBoolean dg_ = context.Operators.Equal(dc_, df_);
+                CodeableConcept dh_ = M?.Code;
+                CqlConcept di_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dh_);
+                CqlValueSet dj_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
+                CqlBoolean dk_ = context.Operators.ConceptInValueSet(di_, dj_);
+                CqlBoolean dl_ = dk_;
+                return dg_
+                    /* CQL 'and' */ && dl_;
             }
 
-            CqlBoolean dj_ = context.Operators.WhereAny<Medication>(dh_, di_);
-            return dj_;
+            CqlBoolean db_ = context.Operators.WhereAny<Medication>(cz_, da_);
+            return db_;
         }
 
         IEnumerable<MedicationRequest> ad_ = context.Operators.Where<MedicationRequest>(w_, ac_);
@@ -476,39 +439,31 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> ai_ = Status_1_15_000.Instance.isMedicationOrder(context, ah_);
 
         bool? aj_(MedicationRequest SUDMedication) {
-            Encounter du_ = this.First_SUD_Episode_During_Measurement_Period(context);
-            Encounter[] dv_ = [
-                du_,
+            Encounter dm_ = this.First_SUD_Episode_During_Measurement_Period(context);
+            Encounter[] dn_ = [
+                dm_,
             ];
 
-            bool? dw_(Encounter FirstSUDEpisode) {
-                FhirDateTime dy_ = SUDMedication?.AuthoredOnElement;
-                CqlDateTime dz_ = context.Operators.Convert<CqlDateTime>(dy_);
-                Period ea_ = FirstSUDEpisode?.Period;
-                CqlInterval<CqlDateTime> eb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ea_);
-                CqlDateTime ec_ = context.Operators.Start(eb_);
-                CqlDate ed_ = context.Operators.DateFrom(ec_);
-                CqlQuantity ee_ = context.Operators.Quantity(60m, "days");
-                CqlDate ef_ = context.Operators.Subtract(ed_, ee_);
-                CqlDateTime eg_ = context.Operators.ConvertDateToDateTime(ef_);
-                CqlDateTime eh_ = context.Operators.ConvertDateToDateTime(ed_);
-                CqlInterval<CqlDateTime> ei_ = context.Operators.Interval(eg_, eh_, true, false);
-                CqlBoolean ej_ = context.Operators.In<CqlDateTime>(dz_, ei_, "day");
-
-                CqlBoolean ek_() {
-                    Period el_ = FirstSUDEpisode?.Period;
-                    CqlInterval<CqlDateTime> em_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, el_);
-                    CqlDateTime en_ = context.Operators.Start(em_);
-                    CqlDate eo_ = context.Operators.DateFrom(en_);
-                    return eo_ is not null;
-                }
-
-                return ej_
-                    /* CQL 'and' (82:21-82:116) */ && ek_();
+            bool? do_(Encounter FirstSUDEpisode) {
+                FhirDateTime dq_ = SUDMedication?.AuthoredOnElement;
+                CqlDateTime dr_ = context.Operators.Convert<CqlDateTime>(dq_);
+                Period ds_ = FirstSUDEpisode?.Period;
+                CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ds_);
+                CqlDateTime du_ = context.Operators.Start(dt_);
+                CqlDate dv_ = context.Operators.DateFrom(du_);
+                CqlQuantity dw_ = context.Operators.Quantity(60m, "days");
+                CqlDate dx_ = context.Operators.Subtract(dv_, dw_);
+                CqlDateTime dy_ = context.Operators.ConvertDateToDateTime(dx_);
+                CqlDateTime dz_ = context.Operators.ConvertDateToDateTime(dv_);
+                CqlInterval<CqlDateTime> ea_ = context.Operators.Interval(dy_, dz_, true, false);
+                CqlBoolean eb_ = context.Operators.In<CqlDateTime>(dr_, ea_, "day");
+                CqlBoolean ec_ = (CqlBoolean)(dv_ is not null);
+                return eb_
+                    /* CQL 'and' (82:21-82:116) */ && ec_;
             }
 
-            CqlBoolean dx_ = context.Operators.WhereAny<Encounter>((IEnumerable<Encounter>)dv_, dw_);
-            return dx_;
+            CqlBoolean dp_ = context.Operators.WhereAny<Encounter>((IEnumerable<Encounter>)dn_, do_);
+            return dp_;
         }
 
         IEnumerable<MedicationRequest> ak_ = context.Operators.Where<MedicationRequest>(ai_, aj_);
@@ -534,16 +489,12 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 13);
-
-        CqlBoolean j_() {
-            IEnumerable<object> k_ = this.History_of_SUD_Diagnosis_or_Treatment(context);
-            CqlBoolean l_ = context.Operators.Exists<object>(k_);
-            return !l_;
-        }
-
+        IEnumerable<object> j_ = this.History_of_SUD_Diagnosis_or_Treatment(context);
+        CqlBoolean k_ = context.Operators.Exists<object>(j_);
+        CqlBoolean l_ = (CqlBoolean)!k_;
         return i_
             /* CQL 'and' (34:3-35:65) */ && ((this.First_SUD_Episode_During_Measurement_Period(context)) is not null)
-            /* CQL 'and' (34:3-36:58) */ && j_();
+            /* CQL 'and' (34:3-36:58) */ && l_;
     }
 
 
@@ -640,33 +591,33 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
 
             bool? k_(Encounter FirstSUDEpisode) {
                 object m_;
-                object z_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                bool ab_ = aa_ is CqlDateTime;
-                if (ab_)
+                object ae_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "performed");
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool ag_ = af_ is CqlDateTime;
+                if (ag_)
                 {
-                    m_ = aa_ as CqlDateTime;
+                    m_ = af_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ac_ = aa_ is CqlQuantity;
-                    if (ac_)
+                    bool ah_ = af_ is CqlQuantity;
+                    if (ah_)
                     {
-                        m_ = aa_ as CqlQuantity;
+                        m_ = af_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
+                        bool ai_ = af_ is CqlInterval<CqlDateTime>;
+                        if (ai_)
                         {
-                            m_ = aa_ as CqlInterval<CqlDateTime>;
+                            m_ = af_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                            if (ae_)
+                            bool aj_ = af_ is CqlInterval<CqlQuantity>;
+                            if (aj_)
                             {
-                                m_ = aa_ as CqlInterval<CqlQuantity>;
+                                m_ = af_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -686,18 +637,14 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 CqlDate v_ = context.Operators.Add(t_, u_);
                 CqlInterval<CqlDate> w_ = context.Operators.Interval(t_, v_, true, false);
                 CqlBoolean x_ = context.Operators.In<CqlDate>(p_, w_, (string)default);
-
-                CqlBoolean y_() {
-                    object af_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "id");
-                    string ag_ = context.Operators.LateBoundProperty<string>(af_, "value");
-                    Id ah_ = FirstSUDEpisode?.IdElement;
-                    string ai_ = ah_?.Value;
-                    CqlBoolean aj_ = context.Operators.Equivalent(ag_, ai_);
-                    return !aj_;
-                }
-
+                object y_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "id");
+                string z_ = context.Operators.LateBoundProperty<string>(y_, "value");
+                Id aa_ = FirstSUDEpisode?.IdElement;
+                string ab_ = aa_?.Value;
+                CqlBoolean ac_ = context.Operators.Equivalent(z_, ab_);
+                CqlBoolean ad_ = (CqlBoolean)!ac_;
                 return x_
-                    /* CQL 'and' (104:19-105:65) */ && y_();
+                    /* CQL 'and' (104:19-105:65) */ && ad_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Encounter>((IEnumerable<Encounter>)j_, k_);
@@ -769,18 +716,14 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 CqlDate bh_ = context.Operators.Add(bf_, bg_);
                 CqlInterval<CqlDate> bi_ = context.Operators.Interval(bf_, bh_, true, false);
                 CqlBoolean bj_ = context.Operators.In<CqlDate>(bb_, bi_, (string)default);
-
-                CqlBoolean bk_() {
-                    object bl_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "id");
-                    string bm_ = context.Operators.LateBoundProperty<string>(bl_, "value");
-                    Id bn_ = FirstSUDEpisode?.IdElement;
-                    string bo_ = bn_?.Value;
-                    CqlBoolean bp_ = context.Operators.Equivalent(bm_, bo_);
-                    return !bp_;
-                }
-
+                object bk_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "id");
+                string bl_ = context.Operators.LateBoundProperty<string>(bk_, "value");
+                Id bm_ = FirstSUDEpisode?.IdElement;
+                string bn_ = bm_?.Value;
+                CqlBoolean bo_ = context.Operators.Equivalent(bl_, bn_);
+                CqlBoolean bp_ = (CqlBoolean)!bo_;
                 return bj_
-                    /* CQL 'and' (111:21-112:67) */ && bk_();
+                    /* CQL 'and' (111:21-112:67) */ && bp_;
             }
 
             CqlBoolean ax_ = context.Operators.WhereAny<Encounter>((IEnumerable<Encounter>)av_, aw_);
@@ -821,17 +764,13 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> af_ = context.Operators.Split((string)ae_, "/");
                 string ag_ = context.Operators.Last<string>(af_);
                 CqlBoolean ah_ = context.Operators.Equal(ad_, ag_);
-
-                CqlBoolean ai_() {
-                    CodeableConcept aj_ = M?.Code;
-                    CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
-                    CqlValueSet al_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
-                    CqlBoolean am_ = context.Operators.ConceptInValueSet(ak_, al_);
-                    return am_;
-                }
-
+                CodeableConcept ai_ = M?.Code;
+                CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ai_);
+                CqlValueSet ak_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
+                CqlBoolean al_ = context.Operators.ConceptInValueSet(aj_, ak_);
+                CqlBoolean am_ = al_;
                 return ah_
-                    /* CQL 'and' */ && ai_();
+                    /* CQL 'and' */ && am_;
             }
 
             CqlBoolean ac_ = context.Operators.WhereAny<Medication>(aa_, ab_);
@@ -852,17 +791,13 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> as_ = context.Operators.Split((string)ar_, "/");
                 string at_ = context.Operators.Last<string>(as_);
                 CqlBoolean au_ = context.Operators.Equal(aq_, at_);
-
-                CqlBoolean av_() {
-                    CodeableConcept aw_ = M?.Code;
-                    CqlConcept ax_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aw_);
-                    CqlValueSet ay_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
-                    CqlBoolean az_ = context.Operators.ConceptInValueSet(ax_, ay_);
-                    return az_;
-                }
-
+                CodeableConcept av_ = M?.Code;
+                CqlConcept aw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, av_);
+                CqlValueSet ax_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
+                CqlBoolean ay_ = context.Operators.ConceptInValueSet(aw_, ax_);
+                CqlBoolean az_ = ay_;
                 return au_
-                    /* CQL 'and' */ && av_();
+                    /* CQL 'and' */ && az_;
             }
 
             CqlBoolean ap_ = context.Operators.WhereAny<Medication>(an_, ao_);
@@ -1042,15 +977,11 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<CqlDate> a_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
         CqlBoolean b_ = context.Operators.Exists<CqlDate>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<CqlDate> d_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
-            CqlBoolean e_ = context.Operators.Exists<CqlDate>(d_);
-            return e_;
-        }
-
+        IEnumerable<CqlDate> c_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
+        CqlBoolean d_ = context.Operators.Exists<CqlDate>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'or' (97:3-98:64) */ || c_();
+            /* CQL 'or' (97:3-98:64) */ || e_;
     }
 
 
@@ -1079,33 +1010,33 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
 
             bool? aa_(CqlDate InitiationTreatmentDate) {
                 object ac_;
-                object al_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
-                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                bool an_ = am_ is CqlDateTime;
-                if (an_)
+                object aq_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "performed");
+                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                bool as_ = ar_ is CqlDateTime;
+                if (as_)
                 {
-                    ac_ = am_ as CqlDateTime;
+                    ac_ = ar_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ao_ = am_ is CqlQuantity;
-                    if (ao_)
+                    bool at_ = ar_ is CqlQuantity;
+                    if (at_)
                     {
-                        ac_ = am_ as CqlQuantity;
+                        ac_ = ar_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ap_ = am_ is CqlInterval<CqlDateTime>;
-                        if (ap_)
+                        bool au_ = ar_ is CqlInterval<CqlDateTime>;
+                        if (au_)
                         {
-                            ac_ = am_ as CqlInterval<CqlDateTime>;
+                            ac_ = ar_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool aq_ = am_ is CqlInterval<CqlQuantity>;
-                            if (aq_)
+                            bool av_ = ar_ is CqlInterval<CqlQuantity>;
+                            if (av_)
                             {
-                                ac_ = am_ as CqlInterval<CqlQuantity>;
+                                ac_ = ar_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1121,23 +1052,16 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 CqlDate ah_ = context.Operators.Add(InitiationTreatmentDate, ag_);
                 CqlInterval<CqlDate> ai_ = context.Operators.Interval(InitiationTreatmentDate, ah_, false, true);
                 CqlBoolean aj_ = context.Operators.In<CqlDate>(af_, ai_, (string)default);
-
-                CqlBoolean ak_() {
-                    object ar_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "period");
-                    CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_ as Period);
-                    CqlDateTime at_ = context.Operators.Start(as_);
-                    CqlDate au_ = context.Operators.DateFrom(at_);
-                    CqlQuantity av_ = context.Operators.Quantity(34m, "days");
-                    CqlDate aw_ = context.Operators.Add(InitiationTreatmentDate, av_);
-                    CqlInterval<CqlDate> ax_ = context.Operators.Interval(InitiationTreatmentDate, aw_, false, true);
-                    CqlBoolean ay_ = context.Operators.In<CqlDate>(au_, ax_, (string)default);
-                    return ay_
-                        /* CQL 'and' (151:16-151:107) */ && (InitiationTreatmentDate is not null);
-                }
-
+                object ak_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "period");
+                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_ as Period);
+                CqlDateTime am_ = context.Operators.Start(al_);
+                CqlDate an_ = context.Operators.DateFrom(am_);
+                CqlBoolean ao_ = context.Operators.In<CqlDate>(an_, ai_, (string)default);
+                CqlBoolean ap_ = ao_
+                    /* CQL 'and' (151:16-151:107) */ && (InitiationTreatmentDate is not null);
                 return (aj_
                     /* CQL 'and' (150:21-150:128) */ && (InitiationTreatmentDate is not null))
-                    /* CQL 'or' (150:21-151:107) */ || ak_();
+                    /* CQL 'or' (150:21-151:107) */ || ap_;
             }
 
             CqlBoolean ab_ = context.Operators.WhereAny<CqlDate>((IEnumerable<CqlDate>)z_, aa_);
@@ -1149,29 +1073,25 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> i_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
         bool? j_(MedicationRequest MR) {
-            IEnumerable<Medication> az_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            IEnumerable<Medication> aw_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ba_(Medication M) {
-                object bc_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object bd_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> be_ = context.Operators.Split((string)bd_, "/");
-                string bf_ = context.Operators.Last<string>(be_);
-                CqlBoolean bg_ = context.Operators.Equal(bc_, bf_);
-
-                CqlBoolean bh_() {
-                    CodeableConcept bi_ = M?.Code;
-                    CqlConcept bj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bi_);
-                    CqlValueSet bk_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
-                    CqlBoolean bl_ = context.Operators.ConceptInValueSet(bj_, bk_);
-                    return bl_;
-                }
-
-                return bg_
-                    /* CQL 'and' */ && bh_();
+            bool? ax_(Medication M) {
+                object az_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ba_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> bb_ = context.Operators.Split((string)ba_, "/");
+                string bc_ = context.Operators.Last<string>(bb_);
+                CqlBoolean bd_ = context.Operators.Equal(az_, bc_);
+                CodeableConcept be_ = M?.Code;
+                CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, be_);
+                CqlValueSet bg_ = this.Substance_Use_Disorder_Short_Acting_Medication(context);
+                CqlBoolean bh_ = context.Operators.ConceptInValueSet(bf_, bg_);
+                CqlBoolean bi_ = bh_;
+                return bd_
+                    /* CQL 'and' */ && bi_;
             }
 
-            CqlBoolean bb_ = context.Operators.WhereAny<Medication>(az_, ba_);
-            return bb_;
+            CqlBoolean ay_ = context.Operators.WhereAny<Medication>(aw_, ax_);
+            return ay_;
         }
 
         IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
@@ -1181,30 +1101,30 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> o_ = Status_1_15_000.Instance.isMedicationOrder(context, n_);
 
         bool? p_(MedicationRequest ShortActingMedOrder) {
-            IEnumerable<CqlDate> bm_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
-            IEnumerable<CqlDate> bn_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
-            IEnumerable<CqlDate> bo_ = context.Operators.Union<CqlDate>(bm_, bn_);
-            CqlDate bp_ = context.Operators.Min<CqlDate>(bo_);
-            CqlDate[] bq_ = [
-                bp_,
+            IEnumerable<CqlDate> bj_ = this.Treatment_Initiation_With_Non_Medication_Intervention_Dates(context);
+            IEnumerable<CqlDate> bk_ = this.Treatment_Initiation_With_Medication_Order_Dates(context);
+            IEnumerable<CqlDate> bl_ = context.Operators.Union<CqlDate>(bj_, bk_);
+            CqlDate bm_ = context.Operators.Min<CqlDate>(bl_);
+            CqlDate[] bn_ = [
+                bm_,
             ];
 
-            bool? br_(CqlDate InitiationTreatmentDate) {
-                FhirDateTime bt_ = ShortActingMedOrder?.AuthoredOnElement;
-                CqlDateTime bu_ = context.Operators.Convert<CqlDateTime>(bt_);
-                CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_);
-                CqlDateTime bw_ = context.Operators.Start(bv_);
-                CqlDate bx_ = context.Operators.DateFrom(bw_);
-                CqlQuantity by_ = context.Operators.Quantity(34m, "days");
-                CqlDate bz_ = context.Operators.Add(InitiationTreatmentDate, by_);
-                CqlInterval<CqlDate> ca_ = context.Operators.Interval(InitiationTreatmentDate, bz_, false, true);
-                CqlBoolean cb_ = context.Operators.In<CqlDate>(bx_, ca_, (string)default);
-                return cb_
+            bool? bo_(CqlDate InitiationTreatmentDate) {
+                FhirDateTime bq_ = ShortActingMedOrder?.AuthoredOnElement;
+                CqlDateTime br_ = context.Operators.Convert<CqlDateTime>(bq_);
+                CqlInterval<CqlDateTime> bs_ = QICoreCommon_4_0_000.Instance.toInterval(context, br_);
+                CqlDateTime bt_ = context.Operators.Start(bs_);
+                CqlDate bu_ = context.Operators.DateFrom(bt_);
+                CqlQuantity bv_ = context.Operators.Quantity(34m, "days");
+                CqlDate bw_ = context.Operators.Add(InitiationTreatmentDate, bv_);
+                CqlInterval<CqlDate> bx_ = context.Operators.Interval(InitiationTreatmentDate, bw_, false, true);
+                CqlBoolean by_ = context.Operators.In<CqlDate>(bu_, bx_, (string)default);
+                return by_
                     /* CQL 'and' (158:23-158:130) */ && (InitiationTreatmentDate is not null);
             }
 
-            CqlBoolean bs_ = context.Operators.WhereAny<CqlDate>((IEnumerable<CqlDate>)bq_, br_);
-            return bs_;
+            CqlBoolean bp_ = context.Operators.WhereAny<CqlDate>((IEnumerable<CqlDate>)bn_, bo_);
+            return bp_;
         }
 
         MedicationRequest q_(MedicationRequest ShortActingMedOrder) => ShortActingMedOrder;
@@ -1235,17 +1155,13 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> v_ = context.Operators.Split((string)u_, "/");
                 string w_ = context.Operators.Last<string>(v_);
                 CqlBoolean x_ = context.Operators.Equal(t_, w_);
-
-                CqlBoolean y_() {
-                    CodeableConcept z_ = M?.Code;
-                    CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-                    CqlValueSet ab_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
-                    CqlBoolean ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
-                    return ac_;
-                }
-
+                CodeableConcept y_ = M?.Code;
+                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+                CqlValueSet aa_ = this.Substance_Use_Disorder_Long_Acting_Medication(context);
+                CqlBoolean ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+                CqlBoolean ac_ = ab_;
                 return x_
-                    /* CQL 'and' */ && y_();
+                    /* CQL 'and' */ && ac_;
             }
 
             CqlBoolean s_ = context.Operators.WhereAny<Medication>(q_, r_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS138FHIRTobaccoScrnCessation-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS138FHIRTobaccoScrnCessation-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS138FHIRTobaccoScrnCessation", "1.0.000")]
 public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISingleton<CMS138FHIRTobaccoScrnCessation_1_0_000>
 {
@@ -421,24 +421,16 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 12);
-
-        CqlBoolean j_() {
-            IEnumerable<Encounter> k_ = this.Qualifying_Visit_During_Measurement_Period(context);
-            int? l_ = context.Operators.Count<Encounter>(k_);
-            CqlBoolean m_ = context.Operators.GreaterOrEqual(l_, 2);
-
-            CqlBoolean n_() {
-                IEnumerable<Encounter> o_ = this.Preventive_Visit_During_Measurement_Period(context);
-                CqlBoolean p_ = context.Operators.Exists<Encounter>(o_);
-                return p_;
-            }
-
-            return m_
-                /* CQL 'or' (65:9-67:5) */ || n_();
-        }
-
+        IEnumerable<Encounter> j_ = this.Qualifying_Visit_During_Measurement_Period(context);
+        int? k_ = context.Operators.Count<Encounter>(j_);
+        CqlBoolean l_ = context.Operators.GreaterOrEqual(k_, 2);
+        IEnumerable<Encounter> m_ = this.Preventive_Visit_During_Measurement_Period(context);
+        CqlBoolean n_ = context.Operators.Exists<Encounter>(m_);
+        CqlBoolean o_ = n_;
+        CqlBoolean p_ = l_
+            /* CQL 'or' (65:9-67:5) */ || o_;
         return i_
-            /* CQL 'and' (64:3-67:5) */ && j_();
+            /* CQL 'and' (64:3-67:5) */ && p_;
     }
 
 
@@ -702,17 +694,13 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
                 string p_ = context.Operators.Last<string>(o_);
                 CqlBoolean q_ = context.Operators.Equal(m_, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = M?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlValueSet u_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
-                    CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                    return v_;
-                }
-
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' */ && r_();
+                    /* CQL 'and' */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Medication>(j_, k_);
@@ -735,33 +723,25 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
             CqlDateTime ac_ = context.Operators.End(y_);
             CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(ab_, ac_, true, true);
             CqlBoolean ae_ = context.Operators.In<CqlDateTime>(x_, ad_, "day");
+            IEnumerable<Task> af_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            CqlBoolean af_() {
-                IEnumerable<Task> ag_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
-
-                bool? ah_(Task TaskReject) {
-                    ResourceReference aj_ = TaskReject?.Focus;
-                    CqlBoolean ak_ = QICoreCommon_4_0_000.Instance.references(context, aj_, CessationPharmacotherapyOrdered);
-
-                    CqlBoolean al_() {
-                        CodeableConcept am_ = TaskReject?.Code;
-                        CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
-                        CqlCode ao_ = this.fulfill(context);
-                        CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
-                        CqlBoolean aq_ = context.Operators.Equivalent(an_, ap_);
-                        return aq_;
-                    }
-
-                    return ak_
-                        /* CQL 'and' (109:11-110:43) */ && al_();
-                }
-
-                CqlBoolean ai_ = context.Operators.WhereAny<Task>(ag_, ah_);
-                return !ai_;
+            bool? ag_(Task TaskReject) {
+                ResourceReference aj_ = TaskReject?.Focus;
+                CqlBoolean ak_ = QICoreCommon_4_0_000.Instance.references(context, aj_, CessationPharmacotherapyOrdered);
+                CodeableConcept al_ = TaskReject?.Code;
+                CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, al_);
+                CqlCode an_ = this.fulfill(context);
+                CqlConcept ao_ = context.Operators.ConvertCodeToConcept(an_);
+                CqlBoolean ap_ = context.Operators.Equivalent(am_, ao_);
+                CqlBoolean aq_ = ap_;
+                return ak_
+                    /* CQL 'and' (109:11-110:43) */ && aq_;
             }
 
+            CqlBoolean ah_ = context.Operators.WhereAny<Task>(af_, ag_);
+            CqlBoolean ai_ = (CqlBoolean)!ah_;
             return ae_
-                /* CQL 'and' (107:5-111:7) */ && af_();
+                /* CQL 'and' (107:5-111:7) */ && ai_;
         }
 
         IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
@@ -788,17 +768,13 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
                 string p_ = context.Operators.Last<string>(o_);
                 CqlBoolean q_ = context.Operators.Equal(m_, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = M?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlValueSet u_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
-                    CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                    return v_;
-                }
-
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Tobacco_Use_Cessation_Pharmacotherapy(context);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' */ && r_();
+                    /* CQL 'and' */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Medication>(j_, k_);
@@ -845,23 +821,15 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
     {
         IEnumerable<object> a_ = this.Tobacco_Cessation_Counseling_Given(context);
         CqlBoolean b_ = context.Operators.Exists<object>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<MedicationRequest> e_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered(context);
-            CqlBoolean f_ = context.Operators.Exists<MedicationRequest>(e_);
-            return f_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<MedicationRequest> g_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation(context);
-            CqlBoolean h_ = context.Operators.Exists<MedicationRequest>(g_);
-            return h_;
-        }
-
+        IEnumerable<MedicationRequest> c_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered(context);
+        CqlBoolean d_ = context.Operators.Exists<MedicationRequest>(c_);
+        CqlBoolean e_ = d_;
+        IEnumerable<MedicationRequest> f_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation(context);
+        CqlBoolean g_ = context.Operators.Exists<MedicationRequest>(f_);
+        CqlBoolean h_ = g_;
         return b_
-            /* CQL 'or' (74:3-75:57) */ || c_()
-            /* CQL 'or' (74:3-76:60) */ || d_();
+            /* CQL 'or' (74:3-75:57) */ || e_
+            /* CQL 'or' (74:3-76:60) */ || h_;
     }
 
 
@@ -874,38 +842,22 @@ public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISinglet
     private bool? Numerator_3_Compute(CqlContext context)
     {
         Observation a_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User(context);
-
-        CqlBoolean b_() {
-            Observation c_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User(context);
-
-            CqlBoolean d_() {
-                IEnumerable<object> e_ = this.Tobacco_Cessation_Counseling_Given(context);
-                CqlBoolean f_ = context.Operators.Exists<object>(e_);
-
-                CqlBoolean g_() {
-                    IEnumerable<MedicationRequest> i_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered(context);
-                    CqlBoolean j_ = context.Operators.Exists<MedicationRequest>(i_);
-                    return j_;
-                }
-
-
-                CqlBoolean h_() {
-                    IEnumerable<MedicationRequest> k_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation(context);
-                    CqlBoolean l_ = context.Operators.Exists<MedicationRequest>(k_);
-                    return l_;
-                }
-
-                return f_
-                    /* CQL 'or' (81:15-82:65) */ || g_()
-                    /* CQL 'or' (81:13-84:9) */ || h_();
-            }
-
-            return (CqlBoolean)(c_ is not null)
-                /* CQL 'and' (80:8-85:5) */ && d_();
-        }
-
+        Observation b_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User(context);
+        IEnumerable<object> c_ = this.Tobacco_Cessation_Counseling_Given(context);
+        CqlBoolean d_ = context.Operators.Exists<object>(c_);
+        IEnumerable<MedicationRequest> e_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered(context);
+        CqlBoolean f_ = context.Operators.Exists<MedicationRequest>(e_);
+        CqlBoolean g_ = f_;
+        IEnumerable<MedicationRequest> h_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation(context);
+        CqlBoolean i_ = context.Operators.Exists<MedicationRequest>(h_);
+        CqlBoolean j_ = i_;
+        CqlBoolean k_ = d_
+            /* CQL 'or' (81:15-82:65) */ || g_
+            /* CQL 'or' (81:13-84:9) */ || j_;
+        CqlBoolean l_ = (CqlBoolean)(b_ is not null)
+            /* CQL 'and' (80:8-85:5) */ && k_;
         return (CqlBoolean)(a_ is not null)
-            /* CQL 'or' (79:3-85:5) */ || b_();
+            /* CQL 'or' (79:3-85:5) */ || l_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS139FHIRFallRiskScreening-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS139FHIRFallRiskScreening-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS139FHIRFallRiskScreening", "1.0.000")]
 public partial class CMS139FHIRFallRiskScreening_1_0_000 : ILibrary, ISingleton<CMS139FHIRFallRiskScreening_1_0_000>
 {
@@ -256,15 +256,11 @@ public partial class CMS139FHIRFallRiskScreening_1_0_000 : ILibrary, ISingleton<
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 65);
-
-        CqlBoolean j_() {
-            IEnumerable<Encounter> k_ = this.Qualifying_Encounter(context);
-            CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
-            return l_;
-        }
-
+        IEnumerable<Encounter> j_ = this.Qualifying_Encounter(context);
+        CqlBoolean k_ = context.Operators.Exists<Encounter>(j_);
+        CqlBoolean l_ = k_;
         return i_
-            /* CQL 'and' (46:3-47:37) */ && j_();
+            /* CQL 'and' (46:3-47:37) */ && l_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS142FHIRCommWithDrManagingDiab", "1.0.000")]
 public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingleton<CMS142FHIRCommWithDrManagingDiab_1_0_000>
 {
@@ -212,27 +212,19 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
             Period r_ = QualifyingEncounter?.Period;
             CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
             CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, "day");
-
-            CqlBoolean u_() {
-                Code<Encounter.EncounterStatus> w_ = QualifyingEncounter?.StatusElement;
-                Encounter.EncounterStatus? x_ = w_?.Value;
-                Code<Encounter.EncounterStatus> y_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(x_);
-                CqlBoolean z_ = context.Operators.Equal(y_, "finished");
-                return z_;
-            }
-
-
-            CqlBoolean v_() {
-                Coding aa_ = QualifyingEncounter?.Class;
-                CqlCode ab_ = FHIRHelpers_4_4_000.Instance.ToCode(context, aa_);
-                CqlCode ac_ = this.@virtual(context);
-                CqlBoolean ad_ = context.Operators.Equivalent(ab_, ac_);
-                return !ad_;
-            }
-
+            Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? v_ = u_?.Value;
+            Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+            CqlBoolean x_ = context.Operators.Equal(w_, "finished");
+            CqlBoolean y_ = x_;
+            Coding z_ = QualifyingEncounter?.Class;
+            CqlCode aa_ = FHIRHelpers_4_4_000.Instance.ToCode(context, z_);
+            CqlCode ab_ = this.@virtual(context);
+            CqlBoolean ac_ = context.Operators.Equivalent(aa_, ab_);
+            CqlBoolean ad_ = (CqlBoolean)!ac_;
             return t_
-                /* CQL 'and' (72:11-73:49) */ && u_()
-                /* CQL 'and' (72:5-74:48) */ && v_();
+                /* CQL 'and' (72:11-73:49) */ && y_
+                /* CQL 'and' (72:5-74:48) */ && ad_;
         }
 
         IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
@@ -245,51 +237,27 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (148:54-149:66) */ || i_()
-                /* CQL 'or' (148:54-150:66) */ || j_()
-                /* CQL 'or' (148:52-152:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (148:54-149:66) */ || i_
+            /* CQL 'or' (148:54-150:66) */ || m_
+            /* CQL 'or' (148:52-152:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (148:3-152:3) */ || c_();
+            /* CQL 'implies' (148:3-152:3) */ || r_;
     }
 
 
@@ -344,15 +312,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 18);
-
-        CqlBoolean j_() {
-            IEnumerable<Encounter> k_ = this.Diabetic_Retinopathy_Encounter(context);
-            CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
-            return l_;
-        }
-
+        IEnumerable<Encounter> j_ = this.Diabetic_Retinopathy_Encounter(context);
+        CqlBoolean k_ = context.Operators.Exists<Encounter>(j_);
+        CqlBoolean l_ = k_;
         return i_
-            /* CQL 'and' (48:3-49:47) */ && j_();
+            /* CQL 'and' (48:3-49:47) */ && l_;
     }
 
 
@@ -389,22 +353,18 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         bool? e_(Observation MacularExam) {
             DataType p_ = MacularExam?.Value;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-
-            CqlBoolean r_() {
-                Code<ObservationStatus> s_ = MacularExam?.StatusElement;
-                ObservationStatus? t_ = s_?.Value;
-                string u_ = context.Operators.Convert<string>(t_);
-                string[] v_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
-                return w_;
-            }
-
+            Code<ObservationStatus> r_ = MacularExam?.StatusElement;
+            ObservationStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            CqlBoolean w_ = v_;
             return (CqlBoolean)(q_ is not null)
-                /* CQL 'and' (87:5-88:67) */ && r_();
+                /* CQL 'and' (87:5-88:67) */ && w_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
@@ -421,15 +381,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
     private bool? Denominator_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Initial_Population(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Observation> c_ = this.Macular_Exam_Performed(context);
-            CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
-            return d_;
-        }
-
+        IEnumerable<Observation> b_ = this.Macular_Exam_Performed(context);
+        CqlBoolean c_ = context.Operators.Exists<Observation>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (52:3-53:39) */ && b_();
+            /* CQL 'and' (52:3-53:39) */ && d_;
     }
 
 
@@ -454,17 +410,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
                 CqlDateTime n_ = context.Operators.Start(m_);
                 CqlBoolean o_ = context.Operators.After(k_, n_, (string)default);
-
-                CqlBoolean p_() {
-                    FhirDateTime q_ = LevelOfSeverityCommunicated?.SentElement;
-                    CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
-                    CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
-                    return t_;
-                }
-
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                CqlBoolean q_ = context.Operators.In<CqlDateTime>(k_, p_, "day");
+                CqlBoolean r_ = q_;
                 return o_
-                    /* CQL 'and' (99:17-100:79) */ && p_();
+                    /* CQL 'and' (99:17-100:79) */ && r_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<Encounter>(g_, h_);
@@ -474,11 +424,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication LevelOfSeverityCommunicated) {
-            Code<EventStatus> u_ = LevelOfSeverityCommunicated?.StatusElement;
-            EventStatus? v_ = u_?.Value;
-            string w_ = context.Operators.Convert<string>(v_);
-            CqlBoolean x_ = context.Operators.Equal(w_, "completed");
-            return x_;
+            Code<EventStatus> s_ = LevelOfSeverityCommunicated?.StatusElement;
+            EventStatus? t_ = s_?.Value;
+            string u_ = context.Operators.Convert<string>(t_);
+            CqlBoolean v_ = context.Operators.Equal(u_, "completed");
+            return v_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -507,17 +457,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
                 CqlDateTime n_ = context.Operators.Start(m_);
                 CqlBoolean o_ = context.Operators.After(k_, n_, (string)default);
-
-                CqlBoolean p_() {
-                    FhirDateTime q_ = MacularEdemaAbsentCommunicated?.SentElement;
-                    CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
-                    CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
-                    return t_;
-                }
-
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                CqlBoolean q_ = context.Operators.In<CqlDateTime>(k_, p_, "day");
+                CqlBoolean r_ = q_;
                 return o_
-                    /* CQL 'and' (106:17-107:82) */ && p_();
+                    /* CQL 'and' (106:17-107:82) */ && r_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<Encounter>(g_, h_);
@@ -527,11 +471,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication MacularEdemaAbsentCommunicated) {
-            Code<EventStatus> u_ = MacularEdemaAbsentCommunicated?.StatusElement;
-            EventStatus? v_ = u_?.Value;
-            string w_ = context.Operators.Convert<string>(v_);
-            CqlBoolean x_ = context.Operators.Equal(w_, "completed");
-            return x_;
+            Code<EventStatus> s_ = MacularEdemaAbsentCommunicated?.StatusElement;
+            EventStatus? t_ = s_?.Value;
+            string u_ = context.Operators.Convert<string>(t_);
+            CqlBoolean v_ = context.Operators.Equal(u_, "completed");
+            return v_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -560,17 +504,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
                 CqlDateTime n_ = context.Operators.Start(m_);
                 CqlBoolean o_ = context.Operators.After(k_, n_, (string)default);
-
-                CqlBoolean p_() {
-                    FhirDateTime q_ = MacularEdemaPresentCommunicated?.SentElement;
-                    CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
-                    CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
-                    return t_;
-                }
-
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                CqlBoolean q_ = context.Operators.In<CqlDateTime>(k_, p_, (string)default);
+                CqlBoolean r_ = q_;
                 return o_
-                    /* CQL 'and' (113:17-114:76) */ && p_();
+                    /* CQL 'and' (113:17-114:76) */ && r_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<Encounter>(g_, h_);
@@ -580,11 +518,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
         IEnumerable<Communication> d_ = context.Operators.Where<Communication>(b_, c_);
 
         bool? e_(Communication MacularEdemaPresentCommunicated) {
-            Code<EventStatus> u_ = MacularEdemaPresentCommunicated?.StatusElement;
-            EventStatus? v_ = u_?.Value;
-            string w_ = context.Operators.Convert<string>(v_);
-            CqlBoolean x_ = context.Operators.Equal(w_, "completed");
-            return x_;
+            Code<EventStatus> s_ = MacularEdemaPresentCommunicated?.StatusElement;
+            EventStatus? t_ = s_?.Value;
+            string u_ = context.Operators.Convert<string>(t_);
+            CqlBoolean v_ = context.Operators.Equal(u_, "completed");
+            return v_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -602,23 +540,15 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Communication> a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated(context);
         CqlBoolean b_ = context.Operators.Exists<Communication>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Communication> d_ = this.Macular_Edema_Absence_Communicated(context);
-            CqlBoolean e_ = context.Operators.Exists<Communication>(d_);
-
-            CqlBoolean f_() {
-                IEnumerable<Communication> g_ = this.Macular_Edema_Presence_Communicated(context);
-                CqlBoolean h_ = context.Operators.Exists<Communication>(g_);
-                return h_;
-            }
-
-            return e_
-                /* CQL 'or' (57:9-59:5) */ || f_();
-        }
-
+        IEnumerable<Communication> c_ = this.Macular_Edema_Absence_Communicated(context);
+        CqlBoolean d_ = context.Operators.Exists<Communication>(c_);
+        IEnumerable<Communication> e_ = this.Macular_Edema_Presence_Communicated(context);
+        CqlBoolean f_ = context.Operators.Exists<Communication>(e_);
+        CqlBoolean g_ = f_;
+        CqlBoolean h_ = d_
+            /* CQL 'or' (57:9-59:5) */ || g_;
         return b_
-            /* CQL 'and' (56:3-59:5) */ && c_();
+            /* CQL 'and' (56:3-59:5) */ && h_;
     }
 
 
@@ -674,17 +604,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
             CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
             CqlValueSet y_ = this.Medical_Reason(context);
             CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-
-            CqlBoolean aa_() {
-                CodeableConcept ab_ = LevelOfSeverityNotCommunicated?.StatusReason;
-                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
-                CqlValueSet ad_ = this.Patient_Reason(context);
-                CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
-                return ae_;
-            }
-
+            CqlValueSet aa_ = this.Patient_Reason(context);
+            CqlBoolean ab_ = context.Operators.ConceptInValueSet(x_, aa_);
+            CqlBoolean ac_ = ab_;
             return z_
-                /* CQL 'or' (121:5-123:5) */ || aa_();
+                /* CQL 'or' (121:5-123:5) */ || ac_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -744,17 +668,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
             CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
             CqlValueSet y_ = this.Medical_Reason(context);
             CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-
-            CqlBoolean aa_() {
-                CodeableConcept ab_ = MacularEdemaAbsentNotCommunicated?.StatusReason;
-                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
-                CqlValueSet ad_ = this.Patient_Reason(context);
-                CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
-                return ae_;
-            }
-
+            CqlValueSet aa_ = this.Patient_Reason(context);
+            CqlBoolean ab_ = context.Operators.ConceptInValueSet(x_, aa_);
+            CqlBoolean ac_ = ab_;
             return z_
-                /* CQL 'or' (143:5-145:5) */ || aa_();
+                /* CQL 'or' (143:5-145:5) */ || ac_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -814,17 +732,11 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
             CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
             CqlValueSet y_ = this.Medical_Reason(context);
             CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-
-            CqlBoolean aa_() {
-                CodeableConcept ab_ = MacularEdemaPresentNotCommunicated?.StatusReason;
-                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
-                CqlValueSet ad_ = this.Patient_Reason(context);
-                CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
-                return ae_;
-            }
-
+            CqlValueSet aa_ = this.Patient_Reason(context);
+            CqlBoolean ab_ = context.Operators.ConceptInValueSet(x_, aa_);
+            CqlBoolean ac_ = ab_;
             return z_
-                /* CQL 'or' (129:5-131:5) */ || aa_();
+                /* CQL 'or' (129:5-131:5) */ || ac_;
         }
 
         IEnumerable<Communication> f_ = context.Operators.Where<Communication>(d_, e_);
@@ -842,23 +754,15 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Communication> a_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy(context);
         CqlBoolean b_ = context.Operators.Exists<Communication>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Communication> e_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema(context);
-            CqlBoolean f_ = context.Operators.Exists<Communication>(e_);
-            return f_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Communication> g_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema(context);
-            CqlBoolean h_ = context.Operators.Exists<Communication>(g_);
-            return h_;
-        }
-
+        IEnumerable<Communication> c_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema(context);
+        CqlBoolean d_ = context.Operators.Exists<Communication>(c_);
+        CqlBoolean e_ = d_;
+        IEnumerable<Communication> f_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema(context);
+        CqlBoolean g_ = context.Operators.Exists<Communication>(f_);
+        CqlBoolean h_ = g_;
         return b_
-            /* CQL 'or' (62:3-63:88) */ || c_()
-            /* CQL 'or' (62:3-64:89) */ || d_();
+            /* CQL 'or' (62:3-63:88) */ || e_
+            /* CQL 'or' (62:3-64:89) */ || h_;
     }
 
 
@@ -872,23 +776,15 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Communication> a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated(context);
         CqlBoolean b_ = context.Operators.Exists<Communication>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Communication> d_ = this.Macular_Edema_Absence_Communicated(context);
-            CqlBoolean e_ = context.Operators.Exists<Communication>(d_);
-
-            CqlBoolean f_() {
-                IEnumerable<Communication> g_ = this.Macular_Edema_Presence_Communicated(context);
-                CqlBoolean h_ = context.Operators.Exists<Communication>(g_);
-                return h_;
-            }
-
-            return e_
-                /* CQL 'or' (92:9-94:5) */ || f_();
-        }
-
+        IEnumerable<Communication> c_ = this.Macular_Edema_Absence_Communicated(context);
+        CqlBoolean d_ = context.Operators.Exists<Communication>(c_);
+        IEnumerable<Communication> e_ = this.Macular_Edema_Presence_Communicated(context);
+        CqlBoolean f_ = context.Operators.Exists<Communication>(e_);
+        CqlBoolean g_ = f_;
+        CqlBoolean h_ = d_
+            /* CQL 'or' (92:9-94:5) */ || g_;
         return b_
-            /* CQL 'and' (91:3-94:5) */ && c_();
+            /* CQL 'and' (91:3-94:5) */ && h_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS143FHIRPOAGOpticNerveEval-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS143FHIRPOAGOpticNerveEval-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS143FHIRPOAGOpticNerveEval", "1.0.000")]
 public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton<CMS143FHIRPOAGOpticNerveEval_1_0_000>
 {
@@ -190,27 +190,19 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
             Period r_ = QualifyingEncounter?.Period;
             CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
             CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, "day");
-
-            CqlBoolean u_() {
-                Code<Encounter.EncounterStatus> w_ = QualifyingEncounter?.StatusElement;
-                Encounter.EncounterStatus? x_ = w_?.Value;
-                Code<Encounter.EncounterStatus> y_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(x_);
-                CqlBoolean z_ = context.Operators.Equal(y_, "finished");
-                return z_;
-            }
-
-
-            CqlBoolean v_() {
-                Coding aa_ = QualifyingEncounter?.Class;
-                CqlCode ab_ = FHIRHelpers_4_4_000.Instance.ToCode(context, aa_);
-                CqlCode ac_ = this.@virtual(context);
-                CqlBoolean ad_ = context.Operators.Equivalent(ab_, ac_);
-                return !ad_;
-            }
-
+            Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? v_ = u_?.Value;
+            Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+            CqlBoolean x_ = context.Operators.Equal(w_, "finished");
+            CqlBoolean y_ = x_;
+            Coding z_ = QualifyingEncounter?.Class;
+            CqlCode aa_ = FHIRHelpers_4_4_000.Instance.ToCode(context, z_);
+            CqlCode ab_ = this.@virtual(context);
+            CqlBoolean ac_ = context.Operators.Equivalent(aa_, ab_);
+            CqlBoolean ad_ = (CqlBoolean)!ac_;
             return t_
-                /* CQL 'and' (53:11-54:49) */ && u_()
-                /* CQL 'and' (53:5-55:48) */ && v_();
+                /* CQL 'and' (53:11-54:49) */ && y_
+                /* CQL 'and' (53:5-55:48) */ && ad_;
         }
 
         IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
@@ -223,51 +215,27 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (99:54-100:66) */ || i_()
-                /* CQL 'or' (99:54-101:66) */ || j_()
-                /* CQL 'or' (99:52-103:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (99:54-100:66) */ || i_
+            /* CQL 'or' (99:54-101:66) */ || m_
+            /* CQL 'or' (99:52-103:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (99:3-103:3) */ || c_();
+            /* CQL 'implies' (99:3-103:3) */ || r_;
     }
 
 
@@ -322,15 +290,11 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 18);
-
-        CqlBoolean j_() {
-            IEnumerable<Encounter> k_ = this.Primary_Open_Angle_Glaucoma_Encounter(context);
-            CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
-            return l_;
-        }
-
+        IEnumerable<Encounter> j_ = this.Primary_Open_Angle_Glaucoma_Encounter(context);
+        CqlBoolean k_ = context.Operators.Exists<Encounter>(j_);
+        CqlBoolean l_ = k_;
         return i_
-            /* CQL 'and' (58:3-59:54) */ && j_();
+            /* CQL 'and' (58:3-59:54) */ && l_;
     }
 
 
@@ -479,15 +443,11 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
     {
         IEnumerable<Observation> a_ = this.Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio(context);
         CqlBoolean b_ = context.Operators.Exists<Observation>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> d_ = this.Medical_Reason_for_Not_Performing_Optic_Disc_Exam(context);
-            CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
-            return e_;
-        }
-
+        IEnumerable<Observation> c_ = this.Medical_Reason_for_Not_Performing_Optic_Disc_Exam(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'or' (44:3-45:65) */ || c_();
+            /* CQL 'or' (44:3-45:65) */ || e_;
     }
 
 
@@ -524,22 +484,18 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
         bool? e_(Observation CupToDiscExamPerformed) {
             DataType p_ = CupToDiscExamPerformed?.Value;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-
-            CqlBoolean r_() {
-                Code<ObservationStatus> s_ = CupToDiscExamPerformed?.StatusElement;
-                ObservationStatus? t_ = s_?.Value;
-                string u_ = context.Operators.Convert<string>(t_);
-                string[] v_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
-                return w_;
-            }
-
+            Code<ObservationStatus> r_ = CupToDiscExamPerformed?.StatusElement;
+            ObservationStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            CqlBoolean w_ = v_;
             return (CqlBoolean)(q_ is not null)
-                /* CQL 'and' (72:5-73:78) */ && r_();
+                /* CQL 'and' (72:5-73:78) */ && w_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
@@ -580,22 +536,18 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
         bool? e_(Observation OpticDiscExamPerformed) {
             DataType p_ = OpticDiscExamPerformed?.Value;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-
-            CqlBoolean r_() {
-                Code<ObservationStatus> s_ = OpticDiscExamPerformed?.StatusElement;
-                ObservationStatus? t_ = s_?.Value;
-                string u_ = context.Operators.Convert<string>(t_);
-                string[] v_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
-                return w_;
-            }
-
+            Code<ObservationStatus> r_ = OpticDiscExamPerformed?.StatusElement;
+            ObservationStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            CqlBoolean w_ = v_;
             return (CqlBoolean)(q_ is not null)
-                /* CQL 'and' (79:5-80:78) */ && r_();
+                /* CQL 'and' (79:5-80:78) */ && w_;
         }
 
         IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
@@ -613,15 +565,11 @@ public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton
     {
         IEnumerable<Observation> a_ = this.Cup_to_Disc_Ratio_Performed_with_Result(context);
         CqlBoolean b_ = context.Operators.Exists<Observation>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> d_ = this.Optic_Disc_Exam_Performed_with_Result(context);
-            CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
-            return e_;
-        }
-
+        IEnumerable<Observation> c_ = this.Optic_Disc_Exam_Performed_with_Result(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'and' (83:3-84:54) */ && c_();
+            /* CQL 'and' (83:3-84:54) */ && e_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS144FHIRHFBetaBlockerForLVSD", "1.0.000")]
 public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISingleton<CMS144FHIRHFBetaBlockerForLVSD_1_0_000>
 {
@@ -148,15 +148,11 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
     private bool? Denominator_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Initial_Population(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = AHAOverall_4_1_000.Instance.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (37:3-38:95) */ && b_();
+            /* CQL 'and' (37:3-38:95) */ && d_;
     }
 
 
@@ -216,17 +212,13 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Beta_Blocker_Therapy_for_LVSD(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -287,79 +279,59 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
             CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
             CqlBoolean p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, (string)default);
+            Code<ObservationStatus> q_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.StatusElement;
+            ObservationStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            string[] t_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+            CqlBoolean v_ = u_;
+            DataType w_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Value;
+            CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_ as Quantity);
+            CqlQuantity y_ = context.Operators.Quantity(50m, "/min");
+            CqlBoolean z_ = context.Operators.Less(x_, y_);
+            CqlBoolean aa_ = z_;
+            IEnumerable<Observation> ab_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
 
-            CqlBoolean q_() {
-                Code<ObservationStatus> t_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.StatusElement;
-                ObservationStatus? u_ = t_?.Value;
-                string v_ = context.Operators.Convert<string>(u_);
-                string[] w_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
-                return x_;
+            bool? ac_(Observation MostRecentPriorHeartRate) {
+                Period al_ = tuple_fufpmqdratbglhghdwfuubanf?.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
+                DataType an_ = MostRecentPriorHeartRate?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+                CqlBoolean aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ap_, (string)default);
+                DataType ar_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
+                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
+                CqlBoolean au_ = context.Operators.Before(ap_, at_, (string)default);
+                CqlBoolean av_ = au_;
+                return aq_
+                    /* CQL 'and' (126:11-127:103) */ && av_;
             }
 
+            IEnumerable<Observation> ad_ = context.Operators.Where<Observation>(ab_, ac_);
 
-            CqlBoolean r_() {
-                DataType y_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Value;
-                CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_ as Quantity);
-                CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
-                CqlBoolean ab_ = context.Operators.Less(z_, aa_);
-                return ab_;
+            object ae_(Observation @this) {
+                DataType aw_ = @this?.Effective;
+                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+                return az_;
             }
 
-
-            CqlBoolean s_() {
-                IEnumerable<Observation> ac_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
-
-                bool? ad_(Observation MostRecentPriorHeartRate) {
-                    Period am_ = tuple_fufpmqdratbglhghdwfuubanf?.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
-                    DataType ao_ = MostRecentPriorHeartRate?.Effective;
-                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                    CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
-                    CqlBoolean ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, (string)default);
-
-                    CqlBoolean as_() {
-                        DataType at_ = MostRecentPriorHeartRate?.Effective;
-                        object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                        CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.toInterval(context, au_);
-                        DataType aw_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
-                        object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                        CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
-                        CqlBoolean az_ = context.Operators.Before(av_, ay_, (string)default);
-                        return az_;
-                    }
-
-                    return ar_
-                        /* CQL 'and' (126:11-127:103) */ && as_();
-                }
-
-                IEnumerable<Observation> ae_ = context.Operators.Where<Observation>(ac_, ad_);
-
-                object af_(Observation @this) {
-                    DataType ba_ = @this?.Effective;
-                    object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                    CqlInterval<CqlDateTime> bc_ = QICoreCommon_4_0_000.Instance.toInterval(context, bb_);
-                    CqlDateTime bd_ = context.Operators.Start(bc_);
-                    return bd_;
-                }
-
-                IEnumerable<Observation> ag_ = context.Operators.SortBy<Observation>(ae_, af_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation ah_ = context.Operators.Last<Observation>(ag_);
-                DataType ai_ = ah_?.Value;
-                CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                CqlQuantity ak_ = context.Operators.Quantity(50m, "/min");
-                CqlBoolean al_ = context.Operators.Less(aj_, ak_);
-                return al_;
-            }
-
+            IEnumerable<Observation> af_ = context.Operators.SortBy<Observation>(ad_, ae_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ag_ = context.Operators.Last<Observation>(af_);
+            DataType ah_ = ag_?.Value;
+            CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+            CqlBoolean aj_ = context.Operators.Less(ai_, y_);
+            CqlBoolean ak_ = aj_;
             return p_
-                /* CQL 'and' (130:13-131:67) */ && q_()
-                /* CQL 'and' (130:13-132:39) */ && r_()
-                /* CQL 'and' (130:7-133:44) */ && s_();
+                /* CQL 'and' (130:13-131:67) */ && v_
+                /* CQL 'and' (130:13-132:39) */ && aa_
+                /* CQL 'and' (130:7-133:44) */ && ak_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter ModerateOrSevereLVSDHFOutpatientEncounter)?> f_ = context.Operators.SelectWhere<ValueTuple<Observation, Encounter>, (CqlTupleMetadata, Observation HeartRate, Encounter ModerateOrSevereLVSDHFOutpatientEncounter)?>(c_, d_, e_);
@@ -403,30 +375,25 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
             List<CodeableConcept> o_ = NoBetaBlockerOrdered?.ReasonCode;
 
             CqlConcept p_(CodeableConcept @this) {
-                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return u_;
+                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return y_;
             }
 
             IEnumerable<CqlConcept> q_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)o_, p_);
             CqlValueSet r_ = this.Medical_Reason(context);
             CqlBoolean s_ = context.Operators.ConceptsInValueSet(q_, r_);
 
-            CqlBoolean t_() {
-                List<CodeableConcept> v_ = NoBetaBlockerOrdered?.ReasonCode;
-
-                CqlConcept w_(CodeableConcept @this) {
-                    CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return aa_;
-                }
-
-                IEnumerable<CqlConcept> x_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)v_, w_);
-                CqlValueSet y_ = this.Patient_Reason(context);
-                CqlBoolean z_ = context.Operators.ConceptsInValueSet(x_, y_);
+            CqlConcept t_(CodeableConcept @this) {
+                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                 return z_;
             }
 
+            IEnumerable<CqlConcept> u_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)o_, t_);
+            CqlValueSet v_ = this.Patient_Reason(context);
+            CqlBoolean w_ = context.Operators.ConceptsInValueSet(u_, v_);
+            CqlBoolean x_ = w_;
             return s_
-                /* CQL 'or' (174:7-176:7) */ || t_();
+                /* CQL 'or' (174:7-176:7) */ || x_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<MedicationRequest>(d_, e_);
@@ -440,29 +407,17 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
     {
         CodeableConcept a_ = allergyIntolerance?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = allergyIntolerance?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept j_ = allergyIntolerance?.VerificationStatus;
-                CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, j_);
-                CqlCode l_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
-                CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
-                CqlBoolean n_ = context.Operators.Equivalent(k_, m_);
-                return n_;
-            }
-
-            return h_
-                /* CQL 'or' (185:61-187:3) */ || i_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlBoolean j_ = e_
+            /* CQL 'or' (185:61-187:3) */ || i_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (185:3-187:3) */ || c_();
+            /* CQL 'implies' (185:3-187:3) */ || j_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS145FHIRCADBBlockerTPMIorLVSD", "1.0.000")]
 public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingleton<CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000>
 {
@@ -217,17 +217,13 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
             Period u_ = ValidEncounter?.Period;
             CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
             CqlBoolean w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, "day");
-
-            CqlBoolean x_() {
-                Code<Encounter.EncounterStatus> y_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? z_ = y_?.Value;
-                Code<Encounter.EncounterStatus> aa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(z_);
-                CqlBoolean ab_ = context.Operators.Equal(aa_, "finished");
-                return ab_;
-            }
-
+            Code<Encounter.EncounterStatus> x_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? y_ = x_?.Value;
+            Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
+            CqlBoolean aa_ = context.Operators.Equal(z_, "finished");
+            CqlBoolean ab_ = aa_;
             return w_
-                /* CQL 'and' (217:5-218:44) */ && x_();
+                /* CQL 'and' (217:5-218:44) */ && ab_;
         }
 
         IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
@@ -263,17 +259,13 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
             Period r_ = QualifyingEncounter?.Period;
             CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
             CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, "day");
-
-            CqlBoolean u_() {
-                Code<Encounter.EncounterStatus> v_ = QualifyingEncounter?.StatusElement;
-                Encounter.EncounterStatus? w_ = v_?.Value;
-                Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "finished");
-                return y_;
-            }
-
+            Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? v_ = u_?.Value;
+            Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+            CqlBoolean x_ = context.Operators.Equal(w_, "finished");
+            CqlBoolean y_ = x_;
             return t_
-                /* CQL 'and' (207:5-208:49) */ && u_();
+                /* CQL 'and' (207:5-208:49) */ && y_;
         }
 
         IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
@@ -370,33 +362,33 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
 
             bool? f_(Procedure CardiacSurgeryProcedure) {
                 object h_;
-                DataType p_ = CardiacSurgeryProcedure?.Performed;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                bool r_ = q_ is CqlDateTime;
-                if (r_)
+                DataType t_ = CardiacSurgeryProcedure?.Performed;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                bool v_ = u_ is CqlDateTime;
+                if (v_)
                 {
-                    h_ = q_ as CqlDateTime;
+                    h_ = u_ as CqlDateTime;
                 }
                 else
                 {
-                    bool s_ = q_ is CqlQuantity;
-                    if (s_)
+                    bool w_ = u_ is CqlQuantity;
+                    if (w_)
                     {
-                        h_ = q_ as CqlQuantity;
+                        h_ = u_ as CqlQuantity;
                     }
                     else
                     {
-                        bool t_ = q_ is CqlInterval<CqlDateTime>;
-                        if (t_)
+                        bool x_ = u_ is CqlInterval<CqlDateTime>;
+                        if (x_)
                         {
-                            h_ = q_ as CqlInterval<CqlDateTime>;
+                            h_ = u_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool u_ = q_ is CqlInterval<CqlQuantity>;
-                            if (u_)
+                            bool y_ = u_ is CqlInterval<CqlQuantity>;
+                            if (y_)
                             {
-                                h_ = q_ as CqlInterval<CqlQuantity>;
+                                h_ = u_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -411,17 +403,13 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                 CqlDateTime m_ = context.Operators.End(l_);
                 CqlBoolean n_ = context.Operators.Before(j_, m_, (string)default);
-
-                CqlBoolean o_() {
-                    Code<EventStatus> v_ = CardiacSurgeryProcedure?.StatusElement;
-                    EventStatus? w_ = v_?.Value;
-                    string x_ = context.Operators.Convert<string>(w_);
-                    CqlBoolean y_ = context.Operators.Equal(x_, "completed");
-                    return y_;
-                }
-
+                Code<EventStatus> o_ = CardiacSurgeryProcedure?.StatusElement;
+                EventStatus? p_ = o_?.Value;
+                string q_ = context.Operators.Convert<string>(p_);
+                CqlBoolean r_ = context.Operators.Equal(q_, "completed");
+                CqlBoolean s_ = r_;
                 return n_
-                    /* CQL 'and' (355:17-356:56) */ && o_();
+                    /* CQL 'and' (355:17-356:56) */ && s_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -465,40 +453,32 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 18);
+        IEnumerable<Encounter> j_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
-        CqlBoolean j_() {
-            IEnumerable<Encounter> l_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        bool? k_(Encounter Encounter1) {
+            IEnumerable<Encounter> q_ = this.Qualifying_Encounter_During_Measurement_Period(context);
 
-            bool? m_(Encounter Encounter1) {
-                IEnumerable<Encounter> o_ = this.Qualifying_Encounter_During_Measurement_Period(context);
-
-                bool? p_(Encounter Encounter2) {
-                    Id r_ = Encounter2?.IdElement;
-                    string s_ = r_?.Value;
-                    Id t_ = Encounter1?.IdElement;
-                    string u_ = t_?.Value;
-                    CqlBoolean v_ = context.Operators.Equivalent(s_, u_);
-                    return !v_;
-                }
-
-                CqlBoolean q_ = context.Operators.WhereAny<Encounter>(o_, p_);
-                return q_;
+            bool? r_(Encounter Encounter2) {
+                Id t_ = Encounter2?.IdElement;
+                string u_ = t_?.Value;
+                Id v_ = Encounter1?.IdElement;
+                string w_ = v_?.Value;
+                CqlBoolean x_ = context.Operators.Equivalent(u_, w_);
+                return !x_;
             }
 
-            CqlBoolean n_ = context.Operators.WhereAny<Encounter>(l_, m_);
-            return n_;
+            CqlBoolean s_ = context.Operators.WhereAny<Encounter>(q_, r_);
+            return s_;
         }
 
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> w_ = this.Qualifying_CAD_Encounter(context);
-            CqlBoolean x_ = context.Operators.Exists<Encounter>(w_);
-            return x_;
-        }
-
+        CqlBoolean l_ = context.Operators.WhereAny<Encounter>(j_, k_);
+        CqlBoolean m_ = l_;
+        IEnumerable<Encounter> n_ = this.Qualifying_CAD_Encounter(context);
+        CqlBoolean o_ = context.Operators.Exists<Encounter>(n_);
+        CqlBoolean p_ = o_;
         return i_
-            /* CQL 'and' (340:3-344:5) */ && j_()
-            /* CQL 'and' (340:3-345:41) */ && k_();
+            /* CQL 'and' (340:3-344:5) */ && m_
+            /* CQL 'and' (340:3-345:41) */ && p_;
     }
 
 
@@ -528,24 +508,13 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(p_, n_, true, false);
                 CqlBoolean r_ = context.Operators.In<CqlDateTime>(k_, q_, "day");
-
-                CqlBoolean s_() {
-                    Period u_ = EncounterWithCADProxy?.Period;
-                    CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    return w_ is not null;
-                }
-
-
-                CqlBoolean t_() {
-                    IEnumerable<object> x_ = AHAOverall_4_1_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
-                    CqlBoolean y_ = context.Operators.Exists<object>(x_);
-                    return !y_;
-                }
-
+                CqlBoolean s_ = (CqlBoolean)(n_ is not null);
+                IEnumerable<object> t_ = AHAOverall_4_1_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
+                CqlBoolean u_ = context.Operators.Exists<object>(t_);
+                CqlBoolean v_ = (CqlBoolean)!u_;
                 return r_
-                    /* CQL 'and' (110:17-110:134) */ && s_()
-                    /* CQL 'and' (110:17-111:61) */ && t_()
+                    /* CQL 'and' (110:17-110:134) */ && s_
+                    /* CQL 'and' (110:17-111:61) */ && v_
                     /* CQL 'and' (110:17-112:47) */ && AHAOverall_4_1_000.Instance.isVerified(context, MyocardialInfarction);
             }
 
@@ -567,15 +536,11 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
     private bool? Denominator_2_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Initial_Population(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (49:3-50:54) */ && b_();
+            /* CQL 'and' (49:3-50:54) */ && d_;
     }
 
 
@@ -639,33 +604,33 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
 
             bool? f_(Encounter CADEncounterMI) {
                 object h_;
-                DataType p_ = ImplantedCardiacPacer?.Performed;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                bool r_ = q_ is CqlDateTime;
-                if (r_)
+                DataType t_ = ImplantedCardiacPacer?.Performed;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                bool v_ = u_ is CqlDateTime;
+                if (v_)
                 {
-                    h_ = q_ as CqlDateTime;
+                    h_ = u_ as CqlDateTime;
                 }
                 else
                 {
-                    bool s_ = q_ is CqlQuantity;
-                    if (s_)
+                    bool w_ = u_ is CqlQuantity;
+                    if (w_)
                     {
-                        h_ = q_ as CqlQuantity;
+                        h_ = u_ as CqlQuantity;
                     }
                     else
                     {
-                        bool t_ = q_ is CqlInterval<CqlDateTime>;
-                        if (t_)
+                        bool x_ = u_ is CqlInterval<CqlDateTime>;
+                        if (x_)
                         {
-                            h_ = q_ as CqlInterval<CqlDateTime>;
+                            h_ = u_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool u_ = q_ is CqlInterval<CqlQuantity>;
-                            if (u_)
+                            bool y_ = u_ is CqlInterval<CqlQuantity>;
+                            if (y_)
                             {
-                                h_ = q_ as CqlInterval<CqlQuantity>;
+                                h_ = u_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -680,17 +645,13 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                 CqlDateTime m_ = context.Operators.End(l_);
                 CqlBoolean n_ = context.Operators.Before(j_, m_, (string)default);
-
-                CqlBoolean o_() {
-                    Code<EventStatus> v_ = ImplantedCardiacPacer?.StatusElement;
-                    EventStatus? w_ = v_?.Value;
-                    string x_ = context.Operators.Convert<string>(w_);
-                    CqlBoolean y_ = context.Operators.Equal(x_, "completed");
-                    return y_;
-                }
-
+                Code<EventStatus> o_ = ImplantedCardiacPacer?.StatusElement;
+                EventStatus? p_ = o_?.Value;
+                string q_ = context.Operators.Convert<string>(p_);
+                CqlBoolean r_ = context.Operators.Equal(q_, "completed");
+                CqlBoolean s_ = r_;
                 return n_
-                    /* CQL 'and' (102:19-103:56) */ && o_();
+                    /* CQL 'and' (102:19-103:56) */ && s_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Encounter>(e_, f_);
@@ -744,101 +705,77 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
             CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
             CqlBoolean p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, (string)default);
+            Code<ObservationStatus> q_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.StatusElement;
+            ObservationStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            string[] t_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+            CqlBoolean v_ = u_;
+            DataType w_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Value;
+            CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_ as Quantity);
+            CqlQuantity y_ = context.Operators.Quantity(50m, "/min");
+            CqlBoolean z_ = context.Operators.Less(x_, y_);
+            CqlBoolean aa_ = z_;
+            IEnumerable<Observation> ab_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
 
-            CqlBoolean q_() {
-                Code<ObservationStatus> t_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.StatusElement;
-                ObservationStatus? u_ = t_?.Value;
-                string v_ = context.Operators.Convert<string>(u_);
-                string[] w_ = [
+            bool? ac_(Observation MostRecentPriorHeartRateExam) {
+                Period al_ = tuple_ezawxthbubhdjanfnawxfxgjj?.CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
+                DataType an_ = MostRecentPriorHeartRateExam?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+                CqlBoolean aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ap_, (string)default);
+                Code<ObservationStatus> ar_ = MostRecentPriorHeartRateExam?.StatusElement;
+                ObservationStatus? as_ = ar_?.Value;
+                string at_ = context.Operators.Convert<string>(as_);
+                string[] au_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
-                return x_;
+                CqlBoolean av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+                CqlBoolean aw_ = av_;
+                DataType ax_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Effective;
+                object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_);
+                CqlBoolean ba_ = context.Operators.Before(ap_, az_, (string)default);
+                CqlBoolean bb_ = ba_;
+                return aq_
+                    /* CQL 'and' (68:17-69:90) */ && aw_
+                    /* CQL 'and' (68:11-70:111) */ && bb_;
             }
 
+            IEnumerable<Observation> ad_ = context.Operators.Where<Observation>(ab_, ac_);
 
-            CqlBoolean r_() {
-                DataType y_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Value;
-                CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_ as Quantity);
-                CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
-                CqlBoolean ab_ = context.Operators.Less(z_, aa_);
-                return ab_;
+            object ae_(Observation @this) {
+                DataType bc_ = @this?.Effective;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlInterval<CqlDateTime> be_ = QICoreCommon_4_0_000.Instance.toInterval(context, bd_);
+                CqlDateTime bf_ = context.Operators.Start(be_);
+                return bf_;
             }
 
-
-            CqlBoolean s_() {
-                IEnumerable<Observation> ac_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
-
-                bool? ad_(Observation MostRecentPriorHeartRateExam) {
-                    Period am_ = tuple_ezawxthbubhdjanfnawxfxgjj?.CADEncounterMI?.Period;
-                    CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
-                    DataType ao_ = MostRecentPriorHeartRateExam?.Effective;
-                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                    CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
-                    CqlBoolean ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, (string)default);
-
-                    CqlBoolean as_() {
-                        Code<ObservationStatus> au_ = MostRecentPriorHeartRateExam?.StatusElement;
-                        ObservationStatus? av_ = au_?.Value;
-                        string aw_ = context.Operators.Convert<string>(av_);
-                        string[] ax_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                        return ay_;
-                    }
-
-
-                    CqlBoolean at_() {
-                        DataType az_ = MostRecentPriorHeartRateExam?.Effective;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
-                        DataType bc_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Effective;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        CqlInterval<CqlDateTime> be_ = QICoreCommon_4_0_000.Instance.toInterval(context, bd_);
-                        CqlBoolean bf_ = context.Operators.Before(bb_, be_, (string)default);
-                        return bf_;
-                    }
-
-                    return ar_
-                        /* CQL 'and' (68:17-69:90) */ && as_()
-                        /* CQL 'and' (68:11-70:111) */ && at_();
-                }
-
-                IEnumerable<Observation> ae_ = context.Operators.Where<Observation>(ac_, ad_);
-
-                object af_(Observation @this) {
-                    DataType bg_ = @this?.Effective;
-                    object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                    CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
-                    CqlDateTime bj_ = context.Operators.Start(bi_);
-                    return bj_;
-                }
-
-                IEnumerable<Observation> ag_ = context.Operators.SortBy<Observation>(ae_, af_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation ah_ = context.Operators.Last<Observation>(ag_);
-                DataType ai_ = ah_?.Value;
-                CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                CqlQuantity ak_ = context.Operators.Quantity(50m, "/min");
-                CqlBoolean al_ = context.Operators.Less(aj_, ak_);
-                return al_;
-            }
-
+            IEnumerable<Observation> af_ = context.Operators.SortBy<Observation>(ad_, ae_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ag_ = context.Operators.Last<Observation>(af_);
+            DataType ah_ = ag_?.Value;
+            CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+            CqlBoolean aj_ = context.Operators.Less(ai_, y_);
+            CqlBoolean ak_ = aj_;
             return p_
-                /* CQL 'and' (73:13-74:71) */ && q_()
-                /* CQL 'and' (73:13-75:43) */ && r_()
-                /* CQL 'and' (73:7-76:48) */ && s_();
+                /* CQL 'and' (73:13-74:71) */ && v_
+                /* CQL 'and' (73:13-75:43) */ && aa_
+                /* CQL 'and' (73:7-76:48) */ && ak_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?> f_ = context.Operators.SelectWhere<ValueTuple<Observation, Encounter>, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?>(c_, d_, e_);
 
         (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? g_((CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? tuple_ezawxthbubhdjanfnawxfxgjj) {
-            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? bk_ = (CqlTupleMetadata_GgEMjKUjZUgEdXjOgPVEWONDD, tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam, tuple_ezawxthbubhdjanfnawxfxgjj?.CADEncounterMI);
-            return bk_;
+            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? bg_ = (CqlTupleMetadata_GgEMjKUjZUgEdXjOgPVEWONDD, tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam, tuple_ezawxthbubhdjanfnawxfxgjj?.CADEncounterMI);
+            return bg_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?> h_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?>(f_, g_);
@@ -894,46 +831,34 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 Period f_ = Visit?.Period;
                 CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
                 CqlBoolean h_ = context.Operators.In<CqlDateTime>(e_, g_, "day");
-
-                CqlBoolean i_() {
-                    Code<MedicationRequest.MedicationrequestStatus> l_ = Order?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? m_ = l_?.Value;
-                    string n_ = context.Operators.Convert<string>(m_);
-                    string[] o_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
-                    return p_;
-                }
-
-
-                CqlBoolean j_() {
-                    Code<MedicationRequest.MedicationRequestIntent> q_ = Order?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? r_ = q_?.Value;
-                    string s_ = context.Operators.Convert<string>(r_);
-                    string[] t_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                    return u_;
-                }
-
-
-                CqlBoolean k_() {
-                    FhirBoolean v_ = Order?.DoNotPerformElement;
-                    CqlBoolean w_ = v_?.Value;
-                    return !((bool?)(/* CQL 'is true' (396:15-396:44) */ w_.IsTrue));
-                }
-
+                Code<MedicationRequest.MedicationrequestStatus> i_ = Order?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? j_ = i_?.Value;
+                string k_ = context.Operators.Convert<string>(j_);
+                string[] l_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+                CqlBoolean n_ = m_;
+                Code<MedicationRequest.MedicationRequestIntent> o_ = Order?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? p_ = o_?.Value;
+                string q_ = context.Operators.Convert<string>(p_);
+                string[] r_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+                CqlBoolean t_ = s_;
+                FhirBoolean u_ = Order?.DoNotPerformElement;
+                CqlBoolean v_ = u_?.Value;
+                CqlBoolean w_ = (CqlBoolean)(!((bool?)(/* CQL 'is true' (396:15-396:44) */ v_.IsTrue)));
                 return (bool?)(h_
-                    /* CQL 'and' (393:46-394:55) */ && i_()
-                    /* CQL 'and' (393:46-395:109) */ && j_()
-                    /* CQL 'and' (393:46-396:44) */ && k_());
+                    /* CQL 'and' (393:46-394:55) */ && n_
+                    /* CQL 'and' (393:46-395:109) */ && t_
+                    /* CQL 'and' (393:46-396:44) */ && w_);
             }
             else if (Order is MedicationRequest)
             {
@@ -942,24 +867,20 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 Period z_ = Visit?.Period;
                 CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
                 CqlBoolean ab_ = context.Operators.In<CqlDateTime>(y_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Code<MedicationRequest.MedicationRequestIntent> ad_ = Order?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
+                Code<MedicationRequest.MedicationRequestIntent> ac_ = Order?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+                string ae_ = context.Operators.Convert<string>(ad_);
+                string[] af_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+                CqlBoolean ah_ = ag_;
                 return (bool?)(ab_
-                    /* CQL 'and' (397:51-398:109) */ && ac_());
+                    /* CQL 'and' (397:51-398:109) */ && ah_);
             }
             else
             {
@@ -1089,24 +1010,20 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 "completed",
             ];
             CqlBoolean aq_ = context.Operators.In<string>(ao_, (IEnumerable<string>)ap_);
-
-            CqlBoolean ar_() {
-                Code<MedicationRequest.MedicationRequestIntent> as_ = ActiveBetaBlockerForLVSD?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? at_ = as_?.Value;
-                string au_ = context.Operators.Convert<string>(at_);
-                string[] av_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
-                return aw_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> ar_ = ActiveBetaBlockerForLVSD?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? as_ = ar_?.Value;
+            string at_ = context.Operators.Convert<string>(as_);
+            string[] au_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+            CqlBoolean aw_ = av_;
             return aq_
-                /* CQL 'and' (197:7-198:126) */ && ar_();
+                /* CQL 'and' (197:7-198:126) */ && aw_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<MedicationRequest>(d_, e_);
@@ -1244,24 +1161,20 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 "completed",
             ];
             CqlBoolean aq_ = context.Operators.In<string>(ao_, (IEnumerable<string>)ap_);
-
-            CqlBoolean ar_() {
-                Code<MedicationRequest.MedicationRequestIntent> as_ = ActiveBetaBlocker?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? at_ = as_?.Value;
-                string au_ = context.Operators.Convert<string>(at_);
-                string[] av_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
-                return aw_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> ar_ = ActiveBetaBlocker?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? as_ = ar_?.Value;
+            string at_ = context.Operators.Convert<string>(as_);
+            string[] au_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+            CqlBoolean aw_ = av_;
             return aq_
-                /* CQL 'and' (185:7-186:119) */ && ar_();
+                /* CQL 'and' (185:7-186:119) */ && aw_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<MedicationRequest>(d_, e_);
@@ -1344,15 +1257,11 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
     private bool? Denominator_1_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Initial_Population(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (115:3-116:80) */ && b_();
+            /* CQL 'and' (115:3-116:80) */ && d_;
     }
 
 
@@ -1511,101 +1420,77 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
             CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
             CqlBoolean p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, (string)default);
+            Code<ObservationStatus> q_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.StatusElement;
+            ObservationStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            string[] t_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+            CqlBoolean v_ = u_;
+            DataType w_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Value;
+            CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_ as Quantity);
+            CqlQuantity y_ = context.Operators.Quantity(50m, "/min");
+            CqlBoolean z_ = context.Operators.Less(x_, y_);
+            CqlBoolean aa_ = z_;
+            IEnumerable<Observation> ab_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
 
-            CqlBoolean q_() {
-                Code<ObservationStatus> t_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.StatusElement;
-                ObservationStatus? u_ = t_?.Value;
-                string v_ = context.Operators.Convert<string>(u_);
-                string[] w_ = [
+            bool? ac_(Observation MostRecentPriorHeartRateExam) {
+                Period al_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
+                DataType an_ = MostRecentPriorHeartRateExam?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+                CqlBoolean aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ap_, (string)default);
+                Code<ObservationStatus> ar_ = MostRecentPriorHeartRateExam?.StatusElement;
+                ObservationStatus? as_ = ar_?.Value;
+                string at_ = context.Operators.Convert<string>(as_);
+                string[] au_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
-                return x_;
+                CqlBoolean av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+                CqlBoolean aw_ = av_;
+                DataType ax_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Effective;
+                object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_);
+                CqlBoolean ba_ = context.Operators.Before(ap_, az_, (string)default);
+                CqlBoolean bb_ = ba_;
+                return aq_
+                    /* CQL 'and' (134:17-135:90) */ && aw_
+                    /* CQL 'and' (134:11-136:111) */ && bb_;
             }
 
+            IEnumerable<Observation> ad_ = context.Operators.Where<Observation>(ab_, ac_);
 
-            CqlBoolean r_() {
-                DataType y_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Value;
-                CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_ as Quantity);
-                CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
-                CqlBoolean ab_ = context.Operators.Less(z_, aa_);
-                return ab_;
+            object ae_(Observation @this) {
+                DataType bc_ = @this?.Effective;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlInterval<CqlDateTime> be_ = QICoreCommon_4_0_000.Instance.toInterval(context, bd_);
+                CqlDateTime bf_ = context.Operators.Start(be_);
+                return bf_;
             }
 
-
-            CqlBoolean s_() {
-                IEnumerable<Observation> ac_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
-
-                bool? ad_(Observation MostRecentPriorHeartRateExam) {
-                    Period am_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.CADEncounterModerateOrSevereLVSD?.Period;
-                    CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
-                    DataType ao_ = MostRecentPriorHeartRateExam?.Effective;
-                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                    CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
-                    CqlBoolean ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, (string)default);
-
-                    CqlBoolean as_() {
-                        Code<ObservationStatus> au_ = MostRecentPriorHeartRateExam?.StatusElement;
-                        ObservationStatus? av_ = au_?.Value;
-                        string aw_ = context.Operators.Convert<string>(av_);
-                        string[] ax_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                        return ay_;
-                    }
-
-
-                    CqlBoolean at_() {
-                        DataType az_ = MostRecentPriorHeartRateExam?.Effective;
-                        object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                        CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
-                        DataType bc_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Effective;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        CqlInterval<CqlDateTime> be_ = QICoreCommon_4_0_000.Instance.toInterval(context, bd_);
-                        CqlBoolean bf_ = context.Operators.Before(bb_, be_, (string)default);
-                        return bf_;
-                    }
-
-                    return ar_
-                        /* CQL 'and' (134:17-135:90) */ && as_()
-                        /* CQL 'and' (134:11-136:111) */ && at_();
-                }
-
-                IEnumerable<Observation> ae_ = context.Operators.Where<Observation>(ac_, ad_);
-
-                object af_(Observation @this) {
-                    DataType bg_ = @this?.Effective;
-                    object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                    CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
-                    CqlDateTime bj_ = context.Operators.Start(bi_);
-                    return bj_;
-                }
-
-                IEnumerable<Observation> ag_ = context.Operators.SortBy<Observation>(ae_, af_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation ah_ = context.Operators.Last<Observation>(ag_);
-                DataType ai_ = ah_?.Value;
-                CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                CqlQuantity ak_ = context.Operators.Quantity(50m, "/min");
-                CqlBoolean al_ = context.Operators.Less(aj_, ak_);
-                return al_;
-            }
-
+            IEnumerable<Observation> af_ = context.Operators.SortBy<Observation>(ad_, ae_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ag_ = context.Operators.Last<Observation>(af_);
+            DataType ah_ = ag_?.Value;
+            CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+            CqlBoolean aj_ = context.Operators.Less(ai_, y_);
+            CqlBoolean ak_ = aj_;
             return p_
-                /* CQL 'and' (139:13-140:71) */ && q_()
-                /* CQL 'and' (139:13-141:43) */ && r_()
-                /* CQL 'and' (139:7-142:48) */ && s_();
+                /* CQL 'and' (139:13-140:71) */ && v_
+                /* CQL 'and' (139:13-141:43) */ && aa_
+                /* CQL 'and' (139:7-142:48) */ && ak_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?> f_ = context.Operators.SelectWhere<ValueTuple<Observation, Encounter>, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?>(c_, d_, e_);
 
         (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? g_((CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? tuple_dyeiilrxycxwhkhdhbjdnjgdc) {
-            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? bk_ = (CqlTupleMetadata_EWMjLSaIFCaWRZLQBiUcVjDES, tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam, tuple_dyeiilrxycxwhkhdhbjdnjgdc?.CADEncounterModerateOrSevereLVSD);
-            return bk_;
+            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? bg_ = (CqlTupleMetadata_EWMjLSaIFCaWRZLQBiUcVjDES, tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam, tuple_dyeiilrxycxwhkhdhbjdnjgdc?.CADEncounterModerateOrSevereLVSD);
+            return bg_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?> h_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?>(f_, g_);
@@ -1631,60 +1516,36 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 Period k_ = Visit?.Period;
                 CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                 CqlBoolean m_ = context.Operators.OverlapsAfter(j_, l_, "day");
-
-                CqlBoolean n_() {
-                    object p_ = context.Operators.LateBoundProperty<object>(Event, "clinicalStatus");
-                    CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_ as CodeableConcept);
-
-                    CqlBoolean r_() {
-                        object s_ = context.Operators.LateBoundProperty<object>(Event, "clinicalStatus");
-                        CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_ as CodeableConcept);
-                        CqlCode u_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
-                        CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                        CqlBoolean w_ = context.Operators.Equivalent(t_, v_);
-                        return w_;
-                    }
-
-                    return (CqlBoolean)(q_ is null)
-                        /* CQL 'or' (377:14-379:11) */ || r_();
-                }
-
-
-                CqlBoolean o_() {
-                    object x_ = context.Operators.LateBoundProperty<object>(Event, "verificationStatus");
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
-
-                    CqlBoolean z_() {
-                        object aa_ = context.Operators.LateBoundProperty<object>(Event, "verificationStatus");
-                        CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_ as CodeableConcept);
-                        CqlCode ac_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
-                        CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
-                        CqlBoolean ae_ = context.Operators.Equivalent(ab_, ad_);
-                        return ae_;
-                    }
-
-                    return (CqlBoolean)(y_ is null)
-                        /* CQL 'or' (380:14-382:11) */ || z_();
-                }
-
+                object n_ = context.Operators.LateBoundProperty<object>(Event, "clinicalStatus");
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_ as CodeableConcept);
+                CqlCode p_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
+                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+                CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
+                CqlBoolean s_ = r_;
+                CqlBoolean t_ = (CqlBoolean)(o_ is null)
+                    /* CQL 'or' (377:14-379:11) */ || s_;
+                object u_ = context.Operators.LateBoundProperty<object>(Event, "verificationStatus");
+                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_ as CodeableConcept);
+                CqlCode w_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
+                CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
+                CqlBoolean y_ = context.Operators.Equivalent(v_, x_);
+                CqlBoolean z_ = y_;
+                CqlBoolean aa_ = (CqlBoolean)(v_ is null)
+                    /* CQL 'or' (380:14-382:11) */ || z_;
                 return (bool?)(m_
-                    /* CQL 'and' (376:47-379:11) */ && n_()
-                    /* CQL 'and' (376:47-382:11) */ && o_());
+                    /* CQL 'and' (376:47-379:11) */ && t_
+                    /* CQL 'and' (376:47-382:11) */ && aa_);
             }
             else if (Event is Condition)
             {
-                CqlBoolean af_ = AHAOverall_4_1_000.Instance.isVerified(context, Event as AllergyIntolerance);
-
-                CqlBoolean ag_() {
-                    CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, (Event as Condition) as Condition);
-                    Period ai_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
-                    CqlBoolean ak_ = context.Operators.OverlapsAfter(ah_, aj_, "day");
-                    return ak_;
-                }
-
-                return (bool?)(af_
-                    /* CQL 'and' (383:60-384:75) */ && ag_());
+                CqlBoolean ab_ = AHAOverall_4_1_000.Instance.isVerified(context, Event as AllergyIntolerance);
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, (Event as Condition) as Condition);
+                Period ad_ = Visit?.Period;
+                CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
+                CqlBoolean af_ = context.Operators.OverlapsAfter(ac_, ae_, "day");
+                CqlBoolean ag_ = af_;
+                return (bool?)(ab_
+                    /* CQL 'and' (383:60-384:75) */ && ag_);
             }
             else
             {
@@ -2016,56 +1877,43 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 "completed",
             ];
             CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            Code<MedicationRequest.MedicationRequestIntent> t_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
+            List<CodeableConcept> z_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
 
-            CqlBoolean t_() {
-                Code<MedicationRequest.MedicationRequestIntent> v_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? w_ = v_?.Value;
-                string x_ = context.Operators.Convert<string>(w_);
-                string[] y_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
-                return z_;
+            CqlConcept aa_(CodeableConcept @this) {
+                CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ak_;
             }
 
+            IEnumerable<CqlConcept> ab_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)z_, aa_);
+            CqlValueSet ac_ = this.Medical_Reason(context);
+            CqlBoolean ad_ = context.Operators.ConceptsInValueSet(ab_, ac_);
 
-            CqlBoolean u_() {
-                List<CodeableConcept> aa_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
-
-                CqlConcept ab_(CodeableConcept @this) {
-                    CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return ag_;
-                }
-
-                IEnumerable<CqlConcept> ac_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)aa_, ab_);
-                CqlValueSet ad_ = this.Medical_Reason(context);
-                CqlBoolean ae_ = context.Operators.ConceptsInValueSet(ac_, ad_);
-
-                CqlBoolean af_() {
-                    List<CodeableConcept> ah_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
-
-                    CqlConcept ai_(CodeableConcept @this) {
-                        CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return am_;
-                    }
-
-                    IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ah_, ai_);
-                    CqlValueSet ak_ = this.Patient_Reason(context);
-                    CqlBoolean al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
-                    return al_;
-                }
-
-                return ae_
-                    /* CQL 'or' (323:13-325:9) */ || af_();
+            CqlConcept ae_(CodeableConcept @this) {
+                CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return al_;
             }
 
+            IEnumerable<CqlConcept> af_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)z_, ae_);
+            CqlValueSet ag_ = this.Patient_Reason(context);
+            CqlBoolean ah_ = context.Operators.ConceptsInValueSet(af_, ag_);
+            CqlBoolean ai_ = ah_;
+            CqlBoolean aj_ = ad_
+                /* CQL 'or' (323:13-325:9) */ || ai_;
             return s_
-                /* CQL 'and' (321:13-322:129) */ && t_()
-                /* CQL 'and' (321:7-325:9) */ && u_();
+                /* CQL 'and' (321:13-322:129) */ && y_
+                /* CQL 'and' (321:7-325:9) */ && aj_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<MedicationRequest>(d_, e_);
@@ -2132,56 +1980,43 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 "completed",
             ];
             CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            Code<MedicationRequest.MedicationRequestIntent> t_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
+            List<CodeableConcept> z_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
 
-            CqlBoolean t_() {
-                Code<MedicationRequest.MedicationRequestIntent> v_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? w_ = v_?.Value;
-                string x_ = context.Operators.Convert<string>(w_);
-                string[] y_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
-                return z_;
+            CqlConcept aa_(CodeableConcept @this) {
+                CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ak_;
             }
 
+            IEnumerable<CqlConcept> ab_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)z_, aa_);
+            CqlValueSet ac_ = this.Medical_Reason(context);
+            CqlBoolean ad_ = context.Operators.ConceptsInValueSet(ab_, ac_);
 
-            CqlBoolean u_() {
-                List<CodeableConcept> aa_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
-
-                CqlConcept ab_(CodeableConcept @this) {
-                    CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return ag_;
-                }
-
-                IEnumerable<CqlConcept> ac_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)aa_, ab_);
-                CqlValueSet ad_ = this.Medical_Reason(context);
-                CqlBoolean ae_ = context.Operators.ConceptsInValueSet(ac_, ad_);
-
-                CqlBoolean af_() {
-                    List<CodeableConcept> ah_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
-
-                    CqlConcept ai_(CodeableConcept @this) {
-                        CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return am_;
-                    }
-
-                    IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ah_, ai_);
-                    CqlValueSet ak_ = this.Patient_Reason(context);
-                    CqlBoolean al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
-                    return al_;
-                }
-
-                return ae_
-                    /* CQL 'or' (334:13-336:9) */ || af_();
+            CqlConcept ae_(CodeableConcept @this) {
+                CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return al_;
             }
 
+            IEnumerable<CqlConcept> af_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)z_, ae_);
+            CqlValueSet ag_ = this.Patient_Reason(context);
+            CqlBoolean ah_ = context.Operators.ConceptsInValueSet(af_, ag_);
+            CqlBoolean ai_ = ah_;
+            CqlBoolean aj_ = ad_
+                /* CQL 'or' (334:13-336:9) */ || ai_;
             return s_
-                /* CQL 'and' (332:13-333:129) */ && t_()
-                /* CQL 'and' (332:7-336:9) */ && u_();
+                /* CQL 'and' (332:13-333:129) */ && y_
+                /* CQL 'and' (332:7-336:9) */ && aj_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<MedicationRequest>(d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS146FHIRApproTestPharyngitis", "1.0.000")]
 public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISingleton<CMS146FHIRApproTestPharyngitis_1_0_000>
 {
@@ -316,17 +316,13 @@ public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
                     string s_ = context.Operators.Last<string>(r_);
                     CqlBoolean t_ = context.Operators.Equal(p_, s_);
-
-                    CqlBoolean u_() {
-                        CodeableConcept v_ = M?.Code;
-                        CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                        CqlValueSet x_ = this.Antibiotic_Medications_for_Pharyngitis(context);
-                        CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
-                        return y_;
-                    }
-
+                    CodeableConcept u_ = M?.Code;
+                    CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
+                    CqlValueSet w_ = this.Antibiotic_Medications_for_Pharyngitis(context);
+                    CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
+                    CqlBoolean y_ = x_;
                     return t_
-                        /* CQL 'and' */ && u_();
+                        /* CQL 'and' */ && y_;
                 }
 
                 CqlBoolean o_ = context.Operators.WhereAny<Medication>(m_, n_);
@@ -350,15 +346,9 @@ public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISinglet
                 CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
                 CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ag_, ae_, true, true);
                 CqlBoolean ai_ = context.Operators.In<CqlDateTime>(ac_, ah_, "day");
-
-                CqlBoolean aj_() {
-                    FhirDateTime ak_ = AntibioticOrdered?.AuthoredOnElement;
-                    CqlDateTime al_ = context.Operators.Convert<CqlDateTime>(ak_);
-                    return al_ is not null;
-                }
-
+                CqlBoolean aj_ = (CqlBoolean)(ae_ is not null);
                 return ai_
-                    /* CQL 'and' (82:17-82:128) */ && aj_();
+                    /* CQL 'and' (82:17-82:128) */ && aj_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<MedicationRequest>(j_, k_);
@@ -517,17 +507,13 @@ public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> ai_ = context.Operators.Split((string)ah_, "/");
                 string aj_ = context.Operators.Last<string>(ai_);
                 CqlBoolean ak_ = context.Operators.Equal(ag_, aj_);
-
-                CqlBoolean al_() {
-                    CodeableConcept am_ = M?.Code;
-                    CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
-                    CqlValueSet ao_ = this.Antibiotic_Medications_for_Pharyngitis(context);
-                    CqlBoolean ap_ = context.Operators.ConceptInValueSet(an_, ao_);
-                    return ap_;
-                }
-
+                CodeableConcept al_ = M?.Code;
+                CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, al_);
+                CqlValueSet an_ = this.Antibiotic_Medications_for_Pharyngitis(context);
+                CqlBoolean ao_ = context.Operators.ConceptInValueSet(am_, an_);
+                CqlBoolean ap_ = ao_;
                 return ak_
-                    /* CQL 'and' */ && al_();
+                    /* CQL 'and' */ && ap_;
             }
 
             CqlBoolean af_ = context.Operators.WhereAny<Medication>(ad_, ae_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS149FHIRDementiaCognitiveAssess-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS149FHIRDementiaCognitiveAssess-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS149FHIRDementiaCognitiveAssess", "1.0.000")]
 public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISingleton<CMS149FHIRDementiaCognitiveAssess_1_0_000>
 {
@@ -156,17 +156,13 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
             Period ad_ = EncounterAssessCognition?.Period;
             CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
             CqlBoolean af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ac_, ae_, "day");
-
-            CqlBoolean ag_() {
-                Code<Encounter.EncounterStatus> ah_ = EncounterAssessCognition?.StatusElement;
-                Encounter.EncounterStatus? ai_ = ah_?.Value;
-                Code<Encounter.EncounterStatus> aj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ai_);
-                CqlBoolean ak_ = context.Operators.Equivalent(aj_, "finished");
-                return ak_;
-            }
-
+            Code<Encounter.EncounterStatus> ag_ = EncounterAssessCognition?.StatusElement;
+            Encounter.EncounterStatus? ah_ = ag_?.Value;
+            Code<Encounter.EncounterStatus> ai_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ah_);
+            CqlBoolean aj_ = context.Operators.Equivalent(ai_, "finished");
+            CqlBoolean ak_ = aj_;
             return af_
-                /* CQL 'and' (81:5-82:54) */ && ag_();
+                /* CQL 'and' (81:5-82:54) */ && ak_;
         }
 
         IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
@@ -179,51 +175,27 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (92:54-93:66) */ || i_()
-                /* CQL 'or' (92:54-94:66) */ || j_()
-                /* CQL 'or' (92:52-96:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (92:54-93:66) */ || i_
+            /* CQL 'or' (92:54-94:66) */ || m_
+            /* CQL 'or' (92:52-96:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (92:3-96:3) */ || c_();
+            /* CQL 'implies' (92:3-96:3) */ || r_;
     }
 
 
@@ -248,38 +220,21 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
                 Period k_ = EncounterAssessCognition?.Period;
                 CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                 CqlBoolean m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, "day");
-
-                CqlBoolean n_() {
-                    CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Dementia);
-                    Period q_ = EncounterAssessCognition?.Period;
-                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.Overlaps(p_, r_, "day");
-                    return s_;
-                }
-
-
-                CqlBoolean o_() {
-                    DataType t_ = Dementia?.Abatement;
-                    object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-
-                    CqlBoolean v_() {
-                        DataType w_ = Dementia?.Abatement;
-                        object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                        CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
-                        CqlDateTime z_ = context.Operators.End(y_);
-                        CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
-                        CqlDateTime ab_ = context.Operators.End(aa_);
-                        CqlBoolean ac_ = context.Operators.After(z_, ab_, "day");
-                        return ac_;
-                    }
-
-                    return (CqlBoolean)(u_ is null)
-                        /* CQL 'or' (66:13-68:9) */ || v_();
-                }
-
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Dementia);
+                CqlBoolean o_ = context.Operators.Overlaps(n_, l_, "day");
+                CqlBoolean p_ = o_;
+                DataType q_ = Dementia?.Abatement;
+                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
+                CqlDateTime t_ = context.Operators.End(s_);
+                CqlDateTime u_ = context.Operators.End(j_);
+                CqlBoolean v_ = context.Operators.After(t_, u_, "day");
+                CqlBoolean w_ = v_;
+                CqlBoolean x_ = (CqlBoolean)(r_ is null)
+                    /* CQL 'or' (66:13-68:9) */ || w_;
                 return m_
-                    /* CQL 'and' (64:17-65:91) */ && n_()
-                    /* CQL 'and' (64:17-68:9) */ && o_()
+                    /* CQL 'and' (64:17-65:91) */ && p_
+                    /* CQL 'and' (64:17-68:9) */ && x_
                     /* CQL 'and' (64:17-69:35) */ && this.isVerified(context, Dementia);
             }
 
@@ -310,17 +265,13 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
             Period h_ = ValidEncounter?.Period;
             CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
             CqlBoolean j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, "day");
-
-            CqlBoolean k_() {
-                Code<Encounter.EncounterStatus> l_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? m_ = l_?.Value;
-                Code<Encounter.EncounterStatus> n_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(m_);
-                CqlBoolean o_ = context.Operators.Equal(n_, "finished");
-                return o_;
-            }
-
+            Code<Encounter.EncounterStatus> k_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? l_ = k_?.Value;
+            Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
+            CqlBoolean n_ = context.Operators.Equal(m_, "finished");
+            CqlBoolean o_ = n_;
             return j_
-                /* CQL 'and' (101:5-102:44) */ && k_();
+                /* CQL 'and' (101:5-102:44) */ && o_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
@@ -338,16 +289,12 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
     {
         IEnumerable<Encounter> a_ = this.Dementia_Encounter_During_Measurement_Period(context);
         CqlBoolean b_ = context.Operators.Exists<Encounter>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Measurement_Period(context);
-            int? e_ = context.Operators.Count<Encounter>(d_);
-            CqlBoolean f_ = context.Operators.GreaterOrEqual(e_, 2);
-            return f_;
-        }
-
+        IEnumerable<Encounter> c_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        int? d_ = context.Operators.Count<Encounter>(c_);
+        CqlBoolean e_ = context.Operators.GreaterOrEqual(d_, 2);
+        CqlBoolean f_ = e_;
         return b_
-            /* CQL 'and' (37:3-38:72) */ && c_();
+            /* CQL 'and' (37:3-38:72) */ && f_;
     }
 
 
@@ -393,16 +340,9 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
                 CqlDateTime u_ = context.Operators.Subtract(s_, t_);
                 CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, s_, true, true);
                 CqlBoolean w_ = context.Operators.In<CqlDateTime>(p_, v_, "day");
-
-                CqlBoolean x_() {
-                    Period y_ = EncounterDementia?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.End(z_);
-                    return aa_ is not null;
-                }
-
+                CqlBoolean x_ = (CqlBoolean)(s_ is not null);
                 return w_
-                    /* CQL 'and' (56:17-56:137) */ && x_();
+                    /* CQL 'and' (56:17-56:137) */ && x_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Encounter>(j_, k_);
@@ -412,24 +352,20 @@ public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISing
         IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
 
         bool? h_(Observation CognitiveAssessment) {
-            DataType ab_ = CognitiveAssessment?.Value;
-            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-
-            CqlBoolean ad_() {
-                Code<ObservationStatus> ae_ = CognitiveAssessment?.StatusElement;
-                ObservationStatus? af_ = ae_?.Value;
-                string ag_ = context.Operators.Convert<string>(af_);
-                string[] ah_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                return ai_;
-            }
-
-            return (CqlBoolean)(ac_ is not null)
-                /* CQL 'and' (57:5-58:75) */ && ad_();
+            DataType y_ = CognitiveAssessment?.Value;
+            object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+            Code<ObservationStatus> aa_ = CognitiveAssessment?.StatusElement;
+            ObservationStatus? ab_ = aa_?.Value;
+            string ac_ = context.Operators.Convert<string>(ab_);
+            string[] ad_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+            CqlBoolean af_ = ae_;
+            return (CqlBoolean)(z_ is not null)
+                /* CQL 'and' (57:5-58:75) */ && af_;
         }
 
         IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS153FHIRChlamydiaScreening", "1.0.000")]
 public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton<CMS153FHIRChlamydiaScreening_1_0_000>
 {
@@ -290,29 +290,25 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
             CqlCode i_ = this.Yes__qualifier_value_(context);
             CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
             CqlBoolean k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
-
-            CqlBoolean l_() {
-                DataType m_ = SexualActivityAssessment?.Effective;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlInterval<CqlDateTime> p_;
-                CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
-                CqlDateTime s_ = context.Operators.End(r_);
-                if (s_ is null)
-                {
-                    p_ = default;
-                }
-                else
-                {
-                    CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, s_, true, true);
-                    p_ = t_;
-                }
-                CqlBoolean q_ = context.Operators.SameOrBefore(o_, p_, (string)default);
-                return q_;
+            DataType l_ = SexualActivityAssessment?.Effective;
+            object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+            CqlInterval<CqlDateTime> o_;
+            CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
+            CqlDateTime s_ = context.Operators.End(r_);
+            if (s_ is null)
+            {
+                o_ = default;
             }
-
+            else
+            {
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, s_, true, true);
+                o_ = t_;
+            }
+            CqlBoolean p_ = context.Operators.SameOrBefore(n_, o_, (string)default);
+            CqlBoolean q_ = p_;
             return k_
-                /* CQL 'and' (170:7-171:102) */ && l_();
+                /* CQL 'and' (170:7-171:102) */ && q_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
@@ -375,17 +371,13 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
                 IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
                 string p_ = context.Operators.Last<string>(o_);
                 CqlBoolean q_ = context.Operators.Equal(m_, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = M?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlValueSet u_ = this.Contraceptive_Medications(context);
-                    CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                    return v_;
-                }
-
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Contraceptive_Medications(context);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' */ && r_();
+                    /* CQL 'and' */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Medication>(j_, k_);
@@ -436,17 +428,13 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
                 IEnumerable<string> o_ = context.Operators.Split((string)n_, "/");
                 string p_ = context.Operators.Last<string>(o_);
                 CqlBoolean q_ = context.Operators.Equal(m_, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = M?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlValueSet u_ = this.Contraceptive_Medications(context);
-                    CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
-                    return v_;
-                }
-
+                CodeableConcept r_ = M?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                CqlValueSet t_ = this.Contraceptive_Medications(context);
+                CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' */ && r_();
+                    /* CQL 'and' */ && v_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Medication>(j_, k_);
@@ -636,62 +624,49 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(16, 24, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
+        List<Extension> k_;
+        bool w_ = a_ is DomainResource;
+        if (w_)
+        {
+            k_ = (a_ as DomainResource).Extension;
+        }
+        else
+        {
+            k_ = default;
+        }
 
-        CqlBoolean k_() {
-            List<Extension> n_;
-            Patient t_ = this.Patient(context);
-            bool u_ = t_ is DomainResource;
-            if (u_)
-            {
-                n_ = (t_ as DomainResource).Extension;
-            }
-            else
-            {
-                n_ = default;
-            }
-
-            bool? o_(Extension @this) {
-                FhirUri v_ = @this?.UrlElement;
-                string w_ = FHIRHelpers_4_4_000.Instance.ToString(context, v_);
-                CqlBoolean x_ = context.Operators.Equal(w_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
-                return x_;
-            }
-
-
-            DataType p_(Extension @this) {
-                DataType y_ = @this?.Value;
-                return y_;
-            }
-
-            IEnumerable<DataType> q_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)n_, o_, p_);
-            DataType r_ = context.Operators.SingletonFrom<DataType>(q_);
-            CqlBoolean s_ = context.Operators.Equal(r_, "248152002");
-            return s_;
+        bool? l_(Extension @this) {
+            FhirUri x_ = @this?.UrlElement;
+            string y_ = FHIRHelpers_4_4_000.Instance.ToString(context, x_);
+            CqlBoolean z_ = context.Operators.Equal(y_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+            return z_;
         }
 
 
-        CqlBoolean l_() {
-            IEnumerable<Encounter> z_ = this.Qualifying_Encounters(context);
-            CqlBoolean aa_ = context.Operators.Exists<Encounter>(z_);
+        DataType m_(Extension @this) {
+            DataType aa_ = @this?.Value;
             return aa_;
         }
 
-
-        CqlBoolean m_() {
-            CqlBoolean ab_ = this.Has_Assessments_Identifying_Sexual_Activity(context);
-            return ab_
-                /* CQL 'or' (64:11-65:58) */ || this.Has_Diagnoses_Identifying_Sexual_Activity(context)
-                /* CQL 'or' (64:11-66:53) */ || this.Has_Active_Contraceptive_Medications(context)
-                /* CQL 'or' (64:11-67:54) */ || this.Has_Ordered_Contraceptive_Medications(context)
-                /* CQL 'or' (64:11-68:65) */ || this.Has_Laboratory_Tests_Identifying_Sexual_Activity(context)
-                /* CQL 'or' (64:11-69:67) */ || this.Has_Diagnostic_Studies_Identifying_Sexual_Activity(context)
-                /* CQL 'or' (64:9-71:5) */ || this.Has_Procedures_Identifying_Sexual_Activity(context);
-        }
-
+        IEnumerable<DataType> n_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)k_, l_, m_);
+        DataType o_ = context.Operators.SingletonFrom<DataType>(n_);
+        CqlBoolean p_ = context.Operators.Equal(o_, "248152002");
+        CqlBoolean q_ = p_;
+        IEnumerable<Encounter> r_ = this.Qualifying_Encounters(context);
+        CqlBoolean s_ = context.Operators.Exists<Encounter>(r_);
+        CqlBoolean t_ = s_;
+        CqlBoolean u_ = this.Has_Assessments_Identifying_Sexual_Activity(context);
+        CqlBoolean v_ = u_
+            /* CQL 'or' (64:11-65:58) */ || this.Has_Diagnoses_Identifying_Sexual_Activity(context)
+            /* CQL 'or' (64:11-66:53) */ || this.Has_Active_Contraceptive_Medications(context)
+            /* CQL 'or' (64:11-67:54) */ || this.Has_Ordered_Contraceptive_Medications(context)
+            /* CQL 'or' (64:11-68:65) */ || this.Has_Laboratory_Tests_Identifying_Sexual_Activity(context)
+            /* CQL 'or' (64:11-69:67) */ || this.Has_Diagnostic_Studies_Identifying_Sexual_Activity(context)
+            /* CQL 'or' (64:9-71:5) */ || this.Has_Procedures_Identifying_Sexual_Activity(context);
         return j_
-            /* CQL 'and' (59:3-62:33) */ && k_()
-            /* CQL 'and' (59:3-63:42) */ && l_()
-            /* CQL 'and' (59:3-71:5) */ && m_();
+            /* CQL 'and' (59:3-62:33) */ && q_
+            /* CQL 'and' (59:3-63:42) */ && t_
+            /* CQL 'and' (59:3-71:5) */ && v_;
     }
 
 
@@ -738,17 +713,9 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
                 CqlDateTime ab_ = context.Operators.Add(z_, aa_);
                 CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_, true, true);
                 CqlBoolean ad_ = context.Operators.In<CqlDateTime>(v_, ac_, "day");
-
-                CqlBoolean ae_() {
-                    FhirDateTime af_ = PregnancyTest?.AuthoredOnElement;
-                    CqlDateTime ag_ = context.Operators.Convert<CqlDateTime>(af_);
-                    CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
-                    CqlDateTime ai_ = context.Operators.End(ah_);
-                    return ai_ is not null;
-                }
-
+                CqlBoolean ae_ = (CqlBoolean)(z_ is not null);
                 return ad_
-                    /* CQL 'and' (143:21-143:136) */ && ae_();
+                    /* CQL 'and' (143:21-143:136) */ && ae_;
             }
 
             CqlBoolean r_ = context.Operators.WhereAny<ServiceRequest>(p_, q_);
@@ -758,90 +725,78 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
         IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
 
         bool? f_(ServiceRequest PregnancyTest) {
-            CqlInterval<CqlDateTime> aj_ = this.Measurement_Period(context);
-            FhirDateTime ak_ = PregnancyTest?.AuthoredOnElement;
-            CqlDateTime al_ = context.Operators.Convert<CqlDateTime>(ak_);
-            CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-            CqlBoolean an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aj_, am_, (string)default);
-            return an_;
+            CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
+            FhirDateTime ag_ = PregnancyTest?.AuthoredOnElement;
+            CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
+            CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
+            CqlBoolean aj_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ai_, (string)default);
+            return aj_;
         }
 
         IEnumerable<ServiceRequest> g_ = context.Operators.Where<ServiceRequest>(e_, f_);
 
         bool? h_(ServiceRequest PregnancyTestOrder) {
-            IEnumerable<MedicationRequest> ao_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> ak_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            bool? ap_(MedicationRequest MR) {
-                IEnumerable<Medication> ax_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? al_(MedicationRequest MR) {
+                IEnumerable<Medication> at_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? ay_(Medication M) {
-                    object ba_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object bb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> bc_ = context.Operators.Split((string)bb_, "/");
-                    string bd_ = context.Operators.Last<string>(bc_);
-                    CqlBoolean be_ = context.Operators.Equal(ba_, bd_);
-
-                    CqlBoolean bf_() {
-                        CodeableConcept bg_ = M?.Code;
-                        CqlConcept bh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bg_);
-                        CqlValueSet bi_ = this.Isotretinoin(context);
-                        CqlBoolean bj_ = context.Operators.ConceptInValueSet(bh_, bi_);
-                        return bj_;
-                    }
-
-                    return be_
-                        /* CQL 'and' */ && bf_();
+                bool? au_(Medication M) {
+                    object aw_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object ax_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> ay_ = context.Operators.Split((string)ax_, "/");
+                    string az_ = context.Operators.Last<string>(ay_);
+                    CqlBoolean ba_ = context.Operators.Equal(aw_, az_);
+                    CodeableConcept bb_ = M?.Code;
+                    CqlConcept bc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bb_);
+                    CqlValueSet bd_ = this.Isotretinoin(context);
+                    CqlBoolean be_ = context.Operators.ConceptInValueSet(bc_, bd_);
+                    CqlBoolean bf_ = be_;
+                    return ba_
+                        /* CQL 'and' */ && bf_;
                 }
 
-                CqlBoolean az_ = context.Operators.WhereAny<Medication>(ax_, ay_);
-                return az_;
+                CqlBoolean av_ = context.Operators.WhereAny<Medication>(at_, au_);
+                return av_;
             }
 
-            IEnumerable<MedicationRequest> aq_ = context.Operators.Where<MedicationRequest>(ao_, ap_);
-            CqlValueSet ar_ = this.Isotretinoin(context);
-            IEnumerable<MedicationRequest> as_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ar_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
-            IEnumerable<MedicationRequest> au_ = Status_1_15_000.Instance.isMedicationOrder(context, at_);
+            IEnumerable<MedicationRequest> am_ = context.Operators.Where<MedicationRequest>(ak_, al_);
+            CqlValueSet an_ = this.Isotretinoin(context);
+            IEnumerable<MedicationRequest> ao_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, an_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> ap_ = context.Operators.Union<MedicationRequest>(am_, ao_);
+            IEnumerable<MedicationRequest> aq_ = Status_1_15_000.Instance.isMedicationOrder(context, ap_);
 
-            bool? av_(MedicationRequest AccutaneOrder) {
-                FhirDateTime bk_ = AccutaneOrder?.AuthoredOnElement;
+            bool? ar_(MedicationRequest AccutaneOrder) {
+                FhirDateTime bg_ = AccutaneOrder?.AuthoredOnElement;
+                CqlDateTime bh_ = context.Operators.Convert<CqlDateTime>(bg_);
+                CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
+                CqlDateTime bj_ = context.Operators.Start(bi_);
+                FhirDateTime bk_ = PregnancyTestOrder?.AuthoredOnElement;
                 CqlDateTime bl_ = context.Operators.Convert<CqlDateTime>(bk_);
                 CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_);
-                CqlDateTime bn_ = context.Operators.Start(bm_);
-                FhirDateTime bo_ = PregnancyTestOrder?.AuthoredOnElement;
-                CqlDateTime bp_ = context.Operators.Convert<CqlDateTime>(bo_);
-                CqlInterval<CqlDateTime> bq_ = QICoreCommon_4_0_000.Instance.toInterval(context, bp_);
-                CqlDateTime br_ = context.Operators.End(bq_);
-                CqlQuantity bs_ = context.Operators.Quantity(6m, "days");
-                CqlDateTime bt_ = context.Operators.Add(br_, bs_);
-                CqlInterval<CqlDateTime> bu_ = context.Operators.Interval(br_, bt_, true, true);
-                CqlBoolean bv_ = context.Operators.In<CqlDateTime>(bn_, bu_, "day");
-
-                CqlBoolean bw_() {
-                    FhirDateTime bx_ = PregnancyTestOrder?.AuthoredOnElement;
-                    CqlDateTime by_ = context.Operators.Convert<CqlDateTime>(bx_);
-                    CqlInterval<CqlDateTime> bz_ = QICoreCommon_4_0_000.Instance.toInterval(context, by_);
-                    CqlDateTime ca_ = context.Operators.End(bz_);
-                    return ca_ is not null;
-                }
-
-                return bv_
-                    /* CQL 'and' (148:21-148:145) */ && bw_();
+                CqlDateTime bn_ = context.Operators.End(bm_);
+                CqlQuantity bo_ = context.Operators.Quantity(6m, "days");
+                CqlDateTime bp_ = context.Operators.Add(bn_, bo_);
+                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bn_, bp_, true, true);
+                CqlBoolean br_ = context.Operators.In<CqlDateTime>(bj_, bq_, "day");
+                CqlBoolean bs_ = (CqlBoolean)(bn_ is not null);
+                return br_
+                    /* CQL 'and' (148:21-148:145) */ && bs_;
             }
 
-            CqlBoolean aw_ = context.Operators.WhereAny<MedicationRequest>(au_, av_);
-            return aw_;
+            CqlBoolean as_ = context.Operators.WhereAny<MedicationRequest>(aq_, ar_);
+            return as_;
         }
 
         IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(c_, h_);
 
         bool? j_(ServiceRequest PregnancyTestOrder) {
-            CqlInterval<CqlDateTime> cb_ = this.Measurement_Period(context);
-            FhirDateTime cc_ = PregnancyTestOrder?.AuthoredOnElement;
-            CqlDateTime cd_ = context.Operators.Convert<CqlDateTime>(cc_);
-            CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.toInterval(context, cd_);
-            CqlBoolean cf_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cb_, ce_, (string)default);
-            return cf_;
+            CqlInterval<CqlDateTime> bt_ = this.Measurement_Period(context);
+            FhirDateTime bu_ = PregnancyTestOrder?.AuthoredOnElement;
+            CqlDateTime bv_ = context.Operators.Convert<CqlDateTime>(bu_);
+            CqlInterval<CqlDateTime> bw_ = QICoreCommon_4_0_000.Instance.toInterval(context, bv_);
+            CqlBoolean bx_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bt_, bw_, (string)default);
+            return bx_;
         }
 
         IEnumerable<ServiceRequest> k_ = context.Operators.Where<ServiceRequest>(i_, j_);
@@ -860,21 +815,17 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
-
-        CqlBoolean b_() {
-            CqlBoolean c_ = this.Has_Pregnancy_Test_Exclusion(context);
-            return c_
-                /* CQL 'and' (130:10-131:65) */ && !(this.Has_Assessments_Identifying_Sexual_Activity(context))
-                /* CQL 'and' (130:10-132:63) */ && !(this.Has_Diagnoses_Identifying_Sexual_Activity(context))
-                /* CQL 'and' (130:10-133:58) */ && !(this.Has_Active_Contraceptive_Medications(context))
-                /* CQL 'and' (130:10-134:59) */ && !(this.Has_Ordered_Contraceptive_Medications(context))
-                /* CQL 'and' (130:10-135:88) */ && !(this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy(context))
-                /* CQL 'and' (130:10-136:72) */ && !(this.Has_Diagnostic_Studies_Identifying_Sexual_Activity(context))
-                /* CQL 'and' (130:8-138:5) */ && !(this.Has_Procedures_Identifying_Sexual_Activity(context));
-        }
-
+        CqlBoolean b_ = this.Has_Pregnancy_Test_Exclusion(context);
+        CqlBoolean c_ = b_
+            /* CQL 'and' (130:10-131:65) */ && !(this.Has_Assessments_Identifying_Sexual_Activity(context))
+            /* CQL 'and' (130:10-132:63) */ && !(this.Has_Diagnoses_Identifying_Sexual_Activity(context))
+            /* CQL 'and' (130:10-133:58) */ && !(this.Has_Active_Contraceptive_Medications(context))
+            /* CQL 'and' (130:10-134:59) */ && !(this.Has_Ordered_Contraceptive_Medications(context))
+            /* CQL 'and' (130:10-135:88) */ && !(this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy(context))
+            /* CQL 'and' (130:10-136:72) */ && !(this.Has_Diagnostic_Studies_Identifying_Sexual_Activity(context))
+            /* CQL 'and' (130:8-138:5) */ && !(this.Has_Procedures_Identifying_Sexual_Activity(context));
         return a_
-            /* CQL 'or' (129:3-138:5) */ || b_();
+            /* CQL 'or' (129:3-138:5) */ || c_;
     }
 
 
@@ -892,25 +843,25 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
 
         bool? d_(Observation ChlamydiaTest) {
             object f_;
-            DataType k_ = ChlamydiaTest?.Effective;
-            object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-            bool m_ = l_ is CqlDateTime;
-            if (m_)
+            DataType m_ = ChlamydiaTest?.Effective;
+            object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+            bool o_ = n_ is CqlDateTime;
+            if (o_)
             {
-                f_ = l_ as CqlDateTime;
+                f_ = n_ as CqlDateTime;
             }
             else
             {
-                if (m_)
+                if (o_)
                 {
-                    f_ = l_ as CqlDateTime;
+                    f_ = n_ as CqlDateTime;
                 }
                 else
                 {
-                    bool n_ = l_ is CqlInterval<CqlDateTime>;
-                    if (n_)
+                    bool p_ = n_ is CqlInterval<CqlDateTime>;
+                    if (p_)
                     {
-                        f_ = l_ as CqlInterval<CqlDateTime>;
+                        f_ = n_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -921,15 +872,11 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
             CqlDateTime g_ = QICoreCommon_4_0_000.Instance.latest(context, f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                DataType o_ = ChlamydiaTest?.Value;
-                object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                return p_ is not null;
-            }
-
+            DataType j_ = ChlamydiaTest?.Value;
+            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
             return i_
-                /* CQL 'and' (154:7-155:43) */ && j_();
+                /* CQL 'and' (154:7-155:43) */ && l_;
         }
 
         CqlBoolean e_ = context.Operators.WhereAny<Observation>(c_, d_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS154FHIRAppropriateTxforURI", "1.0.000")]
 public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleton<CMS154FHIRAppropriateTxforURI_1_0_000>
 {
@@ -322,17 +322,10 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
             Period p_ = tuple_figmirinmncaavfkbmahdktce?.QualifyingEncounters?.Period;
             CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
             CqlBoolean r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, tuple_figmirinmncaavfkbmahdktce?.URI);
-                Period u_ = tuple_figmirinmncaavfkbmahdktce?.QualifyingEncounters?.Period;
-                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                CqlBoolean w_ = context.Operators.OverlapsBefore(t_, v_, (string)default);
-                return w_;
-            }
-
+            CqlBoolean s_ = context.Operators.OverlapsBefore(n_, q_, (string)default);
+            CqlBoolean t_ = s_;
             return r_
-                /* CQL 'or' (78:5-79:79) */ || s_();
+                /* CQL 'or' (78:5-79:79) */ || t_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounters, Condition URI)?> j_ = context.Operators.SelectWhere<ValueTuple<Encounter, Condition>, (CqlTupleMetadata, Encounter QualifyingEncounters, Condition URI)?>(g_, h_, i_);
@@ -435,17 +428,13 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> ao_ = context.Operators.Split((string)an_, "/");
                 string ap_ = context.Operators.Last<string>(ao_);
                 CqlBoolean aq_ = context.Operators.Equal(am_, ap_);
-
-                CqlBoolean ar_() {
-                    CodeableConcept as_ = M?.Code;
-                    CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, as_);
-                    CqlValueSet au_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
-                    CqlBoolean av_ = context.Operators.ConceptInValueSet(at_, au_);
-                    return av_;
-                }
-
+                CodeableConcept ar_ = M?.Code;
+                CqlConcept as_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ar_);
+                CqlValueSet at_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
+                CqlBoolean au_ = context.Operators.ConceptInValueSet(as_, at_);
+                CqlBoolean av_ = au_;
                 return aq_
-                    /* CQL 'and' */ && ar_();
+                    /* CQL 'and' */ && av_;
             }
 
             CqlBoolean al_ = context.Operators.WhereAny<Medication>(aj_, ak_);
@@ -500,17 +489,13 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
                     IEnumerable<string> t_ = context.Operators.Split((string)s_, "/");
                     string u_ = context.Operators.Last<string>(t_);
                     CqlBoolean v_ = context.Operators.Equal(r_, u_);
-
-                    CqlBoolean w_() {
-                        CodeableConcept x_ = M?.Code;
-                        CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                        CqlValueSet z_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
-                        CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                        return aa_;
-                    }
-
+                    CodeableConcept w_ = M?.Code;
+                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
+                    CqlValueSet y_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection(context);
+                    CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
+                    CqlBoolean aa_ = z_;
                     return v_
-                        /* CQL 'and' */ && w_();
+                        /* CQL 'and' */ && aa_;
                 }
 
                 CqlBoolean q_ = context.Operators.WhereAny<Medication>(o_, p_);
@@ -533,16 +518,9 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
                 CqlDateTime ah_ = context.Operators.Add(af_, ag_);
                 CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(af_, ah_, true, true);
                 CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, (string)default);
-
-                CqlBoolean ak_() {
-                    Period al_ = EncounterWithURI?.Period;
-                    CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                    CqlDateTime an_ = context.Operators.Start(am_);
-                    return an_ is not null;
-                }
-
+                CqlBoolean ak_ = (CqlBoolean)(af_ is not null);
                 return aj_
-                    /* CQL 'and' (107:17-107:104) */ && ak_();
+                    /* CQL 'and' (107:17-107:104) */ && ak_;
             }
 
             CqlBoolean n_ = context.Operators.WhereAny<MedicationRequest>(l_, m_);
@@ -576,22 +554,11 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
             CqlDate l_ = context.Operators.DateFrom(k_);
             int? m_ = context.Operators.CalculateAgeAt(i_, l_, "month");
             CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 3);
-
-            CqlBoolean o_() {
-                Patient p_ = this.Patient(context);
-                Date q_ = p_?.BirthDateElement;
-                string r_ = q_?.Value;
-                CqlDate s_ = context.Operators.ConvertStringToDate(r_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlDateTime u_ = context.Operators.Start(t_);
-                CqlDate v_ = context.Operators.DateFrom(u_);
-                int? w_ = context.Operators.CalculateAgeAt(s_, v_, "year");
-                CqlBoolean x_ = context.Operators.LessOrEqual(w_, 17);
-                return x_;
-            }
-
+            int? o_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+            CqlBoolean p_ = context.Operators.LessOrEqual(o_, 17);
+            CqlBoolean q_ = p_;
             return n_
-                /* CQL 'and' (112:5-113:69) */ && o_();
+                /* CQL 'and' (112:5-113:69) */ && q_;
         }
 
         Encounter c_(Encounter EncounterWithURI) => EncounterWithURI;

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS155FHIRWgtAssessCounseling-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS155FHIRWgtAssessCounseling-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS155FHIRWgtAssessCounseling", "1.0.000")]
 public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleton<CMS155FHIRWgtAssessCounseling_1_0_000>
 {
@@ -209,15 +209,11 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(3, 17, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> l_ = this.Qualifying_Encounters(context);
-            CqlBoolean m_ = context.Operators.Exists<Encounter>(l_);
-            return m_;
-        }
-
+        IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
+        CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
+        CqlBoolean m_ = l_;
         return j_
-            /* CQL 'and' (40:3-43:38) */ && k_();
+            /* CQL 'and' (40:3-43:38) */ && m_;
     }
 
 
@@ -269,15 +265,11 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Condition> c_ = this.Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period(context);
-            CqlBoolean d_ = context.Operators.Exists<Condition>(c_);
-            return d_;
-        }
-
+        IEnumerable<Condition> b_ = this.Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period(context);
+        CqlBoolean c_ = context.Operators.Exists<Condition>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'or' (49:3-50:69) */ || b_();
+            /* CQL 'or' (49:3-50:69) */ || d_;
     }
 
 
@@ -298,15 +290,11 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                DataType k_ = BMIPercentile?.Value;
-                CqlQuantity l_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, k_ as Quantity);
-                return l_ is not null;
-            }
-
+            DataType j_ = BMIPercentile?.Value;
+            CqlQuantity k_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, j_ as Quantity);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
             return i_
-                /* CQL 'and' (104:5-105:41) */ && j_();
+                /* CQL 'and' (104:5-105:41) */ && l_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -331,15 +319,11 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                DataType k_ = HeightExam?.Value;
-                CqlQuantity l_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, k_ as Quantity);
-                return l_ is not null;
-            }
-
+            DataType j_ = HeightExam?.Value;
+            CqlQuantity k_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, j_ as Quantity);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
             return i_
-                /* CQL 'and' (94:5-95:38) */ && j_();
+                /* CQL 'and' (94:5-95:38) */ && l_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -364,15 +348,11 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                DataType k_ = WeightExam?.Value;
-                CqlQuantity l_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, k_ as Quantity);
-                return l_ is not null;
-            }
-
+            DataType j_ = WeightExam?.Value;
+            CqlQuantity k_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, j_ as Quantity);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
             return i_
-                /* CQL 'and' (99:5-100:38) */ && j_();
+                /* CQL 'and' (99:5-100:38) */ && l_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -390,23 +370,15 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
     {
         IEnumerable<Observation> a_ = this.BMI_Percentile_in_Measurement_Period(context);
         CqlBoolean b_ = context.Operators.Exists<Observation>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> e_ = this.Height_in_Measurement_Period(context);
-            CqlBoolean f_ = context.Operators.Exists<Observation>(e_);
-            return f_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Observation> g_ = this.Weight_in_Measurement_Period(context);
-            CqlBoolean h_ = context.Operators.Exists<Observation>(g_);
-            return h_;
-        }
-
+        IEnumerable<Observation> c_ = this.Height_in_Measurement_Period(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
+        IEnumerable<Observation> f_ = this.Weight_in_Measurement_Period(context);
+        CqlBoolean g_ = context.Operators.Exists<Observation>(f_);
+        CqlBoolean h_ = g_;
         return b_
-            /* CQL 'and' (59:3-60:45) */ && c_()
-            /* CQL 'and' (59:3-61:45) */ && d_();
+            /* CQL 'and' (59:3-60:45) */ && e_
+            /* CQL 'and' (59:3-61:45) */ && h_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS156FHIRHighRiskMedsElderly", "1.0.000")]
 public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleton<CMS156FHIRHighRiskMedsElderly_1_0_000>
 {
@@ -416,15 +416,11 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 65);
-
-        CqlBoolean j_() {
-            IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
-            CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
-            return l_;
-        }
-
+        IEnumerable<Encounter> j_ = this.Qualifying_Encounters(context);
+        CqlBoolean k_ = context.Operators.Exists<Encounter>(j_);
+        CqlBoolean l_ = k_;
         return i_
-            /* CQL 'and' (82:3-85:38) */ && j_();
+            /* CQL 'and' (82:3-85:38) */ && l_;
     }
 
 
@@ -468,110 +464,45 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlBoolean l_ = context.Operators.In<CqlDateTime>(j_, k_, (string)default);
-
-                CqlBoolean m_() {
-                    MedicationRequest.DispenseRequestComponent p_ = OrderMedication1?.DispenseRequest;
-                    UnsignedInt q_ = p_?.NumberOfRepeatsAllowedElement;
-                    int? r_ = q_?.Value;
-                    CqlBoolean s_ = context.Operators.GreaterOrEqual(r_, 1);
-                    return s_;
-                }
-
-
-                CqlBoolean n_() {
-                    FhirDateTime t_ = OrderMedication1?.AuthoredOnElement;
-                    CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
-                    CqlDate v_ = context.Operators.DateFrom(u_);
-                    FhirDateTime w_ = OrderMedication2?.AuthoredOnElement;
-                    CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
-                    CqlDate y_ = context.Operators.DateFrom(x_);
-                    CqlBoolean z_ = context.Operators.Equivalent(v_, y_);
-
-                    CqlBoolean aa_() {
-                        FhirDateTime ac_ = OrderMedication1?.AuthoredOnElement;
-                        CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(ac_);
-                        CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
-                        CqlBoolean af_ = context.Operators.In<CqlDateTime>(ad_, ae_, (string)default);
-                        return af_;
-                    }
-
-
-                    CqlBoolean ab_() {
-                        FhirDateTime ag_ = OrderMedication2?.AuthoredOnElement;
-                        CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
-                        CqlInterval<CqlDateTime> ai_ = this.Measurement_Period(context);
-                        CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, (string)default);
-                        return aj_;
-                    }
-
-                    return (CqlBoolean)!z_
-                        /* CQL 'and' (253:14-254:71) */ && aa_()
-                        /* CQL 'and' (253:12-256:9) */ && ab_();
-                }
-
-
-                CqlBoolean o_() {
-                    FhirDateTime ak_ = OrderMedication1?.AuthoredOnElement;
-                    CqlDateTime al_ = context.Operators.Convert<CqlDateTime>(ak_);
-                    CqlDate am_ = context.Operators.DateFrom(al_);
-                    FhirDateTime an_ = OrderMedication2?.AuthoredOnElement;
-                    CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(an_);
-                    CqlDate ap_ = context.Operators.DateFrom(ao_);
-                    CqlBoolean aq_ = context.Operators.Equivalent(am_, ap_);
-
-                    CqlBoolean ar_() {
-                        FhirDateTime av_ = OrderMedication1?.AuthoredOnElement;
-                        CqlDateTime aw_ = context.Operators.Convert<CqlDateTime>(av_);
-                        CqlInterval<CqlDateTime> ax_ = this.Measurement_Period(context);
-                        CqlBoolean ay_ = context.Operators.In<CqlDateTime>(aw_, ax_, (string)default);
-                        return ay_;
-                    }
-
-
-                    CqlBoolean as_() {
-                        CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication1);
-                        CqlDate ba_ = context.Operators.Start(az_);
-                        CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
-                        CqlDate bc_ = context.Operators.DateFrom(bb_);
-                        CqlInterval<CqlDate> bd_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication2);
-                        CqlDate be_ = context.Operators.Start(bd_);
-                        CqlDateTime bf_ = context.Operators.ConvertDateToDateTime(be_);
-                        CqlDate bg_ = context.Operators.DateFrom(bf_);
-                        CqlBoolean bh_ = context.Operators.Equivalent(bc_, bg_);
-                        return !bh_;
-                    }
-
-
-                    CqlBoolean at_() {
-                        CqlInterval<CqlDate> bi_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication1);
-                        CqlDate bj_ = context.Operators.Start(bi_);
-                        CqlDateTime bk_ = context.Operators.ConvertDateToDateTime(bj_);
-                        CqlInterval<CqlDateTime> bl_ = this.Measurement_Period(context);
-                        CqlBoolean bm_ = context.Operators.In<CqlDateTime>(bk_, bl_, (string)default);
-                        return bm_;
-                    }
-
-
-                    CqlBoolean au_() {
-                        CqlInterval<CqlDate> bn_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication2);
-                        CqlDate bo_ = context.Operators.Start(bn_);
-                        CqlDateTime bp_ = context.Operators.ConvertDateToDateTime(bo_);
-                        CqlInterval<CqlDateTime> bq_ = this.Measurement_Period(context);
-                        CqlBoolean br_ = context.Operators.In<CqlDateTime>(bp_, bq_, (string)default);
-                        return br_;
-                    }
-
-                    return aq_
-                        /* CQL 'and' (257:14-258:71) */ && ar_()
-                        /* CQL 'and' (257:14-259:146) */ && as_()
-                        /* CQL 'and' (257:14-260:97) */ && at_()
-                        /* CQL 'and' (257:12-262:9) */ && au_();
-                }
-
+                MedicationRequest.DispenseRequestComponent m_ = OrderMedication1?.DispenseRequest;
+                UnsignedInt n_ = m_?.NumberOfRepeatsAllowedElement;
+                int? o_ = n_?.Value;
+                CqlBoolean p_ = context.Operators.GreaterOrEqual(o_, 1);
+                CqlBoolean q_ = p_;
+                CqlDate r_ = context.Operators.DateFrom(j_);
+                FhirDateTime s_ = OrderMedication2?.AuthoredOnElement;
+                CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
+                CqlDate u_ = context.Operators.DateFrom(t_);
+                CqlBoolean v_ = context.Operators.Equivalent(r_, u_);
+                CqlBoolean w_ = l_;
+                CqlBoolean x_ = context.Operators.In<CqlDateTime>(t_, k_, (string)default);
+                CqlBoolean y_ = x_;
+                CqlBoolean z_ = (CqlBoolean)!v_
+                    /* CQL 'and' (253:14-254:71) */ && w_
+                    /* CQL 'and' (253:12-256:9) */ && y_;
+                CqlInterval<CqlDate> aa_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication1);
+                CqlDate ab_ = context.Operators.Start(aa_);
+                CqlDateTime ac_ = context.Operators.ConvertDateToDateTime(ab_);
+                CqlDate ad_ = context.Operators.DateFrom(ac_);
+                CqlInterval<CqlDate> ae_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication2);
+                CqlDate af_ = context.Operators.Start(ae_);
+                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(af_);
+                CqlDate ah_ = context.Operators.DateFrom(ag_);
+                CqlBoolean ai_ = context.Operators.Equivalent(ad_, ah_);
+                CqlBoolean aj_ = (CqlBoolean)!ai_;
+                CqlBoolean ak_ = context.Operators.In<CqlDateTime>(ac_, k_, (string)default);
+                CqlBoolean al_ = ak_;
+                CqlBoolean am_ = context.Operators.In<CqlDateTime>(ag_, k_, (string)default);
+                CqlBoolean an_ = am_;
+                CqlBoolean ao_ = v_
+                    /* CQL 'and' (257:14-258:71) */ && w_
+                    /* CQL 'and' (257:14-259:146) */ && aj_
+                    /* CQL 'and' (257:14-260:97) */ && al_
+                    /* CQL 'and' (257:12-262:9) */ && an_;
                 return (l_
-                    /* CQL 'and' (250:17-252:7) */ && m_())
-                    /* CQL 'or' (250:17-256:9) */ || n_()
-                    /* CQL 'or' (250:17-262:9) */ || o_();
+                    /* CQL 'and' (250:17-252:7) */ && q_)
+                    /* CQL 'or' (250:17-256:9) */ || z_
+                    /* CQL 'or' (250:17-262:9) */ || ao_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<MedicationRequest>(f_, g_);
@@ -604,17 +535,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> ec_ = context.Operators.Split((string)eb_, "/");
                 string ed_ = context.Operators.Last<string>(ec_);
                 CqlBoolean ee_ = context.Operators.Equal(ea_, ed_);
-
-                CqlBoolean ef_() {
-                    CodeableConcept eg_ = M?.Code;
-                    CqlConcept eh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, eg_);
-                    CqlValueSet ei_ = this.Potentially_Harmful_Antihistamines_for_Older_Adults(context);
-                    CqlBoolean ej_ = context.Operators.ConceptInValueSet(eh_, ei_);
-                    return ej_;
-                }
-
+                CodeableConcept ef_ = M?.Code;
+                CqlConcept eg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ef_);
+                CqlValueSet eh_ = this.Potentially_Harmful_Antihistamines_for_Older_Adults(context);
+                CqlBoolean ei_ = context.Operators.ConceptInValueSet(eg_, eh_);
+                CqlBoolean ej_ = ei_;
                 return ee_
-                    /* CQL 'and' */ && ef_();
+                    /* CQL 'and' */ && ej_;
             }
 
             CqlBoolean dz_ = context.Operators.WhereAny<Medication>(dx_, dy_);
@@ -636,17 +563,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> ep_ = context.Operators.Split((string)eo_, "/");
                 string eq_ = context.Operators.Last<string>(ep_);
                 CqlBoolean er_ = context.Operators.Equal(en_, eq_);
-
-                CqlBoolean es_() {
-                    CodeableConcept et_ = M?.Code;
-                    CqlConcept eu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, et_);
-                    CqlValueSet ev_ = this.Potentially_Harmful_Antiparkinsonian_Agents_for_Older_Adults(context);
-                    CqlBoolean ew_ = context.Operators.ConceptInValueSet(eu_, ev_);
-                    return ew_;
-                }
-
+                CodeableConcept es_ = M?.Code;
+                CqlConcept et_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, es_);
+                CqlValueSet eu_ = this.Potentially_Harmful_Antiparkinsonian_Agents_for_Older_Adults(context);
+                CqlBoolean ev_ = context.Operators.ConceptInValueSet(et_, eu_);
+                CqlBoolean ew_ = ev_;
                 return er_
-                    /* CQL 'and' */ && es_();
+                    /* CQL 'and' */ && ew_;
             }
 
             CqlBoolean em_ = context.Operators.WhereAny<Medication>(ek_, el_);
@@ -669,17 +592,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> fc_ = context.Operators.Split((string)fb_, "/");
                 string fd_ = context.Operators.Last<string>(fc_);
                 CqlBoolean fe_ = context.Operators.Equal(fa_, fd_);
-
-                CqlBoolean ff_() {
-                    CodeableConcept fg_ = M?.Code;
-                    CqlConcept fh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fg_);
-                    CqlValueSet fi_ = this.Potentially_Harmful_Gastrointestinal_Antispasmodics_for_Older_Adults(context);
-                    CqlBoolean fj_ = context.Operators.ConceptInValueSet(fh_, fi_);
-                    return fj_;
-                }
-
+                CodeableConcept ff_ = M?.Code;
+                CqlConcept fg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ff_);
+                CqlValueSet fh_ = this.Potentially_Harmful_Gastrointestinal_Antispasmodics_for_Older_Adults(context);
+                CqlBoolean fi_ = context.Operators.ConceptInValueSet(fg_, fh_);
+                CqlBoolean fj_ = fi_;
                 return fe_
-                    /* CQL 'and' */ && ff_();
+                    /* CQL 'and' */ && fj_;
             }
 
             CqlBoolean ez_ = context.Operators.WhereAny<Medication>(ex_, ey_);
@@ -701,17 +620,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> fp_ = context.Operators.Split((string)fo_, "/");
                 string fq_ = context.Operators.Last<string>(fp_);
                 CqlBoolean fr_ = context.Operators.Equal(fn_, fq_);
-
-                CqlBoolean fs_() {
-                    CodeableConcept ft_ = M?.Code;
-                    CqlConcept fu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ft_);
-                    CqlValueSet fv_ = this.Dipyridamole_Medications(context);
-                    CqlBoolean fw_ = context.Operators.ConceptInValueSet(fu_, fv_);
-                    return fw_;
-                }
-
+                CodeableConcept fs_ = M?.Code;
+                CqlConcept ft_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fs_);
+                CqlValueSet fu_ = this.Dipyridamole_Medications(context);
+                CqlBoolean fv_ = context.Operators.ConceptInValueSet(ft_, fu_);
+                CqlBoolean fw_ = fv_;
                 return fr_
-                    /* CQL 'and' */ && fs_();
+                    /* CQL 'and' */ && fw_;
             }
 
             CqlBoolean fm_ = context.Operators.WhereAny<Medication>(fk_, fl_);
@@ -735,17 +650,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> gc_ = context.Operators.Split((string)gb_, "/");
                 string gd_ = context.Operators.Last<string>(gc_);
                 CqlBoolean ge_ = context.Operators.Equal(ga_, gd_);
-
-                CqlBoolean gf_() {
-                    CodeableConcept gg_ = M?.Code;
-                    CqlConcept gh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gg_);
-                    CqlValueSet gi_ = this.Guanfacine_Medications(context);
-                    CqlBoolean gj_ = context.Operators.ConceptInValueSet(gh_, gi_);
-                    return gj_;
-                }
-
+                CodeableConcept gf_ = M?.Code;
+                CqlConcept gg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gf_);
+                CqlValueSet gh_ = this.Guanfacine_Medications(context);
+                CqlBoolean gi_ = context.Operators.ConceptInValueSet(gg_, gh_);
+                CqlBoolean gj_ = gi_;
                 return ge_
-                    /* CQL 'and' */ && gf_();
+                    /* CQL 'and' */ && gj_;
             }
 
             CqlBoolean fz_ = context.Operators.WhereAny<Medication>(fx_, fy_);
@@ -767,17 +678,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> gp_ = context.Operators.Split((string)go_, "/");
                 string gq_ = context.Operators.Last<string>(gp_);
                 CqlBoolean gr_ = context.Operators.Equal(gn_, gq_);
-
-                CqlBoolean gs_() {
-                    CodeableConcept gt_ = M?.Code;
-                    CqlConcept gu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gt_);
-                    CqlValueSet gv_ = this.Nifedipine_Medications(context);
-                    CqlBoolean gw_ = context.Operators.ConceptInValueSet(gu_, gv_);
-                    return gw_;
-                }
-
+                CodeableConcept gs_ = M?.Code;
+                CqlConcept gt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gs_);
+                CqlValueSet gu_ = this.Nifedipine_Medications(context);
+                CqlBoolean gv_ = context.Operators.ConceptInValueSet(gt_, gu_);
+                CqlBoolean gw_ = gv_;
                 return gr_
-                    /* CQL 'and' */ && gs_();
+                    /* CQL 'and' */ && gw_;
             }
 
             CqlBoolean gm_ = context.Operators.WhereAny<Medication>(gk_, gl_);
@@ -801,17 +708,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> hc_ = context.Operators.Split((string)hb_, "/");
                 string hd_ = context.Operators.Last<string>(hc_);
                 CqlBoolean he_ = context.Operators.Equal(ha_, hd_);
-
-                CqlBoolean hf_() {
-                    CodeableConcept hg_ = M?.Code;
-                    CqlConcept hh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hg_);
-                    CqlValueSet hi_ = this.Potentially_Harmful_Antidepressants_for_Older_Adults(context);
-                    CqlBoolean hj_ = context.Operators.ConceptInValueSet(hh_, hi_);
-                    return hj_;
-                }
-
+                CodeableConcept hf_ = M?.Code;
+                CqlConcept hg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hf_);
+                CqlValueSet hh_ = this.Potentially_Harmful_Antidepressants_for_Older_Adults(context);
+                CqlBoolean hi_ = context.Operators.ConceptInValueSet(hg_, hh_);
+                CqlBoolean hj_ = hi_;
                 return he_
-                    /* CQL 'and' */ && hf_();
+                    /* CQL 'and' */ && hj_;
             }
 
             CqlBoolean gz_ = context.Operators.WhereAny<Medication>(gx_, gy_);
@@ -833,17 +736,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> hp_ = context.Operators.Split((string)ho_, "/");
                 string hq_ = context.Operators.Last<string>(hp_);
                 CqlBoolean hr_ = context.Operators.Equal(hn_, hq_);
-
-                CqlBoolean hs_() {
-                    CodeableConcept ht_ = M?.Code;
-                    CqlConcept hu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ht_);
-                    CqlValueSet hv_ = this.Potentially_Harmful_Barbiturates_for_Older_Adults(context);
-                    CqlBoolean hw_ = context.Operators.ConceptInValueSet(hu_, hv_);
-                    return hw_;
-                }
-
+                CodeableConcept hs_ = M?.Code;
+                CqlConcept ht_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, hs_);
+                CqlValueSet hu_ = this.Potentially_Harmful_Barbiturates_for_Older_Adults(context);
+                CqlBoolean hv_ = context.Operators.ConceptInValueSet(ht_, hu_);
+                CqlBoolean hw_ = hv_;
                 return hr_
-                    /* CQL 'and' */ && hs_();
+                    /* CQL 'and' */ && hw_;
             }
 
             CqlBoolean hm_ = context.Operators.WhereAny<Medication>(hk_, hl_);
@@ -867,18 +766,14 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> ic_ = context.Operators.Split((string)ib_, "/");
                 string id_ = context.Operators.Last<string>(ic_);
                 CqlBoolean ie_ = context.Operators.Equal(ia_, id_);
-
-                CqlBoolean if_() {
-                    CodeableConcept ig_ = M?.Code;
-                    CqlConcept ih_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ig_);
-                    CqlCode ii_ = this.ergoloid_mesylates__USP_1_MG_Oral_Tablet(context);
-                    CqlConcept ij_ = context.Operators.ConvertCodeToConcept(ii_);
-                    CqlBoolean ik_ = context.Operators.Equivalent(ih_, ij_);
-                    return ik_;
-                }
-
+                CodeableConcept if_ = M?.Code;
+                CqlConcept ig_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, if_);
+                CqlCode ih_ = this.ergoloid_mesylates__USP_1_MG_Oral_Tablet(context);
+                CqlConcept ii_ = context.Operators.ConvertCodeToConcept(ih_);
+                CqlBoolean ij_ = context.Operators.Equivalent(ig_, ii_);
+                CqlBoolean ik_ = ij_;
                 return ie_
-                    /* CQL 'and' */ && if_();
+                    /* CQL 'and' */ && ik_;
             }
 
             CqlBoolean hz_ = context.Operators.WhereAny<Medication>(hx_, hy_);
@@ -901,17 +796,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> iq_ = context.Operators.Split((string)ip_, "/");
                 string ir_ = context.Operators.Last<string>(iq_);
                 CqlBoolean is_ = context.Operators.Equal(io_, ir_);
-
-                CqlBoolean it_() {
-                    CodeableConcept iu_ = M?.Code;
-                    CqlConcept iv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, iu_);
-                    CqlValueSet iw_ = this.Meprobamate_Medications(context);
-                    CqlBoolean ix_ = context.Operators.ConceptInValueSet(iv_, iw_);
-                    return ix_;
-                }
-
+                CodeableConcept it_ = M?.Code;
+                CqlConcept iu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, it_);
+                CqlValueSet iv_ = this.Meprobamate_Medications(context);
+                CqlBoolean iw_ = context.Operators.ConceptInValueSet(iu_, iv_);
+                CqlBoolean ix_ = iw_;
                 return is_
-                    /* CQL 'and' */ && it_();
+                    /* CQL 'and' */ && ix_;
             }
 
             CqlBoolean in_ = context.Operators.WhereAny<Medication>(il_, im_);
@@ -935,17 +826,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> jd_ = context.Operators.Split((string)jc_, "/");
                 string je_ = context.Operators.Last<string>(jd_);
                 CqlBoolean jf_ = context.Operators.Equal(jb_, je_);
-
-                CqlBoolean jg_() {
-                    CodeableConcept jh_ = M?.Code;
-                    CqlConcept ji_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jh_);
-                    CqlValueSet jj_ = this.Potentially_Harmful_Estrogens_for_Older_Adults(context);
-                    CqlBoolean jk_ = context.Operators.ConceptInValueSet(ji_, jj_);
-                    return jk_;
-                }
-
+                CodeableConcept jg_ = M?.Code;
+                CqlConcept jh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jg_);
+                CqlValueSet ji_ = this.Potentially_Harmful_Estrogens_for_Older_Adults(context);
+                CqlBoolean jj_ = context.Operators.ConceptInValueSet(jh_, ji_);
+                CqlBoolean jk_ = jj_;
                 return jf_
-                    /* CQL 'and' */ && jg_();
+                    /* CQL 'and' */ && jk_;
             }
 
             CqlBoolean ja_ = context.Operators.WhereAny<Medication>(iy_, iz_);
@@ -967,17 +854,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> jq_ = context.Operators.Split((string)jp_, "/");
                 string jr_ = context.Operators.Last<string>(jq_);
                 CqlBoolean js_ = context.Operators.Equal(jo_, jr_);
-
-                CqlBoolean jt_() {
-                    CodeableConcept ju_ = M?.Code;
-                    CqlConcept jv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ju_);
-                    CqlValueSet jw_ = this.Potentially_Harmful_Sulfonylureas_for_Older_Adults(context);
-                    CqlBoolean jx_ = context.Operators.ConceptInValueSet(jv_, jw_);
-                    return jx_;
-                }
-
+                CodeableConcept jt_ = M?.Code;
+                CqlConcept ju_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, jt_);
+                CqlValueSet jv_ = this.Potentially_Harmful_Sulfonylureas_for_Older_Adults(context);
+                CqlBoolean jw_ = context.Operators.ConceptInValueSet(ju_, jv_);
+                CqlBoolean jx_ = jw_;
                 return js_
-                    /* CQL 'and' */ && jt_();
+                    /* CQL 'and' */ && jx_;
             }
 
             CqlBoolean jn_ = context.Operators.WhereAny<Medication>(jl_, jm_);
@@ -1001,17 +884,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> kd_ = context.Operators.Split((string)kc_, "/");
                 string ke_ = context.Operators.Last<string>(kd_);
                 CqlBoolean kf_ = context.Operators.Equal(kb_, ke_);
-
-                CqlBoolean kg_() {
-                    CodeableConcept kh_ = M?.Code;
-                    CqlConcept ki_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kh_);
-                    CqlValueSet kj_ = this.Desiccated_Thyroid_Medications(context);
-                    CqlBoolean kk_ = context.Operators.ConceptInValueSet(ki_, kj_);
-                    return kk_;
-                }
-
+                CodeableConcept kg_ = M?.Code;
+                CqlConcept kh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kg_);
+                CqlValueSet ki_ = this.Desiccated_Thyroid_Medications(context);
+                CqlBoolean kj_ = context.Operators.ConceptInValueSet(kh_, ki_);
+                CqlBoolean kk_ = kj_;
                 return kf_
-                    /* CQL 'and' */ && kg_();
+                    /* CQL 'and' */ && kk_;
             }
 
             CqlBoolean ka_ = context.Operators.WhereAny<Medication>(jy_, jz_);
@@ -1033,17 +912,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> kq_ = context.Operators.Split((string)kp_, "/");
                 string kr_ = context.Operators.Last<string>(kq_);
                 CqlBoolean ks_ = context.Operators.Equal(ko_, kr_);
-
-                CqlBoolean kt_() {
-                    CodeableConcept ku_ = M?.Code;
-                    CqlConcept kv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ku_);
-                    CqlValueSet kw_ = this.Potentially_Harmful_Nonbenzodiazepine_Hypnotics_for_Older_Adults(context);
-                    CqlBoolean kx_ = context.Operators.ConceptInValueSet(kv_, kw_);
-                    return kx_;
-                }
-
+                CodeableConcept kt_ = M?.Code;
+                CqlConcept ku_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, kt_);
+                CqlValueSet kv_ = this.Potentially_Harmful_Nonbenzodiazepine_Hypnotics_for_Older_Adults(context);
+                CqlBoolean kw_ = context.Operators.ConceptInValueSet(ku_, kv_);
+                CqlBoolean kx_ = kw_;
                 return ks_
-                    /* CQL 'and' */ && kt_();
+                    /* CQL 'and' */ && kx_;
             }
 
             CqlBoolean kn_ = context.Operators.WhereAny<Medication>(kl_, km_);
@@ -1067,17 +942,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> ld_ = context.Operators.Split((string)lc_, "/");
                 string le_ = context.Operators.Last<string>(ld_);
                 CqlBoolean lf_ = context.Operators.Equal(lb_, le_);
-
-                CqlBoolean lg_() {
-                    CodeableConcept lh_ = M?.Code;
-                    CqlConcept li_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lh_);
-                    CqlValueSet lj_ = this.Potentially_Harmful_Skeletal_Muscle_Relaxants_for_Older_Adults(context);
-                    CqlBoolean lk_ = context.Operators.ConceptInValueSet(li_, lj_);
-                    return lk_;
-                }
-
+                CodeableConcept lg_ = M?.Code;
+                CqlConcept lh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lg_);
+                CqlValueSet li_ = this.Potentially_Harmful_Skeletal_Muscle_Relaxants_for_Older_Adults(context);
+                CqlBoolean lj_ = context.Operators.ConceptInValueSet(lh_, li_);
+                CqlBoolean lk_ = lj_;
                 return lf_
-                    /* CQL 'and' */ && lg_();
+                    /* CQL 'and' */ && lk_;
             }
 
             CqlBoolean la_ = context.Operators.WhereAny<Medication>(ky_, kz_);
@@ -1099,17 +970,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> lq_ = context.Operators.Split((string)lp_, "/");
                 string lr_ = context.Operators.Last<string>(lq_);
                 CqlBoolean ls_ = context.Operators.Equal(lo_, lr_);
-
-                CqlBoolean lt_() {
-                    CodeableConcept lu_ = M?.Code;
-                    CqlConcept lv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lu_);
-                    CqlValueSet lw_ = this.Potentially_Harmful_Pain_Medications_for_Older_Adults(context);
-                    CqlBoolean lx_ = context.Operators.ConceptInValueSet(lv_, lw_);
-                    return lx_;
-                }
-
+                CodeableConcept lt_ = M?.Code;
+                CqlConcept lu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, lt_);
+                CqlValueSet lv_ = this.Potentially_Harmful_Pain_Medications_for_Older_Adults(context);
+                CqlBoolean lw_ = context.Operators.ConceptInValueSet(lu_, lv_);
+                CqlBoolean lx_ = lw_;
                 return ls_
-                    /* CQL 'and' */ && lt_();
+                    /* CQL 'and' */ && lx_;
             }
 
             CqlBoolean ln_ = context.Operators.WhereAny<Medication>(ll_, lm_);
@@ -1133,17 +1000,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> md_ = context.Operators.Split((string)mc_, "/");
                 string me_ = context.Operators.Last<string>(md_);
                 CqlBoolean mf_ = context.Operators.Equal(mb_, me_);
-
-                CqlBoolean mg_() {
-                    CodeableConcept mh_ = M?.Code;
-                    CqlConcept mi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mh_);
-                    CqlValueSet mj_ = this.Megestrol_Medications(context);
-                    CqlBoolean mk_ = context.Operators.ConceptInValueSet(mi_, mj_);
-                    return mk_;
-                }
-
+                CodeableConcept mg_ = M?.Code;
+                CqlConcept mh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mg_);
+                CqlValueSet mi_ = this.Megestrol_Medications(context);
+                CqlBoolean mj_ = context.Operators.ConceptInValueSet(mh_, mi_);
+                CqlBoolean mk_ = mj_;
                 return mf_
-                    /* CQL 'and' */ && mg_();
+                    /* CQL 'and' */ && mk_;
             }
 
             CqlBoolean ma_ = context.Operators.WhereAny<Medication>(ly_, lz_);
@@ -1165,17 +1028,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> mq_ = context.Operators.Split((string)mp_, "/");
                 string mr_ = context.Operators.Last<string>(mq_);
                 CqlBoolean ms_ = context.Operators.Equal(mo_, mr_);
-
-                CqlBoolean mt_() {
-                    CodeableConcept mu_ = M?.Code;
-                    CqlConcept mv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mu_);
-                    CqlValueSet mw_ = this.Meperidine_Medications(context);
-                    CqlBoolean mx_ = context.Operators.ConceptInValueSet(mv_, mw_);
-                    return mx_;
-                }
-
+                CodeableConcept mt_ = M?.Code;
+                CqlConcept mu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, mt_);
+                CqlValueSet mv_ = this.Meperidine_Medications(context);
+                CqlBoolean mw_ = context.Operators.ConceptInValueSet(mu_, mv_);
+                CqlBoolean mx_ = mw_;
                 return ms_
-                    /* CQL 'and' */ && mt_();
+                    /* CQL 'and' */ && mx_;
             }
 
             CqlBoolean mn_ = context.Operators.WhereAny<Medication>(ml_, mm_);
@@ -1282,17 +1141,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> r_ = context.Operators.Split((string)q_, "/");
                 string s_ = context.Operators.Last<string>(r_);
                 CqlBoolean t_ = context.Operators.Equal(p_, s_);
-
-                CqlBoolean u_() {
-                    CodeableConcept v_ = M?.Code;
-                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                    CqlValueSet x_ = this.Potentially_Harmful_Antiinfectives_for_Older_Adults(context);
-                    CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
-                    return y_;
-                }
-
+                CodeableConcept u_ = M?.Code;
+                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
+                CqlValueSet w_ = this.Potentially_Harmful_Antiinfectives_for_Older_Adults(context);
+                CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
+                CqlBoolean y_ = x_;
                 return t_
-                    /* CQL 'and' */ && u_();
+                    /* CQL 'and' */ && y_;
             }
 
             CqlBoolean o_ = context.Operators.WhereAny<Medication>(m_, n_);
@@ -1327,47 +1182,27 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
 
         CqlQuantity b_(MedicationRequest Order) {
             decimal? e_ = this.medicationRequestPeriodInDays(context, Order);
-
-            CqlBoolean f_() {
-                CqlConcept g_ = CQMCommon_4_1_000.Instance.getMedicationCode(context, Order);
-                CqlQuantity h_ = this.medicationStrengthPerUnit(context, g_);
-                string i_ = h_?.unit;
-                CqlBoolean j_ = context.Operators.Equal(i_, "mg");
-
-                CqlBoolean k_() {
-                    CqlConcept l_ = CQMCommon_4_1_000.Instance.getMedicationCode(context, Order);
-                    CqlQuantity m_ = this.medicationStrengthPerUnit(context, l_);
-                    string n_ = m_?.unit;
-                    CqlBoolean o_ = context.Operators.Equal(n_, "mg/mL");
-
-                    CqlBoolean p_() {
-                        MedicationRequest.DispenseRequestComponent q_ = Order?.DispenseRequest;
-                        Quantity r_ = q_?.Quantity;
-                        CqlQuantity s_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, r_);
-                        string t_ = s_?.unit;
-                        CqlBoolean u_ = context.Operators.Equal(t_, "mL");
-                        return u_;
-                    }
-
-                    return o_
-                        /* CQL 'and' (311:14-313:11) */ && p_();
-                }
-
-                return j_
-                    /* CQL 'or' (310:11-314:7) */ || k_();
-            }
-
+            CqlConcept f_ = CQMCommon_4_1_000.Instance.getMedicationCode(context, Order);
+            CqlQuantity g_ = this.medicationStrengthPerUnit(context, f_);
+            string h_ = g_?.unit;
+            CqlBoolean i_ = context.Operators.Equal(h_, "mg");
+            CqlBoolean j_ = context.Operators.Equal(h_, "mg/mL");
+            MedicationRequest.DispenseRequestComponent k_ = Order?.DispenseRequest;
+            Quantity l_ = k_?.Quantity;
+            CqlQuantity m_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, l_);
+            string n_ = m_?.unit;
+            CqlBoolean o_ = context.Operators.Equal(n_, "mL");
+            CqlBoolean p_ = o_;
+            CqlBoolean q_ = j_
+                /* CQL 'and' (311:14-313:11) */ && p_;
+            CqlBoolean r_ = i_
+                /* CQL 'or' (310:11-314:7) */ || q_;
             if ((CqlBoolean)(e_ is not null)
-                /* CQL 'and' (309:15-314:7) */ && f_())
+                /* CQL 'and' (309:15-314:7) */ && r_)
             {
-                MedicationRequest.DispenseRequestComponent v_ = Order?.DispenseRequest;
-                Quantity w_ = v_?.Quantity;
-                CqlQuantity x_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, w_);
-                CqlConcept y_ = CQMCommon_4_1_000.Instance.getMedicationCode(context, Order);
-                CqlQuantity z_ = this.medicationStrengthPerUnit(context, y_);
-                CqlQuantity aa_ = context.Operators.Multiply(x_, z_);
-                CqlQuantity ab_ = context.Operators.Divide(aa_, new CqlQuantity(e_, "d"));
-                return ab_;
+                CqlQuantity s_ = context.Operators.Multiply(m_, g_);
+                CqlQuantity t_ = context.Operators.Divide(s_, new CqlQuantity(e_, "d"));
+                return t_;
             }
             else
             {
@@ -1564,29 +1399,25 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> a_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
         bool? b_(MedicationRequest MR) {
-            IEnumerable<Medication> l_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            IEnumerable<Medication> u_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? m_(Medication M) {
-                object o_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object p_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
-                string r_ = context.Operators.Last<string>(q_);
-                CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                CqlBoolean t_() {
-                    CodeableConcept u_ = M?.Code;
-                    CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                    CqlValueSet w_ = this.Digoxin_Medications(context);
-                    CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                    return x_;
-                }
-
-                return s_
-                    /* CQL 'and' */ && t_();
+            bool? v_(Medication M) {
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                CqlBoolean ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Digoxin_Medications(context);
+                CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                CqlBoolean ag_ = af_;
+                return ab_
+                    /* CQL 'and' */ && ag_;
             }
 
-            CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
-            return n_;
+            CqlBoolean w_ = context.Operators.WhereAny<Medication>(u_, v_);
+            return w_;
         }
 
         IEnumerable<MedicationRequest> c_ = context.Operators.Where<MedicationRequest>(a_, b_);
@@ -1595,65 +1426,56 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(c_, e_);
 
         bool? g_(MedicationRequest DigoxinOrdered) {
-            CqlQuantity y_ = this.averageDailyDose(context, DigoxinOrdered);
-            CqlQuantity z_ = context.Operators.Quantity(0.125m, "mg/d");
-            CqlBoolean aa_ = context.Operators.Greater(y_, z_);
-            return aa_;
+            CqlQuantity ah_ = this.averageDailyDose(context, DigoxinOrdered);
+            CqlQuantity ai_ = context.Operators.Quantity(0.125m, "mg/d");
+            CqlBoolean aj_ = context.Operators.Greater(ah_, ai_);
+            return aj_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
         IEnumerable<MedicationRequest> i_ = this.moreThanOneOrder(context, h_);
         CqlBoolean j_ = context.Operators.Exists<MedicationRequest>(i_);
 
-        CqlBoolean k_() {
-            IEnumerable<MedicationRequest> ab_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? k_(MedicationRequest MR) {
+            IEnumerable<Medication> ak_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ac_(MedicationRequest MR) {
-                IEnumerable<Medication> al_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
-
-                bool? am_(Medication M) {
-                    object ao_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object ap_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> aq_ = context.Operators.Split((string)ap_, "/");
-                    string ar_ = context.Operators.Last<string>(aq_);
-                    CqlBoolean as_ = context.Operators.Equal(ao_, ar_);
-
-                    CqlBoolean at_() {
-                        CodeableConcept au_ = M?.Code;
-                        CqlConcept av_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, au_);
-                        CqlValueSet aw_ = this.Doxepin_Medications(context);
-                        CqlBoolean ax_ = context.Operators.ConceptInValueSet(av_, aw_);
-                        return ax_;
-                    }
-
-                    return as_
-                        /* CQL 'and' */ && at_();
-                }
-
-                CqlBoolean an_ = context.Operators.WhereAny<Medication>(al_, am_);
-                return an_;
+            bool? al_(Medication M) {
+                object an_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ao_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> ap_ = context.Operators.Split((string)ao_, "/");
+                string aq_ = context.Operators.Last<string>(ap_);
+                CqlBoolean ar_ = context.Operators.Equal(an_, aq_);
+                CodeableConcept as_ = M?.Code;
+                CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, as_);
+                CqlValueSet au_ = this.Doxepin_Medications(context);
+                CqlBoolean av_ = context.Operators.ConceptInValueSet(at_, au_);
+                CqlBoolean aw_ = av_;
+                return ar_
+                    /* CQL 'and' */ && aw_;
             }
 
-            IEnumerable<MedicationRequest> ad_ = context.Operators.Where<MedicationRequest>(ab_, ac_);
-            CqlValueSet ae_ = this.Doxepin_Medications(context);
-            IEnumerable<MedicationRequest> af_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, ae_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> ag_ = context.Operators.Union<MedicationRequest>(ad_, af_);
-
-            bool? ah_(MedicationRequest DoxepinOrdered) {
-                CqlQuantity ay_ = this.averageDailyDose(context, DoxepinOrdered);
-                CqlQuantity az_ = context.Operators.Quantity(6m, "mg/d");
-                CqlBoolean ba_ = context.Operators.Greater(ay_, az_);
-                return ba_;
-            }
-
-            IEnumerable<MedicationRequest> ai_ = context.Operators.Where<MedicationRequest>(ag_, ah_);
-            IEnumerable<MedicationRequest> aj_ = this.moreThanOneOrder(context, ai_);
-            CqlBoolean ak_ = context.Operators.Exists<MedicationRequest>(aj_);
-            return ak_;
+            CqlBoolean am_ = context.Operators.WhereAny<Medication>(ak_, al_);
+            return am_;
         }
 
+        IEnumerable<MedicationRequest> l_ = context.Operators.Where<MedicationRequest>(a_, k_);
+        CqlValueSet m_ = this.Doxepin_Medications(context);
+        IEnumerable<MedicationRequest> n_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, m_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> o_ = context.Operators.Union<MedicationRequest>(l_, n_);
+
+        bool? p_(MedicationRequest DoxepinOrdered) {
+            CqlQuantity ax_ = this.averageDailyDose(context, DoxepinOrdered);
+            CqlQuantity ay_ = context.Operators.Quantity(6m, "mg/d");
+            CqlBoolean az_ = context.Operators.Greater(ax_, ay_);
+            return az_;
+        }
+
+        IEnumerable<MedicationRequest> q_ = context.Operators.Where<MedicationRequest>(o_, p_);
+        IEnumerable<MedicationRequest> r_ = this.moreThanOneOrder(context, q_);
+        CqlBoolean s_ = context.Operators.Exists<MedicationRequest>(r_);
+        CqlBoolean t_ = s_;
         return j_
-            /* CQL 'or' (146:3-153:5) */ || k_();
+            /* CQL 'or' (146:3-153:5) */ || t_;
     }
 
 
@@ -1692,17 +1514,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -1772,17 +1590,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
                 string t_ = context.Operators.Last<string>(s_);
                 CqlBoolean u_ = context.Operators.Equal(q_, t_);
-
-                CqlBoolean v_() {
-                    CodeableConcept w_ = M?.Code;
-                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                    CqlValueSet y_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
-                    CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-                    return z_;
-                }
-
+                CodeableConcept v_ = M?.Code;
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                CqlValueSet x_ = this.Potentially_Harmful_Antipsychotics_for_Older_Adults(context);
+                CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
+                CqlBoolean z_ = y_;
                 return u_
-                    /* CQL 'and' */ && v_();
+                    /* CQL 'and' */ && z_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Medication>(n_, o_);
@@ -1837,17 +1651,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -1968,17 +1778,13 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
                 string t_ = context.Operators.Last<string>(s_);
                 CqlBoolean u_ = context.Operators.Equal(q_, t_);
-
-                CqlBoolean v_() {
-                    CodeableConcept w_ = M?.Code;
-                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                    CqlValueSet y_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
-                    CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-                    return z_;
-                }
-
+                CodeableConcept v_ = M?.Code;
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                CqlValueSet x_ = this.Potentially_Harmful_Benzodiazepines_for_Older_Adults(context);
+                CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
+                CqlBoolean z_ = y_;
                 return u_
-                    /* CQL 'and' */ && v_();
+                    /* CQL 'and' */ && z_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Medication>(n_, o_);
@@ -2023,66 +1829,54 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
     private bool? Numerator_2_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.More_than_One_Antipsychotic_Order(context);
+        IEnumerable<Condition> b_ = this.Schizophrenia_Diagnosis(context);
+        IEnumerable<Condition> c_ = this.Bipolar_Disorder_Diagnosis(context);
+        IEnumerable<Condition> d_ = context.Operators.Union<Condition>(b_, c_);
 
-        CqlBoolean b_() {
-            IEnumerable<Condition> d_ = this.Schizophrenia_Diagnosis(context);
-            IEnumerable<Condition> e_ = this.Bipolar_Disorder_Diagnosis(context);
-            IEnumerable<Condition> f_ = context.Operators.Union<Condition>(d_, e_);
-
-            bool? g_(Condition AntipsychoticTreatedDiagnoses) {
-                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, AntipsychoticTreatedDiagnoses);
-                CqlInterval<CqlDateTime> j_ = this.Measurement_Period(context);
-                CqlDateTime k_ = context.Operators.Start(j_);
-                CqlQuantity l_ = context.Operators.Quantity(1m, "year");
-                CqlDateTime m_ = context.Operators.Subtract(k_, l_);
-                CqlDateTime n_ = this.Antipsychotic_Index_Prescription_Start_Date(context);
-                CqlInterval<CqlDateTime> o_ = context.Operators.Interval(m_, n_, true, true);
-                CqlBoolean p_ = context.Operators.Overlaps(i_, o_, (string)default);
-                return p_;
-            }
-
-            CqlBoolean h_ = context.Operators.WhereAny<Condition>(f_, g_);
-            return !h_;
+        bool? e_(Condition AntipsychoticTreatedDiagnoses) {
+            CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, AntipsychoticTreatedDiagnoses);
+            CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
+            CqlDateTime x_ = context.Operators.Start(w_);
+            CqlQuantity y_ = context.Operators.Quantity(1m, "year");
+            CqlDateTime z_ = context.Operators.Subtract(x_, y_);
+            CqlDateTime aa_ = this.Antipsychotic_Index_Prescription_Start_Date(context);
+            CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(z_, aa_, true, true);
+            CqlBoolean ac_ = context.Operators.Overlaps(v_, ab_, (string)default);
+            return ac_;
         }
 
+        CqlBoolean f_ = context.Operators.WhereAny<Condition>(d_, e_);
+        CqlBoolean g_ = (CqlBoolean)!f_;
+        CqlBoolean h_ = this.More_than_One_Benzodiazepine_Order(context);
+        IEnumerable<Condition> i_ = this.Seizure_Disorder_Diagnosis(context);
+        IEnumerable<Condition> j_ = this.REM_Sleep_Behavior_Disorder_Diagnosis(context);
+        IEnumerable<Condition> k_ = context.Operators.Union<Condition>(i_, j_);
+        IEnumerable<Condition> l_ = this.Benzodiazepine_Withdrawal_Diagnosis(context);
+        IEnumerable<Condition> m_ = this.Alcohol_Withdrawal_Diagnosis(context);
+        IEnumerable<Condition> n_ = context.Operators.Union<Condition>(l_, m_);
+        IEnumerable<Condition> o_ = context.Operators.Union<Condition>(k_, n_);
+        IEnumerable<Condition> p_ = this.Generalized_Anxiety_Disorder_Diagnosis(context);
+        IEnumerable<Condition> q_ = context.Operators.Union<Condition>(o_, p_);
 
-        CqlBoolean c_() {
-            CqlBoolean q_ = this.More_than_One_Benzodiazepine_Order(context);
-
-            CqlBoolean r_() {
-                IEnumerable<Condition> s_ = this.Seizure_Disorder_Diagnosis(context);
-                IEnumerable<Condition> t_ = this.REM_Sleep_Behavior_Disorder_Diagnosis(context);
-                IEnumerable<Condition> u_ = context.Operators.Union<Condition>(s_, t_);
-                IEnumerable<Condition> v_ = this.Benzodiazepine_Withdrawal_Diagnosis(context);
-                IEnumerable<Condition> w_ = this.Alcohol_Withdrawal_Diagnosis(context);
-                IEnumerable<Condition> x_ = context.Operators.Union<Condition>(v_, w_);
-                IEnumerable<Condition> y_ = context.Operators.Union<Condition>(u_, x_);
-                IEnumerable<Condition> z_ = this.Generalized_Anxiety_Disorder_Diagnosis(context);
-                IEnumerable<Condition> aa_ = context.Operators.Union<Condition>(y_, z_);
-
-                bool? ab_(Condition BenzodiazepineTreatedDiagnoses) {
-                    CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BenzodiazepineTreatedDiagnoses);
-                    CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
-                    CqlDateTime af_ = context.Operators.Start(ae_);
-                    CqlQuantity ag_ = context.Operators.Quantity(1m, "year");
-                    CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
-                    CqlDateTime ai_ = this.Benzodiazepine_Index_Prescription_Start_Date(context);
-                    CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ah_, ai_, true, true);
-                    CqlBoolean ak_ = context.Operators.Overlaps(ad_, aj_, (string)default);
-                    return ak_;
-                }
-
-                CqlBoolean ac_ = context.Operators.WhereAny<Condition>(aa_, ab_);
-                return !ac_;
-            }
-
-            return q_
-                /* CQL 'and' (163:8-172:5) */ && r_();
+        bool? r_(Condition BenzodiazepineTreatedDiagnoses) {
+            CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BenzodiazepineTreatedDiagnoses);
+            CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
+            CqlDateTime af_ = context.Operators.Start(ae_);
+            CqlQuantity ag_ = context.Operators.Quantity(1m, "year");
+            CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+            CqlDateTime ai_ = this.Benzodiazepine_Index_Prescription_Start_Date(context);
+            CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ah_, ai_, true, true);
+            CqlBoolean ak_ = context.Operators.Overlaps(ad_, aj_, (string)default);
+            return ak_;
         }
 
+        CqlBoolean s_ = context.Operators.WhereAny<Condition>(q_, r_);
+        CqlBoolean t_ = (CqlBoolean)!s_;
+        CqlBoolean u_ = h_
+            /* CQL 'and' (163:8-172:5) */ && t_;
         return (a_
-            /* CQL 'and' (156:3-162:3) */ && b_())
-            /* CQL 'or' (156:3-172:5) */ || c_();
+            /* CQL 'and' (156:3-162:3) */ && g_)
+            /* CQL 'or' (156:3-172:5) */ || u_;
     }
 
 
@@ -2095,15 +1889,11 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
     private bool? Numerator_3_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Numerator_2(context);
-
-        CqlBoolean b_() {
-            CqlBoolean c_ = this.Numerator_1(context);
-            return c_
-                /* CQL 'and' (231:8-233:5) */ && !(this.Numerator_2(context));
-        }
-
+        CqlBoolean b_ = this.Numerator_1(context);
+        CqlBoolean c_ = b_
+            /* CQL 'and' (231:8-233:5) */ && !(this.Numerator_2(context));
         return a_
-            /* CQL 'or' (230:3-233:5) */ || b_();
+            /* CQL 'or' (230:3-233:5) */ || c_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS157FHIRPainIntensityQuantified", "1.0.000")]
 public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISingleton<CMS157FHIRPainIntensityQuantified_1_0_000>
 {
@@ -117,33 +117,33 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
             CqlDateTime i_ = context.Operators.End(e_);
             CqlInterval<CqlDateTime> j_ = context.Operators.Interval(h_, i_, true, true);
             object k_;
-            DataType o_ = ChemoAdministration?.Performed;
-            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-            bool q_ = p_ is CqlDateTime;
-            if (q_)
+            DataType t_ = ChemoAdministration?.Performed;
+            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+            bool v_ = u_ is CqlDateTime;
+            if (v_)
             {
-                k_ = p_ as CqlDateTime;
+                k_ = u_ as CqlDateTime;
             }
             else
             {
-                bool r_ = p_ is CqlQuantity;
-                if (r_)
+                bool w_ = u_ is CqlQuantity;
+                if (w_)
                 {
-                    k_ = p_ as CqlQuantity;
+                    k_ = u_ as CqlQuantity;
                 }
                 else
                 {
-                    bool s_ = p_ is CqlInterval<CqlDateTime>;
-                    if (s_)
+                    bool x_ = u_ is CqlInterval<CqlDateTime>;
+                    if (x_)
                     {
-                        k_ = p_ as CqlInterval<CqlDateTime>;
+                        k_ = u_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool t_ = p_ is CqlInterval<CqlQuantity>;
-                        if (t_)
+                        bool y_ = u_ is CqlInterval<CqlQuantity>;
+                        if (y_)
                         {
-                            k_ = p_ as CqlInterval<CqlQuantity>;
+                            k_ = u_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
@@ -154,21 +154,17 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
             }
             CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
             CqlBoolean m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
-
-            CqlBoolean n_() {
-                Code<EventStatus> u_ = ChemoAdministration?.StatusElement;
-                EventStatus? v_ = u_?.Value;
-                string w_ = context.Operators.Convert<string>(v_);
-                string[] x_ = [
-                    "completed",
-                    "in-progress",
-                ];
-                CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-                return y_;
-            }
-
+            Code<EventStatus> n_ = ChemoAdministration?.StatusElement;
+            EventStatus? o_ = n_?.Value;
+            string p_ = context.Operators.Convert<string>(o_);
+            string[] q_ = [
+                "completed",
+                "in-progress",
+            ];
+            CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
+            CqlBoolean s_ = r_;
             return m_
-                /* CQL 'and' (40:5-41:70) */ && n_();
+                /* CQL 'and' (40:5-41:70) */ && s_;
         }
 
         IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
@@ -207,228 +203,185 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
             Period s_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.Period;
             CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
             CqlBoolean u_ = context.Operators.Overlaps(r_, t_, "day");
-
-            CqlBoolean v_() {
-                object aa_;
-                DataType al_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoBeforeEncounter?.Performed;
-                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                bool an_ = am_ is CqlDateTime;
-                if (an_)
+            object v_;
+            DataType ba_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoBeforeEncounter?.Performed;
+            object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+            bool bc_ = bb_ is CqlDateTime;
+            if (bc_)
+            {
+                v_ = bb_ as CqlDateTime;
+            }
+            else
+            {
+                bool bd_ = bb_ is CqlQuantity;
+                if (bd_)
                 {
-                    aa_ = am_ as CqlDateTime;
+                    v_ = bb_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ao_ = am_ is CqlQuantity;
-                    if (ao_)
+                    bool be_ = bb_ is CqlInterval<CqlDateTime>;
+                    if (be_)
                     {
-                        aa_ = am_ as CqlQuantity;
+                        v_ = bb_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ap_ = am_ is CqlInterval<CqlDateTime>;
-                        if (ap_)
+                        bool bf_ = bb_ is CqlInterval<CqlQuantity>;
+                        if (bf_)
                         {
-                            aa_ = am_ as CqlInterval<CqlDateTime>;
+                            v_ = bb_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool aq_ = am_ is CqlInterval<CqlQuantity>;
-                            if (aq_)
-                            {
-                                aa_ = am_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                aa_ = null;
-                            }
+                            v_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
-                CqlDateTime ac_ = context.Operators.Start(ab_);
-                Period ad_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.Period;
-                CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                CqlDateTime af_ = context.Operators.End(ae_);
-                CqlQuantity ag_ = context.Operators.Quantity(30m, "days");
-                CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
-                CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ah_, af_, true, true);
-                CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, "day");
-
-                CqlBoolean ak_() {
-                    Period ar_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.Period;
-                    CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
-                    CqlDateTime at_ = context.Operators.End(as_);
-                    return at_ is not null;
-                }
-
-                return aj_
-                    /* CQL 'and' (52:11-52:144) */ && ak_();
             }
-
-
-            CqlBoolean w_() {
-                object au_;
-                DataType bf_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoAfterEncounter?.Performed;
-                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                bool bh_ = bg_ is CqlDateTime;
-                if (bh_)
+            CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
+            CqlDateTime x_ = context.Operators.Start(w_);
+            CqlDateTime y_ = context.Operators.End(t_);
+            CqlQuantity z_ = context.Operators.Quantity(30m, "days");
+            CqlDateTime aa_ = context.Operators.Subtract(y_, z_);
+            CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(aa_, y_, true, true);
+            CqlBoolean ac_ = context.Operators.In<CqlDateTime>(x_, ab_, "day");
+            CqlBoolean ad_ = (CqlBoolean)(y_ is not null);
+            CqlBoolean ae_ = ac_
+                /* CQL 'and' (52:11-52:144) */ && ad_;
+            object af_;
+            DataType bg_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoAfterEncounter?.Performed;
+            object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+            bool bi_ = bh_ is CqlDateTime;
+            if (bi_)
+            {
+                af_ = bh_ as CqlDateTime;
+            }
+            else
+            {
+                bool bj_ = bh_ is CqlQuantity;
+                if (bj_)
                 {
-                    au_ = bg_ as CqlDateTime;
+                    af_ = bh_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bi_ = bg_ is CqlQuantity;
-                    if (bi_)
+                    bool bk_ = bh_ is CqlInterval<CqlDateTime>;
+                    if (bk_)
                     {
-                        au_ = bg_ as CqlQuantity;
+                        af_ = bh_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bj_ = bg_ is CqlInterval<CqlDateTime>;
-                        if (bj_)
+                        bool bl_ = bh_ is CqlInterval<CqlQuantity>;
+                        if (bl_)
                         {
-                            au_ = bg_ as CqlInterval<CqlDateTime>;
+                            af_ = bh_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bk_ = bg_ is CqlInterval<CqlQuantity>;
-                            if (bk_)
-                            {
-                                au_ = bg_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                au_ = null;
-                            }
+                            af_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.toInterval(context, au_);
-                CqlDateTime aw_ = context.Operators.Start(av_);
-                Period ax_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.Period;
-                CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
-                CqlDateTime az_ = context.Operators.End(ay_);
-                CqlQuantity ba_ = context.Operators.Quantity(30m, "days");
-                CqlDateTime bb_ = context.Operators.Add(az_, ba_);
-                CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(az_, bb_, true, true);
-                CqlBoolean bd_ = context.Operators.In<CqlDateTime>(aw_, bc_, "day");
-
-                CqlBoolean be_() {
-                    Period bl_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.Period;
-                    CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
-                    CqlDateTime bn_ = context.Operators.End(bm_);
-                    return bn_ is not null;
-                }
-
-                return bd_
-                    /* CQL 'and' (53:11-53:142) */ && be_();
             }
-
-
-            CqlBoolean x_() {
-                object bo_;
-                DataType bt_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoAfterEncounter?.Performed;
-                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                bool bv_ = bu_ is CqlDateTime;
+            CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
+            CqlDateTime ah_ = context.Operators.Start(ag_);
+            CqlDateTime ai_ = context.Operators.Add(y_, z_);
+            CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(y_, ai_, true, true);
+            CqlBoolean ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, "day");
+            CqlBoolean al_ = ak_
+                /* CQL 'and' (53:11-53:142) */ && ad_;
+            object am_;
+            DataType bm_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoAfterEncounter?.Performed;
+            object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+            bool bo_ = bn_ is CqlDateTime;
+            if (bo_)
+            {
+                am_ = bn_ as CqlDateTime;
+            }
+            else
+            {
+                bool bp_ = bn_ is CqlQuantity;
+                if (bp_)
+                {
+                    am_ = bn_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bq_ = bn_ is CqlInterval<CqlDateTime>;
+                    if (bq_)
+                    {
+                        am_ = bn_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool br_ = bn_ is CqlInterval<CqlQuantity>;
+                        if (br_)
+                        {
+                            am_ = bn_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            am_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
+            object ao_;
+            DataType bs_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoBeforeEncounter?.Performed;
+            object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+            bool bu_ = bt_ is CqlDateTime;
+            if (bu_)
+            {
+                ao_ = bt_ as CqlDateTime;
+            }
+            else
+            {
+                bool bv_ = bt_ is CqlQuantity;
                 if (bv_)
                 {
-                    bo_ = bu_ as CqlDateTime;
+                    ao_ = bt_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bw_ = bu_ is CqlQuantity;
+                    bool bw_ = bt_ is CqlInterval<CqlDateTime>;
                     if (bw_)
                     {
-                        bo_ = bu_ as CqlQuantity;
+                        ao_ = bt_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bx_ = bu_ is CqlInterval<CqlDateTime>;
+                        bool bx_ = bt_ is CqlInterval<CqlQuantity>;
                         if (bx_)
                         {
-                            bo_ = bu_ as CqlInterval<CqlDateTime>;
+                            ao_ = bt_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool by_ = bu_ is CqlInterval<CqlQuantity>;
-                            if (by_)
-                            {
-                                bo_ = bu_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bo_ = null;
-                            }
+                            ao_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_);
-                object bq_;
-                DataType bz_ = tuple_eweddbdxxszcpujsdbltgdxcc?.ChemoBeforeEncounter?.Performed;
-                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                bool cb_ = ca_ is CqlDateTime;
-                if (cb_)
-                {
-                    bq_ = ca_ as CqlDateTime;
-                }
-                else
-                {
-                    bool cc_ = ca_ is CqlQuantity;
-                    if (cc_)
-                    {
-                        bq_ = ca_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cd_ = ca_ is CqlInterval<CqlDateTime>;
-                        if (cd_)
-                        {
-                            bq_ = ca_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ce_ = ca_ is CqlInterval<CqlQuantity>;
-                            if (ce_)
-                            {
-                                bq_ = ca_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bq_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
-                CqlBoolean bs_ = context.Operators.SameAs<CqlDateTime>(bp_, br_, "day");
-                return !bs_;
             }
-
-
-            CqlBoolean y_() {
-                CqlInterval<CqlDateTime> cf_ = this.Measurement_Period(context);
-                Period cg_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.Period;
-                CqlInterval<CqlDateTime> ch_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cg_);
-                CqlBoolean ci_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cf_, ch_, "day");
-                return ci_;
-            }
-
-
-            CqlBoolean z_() {
-                Code<Encounter.EncounterStatus> cj_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.StatusElement;
-                Encounter.EncounterStatus? ck_ = cj_?.Value;
-                Code<Encounter.EncounterStatus> cl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ck_);
-                CqlBoolean cm_ = context.Operators.Equal(cl_, "finished");
-                return cm_;
-            }
-
+            CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+            CqlBoolean aq_ = context.Operators.SameAs<CqlDateTime>(an_, ap_, "day");
+            CqlBoolean ar_ = (CqlBoolean)!aq_;
+            CqlInterval<CqlDateTime> as_ = this.Measurement_Period(context);
+            CqlBoolean at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(as_, t_, "day");
+            CqlBoolean au_ = at_;
+            Code<Encounter.EncounterStatus> av_ = tuple_eweddbdxxszcpujsdbltgdxcc?.FaceToFaceOrTelehealthEncounter?.StatusElement;
+            Encounter.EncounterStatus? aw_ = av_?.Value;
+            Code<Encounter.EncounterStatus> ax_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aw_);
+            CqlBoolean ay_ = context.Operators.Equal(ax_, "finished");
+            CqlBoolean az_ = ay_;
             return u_
-                /* CQL 'and' (51:11-52:144) */ && v_()
-                /* CQL 'and' (51:11-53:142) */ && w_()
-                /* CQL 'and' (51:11-54:120) */ && x_()
-                /* CQL 'and' (51:11-55:83) */ && y_()
-                /* CQL 'and' (51:5-56:61) */ && z_();
+                /* CQL 'and' (51:11-52:144) */ && ae_
+                /* CQL 'and' (51:11-53:142) */ && al_
+                /* CQL 'and' (51:11-54:120) */ && ar_
+                /* CQL 'and' (51:11-55:83) */ && au_
+                /* CQL 'and' (51:5-56:61) */ && az_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter FaceToFaceOrTelehealthEncounter, Procedure ChemoBeforeEncounter, Procedure ChemoAfterEncounter, Condition CancerDx)?> n_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, Procedure, Condition>, (CqlTupleMetadata, Encounter FaceToFaceOrTelehealthEncounter, Procedure ChemoBeforeEncounter, Procedure ChemoAfterEncounter, Condition CancerDx)?>(k_, l_, m_);
@@ -500,17 +453,13 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
             Period r_ = RadiationTreatmentManagement?.Period;
             CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
             CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, "day");
-
-            CqlBoolean u_() {
-                Code<Encounter.EncounterStatus> v_ = RadiationTreatmentManagement?.StatusElement;
-                Encounter.EncounterStatus? w_ = v_?.Value;
-                Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "finished");
-                return y_;
-            }
-
+            Code<Encounter.EncounterStatus> u_ = RadiationTreatmentManagement?.StatusElement;
+            Encounter.EncounterStatus? v_ = u_?.Value;
+            Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+            CqlBoolean x_ = context.Operators.Equal(w_, "finished");
+            CqlBoolean y_ = x_;
             return t_
-                /* CQL 'and' (69:5-70:58) */ && u_();
+                /* CQL 'and' (69:5-70:58) */ && y_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
@@ -642,26 +591,19 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
                     CqlDateTime x_ = context.Operators.Subtract(v_, w_);
                     CqlInterval<CqlDateTime> y_ = context.Operators.Interval(x_, v_, true, true);
                     CqlBoolean z_ = context.Operators.In<CqlDateTime>(s_, y_, "day");
-
-                    CqlBoolean aa_() {
-                        Period ab_ = RadiationManagementEncounter?.Period;
-                        CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                        CqlDateTime ad_ = context.Operators.Start(ac_);
-                        return ad_ is not null;
-                    }
-
+                    CqlBoolean aa_ = (CqlBoolean)(v_ is not null);
                     return (bool?)(z_
-                        /* CQL 'and' (78:16-78:132) */ && aa_());
+                        /* CQL 'and' (78:16-78:132) */ && aa_);
                 }
                 else
                 {
-                    Period ae_ = RadiationManagementEncounter?.Period;
-                    CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
-                    DataType ag_ = PainAssessed?.Effective;
-                    object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                    CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
-                    CqlBoolean aj_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ai_, "day");
-                    return aj_;
+                    Period ab_ = RadiationManagementEncounter?.Period;
+                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+                    DataType ad_ = PainAssessed?.Effective;
+                    object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                    CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+                    CqlBoolean ag_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ac_, af_, "day");
+                    return ag_;
                 }
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS159FHIRDepRemissionat12Months", "1.0.000")]
 public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingleton<CMS159FHIRDepRemissionat12Months_1_0_000>
 {
@@ -183,22 +183,18 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
             DataType e_ = DepressionAssessment?.Value;
             object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
             CqlBoolean g_ = context.Operators.Greater(f_ as int?, 9);
-
-            CqlBoolean h_() {
-                Code<ObservationStatus> i_ = DepressionAssessment?.StatusElement;
-                ObservationStatus? j_ = i_?.Value;
-                string k_ = context.Operators.Convert<string>(j_);
-                string[] l_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-                return m_;
-            }
-
+            Code<ObservationStatus> h_ = DepressionAssessment?.StatusElement;
+            ObservationStatus? i_ = h_?.Value;
+            string j_ = context.Operators.Convert<string>(i_);
+            string[] k_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
+            CqlBoolean m_ = l_;
             return g_
-                /* CQL 'and' (77:5-78:76) */ && h_();
+                /* CQL 'and' (77:5-78:76) */ && m_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -211,51 +207,27 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (175:54-176:66) */ || i_()
-                /* CQL 'or' (175:54-177:66) */ || j_()
-                /* CQL 'or' (175:52-179:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (175:54-176:66) */ || i_
+            /* CQL 'or' (175:54-177:66) */ || m_
+            /* CQL 'or' (175:52-179:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (175:3-179:3) */ || c_();
+            /* CQL 'implies' (175:3-179:3) */ || r_;
     }
 
 
@@ -325,28 +297,18 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
                 CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Depression);
                 CqlBoolean k_ = context.Operators.Overlaps(i_, j_, (string)default);
-
-                CqlBoolean l_() {
-                    Period n_ = ValidEncounter?.Period;
-                    CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                    CqlDateTime p_ = context.Operators.End(o_);
-                    CqlInterval<CqlDateTime> q_ = this.Denominator_Identification_Period(context);
-                    CqlBoolean r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
-                    return r_;
-                }
-
-
-                CqlBoolean m_() {
-                    Code<Encounter.EncounterStatus> s_ = ValidEncounter?.StatusElement;
-                    Encounter.EncounterStatus? t_ = s_?.Value;
-                    Code<Encounter.EncounterStatus> u_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(t_);
-                    CqlBoolean v_ = context.Operators.Equal(u_, "finished");
-                    return v_;
-                }
-
+                CqlDateTime l_ = context.Operators.End(i_);
+                CqlInterval<CqlDateTime> m_ = this.Denominator_Identification_Period(context);
+                CqlBoolean n_ = context.Operators.In<CqlDateTime>(l_, m_, "day");
+                CqlBoolean o_ = n_;
+                Code<Encounter.EncounterStatus> p_ = ValidEncounter?.StatusElement;
+                Encounter.EncounterStatus? q_ = p_?.Value;
+                Code<Encounter.EncounterStatus> r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
+                CqlBoolean s_ = context.Operators.Equal(r_, "finished");
+                CqlBoolean t_ = s_;
                 return k_
-                    /* CQL 'and' (90:17-91:88) */ && l_()
-                    /* CQL 'and' (90:17-92:46) */ && m_();
+                    /* CQL 'and' (90:17-91:88) */ && o_
+                    /* CQL 'and' (90:17-92:46) */ && t_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Condition>(e_, f_);
@@ -488,299 +450,239 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
         IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
         bool? c_(Encounter InpatientEncounter) {
-            Encounter.HospitalizationComponent j_ = InpatientEncounter?.Hospitalization;
-            CodeableConcept k_ = j_?.DischargeDisposition;
-            CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-            CqlCode m_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
-            CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
-            CqlBoolean o_ = context.Operators.Equivalent(l_, n_);
-
-            CqlBoolean p_() {
-                Encounter.HospitalizationComponent s_ = InpatientEncounter?.Hospitalization;
-                CodeableConcept t_ = s_?.DischargeDisposition;
-                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                CqlCode v_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
-                CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
-                CqlBoolean x_ = context.Operators.Equivalent(u_, w_);
-                return x_;
-            }
-
-
-            CqlBoolean q_() {
-                Period y_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.End(z_);
-                CqlInterval<CqlDateTime> ab_ = this.Denominator_Identification_Period(context);
-                CqlDateTime ac_ = context.Operators.Start(ab_);
-                CqlInterval<CqlDate> ad_ = this.Measure_Assessment_Period(context);
-                CqlDate ae_ = context.Operators.End(ad_);
-                CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
-                CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ac_, af_, true, true);
-                CqlBoolean ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, "day");
-                return ah_;
-            }
-
-
-            CqlBoolean r_() {
-                Code<Encounter.EncounterStatus> ai_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? aj_ = ai_?.Value;
-                Code<Encounter.EncounterStatus> ak_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aj_);
-                CqlBoolean al_ = context.Operators.Equal(ak_, "finished");
-                return al_;
-            }
-
-            return (o_
-                /* CQL 'or' (117:13-119:7) */ || p_())
-                /* CQL 'and' (117:13-120:147) */ && q_()
-                /* CQL 'and' (117:7-121:50) */ && r_();
+            Encounter.HospitalizationComponent af_ = InpatientEncounter?.Hospitalization;
+            CodeableConcept ag_ = af_?.DischargeDisposition;
+            CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_);
+            CqlCode ai_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
+            CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+            CqlBoolean ak_ = context.Operators.Equivalent(ah_, aj_);
+            CqlCode al_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
+            CqlConcept am_ = context.Operators.ConvertCodeToConcept(al_);
+            CqlBoolean an_ = context.Operators.Equivalent(ah_, am_);
+            CqlBoolean ao_ = an_;
+            Period ap_ = InpatientEncounter?.Period;
+            CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
+            CqlDateTime ar_ = context.Operators.End(aq_);
+            CqlInterval<CqlDateTime> as_ = this.Denominator_Identification_Period(context);
+            CqlDateTime at_ = context.Operators.Start(as_);
+            CqlInterval<CqlDate> au_ = this.Measure_Assessment_Period(context);
+            CqlDate av_ = context.Operators.End(au_);
+            CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+            CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(at_, aw_, true, true);
+            CqlBoolean ay_ = context.Operators.In<CqlDateTime>(ar_, ax_, "day");
+            CqlBoolean az_ = ay_;
+            Code<Encounter.EncounterStatus> ba_ = InpatientEncounter?.StatusElement;
+            Encounter.EncounterStatus? bb_ = ba_?.Value;
+            Code<Encounter.EncounterStatus> bc_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bb_);
+            CqlBoolean bd_ = context.Operators.Equal(bc_, "finished");
+            CqlBoolean be_ = bd_;
+            return (ak_
+                /* CQL 'or' (117:13-119:7) */ || ao_)
+                /* CQL 'and' (117:13-120:147) */ && az_
+                /* CQL 'and' (117:7-121:50) */ && be_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Encounter>(b_, c_);
+        CqlValueSet e_ = this.Hospice_Encounter(context);
+        IEnumerable<Encounter> f_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, e_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        CqlBoolean e_() {
-            CqlValueSet am_ = this.Hospice_Encounter(context);
-            IEnumerable<Encounter> an_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, am_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-            bool? ao_(Encounter HospiceEncounter) {
-                Period aq_ = HospiceEncounter?.Period;
-                CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aq_);
-                CqlInterval<CqlDateTime> as_ = this.Denominator_Identification_Period(context);
-                CqlDateTime at_ = context.Operators.Start(as_);
-                CqlInterval<CqlDate> au_ = this.Measure_Assessment_Period(context);
-                CqlDate av_ = context.Operators.End(au_);
-                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
-                CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(at_, aw_, true, true);
-                CqlBoolean ay_ = context.Operators.Overlaps(ar_, ax_, "day");
-
-                CqlBoolean az_() {
-                    Code<Encounter.EncounterStatus> ba_ = HospiceEncounter?.StatusElement;
-                    Encounter.EncounterStatus? bb_ = ba_?.Value;
-                    Code<Encounter.EncounterStatus> bc_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bb_);
-                    string bd_ = context.Operators.Convert<string>(bc_);
-                    string[] be_ = [
-                        "cancelled",
-                        "entered-in-error",
-                        "unknown",
-                    ];
-                    CqlBoolean bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
-                    return !bf_;
-                }
-
-                return ay_
-                    /* CQL 'and' (124:9-125:95) */ && az_();
-            }
-
-            CqlBoolean ap_ = context.Operators.WhereAny<Encounter>(an_, ao_);
-            return ap_;
+        bool? g_(Encounter HospiceEncounter) {
+            Period bf_ = HospiceEncounter?.Period;
+            CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
+            CqlInterval<CqlDateTime> bh_ = this.Denominator_Identification_Period(context);
+            CqlDateTime bi_ = context.Operators.Start(bh_);
+            CqlInterval<CqlDate> bj_ = this.Measure_Assessment_Period(context);
+            CqlDate bk_ = context.Operators.End(bj_);
+            CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
+            CqlInterval<CqlDateTime> bm_ = context.Operators.Interval(bi_, bl_, true, true);
+            CqlBoolean bn_ = context.Operators.Overlaps(bg_, bm_, "day");
+            Code<Encounter.EncounterStatus> bo_ = HospiceEncounter?.StatusElement;
+            Encounter.EncounterStatus? bp_ = bo_?.Value;
+            Code<Encounter.EncounterStatus> bq_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bp_);
+            string br_ = context.Operators.Convert<string>(bq_);
+            string[] bs_ = [
+                "cancelled",
+                "entered-in-error",
+                "unknown",
+            ];
+            CqlBoolean bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
+            CqlBoolean bu_ = (CqlBoolean)!bt_;
+            return bn_
+                /* CQL 'and' (124:9-125:95) */ && bu_;
         }
 
+        CqlBoolean h_ = context.Operators.WhereAny<Encounter>(f_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = this.Hospice_care__Minimum_Data_Set_(context);
+        IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
+        IEnumerable<Observation> l_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, k_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
-        CqlBoolean f_() {
-            CqlCode bg_ = this.Hospice_care__Minimum_Data_Set_(context);
-            IEnumerable<CqlCode> bh_ = context.Operators.ToList<CqlCode>(bg_);
-            IEnumerable<Observation> bi_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, bh_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
-
-            bool? bj_(Observation HospiceAssessment) {
-                DataType bl_ = HospiceAssessment?.Value;
-                object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                CqlCode bn_ = this.Yes__qualifier_value_(context);
-                CqlConcept bo_ = context.Operators.ConvertCodeToConcept(bn_);
-                CqlBoolean bp_ = context.Operators.Equivalent(bm_ as CqlConcept, bo_);
-
-                CqlBoolean bq_() {
-                    DataType bs_ = HospiceAssessment?.Effective;
-                    object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                    CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, bt_);
-                    CqlInterval<CqlDateTime> bv_ = this.Denominator_Identification_Period(context);
-                    CqlDateTime bw_ = context.Operators.Start(bv_);
-                    CqlInterval<CqlDate> bx_ = this.Measure_Assessment_Period(context);
-                    CqlDate by_ = context.Operators.End(bx_);
-                    CqlDateTime bz_ = context.Operators.ConvertDateToDateTime(by_);
-                    CqlInterval<CqlDateTime> ca_ = context.Operators.Interval(bw_, bz_, true, true);
-                    CqlBoolean cb_ = context.Operators.Overlaps(bu_, ca_, "day");
-                    return cb_;
-                }
-
-
-                CqlBoolean br_() {
-                    Code<ObservationStatus> cc_ = HospiceAssessment?.StatusElement;
-                    ObservationStatus? cd_ = cc_?.Value;
-                    string ce_ = context.Operators.Convert<string>(cd_);
-                    string[] cf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean cg_ = context.Operators.In<string>(ce_, (IEnumerable<string>)cf_);
-                    return cg_;
-                }
-
-                return bp_
-                    /* CQL 'and' (128:15-129:163) */ && bq_()
-                    /* CQL 'and' (128:9-130:77) */ && br_();
-            }
-
-            CqlBoolean bk_ = context.Operators.WhereAny<Observation>(bi_, bj_);
-            return bk_;
+        bool? m_(Observation HospiceAssessment) {
+            DataType bv_ = HospiceAssessment?.Value;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            CqlCode bx_ = this.Yes__qualifier_value_(context);
+            CqlConcept by_ = context.Operators.ConvertCodeToConcept(bx_);
+            CqlBoolean bz_ = context.Operators.Equivalent(bw_ as CqlConcept, by_);
+            DataType ca_ = HospiceAssessment?.Effective;
+            object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+            CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
+            CqlInterval<CqlDateTime> cd_ = this.Denominator_Identification_Period(context);
+            CqlDateTime ce_ = context.Operators.Start(cd_);
+            CqlInterval<CqlDate> cf_ = this.Measure_Assessment_Period(context);
+            CqlDate cg_ = context.Operators.End(cf_);
+            CqlDateTime ch_ = context.Operators.ConvertDateToDateTime(cg_);
+            CqlInterval<CqlDateTime> ci_ = context.Operators.Interval(ce_, ch_, true, true);
+            CqlBoolean cj_ = context.Operators.Overlaps(cc_, ci_, "day");
+            CqlBoolean ck_ = cj_;
+            Code<ObservationStatus> cl_ = HospiceAssessment?.StatusElement;
+            ObservationStatus? cm_ = cl_?.Value;
+            string cn_ = context.Operators.Convert<string>(cm_);
+            string[] co_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean cp_ = context.Operators.In<string>(cn_, (IEnumerable<string>)co_);
+            CqlBoolean cq_ = cp_;
+            return bz_
+                /* CQL 'and' (128:15-129:163) */ && ck_
+                /* CQL 'and' (128:9-130:77) */ && cq_;
         }
 
+        CqlBoolean n_ = context.Operators.WhereAny<Observation>(l_, m_);
+        CqlBoolean o_ = n_;
+        CqlValueSet p_ = this.Hospice_Care_Ambulatory(context);
+        IEnumerable<ServiceRequest> q_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, p_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
-        CqlBoolean g_() {
-            CqlValueSet ch_ = this.Hospice_Care_Ambulatory(context);
-            IEnumerable<ServiceRequest> ci_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, ch_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
-
-            bool? cj_(ServiceRequest HospiceOrder) {
-                FhirDateTime cl_ = HospiceOrder?.AuthoredOnElement;
-                CqlDateTime cm_ = context.Operators.Convert<CqlDateTime>(cl_);
-                CqlInterval<CqlDateTime> cn_ = this.Denominator_Identification_Period(context);
-                CqlDateTime co_ = context.Operators.Start(cn_);
-                CqlInterval<CqlDate> cp_ = this.Measure_Assessment_Period(context);
-                CqlDate cq_ = context.Operators.End(cp_);
-                CqlDateTime cr_ = context.Operators.ConvertDateToDateTime(cq_);
-                CqlInterval<CqlDateTime> cs_ = context.Operators.Interval(co_, cr_, true, true);
-                CqlBoolean ct_ = context.Operators.In<CqlDateTime>(cm_, cs_, "day");
-
-                CqlBoolean cu_() {
-                    Code<RequestStatus> cw_ = HospiceOrder?.StatusElement;
-                    RequestStatus? cx_ = cw_?.Value;
-                    Code<RequestStatus> cy_ = context.Operators.Convert<Code<RequestStatus>>(cx_);
-                    string cz_ = context.Operators.Convert<string>(cy_);
-                    string[] da_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean db_ = context.Operators.In<string>(cz_, (IEnumerable<string>)da_);
-                    return db_;
-                }
-
-
-                CqlBoolean cv_() {
-                    Code<RequestIntent> dc_ = HospiceOrder?.IntentElement;
-                    RequestIntent? dd_ = dc_?.Value;
-                    Code<RequestIntent> de_ = context.Operators.Convert<Code<RequestIntent>>(dd_);
-                    string df_ = context.Operators.Convert<string>(de_);
-                    string[] dg_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean dh_ = context.Operators.In<string>(df_, (IEnumerable<string>)dg_);
-                    return dh_;
-                }
-
-                return ct_
-                    /* CQL 'and' (133:15-134:62) */ && cu_()
-                    /* CQL 'and' (133:9-135:116) */ && cv_();
-            }
-
-            CqlBoolean ck_ = context.Operators.WhereAny<ServiceRequest>(ci_, cj_);
-            return ck_;
+        bool? r_(ServiceRequest HospiceOrder) {
+            FhirDateTime cr_ = HospiceOrder?.AuthoredOnElement;
+            CqlDateTime cs_ = context.Operators.Convert<CqlDateTime>(cr_);
+            CqlInterval<CqlDateTime> ct_ = this.Denominator_Identification_Period(context);
+            CqlDateTime cu_ = context.Operators.Start(ct_);
+            CqlInterval<CqlDate> cv_ = this.Measure_Assessment_Period(context);
+            CqlDate cw_ = context.Operators.End(cv_);
+            CqlDateTime cx_ = context.Operators.ConvertDateToDateTime(cw_);
+            CqlInterval<CqlDateTime> cy_ = context.Operators.Interval(cu_, cx_, true, true);
+            CqlBoolean cz_ = context.Operators.In<CqlDateTime>(cs_, cy_, "day");
+            Code<RequestStatus> da_ = HospiceOrder?.StatusElement;
+            RequestStatus? db_ = da_?.Value;
+            Code<RequestStatus> dc_ = context.Operators.Convert<Code<RequestStatus>>(db_);
+            string dd_ = context.Operators.Convert<string>(dc_);
+            string[] de_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean df_ = context.Operators.In<string>(dd_, (IEnumerable<string>)de_);
+            CqlBoolean dg_ = df_;
+            Code<RequestIntent> dh_ = HospiceOrder?.IntentElement;
+            RequestIntent? di_ = dh_?.Value;
+            Code<RequestIntent> dj_ = context.Operators.Convert<Code<RequestIntent>>(di_);
+            string dk_ = context.Operators.Convert<string>(dj_);
+            string[] dl_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean dm_ = context.Operators.In<string>(dk_, (IEnumerable<string>)dl_);
+            CqlBoolean dn_ = dm_;
+            return cz_
+                /* CQL 'and' (133:15-134:62) */ && dg_
+                /* CQL 'and' (133:9-135:116) */ && dn_;
         }
 
+        CqlBoolean s_ = context.Operators.WhereAny<ServiceRequest>(q_, r_);
+        CqlBoolean t_ = s_;
+        IEnumerable<Procedure> u_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, p_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        CqlBoolean h_() {
-            CqlValueSet di_ = this.Hospice_Care_Ambulatory(context);
-            IEnumerable<Procedure> dj_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, di_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-            bool? dk_(Procedure HospicePerformed) {
-                object dm_;
-                DataType dw_ = HospicePerformed?.Performed;
-                object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                bool dy_ = dx_ is CqlDateTime;
-                if (dy_)
+        bool? v_(Procedure HospicePerformed) {
+            object do_;
+            DataType ed_ = HospicePerformed?.Performed;
+            object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
+            bool ef_ = ee_ is CqlDateTime;
+            if (ef_)
+            {
+                do_ = ee_ as CqlDateTime;
+            }
+            else
+            {
+                bool eg_ = ee_ is CqlQuantity;
+                if (eg_)
                 {
-                    dm_ = dx_ as CqlDateTime;
+                    do_ = ee_ as CqlQuantity;
                 }
                 else
                 {
-                    bool dz_ = dx_ is CqlQuantity;
-                    if (dz_)
+                    bool eh_ = ee_ is CqlInterval<CqlDateTime>;
+                    if (eh_)
                     {
-                        dm_ = dx_ as CqlQuantity;
+                        do_ = ee_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ea_ = dx_ is CqlInterval<CqlDateTime>;
-                        if (ea_)
+                        bool ei_ = ee_ is CqlInterval<CqlQuantity>;
+                        if (ei_)
                         {
-                            dm_ = dx_ as CqlInterval<CqlDateTime>;
+                            do_ = ee_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool eb_ = dx_ is CqlInterval<CqlQuantity>;
-                            if (eb_)
-                            {
-                                dm_ = dx_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                dm_ = null;
-                            }
+                            do_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> dn_ = QICoreCommon_4_0_000.Instance.toInterval(context, dm_);
-                CqlInterval<CqlDateTime> do_ = this.Denominator_Identification_Period(context);
-                CqlDateTime dp_ = context.Operators.Start(do_);
-                CqlInterval<CqlDate> dq_ = this.Measure_Assessment_Period(context);
-                CqlDate dr_ = context.Operators.End(dq_);
-                CqlDateTime ds_ = context.Operators.ConvertDateToDateTime(dr_);
-                CqlInterval<CqlDateTime> dt_ = context.Operators.Interval(dp_, ds_, true, true);
-                CqlBoolean du_ = context.Operators.Overlaps(dn_, dt_, "day");
-
-                CqlBoolean dv_() {
-                    Code<EventStatus> ec_ = HospicePerformed?.StatusElement;
-                    EventStatus? ed_ = ec_?.Value;
-                    string ee_ = context.Operators.Convert<string>(ed_);
-                    string[] ef_ = [
-                        "not-done",
-                        "entered-in-error",
-                        "unknown",
-                    ];
-                    CqlBoolean eg_ = context.Operators.In<string>(ee_, (IEnumerable<string>)ef_);
-                    return !eg_;
-                }
-
-                return du_
-                    /* CQL 'and' (138:9-139:94) */ && dv_();
             }
-
-            CqlBoolean dl_ = context.Operators.WhereAny<Procedure>(dj_, dk_);
-            return dl_;
+            CqlInterval<CqlDateTime> dp_ = QICoreCommon_4_0_000.Instance.toInterval(context, do_);
+            CqlInterval<CqlDateTime> dq_ = this.Denominator_Identification_Period(context);
+            CqlDateTime dr_ = context.Operators.Start(dq_);
+            CqlInterval<CqlDate> ds_ = this.Measure_Assessment_Period(context);
+            CqlDate dt_ = context.Operators.End(ds_);
+            CqlDateTime du_ = context.Operators.ConvertDateToDateTime(dt_);
+            CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
+            CqlBoolean dw_ = context.Operators.Overlaps(dp_, dv_, "day");
+            Code<EventStatus> dx_ = HospicePerformed?.StatusElement;
+            EventStatus? dy_ = dx_?.Value;
+            string dz_ = context.Operators.Convert<string>(dy_);
+            string[] ea_ = [
+                "not-done",
+                "entered-in-error",
+                "unknown",
+            ];
+            CqlBoolean eb_ = context.Operators.In<string>(dz_, (IEnumerable<string>)ea_);
+            CqlBoolean ec_ = (CqlBoolean)!eb_;
+            return dw_
+                /* CQL 'and' (138:9-139:94) */ && ec_;
         }
 
+        CqlBoolean w_ = context.Operators.WhereAny<Procedure>(u_, v_);
+        CqlBoolean x_ = w_;
+        CqlValueSet y_ = this.Hospice_Diagnosis(context);
+        IEnumerable<Condition> z_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> aa_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> ab_ = context.Operators.Union<Condition>(z_ as IEnumerable<Condition>, aa_ as IEnumerable<Condition>);
 
-        CqlBoolean i_() {
-            CqlValueSet eh_ = this.Hospice_Diagnosis(context);
-            IEnumerable<Condition> ei_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, eh_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> ej_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, eh_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> ek_ = context.Operators.Union<Condition>(ei_ as IEnumerable<Condition>, ej_ as IEnumerable<Condition>);
-
-            bool? el_(Condition HospiceCareDiagnosis) {
-                CqlInterval<CqlDateTime> en_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis);
-                CqlInterval<CqlDateTime> eo_ = this.Denominator_Identification_Period(context);
-                CqlDateTime ep_ = context.Operators.Start(eo_);
-                CqlInterval<CqlDate> eq_ = this.Measure_Assessment_Period(context);
-                CqlDate er_ = context.Operators.End(eq_);
-                CqlDateTime es_ = context.Operators.ConvertDateToDateTime(er_);
-                CqlInterval<CqlDateTime> et_ = context.Operators.Interval(ep_, es_, true, true);
-                CqlBoolean eu_ = context.Operators.Overlaps(en_, et_, "day");
-                return eu_
-                    /* CQL 'and' (143:9-144:49) */ && this.isVerified(context, HospiceCareDiagnosis);
-            }
-
-            CqlBoolean em_ = context.Operators.WhereAny<Condition>(ek_, el_);
-            return em_;
+        bool? ac_(Condition HospiceCareDiagnosis) {
+            CqlInterval<CqlDateTime> ej_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis);
+            CqlInterval<CqlDateTime> ek_ = this.Denominator_Identification_Period(context);
+            CqlDateTime el_ = context.Operators.Start(ek_);
+            CqlInterval<CqlDate> em_ = this.Measure_Assessment_Period(context);
+            CqlDate en_ = context.Operators.End(em_);
+            CqlDateTime eo_ = context.Operators.ConvertDateToDateTime(en_);
+            CqlInterval<CqlDateTime> ep_ = context.Operators.Interval(el_, eo_, true, true);
+            CqlBoolean eq_ = context.Operators.Overlaps(ej_, ep_, "day");
+            return eq_
+                /* CQL 'and' (143:9-144:49) */ && this.isVerified(context, HospiceCareDiagnosis);
         }
 
+        CqlBoolean ad_ = context.Operators.WhereAny<Condition>(ab_, ac_);
+        CqlBoolean ae_ = ad_;
         return d_
-            /* CQL 'or' (116:3-126:5) */ || e_()
-            /* CQL 'or' (116:3-131:5) */ || f_()
-            /* CQL 'or' (116:3-136:5) */ || g_()
-            /* CQL 'or' (116:3-140:5) */ || h_()
-            /* CQL 'or' (116:3-145:5) */ || i_();
+            /* CQL 'or' (116:3-126:5) */ || i_
+            /* CQL 'or' (116:3-131:5) */ || o_
+            /* CQL 'or' (116:3-136:5) */ || t_
+            /* CQL 'or' (116:3-140:5) */ || x_
+            /* CQL 'or' (116:3-145:5) */ || ae_;
     }
 
 
@@ -797,167 +699,143 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
         IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
 
         bool? d_(Observation PalliativeAssessment) {
-            DataType i_ = PalliativeAssessment?.Effective;
-            object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-            CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-            CqlInterval<CqlDateTime> l_ = this.Denominator_Identification_Period(context);
-            CqlDateTime m_ = context.Operators.Start(l_);
-            CqlInterval<CqlDate> n_ = this.Measure_Assessment_Period(context);
-            CqlDate o_ = context.Operators.End(n_);
-            CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
-            CqlInterval<CqlDateTime> q_ = context.Operators.Interval(m_, p_, true, true);
-            CqlBoolean r_ = context.Operators.Overlaps(k_, q_, "day");
-
-            CqlBoolean s_() {
-                Code<ObservationStatus> t_ = PalliativeAssessment?.StatusElement;
-                ObservationStatus? u_ = t_?.Value;
-                string v_ = context.Operators.Convert<string>(u_);
-                string[] w_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
-                return x_;
-            }
-
-            return r_
-                /* CQL 'and' (157:7-158:78) */ && s_();
+            DataType w_ = PalliativeAssessment?.Effective;
+            object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+            CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+            CqlInterval<CqlDateTime> z_ = this.Denominator_Identification_Period(context);
+            CqlDateTime aa_ = context.Operators.Start(z_);
+            CqlInterval<CqlDate> ab_ = this.Measure_Assessment_Period(context);
+            CqlDate ac_ = context.Operators.End(ab_);
+            CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(ac_);
+            CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(aa_, ad_, true, true);
+            CqlBoolean af_ = context.Operators.Overlaps(y_, ae_, "day");
+            Code<ObservationStatus> ag_ = PalliativeAssessment?.StatusElement;
+            ObservationStatus? ah_ = ag_?.Value;
+            string ai_ = context.Operators.Convert<string>(ah_);
+            string[] aj_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
+            CqlBoolean al_ = ak_;
+            return af_
+                /* CQL 'and' (157:7-158:78) */ && al_;
         }
 
         CqlBoolean e_ = context.Operators.WhereAny<Observation>(c_, d_);
+        CqlValueSet f_ = this.Palliative_Care_Diagnosis(context);
+        IEnumerable<Condition> g_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> h_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> i_ = context.Operators.Union<Condition>(g_ as IEnumerable<Condition>, h_ as IEnumerable<Condition>);
 
-        CqlBoolean f_() {
-            CqlValueSet y_ = this.Palliative_Care_Diagnosis(context);
-            IEnumerable<Condition> z_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> aa_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> ab_ = context.Operators.Union<Condition>(z_ as IEnumerable<Condition>, aa_ as IEnumerable<Condition>);
-
-            bool? ac_(Condition PalliativeDiagnosis) {
-                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeDiagnosis);
-                CqlInterval<CqlDateTime> af_ = this.Denominator_Identification_Period(context);
-                CqlDateTime ag_ = context.Operators.Start(af_);
-                CqlInterval<CqlDate> ah_ = this.Measure_Assessment_Period(context);
-                CqlDate ai_ = context.Operators.End(ah_);
-                CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
-                CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ag_, aj_, true, true);
-                CqlBoolean al_ = context.Operators.Overlaps(ae_, ak_, "day");
-                return al_
-                    /* CQL 'and' (162:9-163:48) */ && this.isVerified(context, PalliativeDiagnosis);
-            }
-
-            CqlBoolean ad_ = context.Operators.WhereAny<Condition>(ab_, ac_);
-            return ad_;
+        bool? j_(Condition PalliativeDiagnosis) {
+            CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeDiagnosis);
+            CqlInterval<CqlDateTime> an_ = this.Denominator_Identification_Period(context);
+            CqlDateTime ao_ = context.Operators.Start(an_);
+            CqlInterval<CqlDate> ap_ = this.Measure_Assessment_Period(context);
+            CqlDate aq_ = context.Operators.End(ap_);
+            CqlDateTime ar_ = context.Operators.ConvertDateToDateTime(aq_);
+            CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ao_, ar_, true, true);
+            CqlBoolean at_ = context.Operators.Overlaps(am_, as_, "day");
+            return at_
+                /* CQL 'and' (162:9-163:48) */ && this.isVerified(context, PalliativeDiagnosis);
         }
 
+        CqlBoolean k_ = context.Operators.WhereAny<Condition>(i_, j_);
+        CqlBoolean l_ = k_;
+        CqlValueSet m_ = this.Palliative_Care_Encounter(context);
+        IEnumerable<Encounter> n_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, m_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-        CqlBoolean g_() {
-            CqlValueSet am_ = this.Palliative_Care_Encounter(context);
-            IEnumerable<Encounter> an_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, am_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-            bool? ao_(Encounter PalliativeEncounter) {
-                Period aq_ = PalliativeEncounter?.Period;
-                CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aq_);
-                CqlInterval<CqlDateTime> as_ = this.Denominator_Identification_Period(context);
-                CqlDateTime at_ = context.Operators.Start(as_);
-                CqlInterval<CqlDate> au_ = this.Measure_Assessment_Period(context);
-                CqlDate av_ = context.Operators.End(au_);
-                CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
-                CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(at_, aw_, true, true);
-                CqlBoolean ay_ = context.Operators.Overlaps(ar_, ax_, "day");
-
-                CqlBoolean az_() {
-                    Code<Encounter.EncounterStatus> ba_ = PalliativeEncounter?.StatusElement;
-                    Encounter.EncounterStatus? bb_ = ba_?.Value;
-                    Code<Encounter.EncounterStatus> bc_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bb_);
-                    CqlBoolean bd_ = context.Operators.Equal(bc_, "finished");
-                    return bd_;
-                }
-
-                return ay_
-                    /* CQL 'and' (166:9-167:53) */ && az_();
-            }
-
-            CqlBoolean ap_ = context.Operators.WhereAny<Encounter>(an_, ao_);
-            return ap_;
+        bool? o_(Encounter PalliativeEncounter) {
+            Period au_ = PalliativeEncounter?.Period;
+            CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
+            CqlInterval<CqlDateTime> aw_ = this.Denominator_Identification_Period(context);
+            CqlDateTime ax_ = context.Operators.Start(aw_);
+            CqlInterval<CqlDate> ay_ = this.Measure_Assessment_Period(context);
+            CqlDate az_ = context.Operators.End(ay_);
+            CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
+            CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ax_, ba_, true, true);
+            CqlBoolean bc_ = context.Operators.Overlaps(av_, bb_, "day");
+            Code<Encounter.EncounterStatus> bd_ = PalliativeEncounter?.StatusElement;
+            Encounter.EncounterStatus? be_ = bd_?.Value;
+            Code<Encounter.EncounterStatus> bf_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(be_);
+            CqlBoolean bg_ = context.Operators.Equal(bf_, "finished");
+            CqlBoolean bh_ = bg_;
+            return bc_
+                /* CQL 'and' (166:9-167:53) */ && bh_;
         }
 
+        CqlBoolean p_ = context.Operators.WhereAny<Encounter>(n_, o_);
+        CqlBoolean q_ = p_;
+        CqlValueSet r_ = this.Palliative_Care_Intervention(context);
+        IEnumerable<Procedure> s_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, r_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-        CqlBoolean h_() {
-            CqlValueSet be_ = this.Palliative_Care_Intervention(context);
-            IEnumerable<Procedure> bf_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, be_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-            bool? bg_(Procedure PalliativeIntervention) {
-                object bi_;
-                DataType bs_ = PalliativeIntervention?.Performed;
-                object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                bool bu_ = bt_ is CqlDateTime;
-                if (bu_)
+        bool? t_(Procedure PalliativeIntervention) {
+            object bi_;
+            DataType bx_ = PalliativeIntervention?.Performed;
+            object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+            bool bz_ = by_ is CqlDateTime;
+            if (bz_)
+            {
+                bi_ = by_ as CqlDateTime;
+            }
+            else
+            {
+                bool ca_ = by_ is CqlQuantity;
+                if (ca_)
                 {
-                    bi_ = bt_ as CqlDateTime;
+                    bi_ = by_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bv_ = bt_ is CqlQuantity;
-                    if (bv_)
+                    bool cb_ = by_ is CqlInterval<CqlDateTime>;
+                    if (cb_)
                     {
-                        bi_ = bt_ as CqlQuantity;
+                        bi_ = by_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bw_ = bt_ is CqlInterval<CqlDateTime>;
-                        if (bw_)
+                        bool cc_ = by_ is CqlInterval<CqlQuantity>;
+                        if (cc_)
                         {
-                            bi_ = bt_ as CqlInterval<CqlDateTime>;
+                            bi_ = by_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bx_ = bt_ is CqlInterval<CqlQuantity>;
-                            if (bx_)
-                            {
-                                bi_ = bt_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bi_ = null;
-                            }
+                            bi_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
-                CqlInterval<CqlDateTime> bk_ = this.Denominator_Identification_Period(context);
-                CqlDateTime bl_ = context.Operators.Start(bk_);
-                CqlInterval<CqlDate> bm_ = this.Measure_Assessment_Period(context);
-                CqlDate bn_ = context.Operators.End(bm_);
-                CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(bn_);
-                CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bl_, bo_, true, true);
-                CqlBoolean bq_ = context.Operators.Overlaps(bj_, bp_, "day");
-
-                CqlBoolean br_() {
-                    Code<EventStatus> by_ = PalliativeIntervention?.StatusElement;
-                    EventStatus? bz_ = by_?.Value;
-                    string ca_ = context.Operators.Convert<string>(bz_);
-                    string[] cb_ = [
-                        "not-done",
-                        "entered-in-error",
-                        "unknown",
-                    ];
-                    CqlBoolean cc_ = context.Operators.In<string>(ca_, (IEnumerable<string>)cb_);
-                    return !cc_;
-                }
-
-                return bq_
-                    /* CQL 'and' (170:9-171:100) */ && br_();
             }
-
-            CqlBoolean bh_ = context.Operators.WhereAny<Procedure>(bf_, bg_);
-            return bh_;
+            CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
+            CqlInterval<CqlDateTime> bk_ = this.Denominator_Identification_Period(context);
+            CqlDateTime bl_ = context.Operators.Start(bk_);
+            CqlInterval<CqlDate> bm_ = this.Measure_Assessment_Period(context);
+            CqlDate bn_ = context.Operators.End(bm_);
+            CqlDateTime bo_ = context.Operators.ConvertDateToDateTime(bn_);
+            CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bl_, bo_, true, true);
+            CqlBoolean bq_ = context.Operators.Overlaps(bj_, bp_, "day");
+            Code<EventStatus> br_ = PalliativeIntervention?.StatusElement;
+            EventStatus? bs_ = br_?.Value;
+            string bt_ = context.Operators.Convert<string>(bs_);
+            string[] bu_ = [
+                "not-done",
+                "entered-in-error",
+                "unknown",
+            ];
+            CqlBoolean bv_ = context.Operators.In<string>(bt_, (IEnumerable<string>)bu_);
+            CqlBoolean bw_ = (CqlBoolean)!bv_;
+            return bq_
+                /* CQL 'and' (170:9-171:100) */ && bw_;
         }
 
+        CqlBoolean u_ = context.Operators.WhereAny<Procedure>(s_, t_);
+        CqlBoolean v_ = u_;
         return e_
-            /* CQL 'or' (156:3-164:5) */ || f_()
-            /* CQL 'or' (156:3-168:5) */ || g_()
-            /* CQL 'or' (156:3-172:5) */ || h_();
+            /* CQL 'or' (156:3-164:5) */ || l_
+            /* CQL 'or' (156:3-168:5) */ || q_
+            /* CQL 'or' (156:3-172:5) */ || v_;
     }
 
 
@@ -1065,22 +943,18 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
             CqlBoolean u_ = o_?.highClosed;
             CqlInterval<CqlDateTime> v_ = context.Operators.Interval(q_, s_, t_, u_);
             CqlBoolean w_ = context.Operators.In<CqlDateTime>(n_, v_, "day");
-
-            CqlBoolean x_() {
-                Code<ObservationStatus> y_ = DepressionAssessment?.StatusElement;
-                ObservationStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
-            }
-
+            Code<ObservationStatus> x_ = DepressionAssessment?.StatusElement;
+            ObservationStatus? y_ = x_?.Value;
+            string z_ = context.Operators.Convert<string>(y_);
+            string[] aa_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
+            CqlBoolean ac_ = ab_;
             return w_
-                /* CQL 'and' (55:7-56:78) */ && x_();
+                /* CQL 'and' (55:7-56:78) */ && ac_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS165FHIRControllingHighBP", "1.0.000")]
 public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<CMS165FHIRControllingHighBP_1_0_000>
 {
@@ -167,23 +167,15 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(18, 85, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<Condition> m_ = this.Essential_Hypertension_Diagnosis(context);
-            CqlBoolean n_ = context.Operators.Exists<Condition>(m_);
-            return n_;
-        }
-
-
-        CqlBoolean l_() {
-            IEnumerable<Encounter> o_ = AdultOutpatientEncounters_4_19_000.Instance.Qualifying_Encounters(context);
-            CqlBoolean p_ = context.Operators.Exists<Encounter>(o_);
-            return p_;
-        }
-
+        IEnumerable<Condition> k_ = this.Essential_Hypertension_Diagnosis(context);
+        CqlBoolean l_ = context.Operators.Exists<Condition>(k_);
+        CqlBoolean m_ = l_;
+        IEnumerable<Encounter> n_ = AdultOutpatientEncounters_4_19_000.Instance.Qualifying_Encounters(context);
+        CqlBoolean o_ = context.Operators.Exists<Encounter>(n_);
+        CqlBoolean p_ = o_;
         return j_
-            /* CQL 'and' (36:3-39:49) */ && k_()
-            /* CQL 'and' (36:3-40:64) */ && l_();
+            /* CQL 'and' (36:3-39:49) */ && m_
+            /* CQL 'and' (36:3-40:64) */ && p_;
     }
 
 
@@ -342,31 +334,19 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Condition> e_ = this.Pregnancy_or_Renal_Diagnosis(context);
-            CqlBoolean f_ = context.Operators.Exists<Condition>(e_);
-            return f_;
-        }
-
-
-        CqlBoolean c_() {
-            IEnumerable<Procedure> g_ = this.End_Stage_Renal_Disease_Procedures(context);
-            CqlBoolean h_ = context.Operators.Exists<Procedure>(g_);
-            return h_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Encounter> i_ = this.End_Stage_Renal_Disease_Encounter(context);
-            CqlBoolean j_ = context.Operators.Exists<Encounter>(i_);
-            return j_;
-        }
-
+        IEnumerable<Condition> b_ = this.Pregnancy_or_Renal_Diagnosis(context);
+        CqlBoolean c_ = context.Operators.Exists<Condition>(b_);
+        CqlBoolean d_ = c_;
+        IEnumerable<Procedure> e_ = this.End_Stage_Renal_Disease_Procedures(context);
+        CqlBoolean f_ = context.Operators.Exists<Procedure>(e_);
+        CqlBoolean g_ = f_;
+        IEnumerable<Encounter> h_ = this.End_Stage_Renal_Disease_Encounter(context);
+        CqlBoolean i_ = context.Operators.Exists<Encounter>(h_);
+        CqlBoolean j_ = i_;
         return a_
-            /* CQL 'or' (52:3-53:48) */ || b_()
-            /* CQL 'or' (52:3-54:54) */ || c_()
-            /* CQL 'or' (52:3-55:53) */ || d_()
+            /* CQL 'or' (52:3-53:48) */ || d_
+            /* CQL 'or' (52:3-54:54) */ || g_
+            /* CQL 'or' (52:3-55:53) */ || j_
             /* CQL 'or' (52:3-56:105) */ || AdvancedIllnessandFrailty_1_27_000.Instance.Is_Age_66_to_80_with_Advanced_Illness_and_Frailty_or_Is_Age_81_or_Older_with_Frailty(context)
             /* CQL 'or' (52:3-57:74) */ || AdvancedIllnessandFrailty_1_27_000.Instance.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home(context)
             /* CQL 'or' (52:3-58:69) */ || PalliativeCare_1_18_000.Instance.Has_Palliative_Care_in_the_Measurement_Period(context);
@@ -455,18 +435,14 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
                 "SS",
             ];
             CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-
-            CqlBoolean aj_() {
-                DataType ak_ = BloodPressure?.Effective;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                CqlDateTime am_ = QICoreCommon_4_0_000.Instance.latest(context, al_);
-                CqlInterval<CqlDateTime> an_ = this.Measurement_Period(context);
-                CqlBoolean ao_ = context.Operators.In<CqlDateTime>(am_, an_, "day");
-                return ao_;
-            }
-
+            DataType aj_ = BloodPressure?.Effective;
+            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+            CqlDateTime al_ = QICoreCommon_4_0_000.Instance.latest(context, ak_);
+            CqlInterval<CqlDateTime> am_ = this.Measurement_Period(context);
+            CqlBoolean an_ = context.Operators.In<CqlDateTime>(al_, am_, "day");
+            CqlBoolean ao_ = an_;
             return (CqlBoolean)!ai_
-                /* CQL 'and' (121:9-122:83) */ && aj_();
+                /* CQL 'and' (121:9-122:83) */ && ao_;
         }
 
         IEnumerable<Observation> h_ = context.Operators.Where<Observation>(b_, g_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS177FHIRChildMDDSuicideAssmt", "1.0.000")]
 public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISingleton<CMS177FHIRChildMDDSuicideAssmt_1_0_000>
 {
@@ -199,44 +199,36 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
             Encounter.EncounterStatus? aa_ = z_?.Value;
             Code<Encounter.EncounterStatus> ab_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aa_);
             CqlBoolean ac_ = context.Operators.Equal(ab_, "finished");
+            CqlInterval<CqlDateTime> ad_ = this.Measurement_Period(context);
+            Period ae_ = ValidEncounter?.Period;
+            CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
+            CqlBoolean ag_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ad_, af_, "day");
+            CqlBoolean ah_ = ag_;
+            CqlValueSet ai_ = this.Major_Depressive_Disorder_Active(context);
+            IEnumerable<Condition> aj_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            CqlBoolean ad_() {
-                CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
-                Period ag_ = ValidEncounter?.Period;
-                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                CqlBoolean ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, "day");
-                return ai_;
+            bool? ak_(Condition MDDConditionProb) {
+                List<ResourceReference> as_ = ValidEncounter?.ReasonReference;
+                CqlBoolean at_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)as_, MDDConditionProb);
+                return at_;
             }
 
+            IEnumerable<Condition> al_ = context.Operators.Where<Condition>(aj_, ak_);
+            IEnumerable<Condition> am_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
-            CqlBoolean ae_() {
-                CqlValueSet aj_ = this.Major_Depressive_Disorder_Active(context);
-                IEnumerable<Condition> ak_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-
-                bool? al_(Condition MDDConditionProb) {
-                    List<ResourceReference> as_ = ValidEncounter?.ReasonReference;
-                    CqlBoolean at_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)as_, MDDConditionProb);
-                    return at_;
-                }
-
-                IEnumerable<Condition> am_ = context.Operators.Where<Condition>(ak_, al_);
-                IEnumerable<Condition> an_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-
-                bool? ao_(Condition MDDEncDx) {
-                    List<ResourceReference> au_ = ValidEncounter?.ReasonReference;
-                    CqlBoolean av_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)au_, MDDEncDx);
-                    return av_;
-                }
-
-                IEnumerable<Condition> ap_ = context.Operators.Where<Condition>(an_, ao_);
-                IEnumerable<Condition> aq_ = context.Operators.Union<Condition>(am_ as IEnumerable<Condition>, ap_ as IEnumerable<Condition>);
-                CqlBoolean ar_ = context.Operators.Exists<Condition>(aq_);
-                return ar_;
+            bool? an_(Condition MDDEncDx) {
+                List<ResourceReference> au_ = ValidEncounter?.ReasonReference;
+                CqlBoolean av_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)au_, MDDEncDx);
+                return av_;
             }
 
+            IEnumerable<Condition> ao_ = context.Operators.Where<Condition>(am_, an_);
+            IEnumerable<Condition> ap_ = context.Operators.Union<Condition>(al_ as IEnumerable<Condition>, ao_ as IEnumerable<Condition>);
+            CqlBoolean aq_ = context.Operators.Exists<Condition>(ap_);
+            CqlBoolean ar_ = aq_;
             return ac_
-                /* CQL 'and' (80:11-81:66) */ && ad_()
-                /* CQL 'and' (80:5-88:7) */ && ae_();
+                /* CQL 'and' (80:11-81:66) */ && ah_
+                /* CQL 'and' (80:5-88:7) */ && ar_;
         }
 
         IEnumerable<Encounter> y_ = context.Operators.Where<Encounter>(w_, x_);
@@ -281,33 +273,25 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
             Encounter.EncounterStatus? aa_ = z_?.Value;
             Code<Encounter.EncounterStatus> ab_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aa_);
             CqlBoolean ac_ = context.Operators.Equal(ab_, "finished");
+            CqlInterval<CqlDateTime> ad_ = this.Measurement_Period(context);
+            Period ae_ = ValidEncounter?.Period;
+            CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
+            CqlBoolean ag_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ad_, af_, "day");
+            CqlBoolean ah_ = ag_;
+            List<CodeableConcept> ai_ = ValidEncounter?.ReasonCode;
 
-            CqlBoolean ad_() {
-                CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
-                Period ag_ = ValidEncounter?.Period;
-                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                CqlBoolean ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, "day");
-                return ai_;
+            CqlConcept aj_(CodeableConcept @this) {
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ao_;
             }
 
-
-            CqlBoolean ae_() {
-                List<CodeableConcept> aj_ = ValidEncounter?.ReasonCode;
-
-                CqlConcept ak_(CodeableConcept @this) {
-                    CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return ao_;
-                }
-
-                IEnumerable<CqlConcept> al_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)aj_, ak_);
-                CqlValueSet am_ = this.Major_Depressive_Disorder_Active(context);
-                CqlBoolean an_ = context.Operators.ConceptsInValueSet(al_, am_);
-                return an_;
-            }
-
+            IEnumerable<CqlConcept> ak_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ai_, aj_);
+            CqlValueSet al_ = this.Major_Depressive_Disorder_Active(context);
+            CqlBoolean am_ = context.Operators.ConceptsInValueSet(ak_, al_);
+            CqlBoolean an_ = am_;
             return ac_
-                /* CQL 'and' (99:11-100:66) */ && ad_()
-                /* CQL 'and' (99:5-101:77) */ && ae_();
+                /* CQL 'and' (99:11-100:66) */ && ah_
+                /* CQL 'and' (99:5-101:77) */ && an_;
         }
 
         IEnumerable<Encounter> y_ = context.Operators.Where<Encounter>(w_, x_);
@@ -350,22 +334,10 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
             CqlDate j_ = context.Operators.DateFrom(i_);
             int? k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
             CqlBoolean l_ = context.Operators.GreaterOrEqual(k_, 6);
-
-            CqlBoolean m_() {
-                Patient n_ = this.Patient(context);
-                Date o_ = n_?.BirthDateElement;
-                string p_ = o_?.Value;
-                CqlDate q_ = context.Operators.ConvertStringToDate(p_);
-                CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlDate t_ = context.Operators.DateFrom(s_);
-                int? u_ = context.Operators.CalculateAgeAt(q_, t_, "year");
-                CqlBoolean v_ = context.Operators.LessOrEqual(u_, 16);
-                return v_;
-            }
-
+            CqlBoolean m_ = context.Operators.LessOrEqual(k_, 16);
+            CqlBoolean n_ = m_;
             return l_
-                /* CQL 'and' (43:5-45:5) */ && m_();
+                /* CQL 'and' (43:5-45:5) */ && n_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -406,53 +378,49 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
                 EventStatus? j_ = i_?.Value;
                 string k_ = context.Operators.Convert<string>(j_);
                 CqlBoolean l_ = context.Operators.Equal(k_, "completed");
-
-                CqlBoolean m_() {
-                    Period n_ = MDDEncounter?.Period;
-                    CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                    object p_;
-                    DataType s_ = SuicideRiskAssessmentProcedure?.Performed;
-                    object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                    bool u_ = t_ is CqlDateTime;
-                    if (u_)
+                Period m_ = MDDEncounter?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                object o_;
+                DataType s_ = SuicideRiskAssessmentProcedure?.Performed;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                bool u_ = t_ is CqlDateTime;
+                if (u_)
+                {
+                    o_ = t_ as CqlDateTime;
+                }
+                else
+                {
+                    bool v_ = t_ is CqlQuantity;
+                    if (v_)
                     {
-                        p_ = t_ as CqlDateTime;
+                        o_ = t_ as CqlQuantity;
                     }
                     else
                     {
-                        bool v_ = t_ is CqlQuantity;
-                        if (v_)
+                        bool w_ = t_ is CqlInterval<CqlDateTime>;
+                        if (w_)
                         {
-                            p_ = t_ as CqlQuantity;
+                            o_ = t_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool w_ = t_ is CqlInterval<CqlDateTime>;
-                            if (w_)
+                            bool x_ = t_ is CqlInterval<CqlQuantity>;
+                            if (x_)
                             {
-                                p_ = t_ as CqlInterval<CqlDateTime>;
+                                o_ = t_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool x_ = t_ is CqlInterval<CqlQuantity>;
-                                if (x_)
-                                {
-                                    p_ = t_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    p_ = null;
-                                }
+                                o_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                    CqlBoolean r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
-                    return r_;
                 }
-
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, (string)default);
+                CqlBoolean r_ = q_;
                 return l_
-                    /* CQL 'and' (57:17-58:94) */ && m_();
+                    /* CQL 'and' (57:17-58:94) */ && r_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Procedure>(f_, g_);
@@ -488,22 +456,18 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
                 object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
                 CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
                 CqlBoolean p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, (string)default);
-
-                CqlBoolean q_() {
-                    Code<ObservationStatus> r_ = ObservationSuicideRiskAssmt?.StatusElement;
-                    ObservationStatus? s_ = r_?.Value;
-                    string t_ = context.Operators.Convert<string>(s_);
-                    string[] u_ = [
-                        "final",
-                        "corrected",
-                        "amended",
-                    ];
-                    CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
-                    return v_;
-                }
-
+                Code<ObservationStatus> q_ = ObservationSuicideRiskAssmt?.StatusElement;
+                ObservationStatus? r_ = q_?.Value;
+                string s_ = context.Operators.Convert<string>(r_);
+                string[] t_ = [
+                    "final",
+                    "corrected",
+                    "amended",
+                ];
+                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+                CqlBoolean v_ = u_;
                 return p_
-                    /* CQL 'and' (64:17-65:85) */ && q_();
+                    /* CQL 'and' (64:17-65:85) */ && v_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Observation>(h_, i_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS190FHIRVTEProphylaxisICU-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS190FHIRVTEProphylaxisICU-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS190FHIRVTEProphylaxisICU", "1.0.000")]
 public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<CMS190FHIRVTEProphylaxisICU_1_0_000>
 {
@@ -290,25 +290,21 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 List<CodeableConcept> i_ = h_?.Type;
 
                 CqlConcept j_(CodeableConcept @this) {
-                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return o_;
+                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return t_;
                 }
 
                 IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
                 CqlValueSet l_ = this.Intensive_Care_Unit(context);
                 CqlBoolean m_ = context.Operators.ConceptsInValueSet(k_, l_);
-
-                CqlBoolean n_() {
-                    Period p_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                    Period r_ = Location?.Period;
-                    CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                    CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, (string)default);
-                    return t_;
-                }
-
+                Period n_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                Period p_ = Location?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlBoolean r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
+                CqlBoolean s_ = r_;
                 return m_
-                    /* CQL 'and' (76:9-77:63) */ && n_();
+                    /* CQL 'and' (76:9-77:63) */ && s_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)d_, e_);
@@ -369,55 +365,31 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         bool? b_(Encounter QualifyingEncounterICU) {
             CqlValueSet d_ = this.General_Surgery(context);
             CqlBoolean e_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, d_);
-
-            CqlBoolean f_() {
-                CqlValueSet l_ = this.Gynecological_Surgery(context);
-                CqlBoolean m_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, l_);
-                return m_;
-            }
-
-
-            CqlBoolean g_() {
-                CqlValueSet n_ = this.Hip_Fracture_Surgery(context);
-                CqlBoolean o_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, n_);
-                return o_;
-            }
-
-
-            CqlBoolean h_() {
-                CqlValueSet p_ = this.Hip_Replacement_Surgery(context);
-                CqlBoolean q_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, p_);
-                return q_;
-            }
-
-
-            CqlBoolean i_() {
-                CqlValueSet r_ = this.Intracranial_Neurosurgery(context);
-                CqlBoolean s_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, r_);
-                return s_;
-            }
-
-
-            CqlBoolean j_() {
-                CqlValueSet t_ = this.Knee_Replacement_Surgery(context);
-                CqlBoolean u_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CqlValueSet v_ = this.Urological_Surgery(context);
-                CqlBoolean w_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, v_);
-                return w_;
-            }
-
+            CqlValueSet f_ = this.Gynecological_Surgery(context);
+            CqlBoolean g_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, f_);
+            CqlBoolean h_ = g_;
+            CqlValueSet i_ = this.Hip_Fracture_Surgery(context);
+            CqlBoolean j_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, i_);
+            CqlBoolean k_ = j_;
+            CqlValueSet l_ = this.Hip_Replacement_Surgery(context);
+            CqlBoolean m_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, l_);
+            CqlBoolean n_ = m_;
+            CqlValueSet o_ = this.Intracranial_Neurosurgery(context);
+            CqlBoolean p_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, o_);
+            CqlBoolean q_ = p_;
+            CqlValueSet r_ = this.Knee_Replacement_Surgery(context);
+            CqlBoolean s_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, r_);
+            CqlBoolean t_ = s_;
+            CqlValueSet u_ = this.Urological_Surgery(context);
+            CqlBoolean v_ = VTE_8_18_000.Instance.hasPrincipalProcedureOf(context, QualifyingEncounterICU, u_);
+            CqlBoolean w_ = v_;
             return e_
-                /* CQL 'or' (92:11-93:83) */ || f_()
-                /* CQL 'or' (92:11-94:82) */ || g_()
-                /* CQL 'or' (92:11-95:85) */ || h_()
-                /* CQL 'or' (92:11-96:87) */ || i_()
-                /* CQL 'or' (92:11-97:86) */ || j_()
-                /* CQL 'or' (92:5-98:80) */ || k_();
+                /* CQL 'or' (92:11-93:83) */ || h_
+                /* CQL 'or' (92:11-94:82) */ || k_
+                /* CQL 'or' (92:11-95:85) */ || n_
+                /* CQL 'or' (92:11-96:87) */ || q_
+                /* CQL 'or' (92:11-97:86) */ || t_
+                /* CQL 'or' (92:5-98:80) */ || w_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -449,22 +421,18 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 "instance-order",
             ];
             CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
-
-            CqlBoolean o_() {
-                Code<RequestStatus> p_ = InterventionRequest?.StatusElement;
-                RequestStatus? q_ = p_?.Value;
-                Code<RequestStatus> r_ = context.Operators.Convert<Code<RequestStatus>>(q_);
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                return u_;
-            }
-
+            Code<RequestStatus> o_ = InterventionRequest?.StatusElement;
+            RequestStatus? p_ = o_?.Value;
+            Code<RequestStatus> q_ = context.Operators.Convert<Code<RequestStatus>>(p_);
+            string r_ = context.Operators.Convert<string>(q_);
+            string[] s_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
+            CqlBoolean u_ = t_;
             return n_
-                /* CQL 'and' (107:7-108:67) */ && o_();
+                /* CQL 'and' (107:7-108:67) */ && u_;
         }
 
         IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
@@ -614,265 +582,257 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object r_;
-                DataType y_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
-                {
-                    r_ = z_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ab_ = z_ is CqlQuantity;
-                    if (ab_)
-                    {
-                        r_ = z_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ac_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ac_)
-                        {
-                            r_ = z_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ad_ = z_ is CqlInterval<CqlQuantity>;
-                            if (ad_)
-                            {
-                                r_ = z_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                r_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.End(s_);
-                CqlDateTime u_ = this.startOfFirstICU(context, tuple_gdefgctjcxpzbyfpuogejrgou?.QualifyingEncounterICU);
-                CqlQuantity v_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime w_ = context.Operators.Add(u_, v_);
-                CqlBoolean x_ = context.Operators.SameAs(t_, w_, "day");
-                return x_;
+            object p_;
+            DataType bb_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
+            object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+            bool bd_ = bc_ is CqlDateTime;
+            if (bd_)
+            {
+                p_ = bc_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                object ae_;
-                object bh_ = context.Operators.LateBoundProperty<object>(tuple_gdefgctjcxpzbyfpuogejrgou?.ComfortMeasure, "performed");
-                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                bool bj_ = bi_ is CqlDateTime;
-                if (bj_)
+            else
+            {
+                bool be_ = bc_ is CqlQuantity;
+                if (be_)
                 {
-                    ae_ = bi_ as CqlDateTime;
+                    p_ = bc_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bk_ = bi_ is CqlQuantity;
-                    if (bk_)
+                    bool bf_ = bc_ is CqlInterval<CqlDateTime>;
+                    if (bf_)
                     {
-                        ae_ = bi_ as CqlQuantity;
+                        p_ = bc_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bl_ = bi_ is CqlInterval<CqlDateTime>;
-                        if (bl_)
+                        bool bg_ = bc_ is CqlInterval<CqlQuantity>;
+                        if (bg_)
                         {
-                            ae_ = bi_ as CqlInterval<CqlDateTime>;
+                            p_ = bc_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bm_ = bi_ is CqlInterval<CqlQuantity>;
-                            if (bm_)
-                            {
-                                ae_ = bi_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ae_ = null;
-                            }
+                            p_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
-                CqlDateTime ag_ = context.Operators.Start(af_);
-                object ah_ = context.Operators.LateBoundProperty<object>(tuple_gdefgctjcxpzbyfpuogejrgou?.ComfortMeasure, "authoredOn");
-                CqlDateTime ai_ = context.Operators.LateBoundProperty<CqlDateTime>(ah_, "value");
-                object aj_;
-                DataType bn_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
-                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                bool bp_ = bo_ is CqlDateTime;
-                if (bp_)
-                {
-                    aj_ = bo_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bq_ = bo_ is CqlQuantity;
-                    if (bq_)
-                    {
-                        aj_ = bo_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool br_ = bo_ is CqlInterval<CqlDateTime>;
-                        if (br_)
-                        {
-                            aj_ = bo_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bs_ = bo_ is CqlInterval<CqlQuantity>;
-                            if (bs_)
-                            {
-                                aj_ = bo_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                aj_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.End(ak_);
-                CqlInterval<CqlDate> am_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, al_);
-                CqlDate an_ = am_?.low;
-                CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
-                object ap_;
-                DataType bt_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
-                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                bool bv_ = bu_ is CqlDateTime;
-                if (bv_)
-                {
-                    ap_ = bu_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bw_ = bu_ is CqlQuantity;
-                    if (bw_)
-                    {
-                        ap_ = bu_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bx_ = bu_ is CqlInterval<CqlDateTime>;
-                        if (bx_)
-                        {
-                            ap_ = bu_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool by_ = bu_ is CqlInterval<CqlQuantity>;
-                            if (by_)
-                            {
-                                ap_ = bu_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ap_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
-                CqlDateTime ar_ = context.Operators.End(aq_);
-                CqlInterval<CqlDate> as_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ar_);
-                CqlDate at_ = as_?.high;
-                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
-                object av_;
-                DataType bz_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
-                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                bool cb_ = ca_ is CqlDateTime;
-                if (cb_)
-                {
-                    av_ = ca_ as CqlDateTime;
-                }
-                else
-                {
-                    bool cc_ = ca_ is CqlQuantity;
-                    if (cc_)
-                    {
-                        av_ = ca_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cd_ = ca_ is CqlInterval<CqlDateTime>;
-                        if (cd_)
-                        {
-                            av_ = ca_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ce_ = ca_ is CqlInterval<CqlQuantity>;
-                            if (ce_)
-                            {
-                                av_ = ca_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                av_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
-                CqlDateTime ax_ = context.Operators.End(aw_);
-                CqlInterval<CqlDate> ay_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ax_);
-                CqlBoolean az_ = ay_?.lowClosed;
-                object ba_;
-                DataType cf_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
-                object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
-                bool ch_ = cg_ is CqlDateTime;
-                if (ch_)
-                {
-                    ba_ = cg_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ci_ = cg_ is CqlQuantity;
-                    if (ci_)
-                    {
-                        ba_ = cg_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cj_ = cg_ is CqlInterval<CqlDateTime>;
-                        if (cj_)
-                        {
-                            ba_ = cg_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ck_ = cg_ is CqlInterval<CqlQuantity>;
-                            if (ck_)
-                            {
-                                ba_ = cg_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ba_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
-                CqlDateTime bc_ = context.Operators.End(bb_);
-                CqlInterval<CqlDate> bd_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bc_);
-                CqlBoolean be_ = bd_?.highClosed;
-                CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ao_, au_, az_, be_);
-                CqlBoolean bg_ = context.Operators.In<CqlDateTime>(ag_ ?? ai_, bf_, "day");
-                return bg_;
             }
-
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.End(q_);
+            CqlDateTime s_ = this.startOfFirstICU(context, tuple_gdefgctjcxpzbyfpuogejrgou?.QualifyingEncounterICU);
+            CqlQuantity t_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime u_ = context.Operators.Add(s_, t_);
+            CqlBoolean v_ = context.Operators.SameAs(r_, u_, "day");
+            CqlBoolean w_ = v_;
+            object x_;
+            object bh_ = context.Operators.LateBoundProperty<object>(tuple_gdefgctjcxpzbyfpuogejrgou?.ComfortMeasure, "performed");
+            object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            bool bj_ = bi_ is CqlDateTime;
+            if (bj_)
+            {
+                x_ = bi_ as CqlDateTime;
+            }
+            else
+            {
+                bool bk_ = bi_ is CqlQuantity;
+                if (bk_)
+                {
+                    x_ = bi_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bl_ = bi_ is CqlInterval<CqlDateTime>;
+                    if (bl_)
+                    {
+                        x_ = bi_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bm_ = bi_ is CqlInterval<CqlQuantity>;
+                        if (bm_)
+                        {
+                            x_ = bi_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            x_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+            CqlDateTime z_ = context.Operators.Start(y_);
+            object aa_ = context.Operators.LateBoundProperty<object>(tuple_gdefgctjcxpzbyfpuogejrgou?.ComfortMeasure, "authoredOn");
+            CqlDateTime ab_ = context.Operators.LateBoundProperty<CqlDateTime>(aa_, "value");
+            object ac_;
+            DataType bn_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
+            object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+            bool bp_ = bo_ is CqlDateTime;
+            if (bp_)
+            {
+                ac_ = bo_ as CqlDateTime;
+            }
+            else
+            {
+                bool bq_ = bo_ is CqlQuantity;
+                if (bq_)
+                {
+                    ac_ = bo_ as CqlQuantity;
+                }
+                else
+                {
+                    bool br_ = bo_ is CqlInterval<CqlDateTime>;
+                    if (br_)
+                    {
+                        ac_ = bo_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bs_ = bo_ is CqlInterval<CqlQuantity>;
+                        if (bs_)
+                        {
+                            ac_ = bo_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ac_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+            CqlDateTime ae_ = context.Operators.End(ad_);
+            CqlInterval<CqlDate> af_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ae_);
+            CqlDate ag_ = af_?.low;
+            CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
+            object ai_;
+            DataType bt_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
+            object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+            bool bv_ = bu_ is CqlDateTime;
+            if (bv_)
+            {
+                ai_ = bu_ as CqlDateTime;
+            }
+            else
+            {
+                bool bw_ = bu_ is CqlQuantity;
+                if (bw_)
+                {
+                    ai_ = bu_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bx_ = bu_ is CqlInterval<CqlDateTime>;
+                    if (bx_)
+                    {
+                        ai_ = bu_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool by_ = bu_ is CqlInterval<CqlQuantity>;
+                        if (by_)
+                        {
+                            ai_ = bu_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ai_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+            CqlDateTime ak_ = context.Operators.End(aj_);
+            CqlInterval<CqlDate> al_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ak_);
+            CqlDate am_ = al_?.high;
+            CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+            object ao_;
+            DataType bz_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
+            object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+            bool cb_ = ca_ is CqlDateTime;
+            if (cb_)
+            {
+                ao_ = ca_ as CqlDateTime;
+            }
+            else
+            {
+                bool cc_ = ca_ is CqlQuantity;
+                if (cc_)
+                {
+                    ao_ = ca_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cd_ = ca_ is CqlInterval<CqlDateTime>;
+                    if (cd_)
+                    {
+                        ao_ = ca_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ce_ = ca_ is CqlInterval<CqlQuantity>;
+                        if (ce_)
+                        {
+                            ao_ = ca_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ao_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+            CqlDateTime aq_ = context.Operators.End(ap_);
+            CqlInterval<CqlDate> ar_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aq_);
+            CqlBoolean as_ = ar_?.lowClosed;
+            object at_;
+            DataType cf_ = tuple_gdefgctjcxpzbyfpuogejrgou?.AnesthesiaProcedure?.Performed;
+            object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+            bool ch_ = cg_ is CqlDateTime;
+            if (ch_)
+            {
+                at_ = cg_ as CqlDateTime;
+            }
+            else
+            {
+                bool ci_ = cg_ is CqlQuantity;
+                if (ci_)
+                {
+                    at_ = cg_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cj_ = cg_ is CqlInterval<CqlDateTime>;
+                    if (cj_)
+                    {
+                        at_ = cg_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ck_ = cg_ is CqlInterval<CqlQuantity>;
+                        if (ck_)
+                        {
+                            at_ = cg_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            at_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
+            CqlDateTime av_ = context.Operators.End(au_);
+            CqlInterval<CqlDate> aw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, av_);
+            CqlBoolean ax_ = aw_?.highClosed;
+            CqlInterval<CqlDateTime> ay_ = context.Operators.Interval(ah_, an_, as_, ax_);
+            CqlBoolean az_ = context.Operators.In<CqlDateTime>(z_ ?? ab_, ay_, "day");
+            CqlBoolean ba_ = az_;
             return o_
-                /* CQL 'and' (119:11-120:121) */ && p_()
-                /* CQL 'and' (119:5-121:191) */ && q_();
+                /* CQL 'and' (119:11-120:121) */ && w_
+                /* CQL 'and' (119:5-121:191) */ && ba_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object ComfortMeasure)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object ComfortMeasure)?>(e_, f_, g_);
@@ -920,17 +880,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> be_ = context.Operators.Split((string)bd_, "/");
                 string bf_ = context.Operators.Last<string>(be_);
                 CqlBoolean bg_ = context.Operators.Equal(bc_, bf_);
-
-                CqlBoolean bh_() {
-                    CodeableConcept bi_ = M?.Code;
-                    CqlConcept bj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bi_);
-                    CqlValueSet bk_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean bl_ = context.Operators.ConceptInValueSet(bj_, bk_);
-                    return bl_;
-                }
-
+                CodeableConcept bh_ = M?.Code;
+                CqlConcept bi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bh_);
+                CqlValueSet bj_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean bk_ = context.Operators.ConceptInValueSet(bi_, bj_);
+                CqlBoolean bl_ = bk_;
                 return bg_
-                    /* CQL 'and' */ && bh_();
+                    /* CQL 'and' */ && bl_;
             }
 
             CqlBoolean bb_ = context.Operators.WhereAny<Medication>(az_, ba_);
@@ -947,18 +903,14 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             MedicationAdministration.MedicationAdministrationStatusCodes? bn_ = bm_?.Value;
             string bo_ = context.Operators.Convert<string>(bn_);
             CqlBoolean bp_ = context.Operators.Equal(bo_, "completed");
-
-            CqlBoolean bq_() {
-                MedicationAdministration.DosageComponent br_ = VTEMedication?.Dosage;
-                CodeableConcept bs_ = br_?.Route;
-                CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bs_);
-                CqlValueSet bu_ = this.Subcutaneous_route(context);
-                CqlBoolean bv_ = context.Operators.ConceptInValueSet(bt_, bu_);
-                return bv_;
-            }
-
+            MedicationAdministration.DosageComponent bq_ = VTEMedication?.Dosage;
+            CodeableConcept br_ = bq_?.Route;
+            CqlConcept bs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, br_);
+            CqlValueSet bt_ = this.Subcutaneous_route(context);
+            CqlBoolean bu_ = context.Operators.ConceptInValueSet(bs_, bt_);
+            CqlBoolean bv_ = bu_;
             return bp_
-                /* CQL 'and' (137:7-138:62) */ && bq_();
+                /* CQL 'and' (137:7-138:62) */ && bv_;
         }
 
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
@@ -972,17 +924,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> cb_ = context.Operators.Split((string)ca_, "/");
                 string cc_ = context.Operators.Last<string>(cb_);
                 CqlBoolean cd_ = context.Operators.Equal(bz_, cc_);
-
-                CqlBoolean ce_() {
-                    CodeableConcept cf_ = M?.Code;
-                    CqlConcept cg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cf_);
-                    CqlValueSet ch_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean ci_ = context.Operators.ConceptInValueSet(cg_, ch_);
-                    return ci_;
-                }
-
+                CodeableConcept ce_ = M?.Code;
+                CqlConcept cf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ce_);
+                CqlValueSet cg_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean ch_ = context.Operators.ConceptInValueSet(cf_, cg_);
+                CqlBoolean ci_ = ch_;
                 return cd_
-                    /* CQL 'and' */ && ce_();
+                    /* CQL 'and' */ && ci_;
             }
 
             CqlBoolean by_ = context.Operators.WhereAny<Medication>(bw_, bx_);
@@ -1014,17 +962,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> cs_ = context.Operators.Split((string)cr_, "/");
                 string ct_ = context.Operators.Last<string>(cs_);
                 CqlBoolean cu_ = context.Operators.Equal(cq_, ct_);
-
-                CqlBoolean cv_() {
-                    CodeableConcept cw_ = M?.Code;
-                    CqlConcept cx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cw_);
-                    CqlValueSet cy_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                    CqlBoolean cz_ = context.Operators.ConceptInValueSet(cx_, cy_);
-                    return cz_;
-                }
-
+                CodeableConcept cv_ = M?.Code;
+                CqlConcept cw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cv_);
+                CqlValueSet cx_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                CqlBoolean cy_ = context.Operators.ConceptInValueSet(cw_, cx_);
+                CqlBoolean cz_ = cy_;
                 return cu_
-                    /* CQL 'and' */ && cv_();
+                    /* CQL 'and' */ && cz_;
             }
 
             CqlBoolean cp_ = context.Operators.WhereAny<Medication>(cn_, co_);
@@ -1055,17 +999,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> dj_ = context.Operators.Split((string)di_, "/");
                 string dk_ = context.Operators.Last<string>(dj_);
                 CqlBoolean dl_ = context.Operators.Equal(dh_, dk_);
-
-                CqlBoolean dm_() {
-                    CodeableConcept dn_ = M?.Code;
-                    CqlConcept do_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dn_);
-                    CqlValueSet dp_ = this.Warfarin(context);
-                    CqlBoolean dq_ = context.Operators.ConceptInValueSet(do_, dp_);
-                    return dq_;
-                }
-
+                CodeableConcept dm_ = M?.Code;
+                CqlConcept dn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dm_);
+                CqlValueSet do_ = this.Warfarin(context);
+                CqlBoolean dp_ = context.Operators.ConceptInValueSet(dn_, do_);
+                CqlBoolean dq_ = dp_;
                 return dl_
-                    /* CQL 'and' */ && dm_();
+                    /* CQL 'and' */ && dq_;
             }
 
             CqlBoolean dg_ = context.Operators.WhereAny<Medication>(de_, df_);
@@ -1098,17 +1038,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> ea_ = context.Operators.Split((string)dz_, "/");
                 string eb_ = context.Operators.Last<string>(ea_);
                 CqlBoolean ec_ = context.Operators.Equal(dy_, eb_);
-
-                CqlBoolean ed_() {
-                    CodeableConcept ee_ = M?.Code;
-                    CqlConcept ef_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ee_);
-                    CqlValueSet eg_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                    CqlBoolean eh_ = context.Operators.ConceptInValueSet(ef_, eg_);
-                    return eh_;
-                }
-
+                CodeableConcept ed_ = M?.Code;
+                CqlConcept ee_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ed_);
+                CqlValueSet ef_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                CqlBoolean eg_ = context.Operators.ConceptInValueSet(ee_, ef_);
+                CqlBoolean eh_ = eg_;
                 return ec_
-                    /* CQL 'and' */ && ed_();
+                    /* CQL 'and' */ && eh_;
             }
 
             CqlBoolean dx_ = context.Operators.WhereAny<Medication>(dv_, dw_);
@@ -1242,266 +1178,258 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             EventStatus? ao_ = an_?.Value;
             string ap_ = context.Operators.Convert<string>(ao_);
             CqlBoolean aq_ = context.Operators.Equal(ap_, "completed");
-
-            CqlBoolean ar_() {
-                object at_;
-                DataType ba_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                bool bc_ = bb_ is CqlDateTime;
-                if (bc_)
-                {
-                    at_ = bb_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bd_ = bb_ is CqlQuantity;
-                    if (bd_)
-                    {
-                        at_ = bb_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool be_ = bb_ is CqlInterval<CqlDateTime>;
-                        if (be_)
-                        {
-                            at_ = bb_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bf_ = bb_ is CqlInterval<CqlQuantity>;
-                            if (bf_)
-                            {
-                                at_ = bb_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                at_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
-                CqlDateTime av_ = context.Operators.End(au_);
-                CqlDateTime aw_ = this.startOfFirstICU(context, tuple_drnlhywkgwmzdeyzybtiilbhf?.QualifyingEncounterICU);
-                CqlQuantity ax_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime ay_ = context.Operators.Add(aw_, ax_);
-                CqlBoolean az_ = context.Operators.SameAs(av_, ay_, "day");
-                return az_;
+            object ar_;
+            DataType ce_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+            object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+            bool cg_ = cf_ is CqlDateTime;
+            if (cg_)
+            {
+                ar_ = cf_ as CqlDateTime;
             }
-
-
-            CqlBoolean as_() {
-                object bg_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "effective");
-                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
-                object bj_;
-                object ck_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
-                object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
-                bool cm_ = cl_ is CqlDateTime;
-                if (cm_)
+            else
+            {
+                bool ch_ = cf_ is CqlQuantity;
+                if (ch_)
                 {
-                    bj_ = cl_ as CqlDateTime;
+                    ar_ = cf_ as CqlQuantity;
                 }
                 else
                 {
-                    bool cn_ = cl_ is CqlQuantity;
-                    if (cn_)
+                    bool ci_ = cf_ is CqlInterval<CqlDateTime>;
+                    if (ci_)
                     {
-                        bj_ = cl_ as CqlQuantity;
+                        ar_ = cf_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool co_ = cl_ is CqlInterval<CqlDateTime>;
-                        if (co_)
+                        bool cj_ = cf_ is CqlInterval<CqlQuantity>;
+                        if (cj_)
                         {
-                            bj_ = cl_ as CqlInterval<CqlDateTime>;
+                            ar_ = cf_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool cp_ = cl_ is CqlInterval<CqlQuantity>;
-                            if (cp_)
-                            {
-                                bj_ = cl_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bj_ = null;
-                            }
+                            ar_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
-                CqlDateTime bl_ = context.Operators.Start(bi_ ?? bk_);
-                object bm_;
-                DataType cq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                bool cs_ = cr_ is CqlDateTime;
-                if (cs_)
-                {
-                    bm_ = cr_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ct_ = cr_ is CqlQuantity;
-                    if (ct_)
-                    {
-                        bm_ = cr_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cu_ = cr_ is CqlInterval<CqlDateTime>;
-                        if (cu_)
-                        {
-                            bm_ = cr_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool cv_ = cr_ is CqlInterval<CqlQuantity>;
-                            if (cv_)
-                            {
-                                bm_ = cr_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bm_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bn_ = QICoreCommon_4_0_000.Instance.toInterval(context, bm_);
-                CqlDateTime bo_ = context.Operators.End(bn_);
-                CqlInterval<CqlDate> bp_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bo_);
-                CqlDate bq_ = bp_?.low;
-                CqlDateTime br_ = context.Operators.ConvertDateToDateTime(bq_);
-                object bs_;
-                DataType cw_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                bool cy_ = cx_ is CqlDateTime;
-                if (cy_)
-                {
-                    bs_ = cx_ as CqlDateTime;
-                }
-                else
-                {
-                    bool cz_ = cx_ is CqlQuantity;
-                    if (cz_)
-                    {
-                        bs_ = cx_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool da_ = cx_ is CqlInterval<CqlDateTime>;
-                        if (da_)
-                        {
-                            bs_ = cx_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool db_ = cx_ is CqlInterval<CqlQuantity>;
-                            if (db_)
-                            {
-                                bs_ = cx_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bs_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bt_ = QICoreCommon_4_0_000.Instance.toInterval(context, bs_);
-                CqlDateTime bu_ = context.Operators.End(bt_);
-                CqlInterval<CqlDate> bv_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bu_);
-                CqlDate bw_ = bv_?.high;
-                CqlDateTime bx_ = context.Operators.ConvertDateToDateTime(bw_);
-                object by_;
-                DataType dc_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
-                bool de_ = dd_ is CqlDateTime;
-                if (de_)
-                {
-                    by_ = dd_ as CqlDateTime;
-                }
-                else
-                {
-                    bool df_ = dd_ is CqlQuantity;
-                    if (df_)
-                    {
-                        by_ = dd_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool dg_ = dd_ is CqlInterval<CqlDateTime>;
-                        if (dg_)
-                        {
-                            by_ = dd_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool dh_ = dd_ is CqlInterval<CqlQuantity>;
-                            if (dh_)
-                            {
-                                by_ = dd_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                by_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bz_ = QICoreCommon_4_0_000.Instance.toInterval(context, by_);
-                CqlDateTime ca_ = context.Operators.End(bz_);
-                CqlInterval<CqlDate> cb_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ca_);
-                CqlBoolean cc_ = cb_?.lowClosed;
-                object cd_;
-                DataType di_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
-                object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                bool dk_ = dj_ is CqlDateTime;
-                if (dk_)
-                {
-                    cd_ = dj_ as CqlDateTime;
-                }
-                else
-                {
-                    bool dl_ = dj_ is CqlQuantity;
-                    if (dl_)
-                    {
-                        cd_ = dj_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool dm_ = dj_ is CqlInterval<CqlDateTime>;
-                        if (dm_)
-                        {
-                            cd_ = dj_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool dn_ = dj_ is CqlInterval<CqlQuantity>;
-                            if (dn_)
-                            {
-                                cd_ = dj_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                cd_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.toInterval(context, cd_);
-                CqlDateTime cf_ = context.Operators.End(ce_);
-                CqlInterval<CqlDate> cg_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cf_);
-                CqlBoolean ch_ = cg_?.highClosed;
-                CqlInterval<CqlDateTime> ci_ = context.Operators.Interval(br_, bx_, cc_, ch_);
-                CqlBoolean cj_ = context.Operators.In<CqlDateTime>(bl_, ci_, "day");
-                return cj_;
             }
-
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.End(as_);
+            CqlDateTime au_ = this.startOfFirstICU(context, tuple_drnlhywkgwmzdeyzybtiilbhf?.QualifyingEncounterICU);
+            CqlQuantity av_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime aw_ = context.Operators.Add(au_, av_);
+            CqlBoolean ax_ = context.Operators.SameAs(at_, aw_, "day");
+            CqlBoolean ay_ = ax_;
+            object az_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "effective");
+            object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+            CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
+            object bc_;
+            object ck_ = context.Operators.LateBoundProperty<object>(tuple_drnlhywkgwmzdeyzybtiilbhf?.VTEProphylaxis, "performed");
+            object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+            bool cm_ = cl_ is CqlDateTime;
+            if (cm_)
+            {
+                bc_ = cl_ as CqlDateTime;
+            }
+            else
+            {
+                bool cn_ = cl_ is CqlQuantity;
+                if (cn_)
+                {
+                    bc_ = cl_ as CqlQuantity;
+                }
+                else
+                {
+                    bool co_ = cl_ is CqlInterval<CqlDateTime>;
+                    if (co_)
+                    {
+                        bc_ = cl_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cp_ = cl_ is CqlInterval<CqlQuantity>;
+                        if (cp_)
+                        {
+                            bc_ = cl_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bc_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
+            CqlDateTime be_ = context.Operators.Start(bb_ ?? bd_);
+            object bf_;
+            DataType cq_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+            object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+            bool cs_ = cr_ is CqlDateTime;
+            if (cs_)
+            {
+                bf_ = cr_ as CqlDateTime;
+            }
+            else
+            {
+                bool ct_ = cr_ is CqlQuantity;
+                if (ct_)
+                {
+                    bf_ = cr_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cu_ = cr_ is CqlInterval<CqlDateTime>;
+                    if (cu_)
+                    {
+                        bf_ = cr_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool cv_ = cr_ is CqlInterval<CqlQuantity>;
+                        if (cv_)
+                        {
+                            bf_ = cr_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bf_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bg_ = QICoreCommon_4_0_000.Instance.toInterval(context, bf_);
+            CqlDateTime bh_ = context.Operators.End(bg_);
+            CqlInterval<CqlDate> bi_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bh_);
+            CqlDate bj_ = bi_?.low;
+            CqlDateTime bk_ = context.Operators.ConvertDateToDateTime(bj_);
+            object bl_;
+            DataType cw_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+            object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+            bool cy_ = cx_ is CqlDateTime;
+            if (cy_)
+            {
+                bl_ = cx_ as CqlDateTime;
+            }
+            else
+            {
+                bool cz_ = cx_ is CqlQuantity;
+                if (cz_)
+                {
+                    bl_ = cx_ as CqlQuantity;
+                }
+                else
+                {
+                    bool da_ = cx_ is CqlInterval<CqlDateTime>;
+                    if (da_)
+                    {
+                        bl_ = cx_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool db_ = cx_ is CqlInterval<CqlQuantity>;
+                        if (db_)
+                        {
+                            bl_ = cx_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bl_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_);
+            CqlDateTime bn_ = context.Operators.End(bm_);
+            CqlInterval<CqlDate> bo_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bn_);
+            CqlDate bp_ = bo_?.high;
+            CqlDateTime bq_ = context.Operators.ConvertDateToDateTime(bp_);
+            object br_;
+            DataType dc_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+            object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
+            bool de_ = dd_ is CqlDateTime;
+            if (de_)
+            {
+                br_ = dd_ as CqlDateTime;
+            }
+            else
+            {
+                bool df_ = dd_ is CqlQuantity;
+                if (df_)
+                {
+                    br_ = dd_ as CqlQuantity;
+                }
+                else
+                {
+                    bool dg_ = dd_ is CqlInterval<CqlDateTime>;
+                    if (dg_)
+                    {
+                        br_ = dd_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool dh_ = dd_ is CqlInterval<CqlQuantity>;
+                        if (dh_)
+                        {
+                            br_ = dd_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            br_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bs_ = QICoreCommon_4_0_000.Instance.toInterval(context, br_);
+            CqlDateTime bt_ = context.Operators.End(bs_);
+            CqlInterval<CqlDate> bu_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bt_);
+            CqlBoolean bv_ = bu_?.lowClosed;
+            object bw_;
+            DataType di_ = tuple_drnlhywkgwmzdeyzybtiilbhf?.AnesthesiaProcedure?.Performed;
+            object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+            bool dk_ = dj_ is CqlDateTime;
+            if (dk_)
+            {
+                bw_ = dj_ as CqlDateTime;
+            }
+            else
+            {
+                bool dl_ = dj_ is CqlQuantity;
+                if (dl_)
+                {
+                    bw_ = dj_ as CqlQuantity;
+                }
+                else
+                {
+                    bool dm_ = dj_ is CqlInterval<CqlDateTime>;
+                    if (dm_)
+                    {
+                        bw_ = dj_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool dn_ = dj_ is CqlInterval<CqlQuantity>;
+                        if (dn_)
+                        {
+                            bw_ = dj_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            bw_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> bx_ = QICoreCommon_4_0_000.Instance.toInterval(context, bw_);
+            CqlDateTime by_ = context.Operators.End(bx_);
+            CqlInterval<CqlDate> bz_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, by_);
+            CqlBoolean ca_ = bz_?.highClosed;
+            CqlInterval<CqlDateTime> cb_ = context.Operators.Interval(bk_, bq_, bv_, ca_);
+            CqlBoolean cc_ = context.Operators.In<CqlDateTime>(be_, cb_, "day");
+            CqlBoolean cd_ = cc_;
             return aq_
-                /* CQL 'and' (167:15-168:125) */ && ar_()
-                /* CQL 'and' (167:9-169:207) */ && as_();
+                /* CQL 'and' (167:15-168:125) */ && ay_
+                /* CQL 'and' (167:9-169:207) */ && cd_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)?> j_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object VTEProphylaxis)?>(g_, h_, i_);
@@ -1534,17 +1462,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                     IEnumerable<string> af_ = context.Operators.Split((string)ae_, "/");
                     string ag_ = context.Operators.Last<string>(af_);
                     CqlBoolean ah_ = context.Operators.Equal(ad_, ag_);
-
-                    CqlBoolean ai_() {
-                        CodeableConcept aj_ = M?.Code;
-                        CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
-                        CqlValueSet al_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                        CqlBoolean am_ = context.Operators.ConceptInValueSet(ak_, al_);
-                        return am_;
-                    }
-
+                    CodeableConcept ai_ = M?.Code;
+                    CqlConcept aj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ai_);
+                    CqlValueSet ak_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                    CqlBoolean al_ = context.Operators.ConceptInValueSet(aj_, ak_);
+                    CqlBoolean am_ = al_;
                     return ah_
-                        /* CQL 'and' */ && ai_();
+                        /* CQL 'and' */ && am_;
                 }
 
                 CqlBoolean ac_ = context.Operators.WhereAny<Medication>(aa_, ab_);
@@ -1561,27 +1485,23 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 MedicationAdministration.MedicationAdministrationStatusCodes? ao_ = an_?.Value;
                 string ap_ = context.Operators.Convert<string>(ao_);
                 CqlBoolean aq_ = context.Operators.Equal(ap_, "completed");
-
-                CqlBoolean ar_() {
-                    DataType as_ = FactorXaMedication?.Effective;
-                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                    CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
-                    CqlDateTime av_ = context.Operators.Start(au_);
-                    CqlDateTime aw_ = this.startOfFirstICU(context, QualifyingEncounterICU);
-                    CqlInterval<CqlDate> ax_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aw_);
-                    CqlDate ay_ = ax_?.low;
-                    CqlDateTime az_ = context.Operators.ConvertDateToDateTime(ay_);
-                    CqlDate ba_ = ax_?.high;
-                    CqlDateTime bb_ = context.Operators.ConvertDateToDateTime(ba_);
-                    CqlBoolean bc_ = ax_?.lowClosed;
-                    CqlBoolean bd_ = ax_?.highClosed;
-                    CqlInterval<CqlDateTime> be_ = context.Operators.Interval(az_, bb_, bc_, bd_);
-                    CqlBoolean bf_ = context.Operators.In<CqlDateTime>(av_, be_, "day");
-                    return bf_;
-                }
-
+                DataType ar_ = FactorXaMedication?.Effective;
+                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
+                CqlDateTime au_ = context.Operators.Start(at_);
+                CqlDateTime av_ = this.startOfFirstICU(context, QualifyingEncounterICU);
+                CqlInterval<CqlDate> aw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, av_);
+                CqlDate ax_ = aw_?.low;
+                CqlDateTime ay_ = context.Operators.ConvertDateToDateTime(ax_);
+                CqlDate az_ = aw_?.high;
+                CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
+                CqlBoolean bb_ = aw_?.lowClosed;
+                CqlBoolean bc_ = aw_?.highClosed;
+                CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(ay_, ba_, bb_, bc_);
+                CqlBoolean be_ = context.Operators.In<CqlDateTime>(au_, bd_, "day");
+                CqlBoolean bf_ = be_;
                 return aq_
-                    /* CQL 'and' (176:19-177:149) */ && ar_();
+                    /* CQL 'and' (176:19-177:149) */ && bf_;
             }
 
             CqlBoolean z_ = context.Operators.WhereAny<MedicationAdministration>(x_, y_);
@@ -1602,17 +1522,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> bl_ = context.Operators.Split((string)bk_, "/");
                 string bm_ = context.Operators.Last<string>(bl_);
                 CqlBoolean bn_ = context.Operators.Equal(bj_, bm_);
-
-                CqlBoolean bo_() {
-                    CodeableConcept bp_ = M?.Code;
-                    CqlConcept bq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bp_);
-                    CqlValueSet br_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
-                    CqlBoolean bs_ = context.Operators.ConceptInValueSet(bq_, br_);
-                    return bs_;
-                }
-
+                CodeableConcept bo_ = M?.Code;
+                CqlConcept bp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
+                CqlValueSet bq_ = this.Oral_Factor_Xa_Inhibitor_for_VTE_Prophylaxis_or_VTE_Treatment(context);
+                CqlBoolean br_ = context.Operators.ConceptInValueSet(bp_, bq_);
+                CqlBoolean bs_ = br_;
                 return bn_
-                    /* CQL 'and' */ && bo_();
+                    /* CQL 'and' */ && bs_;
             }
 
             CqlBoolean bi_ = context.Operators.WhereAny<Medication>(bg_, bh_);
@@ -1636,239 +1552,227 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             MedicationAdministration.MedicationAdministrationStatusCodes? bv_ = bu_?.Value;
             string bw_ = context.Operators.Convert<string>(bv_);
             CqlBoolean bx_ = context.Operators.Equal(bw_, "completed");
-
-            CqlBoolean by_() {
-                Code<EventStatus> cb_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.StatusElement;
-                EventStatus? cc_ = cb_?.Value;
-                string cd_ = context.Operators.Convert<string>(cc_);
-                CqlBoolean ce_ = context.Operators.Equal(cd_, "completed");
-                return ce_;
+            Code<EventStatus> by_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? bz_ = by_?.Value;
+            string ca_ = context.Operators.Convert<string>(bz_);
+            CqlBoolean cb_ = context.Operators.Equal(ca_, "completed");
+            CqlBoolean cc_ = cb_;
+            object cd_;
+            DataType do_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+            object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
+            bool dq_ = dp_ is CqlDateTime;
+            if (dq_)
+            {
+                cd_ = dp_ as CqlDateTime;
             }
-
-
-            CqlBoolean bz_() {
-                object cf_;
-                DataType cm_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                bool co_ = cn_ is CqlDateTime;
-                if (co_)
+            else
+            {
+                bool dr_ = dp_ is CqlQuantity;
+                if (dr_)
                 {
-                    cf_ = cn_ as CqlDateTime;
+                    cd_ = dp_ as CqlQuantity;
                 }
                 else
                 {
-                    bool cp_ = cn_ is CqlQuantity;
-                    if (cp_)
+                    bool ds_ = dp_ is CqlInterval<CqlDateTime>;
+                    if (ds_)
                     {
-                        cf_ = cn_ as CqlQuantity;
+                        cd_ = dp_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cq_ = cn_ is CqlInterval<CqlDateTime>;
-                        if (cq_)
+                        bool dt_ = dp_ is CqlInterval<CqlQuantity>;
+                        if (dt_)
                         {
-                            cf_ = cn_ as CqlInterval<CqlDateTime>;
+                            cd_ = dp_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool cr_ = cn_ is CqlInterval<CqlQuantity>;
-                            if (cr_)
-                            {
-                                cf_ = cn_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                cf_ = null;
-                            }
+                            cd_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> cg_ = QICoreCommon_4_0_000.Instance.toInterval(context, cf_);
-                CqlDateTime ch_ = context.Operators.End(cg_);
-                CqlDateTime ci_ = this.startOfFirstICU(context, tuple_elrfucfgncrbdgahdtkitiyzu?.QualifyingEncounterICU);
-                CqlQuantity cj_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime ck_ = context.Operators.Add(ci_, cj_);
-                CqlBoolean cl_ = context.Operators.SameAs(ch_, ck_, "day");
-                return cl_;
             }
-
-
-            CqlBoolean ca_() {
-                DataType cs_ = tuple_elrfucfgncrbdgahdtkitiyzu?.FactorXaMedication?.Effective;
-                object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
-                CqlInterval<CqlDateTime> cu_ = QICoreCommon_4_0_000.Instance.toInterval(context, ct_);
-                CqlDateTime cv_ = context.Operators.Start(cu_);
-                object cw_;
-                DataType du_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
-                bool dw_ = dv_ is CqlDateTime;
-                if (dw_)
-                {
-                    cw_ = dv_ as CqlDateTime;
-                }
-                else
-                {
-                    bool dx_ = dv_ is CqlQuantity;
-                    if (dx_)
-                    {
-                        cw_ = dv_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool dy_ = dv_ is CqlInterval<CqlDateTime>;
-                        if (dy_)
-                        {
-                            cw_ = dv_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool dz_ = dv_ is CqlInterval<CqlQuantity>;
-                            if (dz_)
-                            {
-                                cw_ = dv_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                cw_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> cx_ = QICoreCommon_4_0_000.Instance.toInterval(context, cw_);
-                CqlDateTime cy_ = context.Operators.End(cx_);
-                CqlInterval<CqlDate> cz_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cy_);
-                CqlDate da_ = cz_?.low;
-                CqlDateTime db_ = context.Operators.ConvertDateToDateTime(da_);
-                object dc_;
-                DataType ea_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                bool ec_ = eb_ is CqlDateTime;
-                if (ec_)
-                {
-                    dc_ = eb_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ed_ = eb_ is CqlQuantity;
-                    if (ed_)
-                    {
-                        dc_ = eb_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ee_ = eb_ is CqlInterval<CqlDateTime>;
-                        if (ee_)
-                        {
-                            dc_ = eb_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ef_ = eb_ is CqlInterval<CqlQuantity>;
-                            if (ef_)
-                            {
-                                dc_ = eb_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                dc_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> dd_ = QICoreCommon_4_0_000.Instance.toInterval(context, dc_);
-                CqlDateTime de_ = context.Operators.End(dd_);
-                CqlInterval<CqlDate> df_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, de_);
-                CqlDate dg_ = df_?.high;
-                CqlDateTime dh_ = context.Operators.ConvertDateToDateTime(dg_);
-                object di_;
-                DataType eg_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                object eh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eg_);
-                bool ei_ = eh_ is CqlDateTime;
-                if (ei_)
-                {
-                    di_ = eh_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ej_ = eh_ is CqlQuantity;
-                    if (ej_)
-                    {
-                        di_ = eh_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ek_ = eh_ is CqlInterval<CqlDateTime>;
-                        if (ek_)
-                        {
-                            di_ = eh_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool el_ = eh_ is CqlInterval<CqlQuantity>;
-                            if (el_)
-                            {
-                                di_ = eh_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                di_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> dj_ = QICoreCommon_4_0_000.Instance.toInterval(context, di_);
-                CqlDateTime dk_ = context.Operators.End(dj_);
-                CqlInterval<CqlDate> dl_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dk_);
-                CqlBoolean dm_ = dl_?.lowClosed;
-                object dn_;
-                DataType em_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
-                object en_ = FHIRHelpers_4_4_000.Instance.ToValue(context, em_);
-                bool eo_ = en_ is CqlDateTime;
-                if (eo_)
-                {
-                    dn_ = en_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ep_ = en_ is CqlQuantity;
-                    if (ep_)
-                    {
-                        dn_ = en_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool eq_ = en_ is CqlInterval<CqlDateTime>;
-                        if (eq_)
-                        {
-                            dn_ = en_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool er_ = en_ is CqlInterval<CqlQuantity>;
-                            if (er_)
-                            {
-                                dn_ = en_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                dn_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> do_ = QICoreCommon_4_0_000.Instance.toInterval(context, dn_);
-                CqlDateTime dp_ = context.Operators.End(do_);
-                CqlInterval<CqlDate> dq_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dp_);
-                CqlBoolean dr_ = dq_?.highClosed;
-                CqlInterval<CqlDateTime> ds_ = context.Operators.Interval(db_, dh_, dm_, dr_);
-                CqlBoolean dt_ = context.Operators.In<CqlDateTime>(cv_, ds_, "day");
-                return dt_;
+            CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.toInterval(context, cd_);
+            CqlDateTime cf_ = context.Operators.End(ce_);
+            CqlDateTime cg_ = this.startOfFirstICU(context, tuple_elrfucfgncrbdgahdtkitiyzu?.QualifyingEncounterICU);
+            CqlQuantity ch_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime ci_ = context.Operators.Add(cg_, ch_);
+            CqlBoolean cj_ = context.Operators.SameAs(cf_, ci_, "day");
+            CqlBoolean ck_ = cj_;
+            DataType cl_ = tuple_elrfucfgncrbdgahdtkitiyzu?.FactorXaMedication?.Effective;
+            object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+            CqlInterval<CqlDateTime> cn_ = QICoreCommon_4_0_000.Instance.toInterval(context, cm_);
+            CqlDateTime co_ = context.Operators.Start(cn_);
+            object cp_;
+            DataType du_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+            object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
+            bool dw_ = dv_ is CqlDateTime;
+            if (dw_)
+            {
+                cp_ = dv_ as CqlDateTime;
             }
-
+            else
+            {
+                bool dx_ = dv_ is CqlQuantity;
+                if (dx_)
+                {
+                    cp_ = dv_ as CqlQuantity;
+                }
+                else
+                {
+                    bool dy_ = dv_ is CqlInterval<CqlDateTime>;
+                    if (dy_)
+                    {
+                        cp_ = dv_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool dz_ = dv_ is CqlInterval<CqlQuantity>;
+                        if (dz_)
+                        {
+                            cp_ = dv_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            cp_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> cq_ = QICoreCommon_4_0_000.Instance.toInterval(context, cp_);
+            CqlDateTime cr_ = context.Operators.End(cq_);
+            CqlInterval<CqlDate> cs_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cr_);
+            CqlDate ct_ = cs_?.low;
+            CqlDateTime cu_ = context.Operators.ConvertDateToDateTime(ct_);
+            object cv_;
+            DataType ea_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+            object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
+            bool ec_ = eb_ is CqlDateTime;
+            if (ec_)
+            {
+                cv_ = eb_ as CqlDateTime;
+            }
+            else
+            {
+                bool ed_ = eb_ is CqlQuantity;
+                if (ed_)
+                {
+                    cv_ = eb_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ee_ = eb_ is CqlInterval<CqlDateTime>;
+                    if (ee_)
+                    {
+                        cv_ = eb_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ef_ = eb_ is CqlInterval<CqlQuantity>;
+                        if (ef_)
+                        {
+                            cv_ = eb_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            cv_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> cw_ = QICoreCommon_4_0_000.Instance.toInterval(context, cv_);
+            CqlDateTime cx_ = context.Operators.End(cw_);
+            CqlInterval<CqlDate> cy_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, cx_);
+            CqlDate cz_ = cy_?.high;
+            CqlDateTime da_ = context.Operators.ConvertDateToDateTime(cz_);
+            object db_;
+            DataType eg_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+            object eh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eg_);
+            bool ei_ = eh_ is CqlDateTime;
+            if (ei_)
+            {
+                db_ = eh_ as CqlDateTime;
+            }
+            else
+            {
+                bool ej_ = eh_ is CqlQuantity;
+                if (ej_)
+                {
+                    db_ = eh_ as CqlQuantity;
+                }
+                else
+                {
+                    bool ek_ = eh_ is CqlInterval<CqlDateTime>;
+                    if (ek_)
+                    {
+                        db_ = eh_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool el_ = eh_ is CqlInterval<CqlQuantity>;
+                        if (el_)
+                        {
+                            db_ = eh_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            db_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_);
+            CqlDateTime dd_ = context.Operators.End(dc_);
+            CqlInterval<CqlDate> de_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, dd_);
+            CqlBoolean df_ = de_?.lowClosed;
+            object dg_;
+            DataType em_ = tuple_elrfucfgncrbdgahdtkitiyzu?.AnesthesiaProcedure?.Performed;
+            object en_ = FHIRHelpers_4_4_000.Instance.ToValue(context, em_);
+            bool eo_ = en_ is CqlDateTime;
+            if (eo_)
+            {
+                dg_ = en_ as CqlDateTime;
+            }
+            else
+            {
+                bool ep_ = en_ is CqlQuantity;
+                if (ep_)
+                {
+                    dg_ = en_ as CqlQuantity;
+                }
+                else
+                {
+                    bool eq_ = en_ is CqlInterval<CqlDateTime>;
+                    if (eq_)
+                    {
+                        dg_ = en_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool er_ = en_ is CqlInterval<CqlQuantity>;
+                        if (er_)
+                        {
+                            dg_ = en_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            dg_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> dh_ = QICoreCommon_4_0_000.Instance.toInterval(context, dg_);
+            CqlDateTime di_ = context.Operators.End(dh_);
+            CqlInterval<CqlDate> dj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, di_);
+            CqlBoolean dk_ = dj_?.highClosed;
+            CqlInterval<CqlDateTime> dl_ = context.Operators.Interval(cu_, da_, df_, dk_);
+            CqlBoolean dm_ = context.Operators.In<CqlDateTime>(co_, dl_, "day");
+            CqlBoolean dn_ = dm_;
             return bx_
-                /* CQL 'and' (183:15-184:54) */ && by_()
-                /* CQL 'and' (183:15-185:125) */ && bz_()
-                /* CQL 'and' (183:9-186:162) */ && ca_();
+                /* CQL 'and' (183:15-184:54) */ && cc_
+                /* CQL 'and' (183:15-185:125) */ && ck_
+                /* CQL 'and' (183:9-186:162) */ && dn_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?> o_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, MedicationAdministration>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, MedicationAdministration FactorXaMedication)?>(l_, m_, n_);
@@ -1896,43 +1800,27 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             bool? l_(Condition AtrialFibrillation) {
                 CodeableConcept n_ = AtrialFibrillation?.VerificationStatus;
                 CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-
-                CqlBoolean p_() {
-                    CodeableConcept q_ = AtrialFibrillation?.VerificationStatus;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    CqlCode s_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                    CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-
-                    CqlBoolean v_() {
-                        CodeableConcept x_ = AtrialFibrillation?.VerificationStatus;
-                        CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                        CqlCode z_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
-                        CqlBoolean ab_ = context.Operators.Equivalent(y_, aa_);
-                        return !ab_;
-                    }
-
-
-                    CqlBoolean w_() {
-                        DataType ac_ = AtrialFibrillation?.Onset;
-                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                        CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
-                        CqlDateTime af_ = context.Operators.Start(ae_);
-                        Period ag_ = QualifyingEncounterICU?.Period;
-                        CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                        CqlDateTime ai_ = context.Operators.End(ah_);
-                        CqlBoolean aj_ = context.Operators.SameOrBefore(af_, ai_, (string)default);
-                        return aj_;
-                    }
-
-                    return (CqlBoolean)!u_
-                        /* CQL 'and' (193:77-195:9) */ && v_()
-                        /* CQL 'and' (193:77-196:110) */ && w_();
-                }
-
+                CqlCode p_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+                CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
+                CqlCode s_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
+                CqlBoolean u_ = context.Operators.Equivalent(o_, t_);
+                CqlBoolean v_ = (CqlBoolean)!u_;
+                DataType w_ = AtrialFibrillation?.Onset;
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                Period aa_ = QualifyingEncounterICU?.Period;
+                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
+                CqlDateTime ac_ = context.Operators.End(ab_);
+                CqlBoolean ad_ = context.Operators.SameOrBefore(z_, ac_, (string)default);
+                CqlBoolean ae_ = ad_;
+                CqlBoolean af_ = (CqlBoolean)!r_
+                    /* CQL 'and' (193:77-195:9) */ && v_
+                    /* CQL 'and' (193:77-196:110) */ && ae_;
                 return (CqlBoolean)(o_ is null)
-                    /* CQL 'implies' (193:19-196:110) */ || p_();
+                    /* CQL 'implies' (193:19-196:110) */ || af_;
             }
 
             CqlBoolean m_ = context.Operators.WhereAny<Condition>(k_, l_);
@@ -1942,104 +1830,72 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter QualifyingEncounterICU) {
-            CqlValueSet ak_ = this.Atrial_Fibrillation_or_Flutter(context);
-            CqlBoolean al_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounterICU, ak_);
-            return al_;
+            CqlValueSet ag_ = this.Atrial_Fibrillation_or_Flutter(context);
+            CqlBoolean ah_ = VTE_8_18_000.Instance.hasEncDiagnosisOf(context, QualifyingEncounterICU, ag_);
+            return ah_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(a_, d_);
         IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(c_, e_);
 
         bool? g_(Encounter QualifyingEncounterICU) {
-            CqlValueSet am_ = this.Venous_Thromboembolism(context);
-            IEnumerable<Condition> an_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, am_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            CqlValueSet ai_ = this.Venous_Thromboembolism(context);
+            IEnumerable<Condition> aj_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ai_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            bool? ao_(Condition VTEDiagnosis) {
-                CodeableConcept aq_ = VTEDiagnosis?.ClinicalStatus;
-                CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
-                CqlCode as_ = QICoreCommon_4_0_000.Instance.inactive(context);
-                CqlConcept at_ = context.Operators.ConvertCodeToConcept(as_);
-                CqlBoolean au_ = context.Operators.Equivalent(ar_, at_);
-
-                CqlBoolean av_() {
-                    CodeableConcept az_ = VTEDiagnosis?.ClinicalStatus;
-                    CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                    CqlCode bb_ = QICoreCommon_4_0_000.Instance.remission(context);
-                    CqlConcept bc_ = context.Operators.ConvertCodeToConcept(bb_);
-                    CqlBoolean bd_ = context.Operators.Equivalent(ba_, bc_);
-                    return bd_;
+            bool? ak_(Condition VTEDiagnosis) {
+                CodeableConcept am_ = VTEDiagnosis?.ClinicalStatus;
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
+                CqlCode ao_ = QICoreCommon_4_0_000.Instance.inactive(context);
+                CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+                CqlBoolean aq_ = context.Operators.Equivalent(an_, ap_);
+                CqlCode ar_ = QICoreCommon_4_0_000.Instance.remission(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(an_, as_);
+                CqlBoolean au_ = at_;
+                CqlCode av_ = QICoreCommon_4_0_000.Instance.resolved(context);
+                CqlConcept aw_ = context.Operators.ConvertCodeToConcept(av_);
+                CqlBoolean ax_ = context.Operators.Equivalent(an_, aw_);
+                CqlBoolean ay_ = ax_;
+                CodeableConcept az_ = VTEDiagnosis?.VerificationStatus;
+                CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
+                CqlBoolean bb_ = (CqlBoolean)(ba_ is not null);
+                CqlCode bc_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept bd_ = context.Operators.ConvertCodeToConcept(bc_);
+                CqlBoolean be_ = context.Operators.Equivalent(ba_, bd_);
+                CqlCode bf_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept bg_ = context.Operators.ConvertCodeToConcept(bf_);
+                CqlBoolean bh_ = context.Operators.Equivalent(ba_, bg_);
+                CqlBoolean bi_ = (CqlBoolean)!bh_;
+                DataType bj_ = VTEDiagnosis?.Onset;
+                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+                CqlInterval<CqlDateTime> bl_ = QICoreCommon_4_0_000.Instance.toInterval(context, bk_);
+                CqlInterval<CqlDateTime> bm_;
+                Period bq_ = QualifyingEncounterICU?.Period;
+                CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bq_);
+                CqlDateTime bs_ = context.Operators.Start(br_);
+                if (bs_ is null)
+                {
+                    bm_ = default;
                 }
-
-
-                CqlBoolean aw_() {
-                    CodeableConcept be_ = VTEDiagnosis?.ClinicalStatus;
-                    CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, be_);
-                    CqlCode bg_ = QICoreCommon_4_0_000.Instance.resolved(context);
-                    CqlConcept bh_ = context.Operators.ConvertCodeToConcept(bg_);
-                    CqlBoolean bi_ = context.Operators.Equivalent(bf_, bh_);
-                    return bi_;
+                else
+                {
+                    CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bs_, bs_, true, true);
+                    bm_ = bt_;
                 }
-
-
-                CqlBoolean ax_() {
-                    CodeableConcept bj_ = VTEDiagnosis?.VerificationStatus;
-                    CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
-                    return bk_ is not null;
-                }
-
-
-                CqlBoolean ay_() {
-                    CodeableConcept bl_ = VTEDiagnosis?.VerificationStatus;
-                    CqlConcept bm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bl_);
-                    CqlCode bn_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept bo_ = context.Operators.ConvertCodeToConcept(bn_);
-                    CqlBoolean bp_ = context.Operators.Equivalent(bm_, bo_);
-
-                    CqlBoolean bq_() {
-                        CodeableConcept bs_ = VTEDiagnosis?.VerificationStatus;
-                        CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bs_);
-                        CqlCode bu_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept bv_ = context.Operators.ConvertCodeToConcept(bu_);
-                        CqlBoolean bw_ = context.Operators.Equivalent(bt_, bv_);
-                        return !bw_;
-                    }
-
-
-                    CqlBoolean br_() {
-                        DataType bx_ = VTEDiagnosis?.Onset;
-                        object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
-                        CqlInterval<CqlDateTime> bz_ = QICoreCommon_4_0_000.Instance.toInterval(context, by_);
-                        CqlInterval<CqlDateTime> ca_;
-                        Period cc_ = QualifyingEncounterICU?.Period;
-                        CqlInterval<CqlDateTime> cd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cc_);
-                        CqlDateTime ce_ = context.Operators.Start(cd_);
-                        if (ce_ is null)
-                        {
-                            ca_ = default;
-                        }
-                        else
-                        {
-                            CqlInterval<CqlDateTime> cf_ = context.Operators.Interval(ce_, ce_, true, true);
-                            ca_ = cf_;
-                        }
-                        CqlBoolean cb_ = context.Operators.Before(bz_, ca_, (string)default);
-                        return cb_;
-                    }
-
-                    return (CqlBoolean)!bp_
-                        /* CQL 'and' (207:69-209:11) */ && bq_()
-                        /* CQL 'and' (207:69-210:95) */ && br_();
-                }
-
-                return (CqlBoolean)(!((bool?)((au_
-                    /* CQL 'or' (203:23-204:71) */ || av_()
-                    /* CQL 'or' (203:21-206:11) */ || aw_())
-                    /* CQL 'and' (203:21-207:59) */ && ax_())))
-                    /* CQL 'implies' (203:21-210:95) */ || ay_();
+                CqlBoolean bn_ = context.Operators.Before(bl_, bm_, (string)default);
+                CqlBoolean bo_ = bn_;
+                CqlBoolean bp_ = (CqlBoolean)!be_
+                    /* CQL 'and' (207:69-209:11) */ && bi_
+                    /* CQL 'and' (207:69-210:95) */ && bo_;
+                return (CqlBoolean)(!((bool?)((aq_
+                    /* CQL 'or' (203:23-204:71) */ || au_
+                    /* CQL 'or' (203:21-206:11) */ || ay_)
+                    /* CQL 'and' (203:21-207:59) */ && bb_)))
+                    /* CQL 'implies' (203:21-210:95) */ || bp_;
             }
 
-            CqlBoolean ap_ = context.Operators.WhereAny<Condition>(an_, ao_);
-            return ap_;
+            CqlBoolean al_ = context.Operators.WhereAny<Condition>(aj_, ak_);
+            return al_;
         }
 
         IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(a_, g_);
@@ -2070,55 +1926,51 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 EventStatus? l_ = k_?.Value;
                 string m_ = context.Operators.Convert<string>(l_);
                 CqlBoolean n_ = context.Operators.Equal(m_, "completed");
-
-                CqlBoolean o_() {
-                    object p_;
-                    DataType w_ = HipKneeProcedure?.Performed;
-                    object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                    bool y_ = x_ is CqlDateTime;
-                    if (y_)
+                object o_;
+                DataType w_ = HipKneeProcedure?.Performed;
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                bool y_ = x_ is CqlDateTime;
+                if (y_)
+                {
+                    o_ = x_ as CqlDateTime;
+                }
+                else
+                {
+                    bool z_ = x_ is CqlQuantity;
+                    if (z_)
                     {
-                        p_ = x_ as CqlDateTime;
+                        o_ = x_ as CqlQuantity;
                     }
                     else
                     {
-                        bool z_ = x_ is CqlQuantity;
-                        if (z_)
+                        bool aa_ = x_ is CqlInterval<CqlDateTime>;
+                        if (aa_)
                         {
-                            p_ = x_ as CqlQuantity;
+                            o_ = x_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool aa_ = x_ is CqlInterval<CqlDateTime>;
-                            if (aa_)
+                            bool ab_ = x_ is CqlInterval<CqlQuantity>;
+                            if (ab_)
                             {
-                                p_ = x_ as CqlInterval<CqlDateTime>;
+                                o_ = x_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ab_ = x_ is CqlInterval<CqlQuantity>;
-                                if (ab_)
-                                {
-                                    p_ = x_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    p_ = null;
-                                }
+                                o_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                    CqlDateTime r_ = context.Operators.Start(q_);
-                    Period s_ = QualifyingEncounterICU?.Period;
-                    CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                    CqlDateTime u_ = context.Operators.End(t_);
-                    CqlBoolean v_ = context.Operators.SameOrBefore(r_, u_, (string)default);
-                    return v_;
                 }
-
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                Period r_ = QualifyingEncounterICU?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.End(s_);
+                CqlBoolean u_ = context.Operators.SameOrBefore(q_, t_, (string)default);
+                CqlBoolean v_ = u_;
                 return n_
-                    /* CQL 'and' (217:17-218:110) */ && o_();
+                    /* CQL 'and' (217:17-218:110) */ && v_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Procedure>(h_, i_);
@@ -2147,22 +1999,18 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
             CqlValueSet ap_ = this.Low_Risk(context);
             CqlBoolean aq_ = context.Operators.ConceptInValueSet(ao_ as CqlConcept, ap_);
-
-            CqlBoolean ar_() {
-                Code<ObservationStatus> as_ = VTERiskAssessment?.StatusElement;
-                ObservationStatus? at_ = as_?.Value;
-                string au_ = context.Operators.Convert<string>(at_);
-                string[] av_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
-                return aw_;
-            }
-
+            Code<ObservationStatus> ar_ = VTERiskAssessment?.StatusElement;
+            ObservationStatus? as_ = ar_?.Value;
+            string at_ = context.Operators.Convert<string>(as_);
+            string[] au_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
+            CqlBoolean aw_ = av_;
             return aq_
-                /* CQL 'and' (226:7-227:75) */ && ar_();
+                /* CQL 'and' (226:7-227:75) */ && aw_;
         }
 
 
@@ -2211,22 +2059,18 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
             CqlQuantity bi_ = context.Operators.ConvertDecimalToQuantity(3.0m);
             CqlBoolean bj_ = context.Operators.Greater(bh_ as CqlQuantity, bi_);
-
-            CqlBoolean bk_() {
-                Code<ObservationStatus> bl_ = INRLabTest?.StatusElement;
-                ObservationStatus? bm_ = bl_?.Value;
-                string bn_ = context.Operators.Convert<string>(bm_);
-                string[] bo_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean bp_ = context.Operators.In<string>(bn_, (IEnumerable<string>)bo_);
-                return bp_;
-            }
-
+            Code<ObservationStatus> bk_ = INRLabTest?.StatusElement;
+            ObservationStatus? bl_ = bk_?.Value;
+            string bm_ = context.Operators.Convert<string>(bl_);
+            string[] bn_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean bo_ = context.Operators.In<string>(bm_, (IEnumerable<string>)bn_);
+            CqlBoolean bp_ = bo_;
             return bj_
-                /* CQL 'and' (234:9-235:70) */ && bk_();
+                /* CQL 'and' (234:9-235:70) */ && bp_;
         }
 
 
@@ -2254,17 +2098,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> cb_ = context.Operators.Split((string)ca_, "/");
                 string cc_ = context.Operators.Last<string>(cb_);
                 CqlBoolean cd_ = context.Operators.Equal(bz_, cc_);
-
-                CqlBoolean ce_() {
-                    CodeableConcept cf_ = M?.Code;
-                    CqlConcept cg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cf_);
-                    CqlValueSet ch_ = this.Unfractionated_Heparin(context);
-                    CqlBoolean ci_ = context.Operators.ConceptInValueSet(cg_, ch_);
-                    return ci_;
-                }
-
+                CodeableConcept ce_ = M?.Code;
+                CqlConcept cf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ce_);
+                CqlValueSet cg_ = this.Unfractionated_Heparin(context);
+                CqlBoolean ch_ = context.Operators.ConceptInValueSet(cf_, cg_);
+                CqlBoolean ci_ = ch_;
                 return cd_
-                    /* CQL 'and' */ && ce_();
+                    /* CQL 'and' */ && ci_;
             }
 
             CqlBoolean by_ = context.Operators.WhereAny<Medication>(bw_, bx_);
@@ -2296,17 +2136,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> ct_ = context.Operators.Split((string)cs_, "/");
                 string cu_ = context.Operators.Last<string>(ct_);
                 CqlBoolean cv_ = context.Operators.Equal(cr_, cu_);
-
-                CqlBoolean cw_() {
-                    CodeableConcept cx_ = M?.Code;
-                    CqlConcept cy_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cx_);
-                    CqlValueSet cz_ = this.Direct_Thrombin_Inhibitor(context);
-                    CqlBoolean da_ = context.Operators.ConceptInValueSet(cy_, cz_);
-                    return da_;
-                }
-
+                CodeableConcept cw_ = M?.Code;
+                CqlConcept cx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cw_);
+                CqlValueSet cy_ = this.Direct_Thrombin_Inhibitor(context);
+                CqlBoolean cz_ = context.Operators.ConceptInValueSet(cx_, cy_);
+                CqlBoolean da_ = cz_;
                 return cv_
-                    /* CQL 'and' */ && cw_();
+                    /* CQL 'and' */ && da_;
             }
 
             CqlBoolean cq_ = context.Operators.WhereAny<Medication>(co_, cp_);
@@ -2328,17 +2164,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> dg_ = context.Operators.Split((string)df_, "/");
                 string dh_ = context.Operators.Last<string>(dg_);
                 CqlBoolean di_ = context.Operators.Equal(de_, dh_);
-
-                CqlBoolean dj_() {
-                    CodeableConcept dk_ = M?.Code;
-                    CqlConcept dl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dk_);
-                    CqlValueSet dm_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
-                    CqlBoolean dn_ = context.Operators.ConceptInValueSet(dl_, dm_);
-                    return dn_;
-                }
-
+                CodeableConcept dj_ = M?.Code;
+                CqlConcept dk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dj_);
+                CqlValueSet dl_ = this.Glycoprotein_IIb_IIIa_Inhibitors(context);
+                CqlBoolean dm_ = context.Operators.ConceptInValueSet(dk_, dl_);
+                CqlBoolean dn_ = dm_;
                 return di_
-                    /* CQL 'and' */ && dj_();
+                    /* CQL 'and' */ && dn_;
             }
 
             CqlBoolean dd_ = context.Operators.WhereAny<Medication>(db_, dc_);
@@ -2439,226 +2271,218 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object r_;
-                DataType y_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
-                {
-                    r_ = z_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ab_ = z_ is CqlQuantity;
-                    if (ab_)
-                    {
-                        r_ = z_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ac_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ac_)
-                        {
-                            r_ = z_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ad_ = z_ is CqlInterval<CqlQuantity>;
-                            if (ad_)
-                            {
-                                r_ = z_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                r_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.End(s_);
-                CqlDateTime u_ = this.startOfFirstICU(context, tuple_cchfidtccovheihiyjcdnfkbm?.QualifyingEncounterICU);
-                CqlQuantity v_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime w_ = context.Operators.Add(u_, v_);
-                CqlBoolean x_ = context.Operators.SameAs(t_, w_, "day");
-                return x_;
+            object p_;
+            DataType ax_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
+            object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+            bool az_ = ay_ is CqlDateTime;
+            if (az_)
+            {
+                p_ = ay_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ae_ = tuple_cchfidtccovheihiyjcdnfkbm?.LowRiskForVTE?.LowRiskDatetime;
-                object af_;
-                DataType bd_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
-                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                bool bf_ = be_ is CqlDateTime;
-                if (bf_)
+            else
+            {
+                bool ba_ = ay_ is CqlQuantity;
+                if (ba_)
                 {
-                    af_ = be_ as CqlDateTime;
+                    p_ = ay_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bg_ = be_ is CqlQuantity;
-                    if (bg_)
+                    bool bb_ = ay_ is CqlInterval<CqlDateTime>;
+                    if (bb_)
                     {
-                        af_ = be_ as CqlQuantity;
+                        p_ = ay_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bh_ = be_ is CqlInterval<CqlDateTime>;
-                        if (bh_)
+                        bool bc_ = ay_ is CqlInterval<CqlQuantity>;
+                        if (bc_)
                         {
-                            af_ = be_ as CqlInterval<CqlDateTime>;
+                            p_ = ay_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bi_ = be_ is CqlInterval<CqlQuantity>;
-                            if (bi_)
-                            {
-                                af_ = be_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                af_ = null;
-                            }
+                            p_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                CqlDateTime ah_ = context.Operators.End(ag_);
-                CqlInterval<CqlDate> ai_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ah_);
-                CqlDate aj_ = ai_?.low;
-                CqlDateTime ak_ = context.Operators.ConvertDateToDateTime(aj_);
-                object al_;
-                DataType bj_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                bool bl_ = bk_ is CqlDateTime;
-                if (bl_)
-                {
-                    al_ = bk_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bm_ = bk_ is CqlQuantity;
-                    if (bm_)
-                    {
-                        al_ = bk_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bn_ = bk_ is CqlInterval<CqlDateTime>;
-                        if (bn_)
-                        {
-                            al_ = bk_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bo_ = bk_ is CqlInterval<CqlQuantity>;
-                            if (bo_)
-                            {
-                                al_ = bk_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                al_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                CqlDateTime an_ = context.Operators.End(am_);
-                CqlInterval<CqlDate> ao_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, an_);
-                CqlDate ap_ = ao_?.high;
-                CqlDateTime aq_ = context.Operators.ConvertDateToDateTime(ap_);
-                object ar_;
-                DataType bp_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
-                {
-                    ar_ = bq_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bs_ = bq_ is CqlQuantity;
-                    if (bs_)
-                    {
-                        ar_ = bq_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bt_)
-                        {
-                            ar_ = bq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
-                            if (bu_)
-                            {
-                                ar_ = bq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ar_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.End(as_);
-                CqlInterval<CqlDate> au_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, at_);
-                CqlBoolean av_ = au_?.lowClosed;
-                object aw_;
-                DataType bv_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
-                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                bool bx_ = bw_ is CqlDateTime;
-                if (bx_)
-                {
-                    aw_ = bw_ as CqlDateTime;
-                }
-                else
-                {
-                    bool by_ = bw_ is CqlQuantity;
-                    if (by_)
-                    {
-                        aw_ = bw_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bz_ = bw_ is CqlInterval<CqlDateTime>;
-                        if (bz_)
-                        {
-                            aw_ = bw_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ca_ = bw_ is CqlInterval<CqlQuantity>;
-                            if (ca_)
-                            {
-                                aw_ = bw_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                aw_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_);
-                CqlDateTime ay_ = context.Operators.End(ax_);
-                CqlInterval<CqlDate> az_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ay_);
-                CqlBoolean ba_ = az_?.highClosed;
-                CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ak_, aq_, av_, ba_);
-                CqlBoolean bc_ = context.Operators.In<CqlDateTime>(ae_, bb_, "day");
-                return bc_;
             }
-
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.End(q_);
+            CqlDateTime s_ = this.startOfFirstICU(context, tuple_cchfidtccovheihiyjcdnfkbm?.QualifyingEncounterICU);
+            CqlQuantity t_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime u_ = context.Operators.Add(s_, t_);
+            CqlBoolean v_ = context.Operators.SameAs(r_, u_, "day");
+            CqlBoolean w_ = v_;
+            CqlDateTime x_ = tuple_cchfidtccovheihiyjcdnfkbm?.LowRiskForVTE?.LowRiskDatetime;
+            object y_;
+            DataType bd_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            bool bf_ = be_ is CqlDateTime;
+            if (bf_)
+            {
+                y_ = be_ as CqlDateTime;
+            }
+            else
+            {
+                bool bg_ = be_ is CqlQuantity;
+                if (bg_)
+                {
+                    y_ = be_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bh_ = be_ is CqlInterval<CqlDateTime>;
+                    if (bh_)
+                    {
+                        y_ = be_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bi_ = be_ is CqlInterval<CqlQuantity>;
+                        if (bi_)
+                        {
+                            y_ = be_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            y_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+            CqlDateTime aa_ = context.Operators.End(z_);
+            CqlInterval<CqlDate> ab_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aa_);
+            CqlDate ac_ = ab_?.low;
+            CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(ac_);
+            object ae_;
+            DataType bj_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
+            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+            bool bl_ = bk_ is CqlDateTime;
+            if (bl_)
+            {
+                ae_ = bk_ as CqlDateTime;
+            }
+            else
+            {
+                bool bm_ = bk_ is CqlQuantity;
+                if (bm_)
+                {
+                    ae_ = bk_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bn_ = bk_ is CqlInterval<CqlDateTime>;
+                    if (bn_)
+                    {
+                        ae_ = bk_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bo_ = bk_ is CqlInterval<CqlQuantity>;
+                        if (bo_)
+                        {
+                            ae_ = bk_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ae_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+            CqlDateTime ag_ = context.Operators.End(af_);
+            CqlInterval<CqlDate> ah_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ag_);
+            CqlDate ai_ = ah_?.high;
+            CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
+            object ak_;
+            DataType bp_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
+            object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            bool br_ = bq_ is CqlDateTime;
+            if (br_)
+            {
+                ak_ = bq_ as CqlDateTime;
+            }
+            else
+            {
+                bool bs_ = bq_ is CqlQuantity;
+                if (bs_)
+                {
+                    ak_ = bq_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bt_ = bq_ is CqlInterval<CqlDateTime>;
+                    if (bt_)
+                    {
+                        ak_ = bq_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bu_ = bq_ is CqlInterval<CqlQuantity>;
+                        if (bu_)
+                        {
+                            ak_ = bq_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ak_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
+            CqlDateTime am_ = context.Operators.End(al_);
+            CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, am_);
+            CqlBoolean ao_ = an_?.lowClosed;
+            object ap_;
+            DataType bv_ = tuple_cchfidtccovheihiyjcdnfkbm?.AnesthesiaProcedure?.Performed;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            bool bx_ = bw_ is CqlDateTime;
+            if (bx_)
+            {
+                ap_ = bw_ as CqlDateTime;
+            }
+            else
+            {
+                bool by_ = bw_ is CqlQuantity;
+                if (by_)
+                {
+                    ap_ = bw_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bz_ = bw_ is CqlInterval<CqlDateTime>;
+                    if (bz_)
+                    {
+                        ap_ = bw_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ca_ = bw_ is CqlInterval<CqlQuantity>;
+                        if (ca_)
+                        {
+                            ap_ = bw_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ap_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
+            CqlDateTime ar_ = context.Operators.End(aq_);
+            CqlInterval<CqlDate> as_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ar_);
+            CqlBoolean at_ = as_?.highClosed;
+            CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ad_, aj_, ao_, at_);
+            CqlBoolean av_ = context.Operators.In<CqlDateTime>(x_, au_, "day");
+            CqlBoolean aw_ = av_;
             return o_
-                /* CQL 'and' (263:11-264:121) */ && p_()
-                /* CQL 'and' (263:5-265:137) */ && q_();
+                /* CQL 'and' (263:11-264:121) */ && w_
+                /* CQL 'and' (263:5-265:137) */ && aw_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)?>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlDateTime LowRiskDatetime)? LowRiskForVTE)?>(e_, f_, g_);
@@ -2788,21 +2612,17 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 "instance-order",
             ];
             CqlBoolean ct_ = context.Operators.In<string>(cr_, (IEnumerable<string>)cs_);
-
-            CqlBoolean cu_() {
-                Code<MedicationRequest.MedicationrequestStatus> cv_ = NoMedicationOrder?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? cw_ = cv_?.Value;
-                string cx_ = context.Operators.Convert<string>(cw_);
-                string[] cy_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean cz_ = context.Operators.In<string>(cx_, (IEnumerable<string>)cy_);
-                return cz_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> cu_ = NoMedicationOrder?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? cv_ = cu_?.Value;
+            string cw_ = context.Operators.Convert<string>(cv_);
+            string[] cx_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean cy_ = context.Operators.In<string>(cw_, (IEnumerable<string>)cx_);
+            CqlBoolean cz_ = cy_;
             return ct_
-                /* CQL 'and' (299:9-300:67) */ && cu_();
+                /* CQL 'and' (299:9-300:67) */ && cz_;
         }
 
 
@@ -2837,17 +2657,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> do_ = context.Operators.Split((string)dn_, "/");
                 string dp_ = context.Operators.Last<string>(do_);
                 CqlBoolean dq_ = context.Operators.Equal(dm_, dp_);
-
-                CqlBoolean dr_() {
-                    CodeableConcept ds_ = M?.Code;
-                    CqlConcept dt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ds_);
-                    CqlValueSet du_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean dv_ = context.Operators.ConceptInValueSet(dt_, du_);
-                    return dv_;
-                }
-
+                CodeableConcept dr_ = M?.Code;
+                CqlConcept ds_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dr_);
+                CqlValueSet dt_ = this.Low_Dose_Unfractionated_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean du_ = context.Operators.ConceptInValueSet(ds_, dt_);
+                CqlBoolean dv_ = du_;
                 return dq_
-                    /* CQL 'and' */ && dr_();
+                    /* CQL 'and' */ && dv_;
             }
 
             CqlBoolean dl_ = context.Operators.WhereAny<Medication>(dj_, dk_);
@@ -2867,17 +2683,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> eb_ = context.Operators.Split((string)ea_, "/");
                 string ec_ = context.Operators.Last<string>(eb_);
                 CqlBoolean ed_ = context.Operators.Equal(dz_, ec_);
-
-                CqlBoolean ee_() {
-                    CodeableConcept ef_ = M?.Code;
-                    CqlConcept eg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ef_);
-                    CqlValueSet eh_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
-                    CqlBoolean ei_ = context.Operators.ConceptInValueSet(eg_, eh_);
-                    return ei_;
-                }
-
+                CodeableConcept ee_ = M?.Code;
+                CqlConcept ef_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ee_);
+                CqlValueSet eg_ = this.Low_Molecular_Weight_Heparin_for_VTE_Prophylaxis(context);
+                CqlBoolean eh_ = context.Operators.ConceptInValueSet(ef_, eg_);
+                CqlBoolean ei_ = eh_;
                 return ed_
-                    /* CQL 'and' */ && ee_();
+                    /* CQL 'and' */ && ei_;
             }
 
             CqlBoolean dy_ = context.Operators.WhereAny<Medication>(dw_, dx_);
@@ -2898,17 +2710,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> eo_ = context.Operators.Split((string)en_, "/");
                 string ep_ = context.Operators.Last<string>(eo_);
                 CqlBoolean eq_ = context.Operators.Equal(em_, ep_);
-
-                CqlBoolean er_() {
-                    CodeableConcept es_ = M?.Code;
-                    CqlConcept et_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, es_);
-                    CqlValueSet eu_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
-                    CqlBoolean ev_ = context.Operators.ConceptInValueSet(et_, eu_);
-                    return ev_;
-                }
-
+                CodeableConcept er_ = M?.Code;
+                CqlConcept es_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, er_);
+                CqlValueSet et_ = this.Injectable_Factor_Xa_Inhibitor_for_VTE_Prophylaxis(context);
+                CqlBoolean eu_ = context.Operators.ConceptInValueSet(es_, et_);
+                CqlBoolean ev_ = eu_;
                 return eq_
-                    /* CQL 'and' */ && er_();
+                    /* CQL 'and' */ && ev_;
             }
 
             CqlBoolean el_ = context.Operators.WhereAny<Medication>(ej_, ek_);
@@ -2929,17 +2737,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> fb_ = context.Operators.Split((string)fa_, "/");
                 string fc_ = context.Operators.Last<string>(fb_);
                 CqlBoolean fd_ = context.Operators.Equal(ez_, fc_);
-
-                CqlBoolean fe_() {
-                    CodeableConcept ff_ = M?.Code;
-                    CqlConcept fg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ff_);
-                    CqlValueSet fh_ = this.Warfarin(context);
-                    CqlBoolean fi_ = context.Operators.ConceptInValueSet(fg_, fh_);
-                    return fi_;
-                }
-
+                CodeableConcept fe_ = M?.Code;
+                CqlConcept ff_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fe_);
+                CqlValueSet fg_ = this.Warfarin(context);
+                CqlBoolean fh_ = context.Operators.ConceptInValueSet(ff_, fg_);
+                CqlBoolean fi_ = fh_;
                 return fd_
-                    /* CQL 'and' */ && fe_();
+                    /* CQL 'and' */ && fi_;
             }
 
             CqlBoolean ey_ = context.Operators.WhereAny<Medication>(ew_, ex_);
@@ -2960,17 +2764,13 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<string> fo_ = context.Operators.Split((string)fn_, "/");
                 string fp_ = context.Operators.Last<string>(fo_);
                 CqlBoolean fq_ = context.Operators.Equal(fm_, fp_);
-
-                CqlBoolean fr_() {
-                    CodeableConcept fs_ = M?.Code;
-                    CqlConcept ft_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fs_);
-                    CqlValueSet fu_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
-                    CqlBoolean fv_ = context.Operators.ConceptInValueSet(ft_, fu_);
-                    return fv_;
-                }
-
+                CodeableConcept fr_ = M?.Code;
+                CqlConcept fs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fr_);
+                CqlValueSet ft_ = this.Rivaroxaban_for_VTE_Prophylaxis(context);
+                CqlBoolean fu_ = context.Operators.ConceptInValueSet(fs_, ft_);
+                CqlBoolean fv_ = fu_;
                 return fq_
-                    /* CQL 'and' */ && fr_();
+                    /* CQL 'and' */ && fv_;
             }
 
             CqlBoolean fl_ = context.Operators.WhereAny<Medication>(fj_, fk_);
@@ -2993,28 +2793,20 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
         bool? bs_((CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)? tuple_iiuqmbcjhjbpgddolhattrue) {
             ResourceReference fx_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Focus;
             CqlBoolean fy_ = QICoreCommon_4_0_000.Instance.references(context, fx_, tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject);
-
-            CqlBoolean fz_() {
-                CodeableConcept gb_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
-                CqlConcept gc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, gb_);
-                CqlCode gd_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                CqlConcept ge_ = context.Operators.ConvertCodeToConcept(gd_);
-                CqlBoolean gf_ = context.Operators.Equivalent(gc_, ge_);
-                return gf_;
-            }
-
-
-            CqlBoolean ga_() {
-                Code<MedicationRequest.MedicationrequestStatus> gg_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? gh_ = gg_?.Value;
-                string gi_ = context.Operators.Convert<string>(gh_);
-                CqlBoolean gj_ = context.Operators.Equal(gi_, "active");
-                return gj_;
-            }
-
+            CodeableConcept fz_ = tuple_iiuqmbcjhjbpgddolhattrue?.T?.Code;
+            CqlConcept ga_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fz_);
+            CqlCode gb_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+            CqlConcept gc_ = context.Operators.ConvertCodeToConcept(gb_);
+            CqlBoolean gd_ = context.Operators.Equivalent(ga_, gc_);
+            CqlBoolean ge_ = gd_;
+            Code<MedicationRequest.MedicationrequestStatus> gf_ = tuple_iiuqmbcjhjbpgddolhattrue?.MedicationOrderReject?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? gg_ = gf_?.Value;
+            string gh_ = context.Operators.Convert<string>(gg_);
+            CqlBoolean gi_ = context.Operators.Equal(gh_, "active");
+            CqlBoolean gj_ = gi_;
             return fy_
-                /* CQL 'and' (314:15-315:45) */ && fz_()
-                /* CQL 'and' (314:9-316:53) */ && ga_();
+                /* CQL 'and' (314:15-315:45) */ && ge_
+                /* CQL 'and' (314:9-316:53) */ && gj_;
         }
 
         IEnumerable<(CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?> bt_ = context.Operators.SelectWhere<ValueTuple<MedicationRequest, Task>, (CqlTupleMetadata, MedicationRequest MedicationOrderReject, Task T)?>(bq_, br_, bs_);
@@ -3056,23 +2848,19 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 IEnumerable<CqlConcept> g_ = NoVTEMedication?.medicationStatusReason;
                 CqlValueSet h_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
                 CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
-
-                CqlBoolean j_() {
-                    CqlDateTime k_ = NoVTEMedication?.authoredOn;
-                    CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
-                    CqlDate m_ = l_?.low;
-                    CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
-                    CqlDate o_ = l_?.high;
-                    CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
-                    CqlBoolean q_ = l_?.lowClosed;
-                    CqlBoolean r_ = l_?.highClosed;
-                    CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, p_, q_, r_);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(k_, s_, "day");
-                    return t_;
-                }
-
+                CqlDateTime j_ = NoVTEMedication?.authoredOn;
+                CqlInterval<CqlDate> k_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
+                CqlDate l_ = k_?.low;
+                CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
+                CqlDate n_ = k_?.high;
+                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
+                CqlBoolean p_ = k_?.lowClosed;
+                CqlBoolean q_ = k_?.highClosed;
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(m_, o_, p_, q_);
+                CqlBoolean s_ = context.Operators.In<CqlDateTime>(j_, r_, "day");
+                CqlBoolean t_ = s_;
                 return i_
-                    /* CQL 'and' (279:17-280:129) */ && j_();
+                    /* CQL 'and' (279:17-280:129) */ && t_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<(CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>(d_, e_);
@@ -3194,36 +2982,24 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 "instance-order",
             ];
             CqlBoolean bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
-
-            CqlBoolean by_() {
-                Code<RequestStatus> cb_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject?.StatusElement;
-                RequestStatus? cc_ = cb_?.Value;
-                Code<RequestStatus> cd_ = context.Operators.Convert<Code<RequestStatus>>(cc_);
-                CqlBoolean ce_ = context.Operators.Equal(cd_, "active");
-                return ce_;
-            }
-
-
-            CqlBoolean bz_() {
-                ResourceReference cf_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Focus;
-                CqlBoolean cg_ = QICoreCommon_4_0_000.Instance.references(context, cf_, tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject);
-                return cg_;
-            }
-
-
-            CqlBoolean ca_() {
-                CodeableConcept ch_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Code;
-                CqlConcept ci_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ch_);
-                CqlCode cj_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                CqlConcept ck_ = context.Operators.ConvertCodeToConcept(cj_);
-                CqlBoolean cl_ = context.Operators.Equivalent(ci_, ck_);
-                return cl_;
-            }
-
+            Code<RequestStatus> by_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject?.StatusElement;
+            RequestStatus? bz_ = by_?.Value;
+            Code<RequestStatus> ca_ = context.Operators.Convert<Code<RequestStatus>>(bz_);
+            CqlBoolean cb_ = context.Operators.Equal(ca_, "active");
+            CqlBoolean cc_ = cb_;
+            ResourceReference cd_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Focus;
+            CqlBoolean ce_ = QICoreCommon_4_0_000.Instance.references(context, cd_, tuple_yyidpxbnjhogfrjkyrbmgchb?.DeviceOrderReject);
+            CqlBoolean cf_ = ce_;
+            CodeableConcept cg_ = tuple_yyidpxbnjhogfrjkyrbmgchb?.T?.Code;
+            CqlConcept ch_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cg_);
+            CqlCode ci_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+            CqlConcept cj_ = context.Operators.ConvertCodeToConcept(ci_);
+            CqlBoolean ck_ = context.Operators.Equivalent(ch_, cj_);
+            CqlBoolean cl_ = ck_;
             return bx_
-                /* CQL 'and' (346:15-347:49) */ && by_()
-                /* CQL 'and' (346:15-348:54) */ && bz_()
-                /* CQL 'and' (346:9-349:45) */ && ca_();
+                /* CQL 'and' (346:15-347:49) */ && cc_
+                /* CQL 'and' (346:15-348:54) */ && cf_
+                /* CQL 'and' (346:9-349:45) */ && cl_;
         }
 
         IEnumerable<(CqlTupleMetadata, ServiceRequest DeviceOrderReject, Task T)?> aa_ = context.Operators.SelectWhere<ValueTuple<ServiceRequest, Task>, (CqlTupleMetadata, ServiceRequest DeviceOrderReject, Task T)?>(x_, y_, z_);
@@ -3319,23 +3095,19 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
                 CqlConcept g_ = NoVTEDevice?.requestStatusReason;
                 CqlValueSet h_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
                 CqlBoolean i_ = context.Operators.ConceptInValueSet(g_, h_);
-
-                CqlBoolean j_() {
-                    CqlDateTime k_ = NoVTEDevice?.authoredOn;
-                    CqlInterval<CqlDate> l_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
-                    CqlDate m_ = l_?.low;
-                    CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
-                    CqlDate o_ = l_?.high;
-                    CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
-                    CqlBoolean q_ = l_?.lowClosed;
-                    CqlBoolean r_ = l_?.highClosed;
-                    CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, p_, q_, r_);
-                    CqlBoolean t_ = context.Operators.In<CqlDateTime>(k_, s_, "day");
-                    return t_;
-                }
-
+                CqlDateTime j_ = NoVTEDevice?.authoredOn;
+                CqlInterval<CqlDate> k_ = this.fromDayOfStartOfHospitalizationToDayAfterFirstICU(context, QualifyingEncounterICU);
+                CqlDate l_ = k_?.low;
+                CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
+                CqlDate n_ = k_?.high;
+                CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
+                CqlBoolean p_ = k_?.lowClosed;
+                CqlBoolean q_ = k_?.highClosed;
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(m_, o_, p_, q_);
+                CqlBoolean s_ = context.Operators.In<CqlDateTime>(j_, r_, "day");
+                CqlBoolean t_ = s_;
                 return i_
-                    /* CQL 'and' (327:17-328:125) */ && j_();
+                    /* CQL 'and' (327:17-328:125) */ && t_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<(CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>(d_, e_);
@@ -3371,236 +3143,224 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             IEnumerable<CqlConcept> l_ = tuple_fpgtpszgoyfdaobujrgcsedde?.NoVTEMedication?.medicationStatusReason;
             CqlValueSet m_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
             CqlBoolean n_ = context.Operators.ConceptsInValueSet(l_, m_);
-
-            CqlBoolean o_() {
-                Code<EventStatus> r_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.StatusElement;
-                EventStatus? s_ = r_?.Value;
-                string t_ = context.Operators.Convert<string>(s_);
-                CqlBoolean u_ = context.Operators.Equal(t_, "completed");
-                return u_;
+            Code<EventStatus> o_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            CqlBoolean r_ = context.Operators.Equal(q_, "completed");
+            CqlBoolean s_ = r_;
+            object t_;
+            DataType bb_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
+            object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+            bool bd_ = bc_ is CqlDateTime;
+            if (bd_)
+            {
+                t_ = bc_ as CqlDateTime;
             }
-
-
-            CqlBoolean p_() {
-                object v_;
-                DataType ac_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                bool ae_ = ad_ is CqlDateTime;
-                if (ae_)
+            else
+            {
+                bool be_ = bc_ is CqlQuantity;
+                if (be_)
                 {
-                    v_ = ad_ as CqlDateTime;
+                    t_ = bc_ as CqlQuantity;
                 }
                 else
                 {
-                    bool af_ = ad_ is CqlQuantity;
-                    if (af_)
+                    bool bf_ = bc_ is CqlInterval<CqlDateTime>;
+                    if (bf_)
                     {
-                        v_ = ad_ as CqlQuantity;
+                        t_ = bc_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool bg_ = bc_ is CqlInterval<CqlQuantity>;
+                        if (bg_)
                         {
-                            v_ = ad_ as CqlInterval<CqlDateTime>;
+                            t_ = bc_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                            if (ah_)
-                            {
-                                v_ = ad_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                v_ = null;
-                            }
+                            t_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlDateTime y_ = this.startOfFirstICU(context, tuple_fpgtpszgoyfdaobujrgcsedde?.QualifyingEncounterICU);
-                CqlQuantity z_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime aa_ = context.Operators.Add(y_, z_);
-                CqlBoolean ab_ = context.Operators.SameAs(x_, aa_, "day");
-                return ab_;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ai_ = tuple_fpgtpszgoyfdaobujrgcsedde?.NoVTEMedication?.authoredOn;
-                object aj_;
-                DataType bh_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
-                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                bool bj_ = bi_ is CqlDateTime;
-                if (bj_)
-                {
-                    aj_ = bi_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bk_ = bi_ is CqlQuantity;
-                    if (bk_)
-                    {
-                        aj_ = bi_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bl_ = bi_ is CqlInterval<CqlDateTime>;
-                        if (bl_)
-                        {
-                            aj_ = bi_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bm_ = bi_ is CqlInterval<CqlQuantity>;
-                            if (bm_)
-                            {
-                                aj_ = bi_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                aj_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.End(ak_);
-                CqlInterval<CqlDate> am_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, al_);
-                CqlDate an_ = am_?.low;
-                CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
-                object ap_;
-                DataType bn_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
-                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                bool bp_ = bo_ is CqlDateTime;
-                if (bp_)
-                {
-                    ap_ = bo_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bq_ = bo_ is CqlQuantity;
-                    if (bq_)
-                    {
-                        ap_ = bo_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool br_ = bo_ is CqlInterval<CqlDateTime>;
-                        if (br_)
-                        {
-                            ap_ = bo_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bs_ = bo_ is CqlInterval<CqlQuantity>;
-                            if (bs_)
-                            {
-                                ap_ = bo_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ap_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
-                CqlDateTime ar_ = context.Operators.End(aq_);
-                CqlInterval<CqlDate> as_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ar_);
-                CqlDate at_ = as_?.high;
-                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
-                object av_;
-                DataType bt_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
-                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                bool bv_ = bu_ is CqlDateTime;
-                if (bv_)
-                {
-                    av_ = bu_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bw_ = bu_ is CqlQuantity;
-                    if (bw_)
-                    {
-                        av_ = bu_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bx_ = bu_ is CqlInterval<CqlDateTime>;
-                        if (bx_)
-                        {
-                            av_ = bu_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool by_ = bu_ is CqlInterval<CqlQuantity>;
-                            if (by_)
-                            {
-                                av_ = bu_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                av_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
-                CqlDateTime ax_ = context.Operators.End(aw_);
-                CqlInterval<CqlDate> ay_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ax_);
-                CqlBoolean az_ = ay_?.lowClosed;
-                object ba_;
-                DataType bz_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
-                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                bool cb_ = ca_ is CqlDateTime;
-                if (cb_)
-                {
-                    ba_ = ca_ as CqlDateTime;
-                }
-                else
-                {
-                    bool cc_ = ca_ is CqlQuantity;
-                    if (cc_)
-                    {
-                        ba_ = ca_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cd_ = ca_ is CqlInterval<CqlDateTime>;
-                        if (cd_)
-                        {
-                            ba_ = ca_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ce_ = ca_ is CqlInterval<CqlQuantity>;
-                            if (ce_)
-                            {
-                                ba_ = ca_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ba_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
-                CqlDateTime bc_ = context.Operators.End(bb_);
-                CqlInterval<CqlDate> bd_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bc_);
-                CqlBoolean be_ = bd_?.highClosed;
-                CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ao_, au_, az_, be_);
-                CqlBoolean bg_ = context.Operators.In<CqlDateTime>(ai_, bf_, "day");
-                return bg_;
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+            CqlDateTime v_ = context.Operators.End(u_);
+            CqlDateTime w_ = this.startOfFirstICU(context, tuple_fpgtpszgoyfdaobujrgcsedde?.QualifyingEncounterICU);
+            CqlQuantity x_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime y_ = context.Operators.Add(w_, x_);
+            CqlBoolean z_ = context.Operators.SameAs(v_, y_, "day");
+            CqlBoolean aa_ = z_;
+            CqlDateTime ab_ = tuple_fpgtpszgoyfdaobujrgcsedde?.NoVTEMedication?.authoredOn;
+            object ac_;
+            DataType bh_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
+            object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            bool bj_ = bi_ is CqlDateTime;
+            if (bj_)
+            {
+                ac_ = bi_ as CqlDateTime;
             }
-
+            else
+            {
+                bool bk_ = bi_ is CqlQuantity;
+                if (bk_)
+                {
+                    ac_ = bi_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bl_ = bi_ is CqlInterval<CqlDateTime>;
+                    if (bl_)
+                    {
+                        ac_ = bi_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bm_ = bi_ is CqlInterval<CqlQuantity>;
+                        if (bm_)
+                        {
+                            ac_ = bi_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ac_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+            CqlDateTime ae_ = context.Operators.End(ad_);
+            CqlInterval<CqlDate> af_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ae_);
+            CqlDate ag_ = af_?.low;
+            CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
+            object ai_;
+            DataType bn_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
+            object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+            bool bp_ = bo_ is CqlDateTime;
+            if (bp_)
+            {
+                ai_ = bo_ as CqlDateTime;
+            }
+            else
+            {
+                bool bq_ = bo_ is CqlQuantity;
+                if (bq_)
+                {
+                    ai_ = bo_ as CqlQuantity;
+                }
+                else
+                {
+                    bool br_ = bo_ is CqlInterval<CqlDateTime>;
+                    if (br_)
+                    {
+                        ai_ = bo_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bs_ = bo_ is CqlInterval<CqlQuantity>;
+                        if (bs_)
+                        {
+                            ai_ = bo_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ai_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+            CqlDateTime ak_ = context.Operators.End(aj_);
+            CqlInterval<CqlDate> al_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ak_);
+            CqlDate am_ = al_?.high;
+            CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+            object ao_;
+            DataType bt_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
+            object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+            bool bv_ = bu_ is CqlDateTime;
+            if (bv_)
+            {
+                ao_ = bu_ as CqlDateTime;
+            }
+            else
+            {
+                bool bw_ = bu_ is CqlQuantity;
+                if (bw_)
+                {
+                    ao_ = bu_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bx_ = bu_ is CqlInterval<CqlDateTime>;
+                    if (bx_)
+                    {
+                        ao_ = bu_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool by_ = bu_ is CqlInterval<CqlQuantity>;
+                        if (by_)
+                        {
+                            ao_ = bu_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ao_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+            CqlDateTime aq_ = context.Operators.End(ap_);
+            CqlInterval<CqlDate> ar_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aq_);
+            CqlBoolean as_ = ar_?.lowClosed;
+            object at_;
+            DataType bz_ = tuple_fpgtpszgoyfdaobujrgcsedde?.AnesthesiaProcedure?.Performed;
+            object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+            bool cb_ = ca_ is CqlDateTime;
+            if (cb_)
+            {
+                at_ = ca_ as CqlDateTime;
+            }
+            else
+            {
+                bool cc_ = ca_ is CqlQuantity;
+                if (cc_)
+                {
+                    at_ = ca_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cd_ = ca_ is CqlInterval<CqlDateTime>;
+                    if (cd_)
+                    {
+                        at_ = ca_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ce_ = ca_ is CqlInterval<CqlQuantity>;
+                        if (ce_)
+                        {
+                            at_ = ca_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            at_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
+            CqlDateTime av_ = context.Operators.End(au_);
+            CqlInterval<CqlDate> aw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, av_);
+            CqlBoolean ax_ = aw_?.highClosed;
+            CqlInterval<CqlDateTime> ay_ = context.Operators.Interval(ah_, an_, as_, ax_);
+            CqlBoolean az_ = context.Operators.In<CqlDateTime>(ab_, ay_, "day");
+            CqlBoolean ba_ = az_;
             return n_
-                /* CQL 'and' (372:11-373:50) */ && o_()
-                /* CQL 'and' (372:11-374:121) */ && p_()
-                /* CQL 'and' (372:5-375:134) */ && q_();
+                /* CQL 'and' (372:11-373:50) */ && s_
+                /* CQL 'and' (372:11-374:121) */ && aa_
+                /* CQL 'and' (372:5-375:134) */ && ba_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)?>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, IEnumerable<CqlConcept> medicationStatusReason, CqlDateTime authoredOn)? NoVTEMedication)?>(e_, f_, g_);
@@ -3634,236 +3394,224 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             CqlConcept l_ = tuple_fnrkedfurymcjidjkbtaenork?.NoVTEDevice?.requestStatusReason;
             CqlValueSet m_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
             CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
-
-            CqlBoolean o_() {
-                Code<EventStatus> r_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.StatusElement;
-                EventStatus? s_ = r_?.Value;
-                string t_ = context.Operators.Convert<string>(s_);
-                CqlBoolean u_ = context.Operators.Equal(t_, "completed");
-                return u_;
+            Code<EventStatus> o_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.StatusElement;
+            EventStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            CqlBoolean r_ = context.Operators.Equal(q_, "completed");
+            CqlBoolean s_ = r_;
+            object t_;
+            DataType bb_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
+            object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+            bool bd_ = bc_ is CqlDateTime;
+            if (bd_)
+            {
+                t_ = bc_ as CqlDateTime;
             }
-
-
-            CqlBoolean p_() {
-                object v_;
-                DataType ac_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                bool ae_ = ad_ is CqlDateTime;
-                if (ae_)
+            else
+            {
+                bool be_ = bc_ is CqlQuantity;
+                if (be_)
                 {
-                    v_ = ad_ as CqlDateTime;
+                    t_ = bc_ as CqlQuantity;
                 }
                 else
                 {
-                    bool af_ = ad_ is CqlQuantity;
-                    if (af_)
+                    bool bf_ = bc_ is CqlInterval<CqlDateTime>;
+                    if (bf_)
                     {
-                        v_ = ad_ as CqlQuantity;
+                        t_ = bc_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool bg_ = bc_ is CqlInterval<CqlQuantity>;
+                        if (bg_)
                         {
-                            v_ = ad_ as CqlInterval<CqlDateTime>;
+                            t_ = bc_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                            if (ah_)
-                            {
-                                v_ = ad_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                v_ = null;
-                            }
+                            t_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlDateTime y_ = this.startOfFirstICU(context, tuple_fnrkedfurymcjidjkbtaenork?.QualifyingEncounterICU);
-                CqlQuantity z_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime aa_ = context.Operators.Add(y_, z_);
-                CqlBoolean ab_ = context.Operators.SameAs(x_, aa_, "day");
-                return ab_;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ai_ = tuple_fnrkedfurymcjidjkbtaenork?.NoVTEDevice?.authoredOn;
-                object aj_;
-                DataType bh_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
-                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                bool bj_ = bi_ is CqlDateTime;
-                if (bj_)
-                {
-                    aj_ = bi_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bk_ = bi_ is CqlQuantity;
-                    if (bk_)
-                    {
-                        aj_ = bi_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bl_ = bi_ is CqlInterval<CqlDateTime>;
-                        if (bl_)
-                        {
-                            aj_ = bi_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bm_ = bi_ is CqlInterval<CqlQuantity>;
-                            if (bm_)
-                            {
-                                aj_ = bi_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                aj_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.End(ak_);
-                CqlInterval<CqlDate> am_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, al_);
-                CqlDate an_ = am_?.low;
-                CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
-                object ap_;
-                DataType bn_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
-                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                bool bp_ = bo_ is CqlDateTime;
-                if (bp_)
-                {
-                    ap_ = bo_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bq_ = bo_ is CqlQuantity;
-                    if (bq_)
-                    {
-                        ap_ = bo_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool br_ = bo_ is CqlInterval<CqlDateTime>;
-                        if (br_)
-                        {
-                            ap_ = bo_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bs_ = bo_ is CqlInterval<CqlQuantity>;
-                            if (bs_)
-                            {
-                                ap_ = bo_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ap_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
-                CqlDateTime ar_ = context.Operators.End(aq_);
-                CqlInterval<CqlDate> as_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ar_);
-                CqlDate at_ = as_?.high;
-                CqlDateTime au_ = context.Operators.ConvertDateToDateTime(at_);
-                object av_;
-                DataType bt_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
-                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                bool bv_ = bu_ is CqlDateTime;
-                if (bv_)
-                {
-                    av_ = bu_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bw_ = bu_ is CqlQuantity;
-                    if (bw_)
-                    {
-                        av_ = bu_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bx_ = bu_ is CqlInterval<CqlDateTime>;
-                        if (bx_)
-                        {
-                            av_ = bu_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool by_ = bu_ is CqlInterval<CqlQuantity>;
-                            if (by_)
-                            {
-                                av_ = bu_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                av_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
-                CqlDateTime ax_ = context.Operators.End(aw_);
-                CqlInterval<CqlDate> ay_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ax_);
-                CqlBoolean az_ = ay_?.lowClosed;
-                object ba_;
-                DataType bz_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
-                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                bool cb_ = ca_ is CqlDateTime;
-                if (cb_)
-                {
-                    ba_ = ca_ as CqlDateTime;
-                }
-                else
-                {
-                    bool cc_ = ca_ is CqlQuantity;
-                    if (cc_)
-                    {
-                        ba_ = ca_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool cd_ = ca_ is CqlInterval<CqlDateTime>;
-                        if (cd_)
-                        {
-                            ba_ = ca_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ce_ = ca_ is CqlInterval<CqlQuantity>;
-                            if (ce_)
-                            {
-                                ba_ = ca_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ba_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
-                CqlDateTime bc_ = context.Operators.End(bb_);
-                CqlInterval<CqlDate> bd_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, bc_);
-                CqlBoolean be_ = bd_?.highClosed;
-                CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(ao_, au_, az_, be_);
-                CqlBoolean bg_ = context.Operators.In<CqlDateTime>(ai_, bf_, "day");
-                return bg_;
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+            CqlDateTime v_ = context.Operators.End(u_);
+            CqlDateTime w_ = this.startOfFirstICU(context, tuple_fnrkedfurymcjidjkbtaenork?.QualifyingEncounterICU);
+            CqlQuantity x_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime y_ = context.Operators.Add(w_, x_);
+            CqlBoolean z_ = context.Operators.SameAs(v_, y_, "day");
+            CqlBoolean aa_ = z_;
+            CqlDateTime ab_ = tuple_fnrkedfurymcjidjkbtaenork?.NoVTEDevice?.authoredOn;
+            object ac_;
+            DataType bh_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
+            object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            bool bj_ = bi_ is CqlDateTime;
+            if (bj_)
+            {
+                ac_ = bi_ as CqlDateTime;
             }
-
+            else
+            {
+                bool bk_ = bi_ is CqlQuantity;
+                if (bk_)
+                {
+                    ac_ = bi_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bl_ = bi_ is CqlInterval<CqlDateTime>;
+                    if (bl_)
+                    {
+                        ac_ = bi_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bm_ = bi_ is CqlInterval<CqlQuantity>;
+                        if (bm_)
+                        {
+                            ac_ = bi_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ac_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+            CqlDateTime ae_ = context.Operators.End(ad_);
+            CqlInterval<CqlDate> af_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ae_);
+            CqlDate ag_ = af_?.low;
+            CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
+            object ai_;
+            DataType bn_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
+            object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+            bool bp_ = bo_ is CqlDateTime;
+            if (bp_)
+            {
+                ai_ = bo_ as CqlDateTime;
+            }
+            else
+            {
+                bool bq_ = bo_ is CqlQuantity;
+                if (bq_)
+                {
+                    ai_ = bo_ as CqlQuantity;
+                }
+                else
+                {
+                    bool br_ = bo_ is CqlInterval<CqlDateTime>;
+                    if (br_)
+                    {
+                        ai_ = bo_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bs_ = bo_ is CqlInterval<CqlQuantity>;
+                        if (bs_)
+                        {
+                            ai_ = bo_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ai_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+            CqlDateTime ak_ = context.Operators.End(aj_);
+            CqlInterval<CqlDate> al_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ak_);
+            CqlDate am_ = al_?.high;
+            CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+            object ao_;
+            DataType bt_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
+            object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+            bool bv_ = bu_ is CqlDateTime;
+            if (bv_)
+            {
+                ao_ = bu_ as CqlDateTime;
+            }
+            else
+            {
+                bool bw_ = bu_ is CqlQuantity;
+                if (bw_)
+                {
+                    ao_ = bu_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bx_ = bu_ is CqlInterval<CqlDateTime>;
+                    if (bx_)
+                    {
+                        ao_ = bu_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool by_ = bu_ is CqlInterval<CqlQuantity>;
+                        if (by_)
+                        {
+                            ao_ = bu_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ao_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+            CqlDateTime aq_ = context.Operators.End(ap_);
+            CqlInterval<CqlDate> ar_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aq_);
+            CqlBoolean as_ = ar_?.lowClosed;
+            object at_;
+            DataType bz_ = tuple_fnrkedfurymcjidjkbtaenork?.AnesthesiaProcedure?.Performed;
+            object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+            bool cb_ = ca_ is CqlDateTime;
+            if (cb_)
+            {
+                at_ = ca_ as CqlDateTime;
+            }
+            else
+            {
+                bool cc_ = ca_ is CqlQuantity;
+                if (cc_)
+                {
+                    at_ = ca_ as CqlQuantity;
+                }
+                else
+                {
+                    bool cd_ = ca_ is CqlInterval<CqlDateTime>;
+                    if (cd_)
+                    {
+                        at_ = ca_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ce_ = ca_ is CqlInterval<CqlQuantity>;
+                        if (ce_)
+                        {
+                            at_ = ca_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            at_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
+            CqlDateTime av_ = context.Operators.End(au_);
+            CqlInterval<CqlDate> aw_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, av_);
+            CqlBoolean ax_ = aw_?.highClosed;
+            CqlInterval<CqlDateTime> ay_ = context.Operators.Interval(ah_, an_, as_, ax_);
+            CqlBoolean az_ = context.Operators.In<CqlDateTime>(ab_, ay_, "day");
+            CqlBoolean ba_ = az_;
             return n_
-                /* CQL 'and' (383:11-384:50) */ && o_()
-                /* CQL 'and' (383:11-385:121) */ && p_()
-                /* CQL 'and' (383:5-386:130) */ && q_();
+                /* CQL 'and' (383:11-384:50) */ && s_
+                /* CQL 'and' (383:11-385:121) */ && aa_
+                /* CQL 'and' (383:5-386:130) */ && ba_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, (CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)?>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, (CqlTupleMetadata, string id, CqlConcept requestStatusReason, CqlDateTime authoredOn)? NoVTEDevice)?>(e_, f_, g_);
@@ -3988,226 +3736,218 @@ public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<
             EventStatus? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
             CqlBoolean o_ = context.Operators.Equal(n_, "completed");
-
-            CqlBoolean p_() {
-                object r_;
-                DataType y_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
-                {
-                    r_ = z_ as CqlDateTime;
-                }
-                else
-                {
-                    bool ab_ = z_ is CqlQuantity;
-                    if (ab_)
-                    {
-                        r_ = z_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool ac_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ac_)
-                        {
-                            r_ = z_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ad_ = z_ is CqlInterval<CqlQuantity>;
-                            if (ad_)
-                            {
-                                r_ = z_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                r_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlDateTime t_ = context.Operators.End(s_);
-                CqlDateTime u_ = this.startOfFirstICU(context, tuple_bvgardhyjgbgfxidntuflexa?.QualifyingEncounterICU);
-                CqlQuantity v_ = context.Operators.Quantity(1m, "day");
-                CqlDateTime w_ = context.Operators.Add(u_, v_);
-                CqlBoolean x_ = context.Operators.SameAs(t_, w_, "day");
-                return x_;
+            object p_;
+            DataType ax_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
+            object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+            bool az_ = ay_ is CqlDateTime;
+            if (az_)
+            {
+                p_ = ay_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                CqlDateTime ae_ = context.Operators.LateBoundProperty<CqlDateTime>(tuple_bvgardhyjgbgfxidntuflexa?.PatientRefusal, "authoredOn");
-                object af_;
-                DataType bd_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
-                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                bool bf_ = be_ is CqlDateTime;
-                if (bf_)
+            else
+            {
+                bool ba_ = ay_ is CqlQuantity;
+                if (ba_)
                 {
-                    af_ = be_ as CqlDateTime;
+                    p_ = ay_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bg_ = be_ is CqlQuantity;
-                    if (bg_)
+                    bool bb_ = ay_ is CqlInterval<CqlDateTime>;
+                    if (bb_)
                     {
-                        af_ = be_ as CqlQuantity;
+                        p_ = ay_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bh_ = be_ is CqlInterval<CqlDateTime>;
-                        if (bh_)
+                        bool bc_ = ay_ is CqlInterval<CqlQuantity>;
+                        if (bc_)
                         {
-                            af_ = be_ as CqlInterval<CqlDateTime>;
+                            p_ = ay_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bi_ = be_ is CqlInterval<CqlQuantity>;
-                            if (bi_)
-                            {
-                                af_ = be_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                af_ = null;
-                            }
+                            p_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                CqlDateTime ah_ = context.Operators.End(ag_);
-                CqlInterval<CqlDate> ai_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ah_);
-                CqlDate aj_ = ai_?.low;
-                CqlDateTime ak_ = context.Operators.ConvertDateToDateTime(aj_);
-                object al_;
-                DataType bj_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                bool bl_ = bk_ is CqlDateTime;
-                if (bl_)
-                {
-                    al_ = bk_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bm_ = bk_ is CqlQuantity;
-                    if (bm_)
-                    {
-                        al_ = bk_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bn_ = bk_ is CqlInterval<CqlDateTime>;
-                        if (bn_)
-                        {
-                            al_ = bk_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bo_ = bk_ is CqlInterval<CqlQuantity>;
-                            if (bo_)
-                            {
-                                al_ = bk_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                al_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                CqlDateTime an_ = context.Operators.End(am_);
-                CqlInterval<CqlDate> ao_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, an_);
-                CqlDate ap_ = ao_?.high;
-                CqlDateTime aq_ = context.Operators.ConvertDateToDateTime(ap_);
-                object ar_;
-                DataType bp_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
-                {
-                    ar_ = bq_ as CqlDateTime;
-                }
-                else
-                {
-                    bool bs_ = bq_ is CqlQuantity;
-                    if (bs_)
-                    {
-                        ar_ = bq_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bt_)
-                        {
-                            ar_ = bq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
-                            if (bu_)
-                            {
-                                ar_ = bq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ar_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                CqlDateTime at_ = context.Operators.End(as_);
-                CqlInterval<CqlDate> au_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, at_);
-                CqlBoolean av_ = au_?.lowClosed;
-                object aw_;
-                DataType bv_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
-                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                bool bx_ = bw_ is CqlDateTime;
-                if (bx_)
-                {
-                    aw_ = bw_ as CqlDateTime;
-                }
-                else
-                {
-                    bool by_ = bw_ is CqlQuantity;
-                    if (by_)
-                    {
-                        aw_ = bw_ as CqlQuantity;
-                    }
-                    else
-                    {
-                        bool bz_ = bw_ is CqlInterval<CqlDateTime>;
-                        if (bz_)
-                        {
-                            aw_ = bw_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bool ca_ = bw_ is CqlInterval<CqlQuantity>;
-                            if (ca_)
-                            {
-                                aw_ = bw_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                aw_ = null;
-                            }
-                        }
-                    }
-                }
-                CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_);
-                CqlDateTime ay_ = context.Operators.End(ax_);
-                CqlInterval<CqlDate> az_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ay_);
-                CqlBoolean ba_ = az_?.highClosed;
-                CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ak_, aq_, av_, ba_);
-                CqlBoolean bc_ = context.Operators.In<CqlDateTime>(ae_, bb_, "day");
-                return bc_;
             }
-
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.End(q_);
+            CqlDateTime s_ = this.startOfFirstICU(context, tuple_bvgardhyjgbgfxidntuflexa?.QualifyingEncounterICU);
+            CqlQuantity t_ = context.Operators.Quantity(1m, "day");
+            CqlDateTime u_ = context.Operators.Add(s_, t_);
+            CqlBoolean v_ = context.Operators.SameAs(r_, u_, "day");
+            CqlBoolean w_ = v_;
+            CqlDateTime x_ = context.Operators.LateBoundProperty<CqlDateTime>(tuple_bvgardhyjgbgfxidntuflexa?.PatientRefusal, "authoredOn");
+            object y_;
+            DataType bd_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            bool bf_ = be_ is CqlDateTime;
+            if (bf_)
+            {
+                y_ = be_ as CqlDateTime;
+            }
+            else
+            {
+                bool bg_ = be_ is CqlQuantity;
+                if (bg_)
+                {
+                    y_ = be_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bh_ = be_ is CqlInterval<CqlDateTime>;
+                    if (bh_)
+                    {
+                        y_ = be_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bi_ = be_ is CqlInterval<CqlQuantity>;
+                        if (bi_)
+                        {
+                            y_ = be_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            y_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+            CqlDateTime aa_ = context.Operators.End(z_);
+            CqlInterval<CqlDate> ab_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aa_);
+            CqlDate ac_ = ab_?.low;
+            CqlDateTime ad_ = context.Operators.ConvertDateToDateTime(ac_);
+            object ae_;
+            DataType bj_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
+            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+            bool bl_ = bk_ is CqlDateTime;
+            if (bl_)
+            {
+                ae_ = bk_ as CqlDateTime;
+            }
+            else
+            {
+                bool bm_ = bk_ is CqlQuantity;
+                if (bm_)
+                {
+                    ae_ = bk_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bn_ = bk_ is CqlInterval<CqlDateTime>;
+                    if (bn_)
+                    {
+                        ae_ = bk_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bo_ = bk_ is CqlInterval<CqlQuantity>;
+                        if (bo_)
+                        {
+                            ae_ = bk_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ae_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+            CqlDateTime ag_ = context.Operators.End(af_);
+            CqlInterval<CqlDate> ah_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ag_);
+            CqlDate ai_ = ah_?.high;
+            CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
+            object ak_;
+            DataType bp_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
+            object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            bool br_ = bq_ is CqlDateTime;
+            if (br_)
+            {
+                ak_ = bq_ as CqlDateTime;
+            }
+            else
+            {
+                bool bs_ = bq_ is CqlQuantity;
+                if (bs_)
+                {
+                    ak_ = bq_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bt_ = bq_ is CqlInterval<CqlDateTime>;
+                    if (bt_)
+                    {
+                        ak_ = bq_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool bu_ = bq_ is CqlInterval<CqlQuantity>;
+                        if (bu_)
+                        {
+                            ak_ = bq_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ak_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
+            CqlDateTime am_ = context.Operators.End(al_);
+            CqlInterval<CqlDate> an_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, am_);
+            CqlBoolean ao_ = an_?.lowClosed;
+            object ap_;
+            DataType bv_ = tuple_bvgardhyjgbgfxidntuflexa?.AnesthesiaProcedure?.Performed;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            bool bx_ = bw_ is CqlDateTime;
+            if (bx_)
+            {
+                ap_ = bw_ as CqlDateTime;
+            }
+            else
+            {
+                bool by_ = bw_ is CqlQuantity;
+                if (by_)
+                {
+                    ap_ = bw_ as CqlQuantity;
+                }
+                else
+                {
+                    bool bz_ = bw_ is CqlInterval<CqlDateTime>;
+                    if (bz_)
+                    {
+                        ap_ = bw_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bool ca_ = bw_ is CqlInterval<CqlQuantity>;
+                        if (ca_)
+                        {
+                            ap_ = bw_ as CqlInterval<CqlQuantity>;
+                        }
+                        else
+                        {
+                            ap_ = null;
+                        }
+                    }
+                }
+            }
+            CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
+            CqlDateTime ar_ = context.Operators.End(aq_);
+            CqlInterval<CqlDate> as_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ar_);
+            CqlBoolean at_ = as_?.highClosed;
+            CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ad_, aj_, ao_, at_);
+            CqlBoolean av_ = context.Operators.In<CqlDateTime>(x_, au_, "day");
+            CqlBoolean aw_ = av_;
             return o_
-                /* CQL 'and' (403:11-404:121) */ && p_()
-                /* CQL 'and' (403:5-405:133) */ && q_();
+                /* CQL 'and' (403:11-404:121) */ && w_
+                /* CQL 'and' (403:5-405:133) */ && aw_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object PatientRefusal)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Procedure, object>, (CqlTupleMetadata, Encounter QualifyingEncounterICU, Procedure AnesthesiaProcedure, object PatientRefusal)?>(e_, f_, g_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS22FHIRPCSBPScreeningFollowUp", "1.0.000")]
 public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingleton<CMS22FHIRPCSBPScreeningFollowUp_1_0_000>
 {
@@ -186,27 +186,19 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> l_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? m_ = l_?.Value;
-                Code<Encounter.EncounterStatus> n_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(m_);
-                CqlBoolean o_ = context.Operators.Equivalent(n_, "finished");
-                return o_;
-            }
-
-
-            CqlBoolean k_() {
-                Coding p_ = ValidEncounter?.Class;
-                CqlCode q_ = FHIRHelpers_4_4_000.Instance.ToCode(context, p_);
-                CqlCode r_ = this.@virtual(context);
-                CqlBoolean s_ = context.Operators.Equivalent(q_, r_);
-                return !s_;
-            }
-
+            Code<Encounter.EncounterStatus> j_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? k_ = j_?.Value;
+            Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
+            CqlBoolean m_ = context.Operators.Equivalent(l_, "finished");
+            CqlBoolean n_ = m_;
+            Coding o_ = ValidEncounter?.Class;
+            CqlCode p_ = FHIRHelpers_4_4_000.Instance.ToCode(context, o_);
+            CqlCode q_ = this.@virtual(context);
+            CqlBoolean r_ = context.Operators.Equivalent(p_, q_);
+            CqlBoolean s_ = (CqlBoolean)!r_;
             return i_
-                /* CQL 'and' (145:11-146:44) */ && j_()
-                /* CQL 'and' (145:5-147:43) */ && k_();
+                /* CQL 'and' (145:11-146:44) */ && n_
+                /* CQL 'and' (145:5-147:43) */ && s_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -261,51 +253,27 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (408:54-409:66) */ || i_()
-                /* CQL 'or' (408:54-410:66) */ || j_()
-                /* CQL 'or' (408:52-412:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (408:54-409:66) */ || i_
+            /* CQL 'or' (408:54-410:66) */ || m_
+            /* CQL 'or' (408:52-412:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (408:3-412:3) */ || c_();
+            /* CQL 'implies' (408:3-412:3) */ || r_;
     }
 
 
@@ -366,39 +334,35 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
 
             bool? e_(Observation BloodPressure) {
-                DataType u_ = BloodPressure?.Effective;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                Period y_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                CqlBoolean aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ac_ = BloodPressure?.StatusElement;
-                    ObservationStatus? ad_ = ac_?.Value;
-                    string ae_ = context.Operators.Convert<string>(ad_);
-                    string[] af_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                    return ag_;
-                }
-
-                return aa_
-                    /* CQL 'and' (164:9-165:73) */ && ab_();
+                DataType ai_ = BloodPressure?.Effective;
+                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
+                CqlDateTime al_ = context.Operators.End(ak_);
+                Period am_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
+                CqlBoolean ao_ = context.Operators.In<CqlDateTime>(al_, an_, "day");
+                Code<ObservationStatus> ap_ = BloodPressure?.StatusElement;
+                ObservationStatus? aq_ = ap_?.Value;
+                string ar_ = context.Operators.Convert<string>(aq_);
+                string[] as_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean at_ = context.Operators.In<string>(ar_, (IEnumerable<string>)as_);
+                CqlBoolean au_ = at_;
+                return ao_
+                    /* CQL 'and' (164:9-165:73) */ && au_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 
             object g_(Observation @this) {
-                DataType ah_ = @this?.Effective;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                CqlDateTime ak_ = context.Operators.Start(aj_);
-                return ak_;
+                DataType av_ = @this?.Effective;
+                object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                return ay_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
@@ -406,12 +370,12 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             List<Observation.ComponentComponent> j_ = i_?.Component;
 
             bool? k_(Observation.ComponentComponent C) {
-                CodeableConcept al_ = C?.Code;
-                CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, al_);
-                CqlCode an_ = this.Systolic_blood_pressure(context);
-                CqlConcept ao_ = context.Operators.ConvertCodeToConcept(an_);
-                CqlBoolean ap_ = context.Operators.Equivalent(am_, ao_);
-                return ap_;
+                CodeableConcept az_ = C?.Code;
+                CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
+                CqlCode bb_ = this.Systolic_blood_pressure(context);
+                CqlConcept bc_ = context.Operators.ConvertCodeToConcept(bb_);
+                CqlBoolean bd_ = context.Operators.Equivalent(ba_, bc_);
+                return bd_;
             }
 
             IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
@@ -423,71 +387,61 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, false);
             CqlBoolean s_ = context.Operators.In<CqlQuantity>(o_ as CqlQuantity, r_, (string)default);
 
-            CqlBoolean t_() {
-                IEnumerable<Observation> aq_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? ar_(Observation BloodPressure) {
-                    DataType bg_ = BloodPressure?.Effective;
-                    object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                    CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
-                    CqlDateTime bj_ = context.Operators.End(bi_);
-                    Period bk_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
-                    CqlBoolean bm_ = context.Operators.In<CqlDateTime>(bj_, bl_, "day");
-
-                    CqlBoolean bn_() {
-                        Code<ObservationStatus> bo_ = BloodPressure?.StatusElement;
-                        ObservationStatus? bp_ = bo_?.Value;
-                        string bq_ = context.Operators.Convert<string>(bp_);
-                        string[] br_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
-                        return bs_;
-                    }
-
-                    return bm_
-                        /* CQL 'and' (164:9-165:73) */ && bn_();
-                }
-
-                IEnumerable<Observation> as_ = context.Operators.Where<Observation>(aq_, ar_);
-
-                object at_(Observation @this) {
-                    DataType bt_ = @this?.Effective;
-                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                    CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_);
-                    CqlDateTime bw_ = context.Operators.Start(bv_);
-                    return bw_;
-                }
-
-                IEnumerable<Observation> au_ = context.Operators.SortBy<Observation>(as_, at_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation av_ = context.Operators.Last<Observation>(au_);
-                List<Observation.ComponentComponent> aw_ = av_?.Component;
-
-                bool? ax_(Observation.ComponentComponent C) {
-                    CodeableConcept bx_ = C?.Code;
-                    CqlConcept by_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bx_);
-                    CqlCode bz_ = this.Diastolic_blood_pressure(context);
-                    CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
-                    CqlBoolean cb_ = context.Operators.Equivalent(by_, ca_);
-                    return cb_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> ay_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aw_, ax_);
-                Observation.ComponentComponent az_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ay_);
-                DataType ba_ = az_?.Value;
-                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                CqlQuantity bc_ = context.Operators.Quantity(1m, "mm[Hg]");
-                CqlQuantity bd_ = context.Operators.Quantity(80m, "mm[Hg]");
-                CqlInterval<CqlQuantity> be_ = context.Operators.Interval(bc_, bd_, true, false);
-                CqlBoolean bf_ = context.Operators.In<CqlQuantity>(bb_ as CqlQuantity, be_, (string)default);
-                return bf_;
+            bool? t_(Observation BloodPressure) {
+                DataType be_ = BloodPressure?.Effective;
+                object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+                CqlInterval<CqlDateTime> bg_ = QICoreCommon_4_0_000.Instance.toInterval(context, bf_);
+                CqlDateTime bh_ = context.Operators.End(bg_);
+                Period bi_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bi_);
+                CqlBoolean bk_ = context.Operators.In<CqlDateTime>(bh_, bj_, "day");
+                Code<ObservationStatus> bl_ = BloodPressure?.StatusElement;
+                ObservationStatus? bm_ = bl_?.Value;
+                string bn_ = context.Operators.Convert<string>(bm_);
+                string[] bo_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bp_ = context.Operators.In<string>(bn_, (IEnumerable<string>)bo_);
+                CqlBoolean bq_ = bp_;
+                return bk_
+                    /* CQL 'and' (164:9-165:73) */ && bq_;
             }
 
+            IEnumerable<Observation> u_ = context.Operators.Where<Observation>(d_, t_);
+
+            object v_(Observation @this) {
+                DataType br_ = @this?.Effective;
+                object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+                CqlInterval<CqlDateTime> bt_ = QICoreCommon_4_0_000.Instance.toInterval(context, bs_);
+                CqlDateTime bu_ = context.Operators.Start(bt_);
+                return bu_;
+            }
+
+            IEnumerable<Observation> w_ = context.Operators.SortBy<Observation>(u_, v_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation x_ = context.Operators.Last<Observation>(w_);
+            List<Observation.ComponentComponent> y_ = x_?.Component;
+
+            bool? z_(Observation.ComponentComponent C) {
+                CodeableConcept bv_ = C?.Code;
+                CqlConcept bw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bv_);
+                CqlCode bx_ = this.Diastolic_blood_pressure(context);
+                CqlConcept by_ = context.Operators.ConvertCodeToConcept(bx_);
+                CqlBoolean bz_ = context.Operators.Equivalent(bw_, by_);
+                return bz_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> aa_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)y_, z_);
+            Observation.ComponentComponent ab_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(aa_);
+            DataType ac_ = ab_?.Value;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            CqlQuantity ae_ = context.Operators.Quantity(80m, "mm[Hg]");
+            CqlInterval<CqlQuantity> af_ = context.Operators.Interval(p_, ae_, true, false);
+            CqlBoolean ag_ = context.Operators.In<CqlQuantity>(ad_ as CqlQuantity, af_, (string)default);
+            CqlBoolean ah_ = ag_;
             return s_
-                /* CQL 'and' (168:5-175:51) */ && t_();
+                /* CQL 'and' (168:5-175:51) */ && ah_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -509,39 +463,35 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
 
             bool? e_(Observation BloodPressure) {
-                DataType u_ = BloodPressure?.Effective;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                Period y_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                CqlBoolean aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ac_ = BloodPressure?.StatusElement;
-                    ObservationStatus? ad_ = ac_?.Value;
-                    string ae_ = context.Operators.Convert<string>(ad_);
-                    string[] af_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                    return ag_;
-                }
-
-                return aa_
-                    /* CQL 'and' (180:9-181:73) */ && ab_();
+                DataType aj_ = BloodPressure?.Effective;
+                object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
+                CqlDateTime am_ = context.Operators.End(al_);
+                Period an_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlBoolean ap_ = context.Operators.In<CqlDateTime>(am_, ao_, "day");
+                Code<ObservationStatus> aq_ = BloodPressure?.StatusElement;
+                ObservationStatus? ar_ = aq_?.Value;
+                string as_ = context.Operators.Convert<string>(ar_);
+                string[] at_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
+                CqlBoolean av_ = au_;
+                return ap_
+                    /* CQL 'and' (180:9-181:73) */ && av_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 
             object g_(Observation @this) {
-                DataType ah_ = @this?.Effective;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                CqlDateTime ak_ = context.Operators.Start(aj_);
-                return ak_;
+                DataType aw_ = @this?.Effective;
+                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+                return az_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
@@ -549,12 +499,12 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             List<Observation.ComponentComponent> j_ = i_?.Component;
 
             bool? k_(Observation.ComponentComponent C) {
-                CodeableConcept al_ = C?.Code;
-                CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, al_);
-                CqlCode an_ = this.Systolic_blood_pressure(context);
-                CqlConcept ao_ = context.Operators.ConvertCodeToConcept(an_);
-                CqlBoolean ap_ = context.Operators.Equivalent(am_, ao_);
-                return ap_;
+                CodeableConcept ba_ = C?.Code;
+                CqlConcept bb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ba_);
+                CqlCode bc_ = this.Systolic_blood_pressure(context);
+                CqlConcept bd_ = context.Operators.ConvertCodeToConcept(bc_);
+                CqlBoolean be_ = context.Operators.Equivalent(bb_, bd_);
+                return be_;
             }
 
             IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
@@ -566,71 +516,62 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
             CqlBoolean s_ = context.Operators.In<CqlQuantity>(o_ as CqlQuantity, r_, (string)default);
 
-            CqlBoolean t_() {
-                IEnumerable<Observation> aq_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? ar_(Observation BloodPressure) {
-                    DataType bg_ = BloodPressure?.Effective;
-                    object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                    CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
-                    CqlDateTime bj_ = context.Operators.End(bi_);
-                    Period bk_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
-                    CqlBoolean bm_ = context.Operators.In<CqlDateTime>(bj_, bl_, "day");
-
-                    CqlBoolean bn_() {
-                        Code<ObservationStatus> bo_ = BloodPressure?.StatusElement;
-                        ObservationStatus? bp_ = bo_?.Value;
-                        string bq_ = context.Operators.Convert<string>(bp_);
-                        string[] br_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
-                        return bs_;
-                    }
-
-                    return bm_
-                        /* CQL 'and' (180:9-181:73) */ && bn_();
-                }
-
-                IEnumerable<Observation> as_ = context.Operators.Where<Observation>(aq_, ar_);
-
-                object at_(Observation @this) {
-                    DataType bt_ = @this?.Effective;
-                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                    CqlInterval<CqlDateTime> bv_ = QICoreCommon_4_0_000.Instance.toInterval(context, bu_);
-                    CqlDateTime bw_ = context.Operators.Start(bv_);
-                    return bw_;
-                }
-
-                IEnumerable<Observation> au_ = context.Operators.SortBy<Observation>(as_, at_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation av_ = context.Operators.Last<Observation>(au_);
-                List<Observation.ComponentComponent> aw_ = av_?.Component;
-
-                bool? ax_(Observation.ComponentComponent C) {
-                    CodeableConcept bx_ = C?.Code;
-                    CqlConcept by_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bx_);
-                    CqlCode bz_ = this.Diastolic_blood_pressure(context);
-                    CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
-                    CqlBoolean cb_ = context.Operators.Equivalent(by_, ca_);
-                    return cb_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> ay_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aw_, ax_);
-                Observation.ComponentComponent az_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ay_);
-                DataType ba_ = az_?.Value;
-                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                CqlQuantity bc_ = context.Operators.Quantity(1m, "mm[Hg]");
-                CqlQuantity bd_ = context.Operators.Quantity(80m, "mm[Hg]");
-                CqlInterval<CqlQuantity> be_ = context.Operators.Interval(bc_, bd_, true, false);
-                CqlBoolean bf_ = context.Operators.In<CqlQuantity>(bb_ as CqlQuantity, be_, (string)default);
-                return bf_;
+            bool? t_(Observation BloodPressure) {
+                DataType bf_ = BloodPressure?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                CqlInterval<CqlDateTime> bh_ = QICoreCommon_4_0_000.Instance.toInterval(context, bg_);
+                CqlDateTime bi_ = context.Operators.End(bh_);
+                Period bj_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bj_);
+                CqlBoolean bl_ = context.Operators.In<CqlDateTime>(bi_, bk_, "day");
+                Code<ObservationStatus> bm_ = BloodPressure?.StatusElement;
+                ObservationStatus? bn_ = bm_?.Value;
+                string bo_ = context.Operators.Convert<string>(bn_);
+                string[] bp_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bq_ = context.Operators.In<string>(bo_, (IEnumerable<string>)bp_);
+                CqlBoolean br_ = bq_;
+                return bl_
+                    /* CQL 'and' (180:9-181:73) */ && br_;
             }
 
+            IEnumerable<Observation> u_ = context.Operators.Where<Observation>(d_, t_);
+
+            object v_(Observation @this) {
+                DataType bs_ = @this?.Effective;
+                object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+                CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, bt_);
+                CqlDateTime bv_ = context.Operators.Start(bu_);
+                return bv_;
+            }
+
+            IEnumerable<Observation> w_ = context.Operators.SortBy<Observation>(u_, v_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation x_ = context.Operators.Last<Observation>(w_);
+            List<Observation.ComponentComponent> y_ = x_?.Component;
+
+            bool? z_(Observation.ComponentComponent C) {
+                CodeableConcept bw_ = C?.Code;
+                CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
+                CqlCode by_ = this.Diastolic_blood_pressure(context);
+                CqlConcept bz_ = context.Operators.ConvertCodeToConcept(by_);
+                CqlBoolean ca_ = context.Operators.Equivalent(bx_, bz_);
+                return ca_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> aa_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)y_, z_);
+            Observation.ComponentComponent ab_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(aa_);
+            DataType ac_ = ab_?.Value;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            CqlQuantity ae_ = context.Operators.Quantity(1m, "mm[Hg]");
+            CqlQuantity af_ = context.Operators.Quantity(80m, "mm[Hg]");
+            CqlInterval<CqlQuantity> ag_ = context.Operators.Interval(ae_, af_, true, false);
+            CqlBoolean ah_ = context.Operators.In<CqlQuantity>(ad_ as CqlQuantity, ag_, (string)default);
+            CqlBoolean ai_ = ah_;
             return s_
-                /* CQL 'and' (184:5-192:5) */ && t_();
+                /* CQL 'and' (184:5-192:5) */ && ai_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -721,32 +662,28 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             List<CodeableConcept> e_ = Referral?.ReasonCode;
 
             CqlConcept f_(CodeableConcept @this) {
-                CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return k_;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return q_;
             }
 
             IEnumerable<CqlConcept> g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
             CqlValueSet h_ = this.Finding_of_Elevated_Blood_Pressure_or_Hypertension(context);
             CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
-
-            CqlBoolean j_() {
-                Code<RequestIntent> l_ = Referral?.IntentElement;
-                RequestIntent? m_ = l_?.Value;
-                Code<RequestIntent> n_ = context.Operators.Convert<Code<RequestIntent>>(m_);
-                string o_ = context.Operators.Convert<string>(n_);
-                string[] p_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
-                return q_;
-            }
-
+            Code<RequestIntent> j_ = Referral?.IntentElement;
+            RequestIntent? k_ = j_?.Value;
+            Code<RequestIntent> l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
+            string m_ = context.Operators.Convert<string>(l_);
+            string[] n_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
+            CqlBoolean p_ = o_;
             return i_
-                /* CQL 'and' (118:5-119:108) */ && j_();
+                /* CQL 'and' (118:5-119:108) */ && p_;
         }
 
         IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
@@ -836,52 +773,41 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<Observation> d_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
 
             bool? e_(Observation BloodPressure) {
-                DataType t_ = BloodPressure?.Effective;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                CqlDateTime w_ = context.Operators.End(v_);
-                Period x_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
-                CqlDateTime z_ = context.Operators.Start(y_);
-                CqlQuantity aa_ = context.Operators.Quantity(1m, "year");
-                CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
-                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(ab_, z_, true, true);
-                CqlBoolean ad_ = context.Operators.In<CqlDateTime>(w_, ac_, (string)default);
-
-                CqlBoolean ae_() {
-                    Period ag_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                    CqlDateTime ai_ = context.Operators.Start(ah_);
-                    return ai_ is not null;
-                }
-
-
-                CqlBoolean af_() {
-                    Code<ObservationStatus> aj_ = BloodPressure?.StatusElement;
-                    ObservationStatus? ak_ = aj_?.Value;
-                    string al_ = context.Operators.Convert<string>(ak_);
-                    string[] am_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
-                    return an_;
-                }
-
-                return ad_
-                    /* CQL 'and' (285:17-285:121) */ && ae_()
-                    /* CQL 'and' (285:11-286:75) */ && af_();
+                DataType bg_ = BloodPressure?.Effective;
+                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
+                CqlDateTime bj_ = context.Operators.End(bi_);
+                Period bk_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bk_);
+                CqlDateTime bm_ = context.Operators.Start(bl_);
+                CqlQuantity bn_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime bo_ = context.Operators.Subtract(bm_, bn_);
+                CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bo_, bm_, true, true);
+                CqlBoolean bq_ = context.Operators.In<CqlDateTime>(bj_, bp_, (string)default);
+                CqlBoolean br_ = (CqlBoolean)(bm_ is not null);
+                Code<ObservationStatus> bs_ = BloodPressure?.StatusElement;
+                ObservationStatus? bt_ = bs_?.Value;
+                string bu_ = context.Operators.Convert<string>(bt_);
+                string[] bv_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
+                CqlBoolean bx_ = bw_;
+                return bq_
+                    /* CQL 'and' (285:17-285:121) */ && br_
+                    /* CQL 'and' (285:11-286:75) */ && bx_;
             }
 
             IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 
             object g_(Observation @this) {
-                DataType ao_ = @this?.Effective;
-                object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
-                CqlDateTime ar_ = context.Operators.Start(aq_);
-                return ar_;
+                DataType by_ = @this?.Effective;
+                object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
+                CqlInterval<CqlDateTime> ca_ = QICoreCommon_4_0_000.Instance.toInterval(context, bz_);
+                CqlDateTime cb_ = context.Operators.Start(ca_);
+                return cb_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
@@ -889,12 +815,12 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             List<Observation.ComponentComponent> j_ = i_?.Component;
 
             bool? k_(Observation.ComponentComponent C) {
-                CodeableConcept as_ = C?.Code;
-                CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, as_);
-                CqlCode au_ = this.Systolic_blood_pressure(context);
-                CqlConcept av_ = context.Operators.ConvertCodeToConcept(au_);
-                CqlBoolean aw_ = context.Operators.Equivalent(at_, av_);
-                return aw_;
+                CodeableConcept cc_ = C?.Code;
+                CqlConcept cd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cc_);
+                CqlCode ce_ = this.Systolic_blood_pressure(context);
+                CqlConcept cf_ = context.Operators.ConvertCodeToConcept(ce_);
+                CqlBoolean cg_ = context.Operators.Equivalent(cd_, cf_);
+                return cg_;
             }
 
             IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
@@ -904,234 +830,185 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             CqlQuantity p_ = context.Operators.Quantity(0m, "mm[Hg]");
             CqlBoolean q_ = context.Operators.Greater(o_ as CqlQuantity, p_);
 
-            CqlBoolean r_() {
-                IEnumerable<Observation> ax_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? ay_(Observation BloodPressure) {
-                    DataType bl_ = BloodPressure?.Effective;
-                    object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-                    CqlInterval<CqlDateTime> bn_ = QICoreCommon_4_0_000.Instance.toInterval(context, bm_);
-                    CqlDateTime bo_ = context.Operators.End(bn_);
-                    Period bp_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bp_);
-                    CqlDateTime br_ = context.Operators.Start(bq_);
-                    CqlQuantity bs_ = context.Operators.Quantity(1m, "year");
-                    CqlDateTime bt_ = context.Operators.Subtract(br_, bs_);
-                    CqlInterval<CqlDateTime> bu_ = context.Operators.Interval(bt_, br_, true, true);
-                    CqlBoolean bv_ = context.Operators.In<CqlDateTime>(bo_, bu_, (string)default);
-
-                    CqlBoolean bw_() {
-                        Period by_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, by_);
-                        CqlDateTime ca_ = context.Operators.Start(bz_);
-                        return ca_ is not null;
-                    }
-
-
-                    CqlBoolean bx_() {
-                        Code<ObservationStatus> cb_ = BloodPressure?.StatusElement;
-                        ObservationStatus? cc_ = cb_?.Value;
-                        string cd_ = context.Operators.Convert<string>(cc_);
-                        string[] ce_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean cf_ = context.Operators.In<string>(cd_, (IEnumerable<string>)ce_);
-                        return cf_;
-                    }
-
-                    return bv_
-                        /* CQL 'and' (285:17-285:121) */ && bw_()
-                        /* CQL 'and' (285:11-286:75) */ && bx_();
-                }
-
-                IEnumerable<Observation> az_ = context.Operators.Where<Observation>(ax_, ay_);
-
-                object ba_(Observation @this) {
-                    DataType cg_ = @this?.Effective;
-                    object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
-                    CqlInterval<CqlDateTime> ci_ = QICoreCommon_4_0_000.Instance.toInterval(context, ch_);
-                    CqlDateTime cj_ = context.Operators.Start(ci_);
-                    return cj_;
-                }
-
-                IEnumerable<Observation> bb_ = context.Operators.SortBy<Observation>(az_, ba_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation bc_ = context.Operators.Last<Observation>(bb_);
-                List<Observation.ComponentComponent> bd_ = bc_?.Component;
-
-                bool? be_(Observation.ComponentComponent C) {
-                    CodeableConcept ck_ = C?.Code;
-                    CqlConcept cl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ck_);
-                    CqlCode cm_ = this.Diastolic_blood_pressure(context);
-                    CqlConcept cn_ = context.Operators.ConvertCodeToConcept(cm_);
-                    CqlBoolean co_ = context.Operators.Equivalent(cl_, cn_);
-                    return co_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> bf_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)bd_, be_);
-                Observation.ComponentComponent bg_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bf_);
-                DataType bh_ = bg_?.Value;
-                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                CqlQuantity bj_ = context.Operators.Quantity(0m, "mm[Hg]");
-                CqlBoolean bk_ = context.Operators.Greater(bi_ as CqlQuantity, bj_);
-                return bk_;
+            bool? r_(Observation BloodPressure) {
+                DataType ch_ = BloodPressure?.Effective;
+                object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                CqlInterval<CqlDateTime> cj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ci_);
+                CqlDateTime ck_ = context.Operators.End(cj_);
+                Period cl_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cl_);
+                CqlDateTime cn_ = context.Operators.Start(cm_);
+                CqlQuantity co_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime cp_ = context.Operators.Subtract(cn_, co_);
+                CqlInterval<CqlDateTime> cq_ = context.Operators.Interval(cp_, cn_, true, true);
+                CqlBoolean cr_ = context.Operators.In<CqlDateTime>(ck_, cq_, (string)default);
+                CqlBoolean cs_ = (CqlBoolean)(cn_ is not null);
+                Code<ObservationStatus> ct_ = BloodPressure?.StatusElement;
+                ObservationStatus? cu_ = ct_?.Value;
+                string cv_ = context.Operators.Convert<string>(cu_);
+                string[] cw_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean cx_ = context.Operators.In<string>(cv_, (IEnumerable<string>)cw_);
+                CqlBoolean cy_ = cx_;
+                return cr_
+                    /* CQL 'and' (285:17-285:121) */ && cs_
+                    /* CQL 'and' (285:11-286:75) */ && cy_;
             }
 
+            IEnumerable<Observation> s_ = context.Operators.Where<Observation>(d_, r_);
 
-            CqlBoolean s_() {
-                IEnumerable<Observation> cp_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? cq_(Observation BloodPressure) {
-                    DataType de_ = BloodPressure?.Effective;
-                    object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
-                    CqlInterval<CqlDateTime> dg_ = QICoreCommon_4_0_000.Instance.toInterval(context, df_);
-                    CqlDateTime dh_ = context.Operators.End(dg_);
-                    Period di_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> dj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, di_);
-                    CqlDateTime dk_ = context.Operators.Start(dj_);
-                    CqlQuantity dl_ = context.Operators.Quantity(1m, "year");
-                    CqlDateTime dm_ = context.Operators.Subtract(dk_, dl_);
-                    CqlInterval<CqlDateTime> dn_ = context.Operators.Interval(dm_, dk_, true, true);
-                    CqlBoolean do_ = context.Operators.In<CqlDateTime>(dh_, dn_, (string)default);
-
-                    CqlBoolean dp_() {
-                        Period dr_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> ds_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dr_);
-                        CqlDateTime dt_ = context.Operators.Start(ds_);
-                        return dt_ is not null;
-                    }
-
-
-                    CqlBoolean dq_() {
-                        Code<ObservationStatus> du_ = BloodPressure?.StatusElement;
-                        ObservationStatus? dv_ = du_?.Value;
-                        string dw_ = context.Operators.Convert<string>(dv_);
-                        string[] dx_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean dy_ = context.Operators.In<string>(dw_, (IEnumerable<string>)dx_);
-                        return dy_;
-                    }
-
-                    return do_
-                        /* CQL 'and' (285:17-285:121) */ && dp_()
-                        /* CQL 'and' (285:11-286:75) */ && dq_();
-                }
-
-                IEnumerable<Observation> cr_ = context.Operators.Where<Observation>(cp_, cq_);
-
-                object cs_(Observation @this) {
-                    DataType dz_ = @this?.Effective;
-                    object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
-                    CqlInterval<CqlDateTime> eb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ea_);
-                    CqlDateTime ec_ = context.Operators.Start(eb_);
-                    return ec_;
-                }
-
-                IEnumerable<Observation> ct_ = context.Operators.SortBy<Observation>(cr_, cs_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation cu_ = context.Operators.Last<Observation>(ct_);
-                List<Observation.ComponentComponent> cv_ = cu_?.Component;
-
-                bool? cw_(Observation.ComponentComponent C) {
-                    CodeableConcept ed_ = C?.Code;
-                    CqlConcept ee_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ed_);
-                    CqlCode ef_ = this.Systolic_blood_pressure(context);
-                    CqlConcept eg_ = context.Operators.ConvertCodeToConcept(ef_);
-                    CqlBoolean eh_ = context.Operators.Equivalent(ee_, eg_);
-                    return eh_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> cx_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)cv_, cw_);
-                Observation.ComponentComponent cy_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(cx_);
-                DataType cz_ = cy_?.Value;
+            object t_(Observation @this) {
+                DataType cz_ = @this?.Effective;
                 object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
-                CqlQuantity db_ = context.Operators.Quantity(130m, "mm[Hg]");
-                CqlBoolean dc_ = context.Operators.GreaterOrEqual(da_ as CqlQuantity, db_);
-
-                CqlBoolean dd_() {
-                    IEnumerable<Observation> ei_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                    bool? ej_(Observation BloodPressure) {
-                        DataType ew_ = BloodPressure?.Effective;
-                        object ex_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ew_);
-                        CqlInterval<CqlDateTime> ey_ = QICoreCommon_4_0_000.Instance.toInterval(context, ex_);
-                        CqlDateTime ez_ = context.Operators.End(ey_);
-                        Period fa_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> fb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fa_);
-                        CqlDateTime fc_ = context.Operators.Start(fb_);
-                        CqlQuantity fd_ = context.Operators.Quantity(1m, "year");
-                        CqlDateTime fe_ = context.Operators.Subtract(fc_, fd_);
-                        CqlInterval<CqlDateTime> ff_ = context.Operators.Interval(fe_, fc_, true, true);
-                        CqlBoolean fg_ = context.Operators.In<CqlDateTime>(ez_, ff_, (string)default);
-
-                        CqlBoolean fh_() {
-                            Period fj_ = QualifyingEncounter?.Period;
-                            CqlInterval<CqlDateTime> fk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fj_);
-                            CqlDateTime fl_ = context.Operators.Start(fk_);
-                            return fl_ is not null;
-                        }
-
-
-                        CqlBoolean fi_() {
-                            Code<ObservationStatus> fm_ = BloodPressure?.StatusElement;
-                            ObservationStatus? fn_ = fm_?.Value;
-                            string fo_ = context.Operators.Convert<string>(fn_);
-                            string[] fp_ = [
-                                "final",
-                                "amended",
-                                "corrected",
-                            ];
-                            CqlBoolean fq_ = context.Operators.In<string>(fo_, (IEnumerable<string>)fp_);
-                            return fq_;
-                        }
-
-                        return fg_
-                            /* CQL 'and' (285:17-285:121) */ && fh_()
-                            /* CQL 'and' (285:11-286:75) */ && fi_();
-                    }
-
-                    IEnumerable<Observation> ek_ = context.Operators.Where<Observation>(ei_, ej_);
-
-                    object el_(Observation @this) {
-                        DataType fr_ = @this?.Effective;
-                        object fs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fr_);
-                        CqlInterval<CqlDateTime> ft_ = QICoreCommon_4_0_000.Instance.toInterval(context, fs_);
-                        CqlDateTime fu_ = context.Operators.Start(ft_);
-                        return fu_;
-                    }
-
-                    IEnumerable<Observation> em_ = context.Operators.SortBy<Observation>(ek_, el_, System.ComponentModel.ListSortDirection.Ascending);
-                    Observation en_ = context.Operators.Last<Observation>(em_);
-                    List<Observation.ComponentComponent> eo_ = en_?.Component;
-
-                    bool? ep_(Observation.ComponentComponent C) {
-                        CodeableConcept fv_ = C?.Code;
-                        CqlConcept fw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, fv_);
-                        CqlCode fx_ = this.Diastolic_blood_pressure(context);
-                        CqlConcept fy_ = context.Operators.ConvertCodeToConcept(fx_);
-                        CqlBoolean fz_ = context.Operators.Equivalent(fw_, fy_);
-                        return fz_;
-                    }
-
-                    IEnumerable<Observation.ComponentComponent> eq_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)eo_, ep_);
-                    Observation.ComponentComponent er_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(eq_);
-                    DataType es_ = er_?.Value;
-                    object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
-                    CqlQuantity eu_ = context.Operators.Quantity(80m, "mm[Hg]");
-                    CqlBoolean ev_ = context.Operators.GreaterOrEqual(et_ as CqlQuantity, eu_);
-                    return ev_;
-                }
-
-                return dc_
-                    /* CQL 'or' (297:15-305:11) */ || dd_();
+                CqlInterval<CqlDateTime> db_ = QICoreCommon_4_0_000.Instance.toInterval(context, da_);
+                CqlDateTime dc_ = context.Operators.Start(db_);
+                return dc_;
             }
 
+            IEnumerable<Observation> u_ = context.Operators.SortBy<Observation>(s_, t_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation v_ = context.Operators.Last<Observation>(u_);
+            List<Observation.ComponentComponent> w_ = v_?.Component;
+
+            bool? x_(Observation.ComponentComponent C) {
+                CodeableConcept dd_ = C?.Code;
+                CqlConcept de_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dd_);
+                CqlCode df_ = this.Diastolic_blood_pressure(context);
+                CqlConcept dg_ = context.Operators.ConvertCodeToConcept(df_);
+                CqlBoolean dh_ = context.Operators.Equivalent(de_, dg_);
+                return dh_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> y_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)w_, x_);
+            Observation.ComponentComponent z_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(y_);
+            DataType aa_ = z_?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = context.Operators.Greater(ab_ as CqlQuantity, p_);
+            CqlBoolean ad_ = ac_;
+
+            bool? ae_(Observation BloodPressure) {
+                DataType di_ = BloodPressure?.Effective;
+                object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+                CqlInterval<CqlDateTime> dk_ = QICoreCommon_4_0_000.Instance.toInterval(context, dj_);
+                CqlDateTime dl_ = context.Operators.End(dk_);
+                Period dm_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dm_);
+                CqlDateTime do_ = context.Operators.Start(dn_);
+                CqlQuantity dp_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime dq_ = context.Operators.Subtract(do_, dp_);
+                CqlInterval<CqlDateTime> dr_ = context.Operators.Interval(dq_, do_, true, true);
+                CqlBoolean ds_ = context.Operators.In<CqlDateTime>(dl_, dr_, (string)default);
+                CqlBoolean dt_ = (CqlBoolean)(do_ is not null);
+                Code<ObservationStatus> du_ = BloodPressure?.StatusElement;
+                ObservationStatus? dv_ = du_?.Value;
+                string dw_ = context.Operators.Convert<string>(dv_);
+                string[] dx_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean dy_ = context.Operators.In<string>(dw_, (IEnumerable<string>)dx_);
+                CqlBoolean dz_ = dy_;
+                return ds_
+                    /* CQL 'and' (285:17-285:121) */ && dt_
+                    /* CQL 'and' (285:11-286:75) */ && dz_;
+            }
+
+            IEnumerable<Observation> af_ = context.Operators.Where<Observation>(d_, ae_);
+
+            object ag_(Observation @this) {
+                DataType ea_ = @this?.Effective;
+                object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
+                CqlInterval<CqlDateTime> ec_ = QICoreCommon_4_0_000.Instance.toInterval(context, eb_);
+                CqlDateTime ed_ = context.Operators.Start(ec_);
+                return ed_;
+            }
+
+            IEnumerable<Observation> ah_ = context.Operators.SortBy<Observation>(af_, ag_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ai_ = context.Operators.Last<Observation>(ah_);
+            List<Observation.ComponentComponent> aj_ = ai_?.Component;
+
+            bool? ak_(Observation.ComponentComponent C) {
+                CodeableConcept ee_ = C?.Code;
+                CqlConcept ef_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ee_);
+                CqlCode eg_ = this.Systolic_blood_pressure(context);
+                CqlConcept eh_ = context.Operators.ConvertCodeToConcept(eg_);
+                CqlBoolean ei_ = context.Operators.Equivalent(ef_, eh_);
+                return ei_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> al_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aj_, ak_);
+            Observation.ComponentComponent am_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(al_);
+            DataType an_ = am_?.Value;
+            object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+            CqlQuantity ap_ = context.Operators.Quantity(130m, "mm[Hg]");
+            CqlBoolean aq_ = context.Operators.GreaterOrEqual(ao_ as CqlQuantity, ap_);
+
+            bool? ar_(Observation BloodPressure) {
+                DataType ej_ = BloodPressure?.Effective;
+                object ek_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ej_);
+                CqlInterval<CqlDateTime> el_ = QICoreCommon_4_0_000.Instance.toInterval(context, ek_);
+                CqlDateTime em_ = context.Operators.End(el_);
+                Period en_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> eo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, en_);
+                CqlDateTime ep_ = context.Operators.Start(eo_);
+                CqlQuantity eq_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime er_ = context.Operators.Subtract(ep_, eq_);
+                CqlInterval<CqlDateTime> es_ = context.Operators.Interval(er_, ep_, true, true);
+                CqlBoolean et_ = context.Operators.In<CqlDateTime>(em_, es_, (string)default);
+                CqlBoolean eu_ = (CqlBoolean)(ep_ is not null);
+                Code<ObservationStatus> ev_ = BloodPressure?.StatusElement;
+                ObservationStatus? ew_ = ev_?.Value;
+                string ex_ = context.Operators.Convert<string>(ew_);
+                string[] ey_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ez_ = context.Operators.In<string>(ex_, (IEnumerable<string>)ey_);
+                CqlBoolean fa_ = ez_;
+                return et_
+                    /* CQL 'and' (285:17-285:121) */ && eu_
+                    /* CQL 'and' (285:11-286:75) */ && fa_;
+            }
+
+            IEnumerable<Observation> as_ = context.Operators.Where<Observation>(d_, ar_);
+
+            object at_(Observation @this) {
+                DataType fb_ = @this?.Effective;
+                object fc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fb_);
+                CqlInterval<CqlDateTime> fd_ = QICoreCommon_4_0_000.Instance.toInterval(context, fc_);
+                CqlDateTime fe_ = context.Operators.Start(fd_);
+                return fe_;
+            }
+
+            IEnumerable<Observation> au_ = context.Operators.SortBy<Observation>(as_, at_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation av_ = context.Operators.Last<Observation>(au_);
+            List<Observation.ComponentComponent> aw_ = av_?.Component;
+
+            bool? ax_(Observation.ComponentComponent C) {
+                CodeableConcept ff_ = C?.Code;
+                CqlConcept fg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ff_);
+                CqlCode fh_ = this.Diastolic_blood_pressure(context);
+                CqlConcept fi_ = context.Operators.ConvertCodeToConcept(fh_);
+                CqlBoolean fj_ = context.Operators.Equivalent(fg_, fi_);
+                return fj_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> ay_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aw_, ax_);
+            Observation.ComponentComponent az_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ay_);
+            DataType ba_ = az_?.Value;
+            object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+            CqlQuantity bc_ = context.Operators.Quantity(80m, "mm[Hg]");
+            CqlBoolean bd_ = context.Operators.GreaterOrEqual(bb_ as CqlQuantity, bc_);
+            CqlBoolean be_ = bd_;
+            CqlBoolean bf_ = aq_
+                /* CQL 'or' (297:15-305:11) */ || be_;
             return q_
-                /* CQL 'and' (289:15-296:30) */ && r_()
-                /* CQL 'and' (289:7-306:7) */ && s_();
+                /* CQL 'and' (289:15-296:30) */ && ad_
+                /* CQL 'and' (289:7-306:7) */ && bf_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1153,39 +1030,35 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
 
             bool? g_(Observation BloodPressure) {
-                DataType v_ = BloodPressure?.Effective;
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                CqlDateTime y_ = context.Operators.End(x_);
-                Period z_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(y_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Code<ObservationStatus> ad_ = BloodPressure?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-                return ab_
-                    /* CQL 'and' (256:11-257:75) */ && ac_();
+                DataType bi_ = BloodPressure?.Effective;
+                object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
+                CqlDateTime bl_ = context.Operators.End(bk_);
+                Period bm_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
+                CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bl_, bn_, "day");
+                Code<ObservationStatus> bp_ = BloodPressure?.StatusElement;
+                ObservationStatus? bq_ = bp_?.Value;
+                string br_ = context.Operators.Convert<string>(bq_);
+                string[] bs_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
+                CqlBoolean bu_ = bt_;
+                return bo_
+                    /* CQL 'and' (256:11-257:75) */ && bu_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 
             object i_(Observation @this) {
-                DataType ai_ = @this?.Effective;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.Start(ak_);
-                return al_;
+                DataType bv_ = @this?.Effective;
+                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                CqlInterval<CqlDateTime> bx_ = QICoreCommon_4_0_000.Instance.toInterval(context, bw_);
+                CqlDateTime by_ = context.Operators.Start(bx_);
+                return by_;
             }
 
             IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1193,12 +1066,12 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             List<Observation.ComponentComponent> l_ = k_?.Component;
 
             bool? m_(Observation.ComponentComponent C) {
-                CodeableConcept am_ = C?.Code;
-                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
-                CqlCode ao_ = this.Systolic_blood_pressure(context);
-                CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
-                CqlBoolean aq_ = context.Operators.Equivalent(an_, ap_);
-                return aq_;
+                CodeableConcept bz_ = C?.Code;
+                CqlConcept ca_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bz_);
+                CqlCode cb_ = this.Systolic_blood_pressure(context);
+                CqlConcept cc_ = context.Operators.ConvertCodeToConcept(cb_);
+                CqlBoolean cd_ = context.Operators.Equivalent(ca_, cc_);
+                return cd_;
             }
 
             IEnumerable<Observation.ComponentComponent> n_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)l_, m_);
@@ -1208,195 +1081,167 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             CqlQuantity r_ = context.Operators.Quantity(0m, "mm[Hg]");
             CqlBoolean s_ = context.Operators.Greater(q_ as CqlQuantity, r_);
 
-            CqlBoolean t_() {
-                IEnumerable<Observation> ar_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? as_(Observation BloodPressure) {
-                    DataType bf_ = BloodPressure?.Effective;
-                    object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                    CqlInterval<CqlDateTime> bh_ = QICoreCommon_4_0_000.Instance.toInterval(context, bg_);
-                    CqlDateTime bi_ = context.Operators.End(bh_);
-                    Period bj_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bj_);
-                    CqlBoolean bl_ = context.Operators.In<CqlDateTime>(bi_, bk_, "day");
-
-                    CqlBoolean bm_() {
-                        Code<ObservationStatus> bn_ = BloodPressure?.StatusElement;
-                        ObservationStatus? bo_ = bn_?.Value;
-                        string bp_ = context.Operators.Convert<string>(bo_);
-                        string[] bq_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
-                        return br_;
-                    }
-
-                    return bl_
-                        /* CQL 'and' (256:11-257:75) */ && bm_();
-                }
-
-                IEnumerable<Observation> at_ = context.Operators.Where<Observation>(ar_, as_);
-
-                object au_(Observation @this) {
-                    DataType bs_ = @this?.Effective;
-                    object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                    CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, bt_);
-                    CqlDateTime bv_ = context.Operators.Start(bu_);
-                    return bv_;
-                }
-
-                IEnumerable<Observation> av_ = context.Operators.SortBy<Observation>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation aw_ = context.Operators.Last<Observation>(av_);
-                List<Observation.ComponentComponent> ax_ = aw_?.Component;
-
-                bool? ay_(Observation.ComponentComponent C) {
-                    CodeableConcept bw_ = C?.Code;
-                    CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
-                    CqlCode by_ = this.Diastolic_blood_pressure(context);
-                    CqlConcept bz_ = context.Operators.ConvertCodeToConcept(by_);
-                    CqlBoolean ca_ = context.Operators.Equivalent(bx_, bz_);
-                    return ca_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> az_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ax_, ay_);
-                Observation.ComponentComponent ba_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(az_);
-                DataType bb_ = ba_?.Value;
-                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                CqlQuantity bd_ = context.Operators.Quantity(0m, "mm[Hg]");
-                CqlBoolean be_ = context.Operators.Greater(bc_ as CqlQuantity, bd_);
-                return be_;
+            bool? t_(Observation BloodPressure) {
+                DataType ce_ = BloodPressure?.Effective;
+                object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                CqlInterval<CqlDateTime> cg_ = QICoreCommon_4_0_000.Instance.toInterval(context, cf_);
+                CqlDateTime ch_ = context.Operators.End(cg_);
+                Period ci_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ci_);
+                CqlBoolean ck_ = context.Operators.In<CqlDateTime>(ch_, cj_, "day");
+                Code<ObservationStatus> cl_ = BloodPressure?.StatusElement;
+                ObservationStatus? cm_ = cl_?.Value;
+                string cn_ = context.Operators.Convert<string>(cm_);
+                string[] co_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean cp_ = context.Operators.In<string>(cn_, (IEnumerable<string>)co_);
+                CqlBoolean cq_ = cp_;
+                return ck_
+                    /* CQL 'and' (256:11-257:75) */ && cq_;
             }
 
+            IEnumerable<Observation> u_ = context.Operators.Where<Observation>(f_, t_);
 
-            CqlBoolean u_() {
-                IEnumerable<Observation> cb_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? cc_(Observation BloodPressure) {
-                    DataType cq_ = BloodPressure?.Effective;
-                    object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                    CqlInterval<CqlDateTime> cs_ = QICoreCommon_4_0_000.Instance.toInterval(context, cr_);
-                    CqlDateTime ct_ = context.Operators.End(cs_);
-                    Period cu_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> cv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cu_);
-                    CqlBoolean cw_ = context.Operators.In<CqlDateTime>(ct_, cv_, "day");
-
-                    CqlBoolean cx_() {
-                        Code<ObservationStatus> cy_ = BloodPressure?.StatusElement;
-                        ObservationStatus? cz_ = cy_?.Value;
-                        string da_ = context.Operators.Convert<string>(cz_);
-                        string[] db_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean dc_ = context.Operators.In<string>(da_, (IEnumerable<string>)db_);
-                        return dc_;
-                    }
-
-                    return cw_
-                        /* CQL 'and' (256:11-257:75) */ && cx_();
-                }
-
-                IEnumerable<Observation> cd_ = context.Operators.Where<Observation>(cb_, cc_);
-
-                object ce_(Observation @this) {
-                    DataType dd_ = @this?.Effective;
-                    object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
-                    CqlInterval<CqlDateTime> df_ = QICoreCommon_4_0_000.Instance.toInterval(context, de_);
-                    CqlDateTime dg_ = context.Operators.Start(df_);
-                    return dg_;
-                }
-
-                IEnumerable<Observation> cf_ = context.Operators.SortBy<Observation>(cd_, ce_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation cg_ = context.Operators.Last<Observation>(cf_);
-                List<Observation.ComponentComponent> ch_ = cg_?.Component;
-
-                bool? ci_(Observation.ComponentComponent C) {
-                    CodeableConcept dh_ = C?.Code;
-                    CqlConcept di_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dh_);
-                    CqlCode dj_ = this.Systolic_blood_pressure(context);
-                    CqlConcept dk_ = context.Operators.ConvertCodeToConcept(dj_);
-                    CqlBoolean dl_ = context.Operators.Equivalent(di_, dk_);
-                    return dl_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> cj_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ch_, ci_);
-                Observation.ComponentComponent ck_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(cj_);
-                DataType cl_ = ck_?.Value;
-                object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                CqlQuantity cn_ = context.Operators.Quantity(130m, "mm[Hg]");
-                CqlBoolean co_ = context.Operators.GreaterOrEqual(cm_ as CqlQuantity, cn_);
-
-                CqlBoolean cp_() {
-                    IEnumerable<Observation> dm_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                    bool? dn_(Observation BloodPressure) {
-                        DataType ea_ = BloodPressure?.Effective;
-                        object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                        CqlInterval<CqlDateTime> ec_ = QICoreCommon_4_0_000.Instance.toInterval(context, eb_);
-                        CqlDateTime ed_ = context.Operators.End(ec_);
-                        Period ee_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ee_);
-                        CqlBoolean eg_ = context.Operators.In<CqlDateTime>(ed_, ef_, "day");
-
-                        CqlBoolean eh_() {
-                            Code<ObservationStatus> ei_ = BloodPressure?.StatusElement;
-                            ObservationStatus? ej_ = ei_?.Value;
-                            string ek_ = context.Operators.Convert<string>(ej_);
-                            string[] el_ = [
-                                "final",
-                                "amended",
-                                "corrected",
-                            ];
-                            CqlBoolean em_ = context.Operators.In<string>(ek_, (IEnumerable<string>)el_);
-                            return em_;
-                        }
-
-                        return eg_
-                            /* CQL 'and' (256:11-257:75) */ && eh_();
-                    }
-
-                    IEnumerable<Observation> do_ = context.Operators.Where<Observation>(dm_, dn_);
-
-                    object dp_(Observation @this) {
-                        DataType en_ = @this?.Effective;
-                        object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
-                        CqlInterval<CqlDateTime> ep_ = QICoreCommon_4_0_000.Instance.toInterval(context, eo_);
-                        CqlDateTime eq_ = context.Operators.Start(ep_);
-                        return eq_;
-                    }
-
-                    IEnumerable<Observation> dq_ = context.Operators.SortBy<Observation>(do_, dp_, System.ComponentModel.ListSortDirection.Ascending);
-                    Observation dr_ = context.Operators.Last<Observation>(dq_);
-                    List<Observation.ComponentComponent> ds_ = dr_?.Component;
-
-                    bool? dt_(Observation.ComponentComponent C) {
-                        CodeableConcept er_ = C?.Code;
-                        CqlConcept es_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, er_);
-                        CqlCode et_ = this.Diastolic_blood_pressure(context);
-                        CqlConcept eu_ = context.Operators.ConvertCodeToConcept(et_);
-                        CqlBoolean ev_ = context.Operators.Equivalent(es_, eu_);
-                        return ev_;
-                    }
-
-                    IEnumerable<Observation.ComponentComponent> du_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ds_, dt_);
-                    Observation.ComponentComponent dv_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(du_);
-                    DataType dw_ = dv_?.Value;
-                    object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                    CqlQuantity dy_ = context.Operators.Quantity(80m, "mm[Hg]");
-                    CqlBoolean dz_ = context.Operators.GreaterOrEqual(dx_ as CqlQuantity, dy_);
-                    return dz_;
-                }
-
-                return co_
-                    /* CQL 'or' (269:15-277:11) */ || cp_();
+            object v_(Observation @this) {
+                DataType cr_ = @this?.Effective;
+                object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+                CqlInterval<CqlDateTime> ct_ = QICoreCommon_4_0_000.Instance.toInterval(context, cs_);
+                CqlDateTime cu_ = context.Operators.Start(ct_);
+                return cu_;
             }
 
+            IEnumerable<Observation> w_ = context.Operators.SortBy<Observation>(u_, v_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation x_ = context.Operators.Last<Observation>(w_);
+            List<Observation.ComponentComponent> y_ = x_?.Component;
+
+            bool? z_(Observation.ComponentComponent C) {
+                CodeableConcept cv_ = C?.Code;
+                CqlConcept cw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cv_);
+                CqlCode cx_ = this.Diastolic_blood_pressure(context);
+                CqlConcept cy_ = context.Operators.ConvertCodeToConcept(cx_);
+                CqlBoolean cz_ = context.Operators.Equivalent(cw_, cy_);
+                return cz_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> aa_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)y_, z_);
+            Observation.ComponentComponent ab_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(aa_);
+            DataType ac_ = ab_?.Value;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            CqlBoolean ae_ = context.Operators.Greater(ad_ as CqlQuantity, r_);
+            CqlBoolean af_ = ae_;
+
+            bool? ag_(Observation BloodPressure) {
+                DataType da_ = BloodPressure?.Effective;
+                object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
+                CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_);
+                CqlDateTime dd_ = context.Operators.End(dc_);
+                Period de_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, de_);
+                CqlBoolean dg_ = context.Operators.In<CqlDateTime>(dd_, df_, "day");
+                Code<ObservationStatus> dh_ = BloodPressure?.StatusElement;
+                ObservationStatus? di_ = dh_?.Value;
+                string dj_ = context.Operators.Convert<string>(di_);
+                string[] dk_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean dl_ = context.Operators.In<string>(dj_, (IEnumerable<string>)dk_);
+                CqlBoolean dm_ = dl_;
+                return dg_
+                    /* CQL 'and' (256:11-257:75) */ && dm_;
+            }
+
+            IEnumerable<Observation> ah_ = context.Operators.Where<Observation>(f_, ag_);
+
+            object ai_(Observation @this) {
+                DataType dn_ = @this?.Effective;
+                object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+                CqlInterval<CqlDateTime> dp_ = QICoreCommon_4_0_000.Instance.toInterval(context, do_);
+                CqlDateTime dq_ = context.Operators.Start(dp_);
+                return dq_;
+            }
+
+            IEnumerable<Observation> aj_ = context.Operators.SortBy<Observation>(ah_, ai_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ak_ = context.Operators.Last<Observation>(aj_);
+            List<Observation.ComponentComponent> al_ = ak_?.Component;
+
+            bool? am_(Observation.ComponentComponent C) {
+                CodeableConcept dr_ = C?.Code;
+                CqlConcept ds_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dr_);
+                CqlCode dt_ = this.Systolic_blood_pressure(context);
+                CqlConcept du_ = context.Operators.ConvertCodeToConcept(dt_);
+                CqlBoolean dv_ = context.Operators.Equivalent(ds_, du_);
+                return dv_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> an_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)al_, am_);
+            Observation.ComponentComponent ao_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(an_);
+            DataType ap_ = ao_?.Value;
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+            CqlQuantity ar_ = context.Operators.Quantity(130m, "mm[Hg]");
+            CqlBoolean as_ = context.Operators.GreaterOrEqual(aq_ as CqlQuantity, ar_);
+
+            bool? at_(Observation BloodPressure) {
+                DataType dw_ = BloodPressure?.Effective;
+                object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                CqlInterval<CqlDateTime> dy_ = QICoreCommon_4_0_000.Instance.toInterval(context, dx_);
+                CqlDateTime dz_ = context.Operators.End(dy_);
+                Period ea_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> eb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ea_);
+                CqlBoolean ec_ = context.Operators.In<CqlDateTime>(dz_, eb_, "day");
+                Code<ObservationStatus> ed_ = BloodPressure?.StatusElement;
+                ObservationStatus? ee_ = ed_?.Value;
+                string ef_ = context.Operators.Convert<string>(ee_);
+                string[] eg_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean eh_ = context.Operators.In<string>(ef_, (IEnumerable<string>)eg_);
+                CqlBoolean ei_ = eh_;
+                return ec_
+                    /* CQL 'and' (256:11-257:75) */ && ei_;
+            }
+
+            IEnumerable<Observation> au_ = context.Operators.Where<Observation>(f_, at_);
+
+            object av_(Observation @this) {
+                DataType ej_ = @this?.Effective;
+                object ek_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ej_);
+                CqlInterval<CqlDateTime> el_ = QICoreCommon_4_0_000.Instance.toInterval(context, ek_);
+                CqlDateTime em_ = context.Operators.Start(el_);
+                return em_;
+            }
+
+            IEnumerable<Observation> aw_ = context.Operators.SortBy<Observation>(au_, av_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ax_ = context.Operators.Last<Observation>(aw_);
+            List<Observation.ComponentComponent> ay_ = ax_?.Component;
+
+            bool? az_(Observation.ComponentComponent C) {
+                CodeableConcept en_ = C?.Code;
+                CqlConcept eo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, en_);
+                CqlCode ep_ = this.Diastolic_blood_pressure(context);
+                CqlConcept eq_ = context.Operators.ConvertCodeToConcept(ep_);
+                CqlBoolean er_ = context.Operators.Equivalent(eo_, eq_);
+                return er_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> ba_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ay_, az_);
+            Observation.ComponentComponent bb_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ba_);
+            DataType bc_ = bb_?.Value;
+            object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+            CqlQuantity be_ = context.Operators.Quantity(80m, "mm[Hg]");
+            CqlBoolean bf_ = context.Operators.GreaterOrEqual(bd_ as CqlQuantity, be_);
+            CqlBoolean bg_ = bf_;
+            CqlBoolean bh_ = as_
+                /* CQL 'or' (269:15-277:11) */ || bg_;
             return s_
-                /* CQL 'and' (260:15-268:9) */ && t_()
-                /* CQL 'and' (260:7-278:7) */ && u_();
+                /* CQL 'and' (260:15-268:9) */ && af_
+                /* CQL 'and' (260:7-278:7) */ && bh_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1425,35 +1270,26 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
                 CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
                 CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
-
-                CqlBoolean n_() {
-                    FhirDateTime p_ = NonPharmInterventionsHTN?.AuthoredOnElement;
-                    CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                    CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
-                    CqlBoolean s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
-                    return s_;
-                }
-
-
-                CqlBoolean o_() {
-                    Code<RequestIntent> t_ = FourWeekRescreen?.IntentElement;
-                    RequestIntent? u_ = t_?.Value;
-                    Code<RequestIntent> v_ = context.Operators.Convert<Code<RequestIntent>>(u_);
-                    string w_ = context.Operators.Convert<string>(v_);
-                    string[] x_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-                    return y_;
-                }
-
+                FhirDateTime n_ = NonPharmInterventionsHTN?.AuthoredOnElement;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                CqlBoolean p_ = context.Operators.In<CqlDateTime>(o_, l_, "day");
+                CqlBoolean q_ = p_;
+                Code<RequestIntent> r_ = FourWeekRescreen?.IntentElement;
+                RequestIntent? s_ = r_?.Value;
+                Code<RequestIntent> t_ = context.Operators.Convert<Code<RequestIntent>>(s_);
+                string u_ = context.Operators.Convert<string>(t_);
+                string[] v_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
+                CqlBoolean x_ = w_;
                 return m_
-                    /* CQL 'and' (110:19-111:84) */ && n_()
-                    /* CQL 'and' (110:19-112:120) */ && o_();
+                    /* CQL 'and' (110:19-111:84) */ && q_
+                    /* CQL 'and' (110:19-112:120) */ && x_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<ServiceRequest>(g_, h_);
@@ -1512,39 +1348,35 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
 
             bool? g_(Observation BloodPressure) {
-                DataType x_ = BloodPressure?.Effective;
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
-                CqlDateTime aa_ = context.Operators.End(z_);
-                Period ab_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                CqlBoolean ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, "day");
-
-                CqlBoolean ae_() {
-                    Code<ObservationStatus> af_ = BloodPressure?.StatusElement;
-                    ObservationStatus? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    string[] ai_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-                    return aj_;
-                }
-
-                return ad_
-                    /* CQL 'and' (226:13-227:77) */ && ae_();
+                DataType bn_ = BloodPressure?.Effective;
+                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+                CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_);
+                CqlDateTime bq_ = context.Operators.End(bp_);
+                Period br_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> bs_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, br_);
+                CqlBoolean bt_ = context.Operators.In<CqlDateTime>(bq_, bs_, "day");
+                Code<ObservationStatus> bu_ = BloodPressure?.StatusElement;
+                ObservationStatus? bv_ = bu_?.Value;
+                string bw_ = context.Operators.Convert<string>(bv_);
+                string[] bx_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
+                CqlBoolean bz_ = by_;
+                return bt_
+                    /* CQL 'and' (226:13-227:77) */ && bz_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 
             object i_(Observation @this) {
-                DataType ak_ = @this?.Effective;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                CqlDateTime an_ = context.Operators.Start(am_);
-                return an_;
+                DataType ca_ = @this?.Effective;
+                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
+                CqlDateTime cd_ = context.Operators.Start(cc_);
+                return cd_;
             }
 
             IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1552,12 +1384,12 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             List<Observation.ComponentComponent> l_ = k_?.Component;
 
             bool? m_(Observation.ComponentComponent C) {
-                CodeableConcept ao_ = C?.Code;
-                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ao_);
-                CqlCode aq_ = this.Systolic_blood_pressure(context);
-                CqlConcept ar_ = context.Operators.ConvertCodeToConcept(aq_);
-                CqlBoolean as_ = context.Operators.Equivalent(ap_, ar_);
-                return as_;
+                CodeableConcept ce_ = C?.Code;
+                CqlConcept cf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ce_);
+                CqlCode cg_ = this.Systolic_blood_pressure(context);
+                CqlConcept ch_ = context.Operators.ConvertCodeToConcept(cg_);
+                CqlBoolean ci_ = context.Operators.Equivalent(cf_, ch_);
+                return ci_;
             }
 
             IEnumerable<Observation.ComponentComponent> n_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)l_, m_);
@@ -1569,197 +1401,170 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             CqlInterval<CqlQuantity> t_ = context.Operators.Interval(r_, s_, true, true);
             CqlBoolean u_ = context.Operators.In<CqlQuantity>(q_ as CqlQuantity, t_, (string)default);
 
-            CqlBoolean v_() {
-                IEnumerable<Observation> at_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? au_(Observation BloodPressure) {
-                    DataType bj_ = BloodPressure?.Effective;
-                    object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                    CqlInterval<CqlDateTime> bl_ = QICoreCommon_4_0_000.Instance.toInterval(context, bk_);
-                    CqlDateTime bm_ = context.Operators.End(bl_);
-                    Period bn_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bn_);
-                    CqlBoolean bp_ = context.Operators.In<CqlDateTime>(bm_, bo_, "day");
-
-                    CqlBoolean bq_() {
-                        Code<ObservationStatus> br_ = BloodPressure?.StatusElement;
-                        ObservationStatus? bs_ = br_?.Value;
-                        string bt_ = context.Operators.Convert<string>(bs_);
-                        string[] bu_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean bv_ = context.Operators.In<string>(bt_, (IEnumerable<string>)bu_);
-                        return bv_;
-                    }
-
-                    return bp_
-                        /* CQL 'and' (226:13-227:77) */ && bq_();
-                }
-
-                IEnumerable<Observation> av_ = context.Operators.Where<Observation>(at_, au_);
-
-                object aw_(Observation @this) {
-                    DataType bw_ = @this?.Effective;
-                    object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                    CqlInterval<CqlDateTime> by_ = QICoreCommon_4_0_000.Instance.toInterval(context, bx_);
-                    CqlDateTime bz_ = context.Operators.Start(by_);
-                    return bz_;
-                }
-
-                IEnumerable<Observation> ax_ = context.Operators.SortBy<Observation>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation ay_ = context.Operators.Last<Observation>(ax_);
-                List<Observation.ComponentComponent> az_ = ay_?.Component;
-
-                bool? ba_(Observation.ComponentComponent C) {
-                    CodeableConcept ca_ = C?.Code;
-                    CqlConcept cb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ca_);
-                    CqlCode cc_ = this.Diastolic_blood_pressure(context);
-                    CqlConcept cd_ = context.Operators.ConvertCodeToConcept(cc_);
-                    CqlBoolean ce_ = context.Operators.Equivalent(cb_, cd_);
-                    return ce_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> bb_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)az_, ba_);
-                Observation.ComponentComponent bc_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bb_);
-                DataType bd_ = bc_?.Value;
-                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                CqlQuantity bf_ = context.Operators.Quantity(80m, "mm[Hg]");
-                CqlQuantity bg_ = context.Operators.Quantity(89m, "mm[Hg]");
-                CqlInterval<CqlQuantity> bh_ = context.Operators.Interval(bf_, bg_, true, true);
-                CqlBoolean bi_ = context.Operators.In<CqlQuantity>(be_ as CqlQuantity, bh_, (string)default);
-                return bi_;
+            bool? v_(Observation BloodPressure) {
+                DataType cj_ = BloodPressure?.Effective;
+                object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                CqlInterval<CqlDateTime> cl_ = QICoreCommon_4_0_000.Instance.toInterval(context, ck_);
+                CqlDateTime cm_ = context.Operators.End(cl_);
+                Period cn_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cn_);
+                CqlBoolean cp_ = context.Operators.In<CqlDateTime>(cm_, co_, "day");
+                Code<ObservationStatus> cq_ = BloodPressure?.StatusElement;
+                ObservationStatus? cr_ = cq_?.Value;
+                string cs_ = context.Operators.Convert<string>(cr_);
+                string[] ct_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
+                CqlBoolean cv_ = cu_;
+                return cp_
+                    /* CQL 'and' (226:13-227:77) */ && cv_;
             }
 
+            IEnumerable<Observation> w_ = context.Operators.Where<Observation>(f_, v_);
 
-            CqlBoolean w_() {
-                IEnumerable<Observation> cf_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? cg_(Observation BloodPressure) {
-                    DataType cu_ = BloodPressure?.Effective;
-                    object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
-                    CqlInterval<CqlDateTime> cw_ = QICoreCommon_4_0_000.Instance.toInterval(context, cv_);
-                    CqlDateTime cx_ = context.Operators.End(cw_);
-                    Period cy_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> cz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cy_);
-                    CqlBoolean da_ = context.Operators.In<CqlDateTime>(cx_, cz_, "day");
-
-                    CqlBoolean db_() {
-                        Code<ObservationStatus> dc_ = BloodPressure?.StatusElement;
-                        ObservationStatus? dd_ = dc_?.Value;
-                        string de_ = context.Operators.Convert<string>(dd_);
-                        string[] df_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean dg_ = context.Operators.In<string>(de_, (IEnumerable<string>)df_);
-                        return dg_;
-                    }
-
-                    return da_
-                        /* CQL 'and' (226:13-227:77) */ && db_();
-                }
-
-                IEnumerable<Observation> ch_ = context.Operators.Where<Observation>(cf_, cg_);
-
-                object ci_(Observation @this) {
-                    DataType dh_ = @this?.Effective;
-                    object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
-                    CqlInterval<CqlDateTime> dj_ = QICoreCommon_4_0_000.Instance.toInterval(context, di_);
-                    CqlDateTime dk_ = context.Operators.Start(dj_);
-                    return dk_;
-                }
-
-                IEnumerable<Observation> cj_ = context.Operators.SortBy<Observation>(ch_, ci_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation ck_ = context.Operators.Last<Observation>(cj_);
-                List<Observation.ComponentComponent> cl_ = ck_?.Component;
-
-                bool? cm_(Observation.ComponentComponent C) {
-                    CodeableConcept dl_ = C?.Code;
-                    CqlConcept dm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dl_);
-                    CqlCode dn_ = this.Systolic_blood_pressure(context);
-                    CqlConcept do_ = context.Operators.ConvertCodeToConcept(dn_);
-                    CqlBoolean dp_ = context.Operators.Equivalent(dm_, do_);
-                    return dp_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> cn_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)cl_, cm_);
-                Observation.ComponentComponent co_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(cn_);
-                DataType cp_ = co_?.Value;
-                object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
-                CqlQuantity cr_ = context.Operators.Quantity(140m, "mm[Hg]");
-                CqlBoolean cs_ = context.Operators.GreaterOrEqual(cq_ as CqlQuantity, cr_);
-
-                CqlBoolean ct_() {
-                    IEnumerable<Observation> dq_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                    bool? dr_(Observation BloodPressure) {
-                        DataType ee_ = BloodPressure?.Effective;
-                        object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
-                        CqlInterval<CqlDateTime> eg_ = QICoreCommon_4_0_000.Instance.toInterval(context, ef_);
-                        CqlDateTime eh_ = context.Operators.End(eg_);
-                        Period ei_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> ej_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ei_);
-                        CqlBoolean ek_ = context.Operators.In<CqlDateTime>(eh_, ej_, "day");
-
-                        CqlBoolean el_() {
-                            Code<ObservationStatus> em_ = BloodPressure?.StatusElement;
-                            ObservationStatus? en_ = em_?.Value;
-                            string eo_ = context.Operators.Convert<string>(en_);
-                            string[] ep_ = [
-                                "final",
-                                "amended",
-                                "corrected",
-                            ];
-                            CqlBoolean eq_ = context.Operators.In<string>(eo_, (IEnumerable<string>)ep_);
-                            return eq_;
-                        }
-
-                        return ek_
-                            /* CQL 'and' (226:13-227:77) */ && el_();
-                    }
-
-                    IEnumerable<Observation> ds_ = context.Operators.Where<Observation>(dq_, dr_);
-
-                    object dt_(Observation @this) {
-                        DataType er_ = @this?.Effective;
-                        object es_ = FHIRHelpers_4_4_000.Instance.ToValue(context, er_);
-                        CqlInterval<CqlDateTime> et_ = QICoreCommon_4_0_000.Instance.toInterval(context, es_);
-                        CqlDateTime eu_ = context.Operators.Start(et_);
-                        return eu_;
-                    }
-
-                    IEnumerable<Observation> du_ = context.Operators.SortBy<Observation>(ds_, dt_, System.ComponentModel.ListSortDirection.Ascending);
-                    Observation dv_ = context.Operators.Last<Observation>(du_);
-                    List<Observation.ComponentComponent> dw_ = dv_?.Component;
-
-                    bool? dx_(Observation.ComponentComponent C) {
-                        CodeableConcept ev_ = C?.Code;
-                        CqlConcept ew_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ev_);
-                        CqlCode ex_ = this.Diastolic_blood_pressure(context);
-                        CqlConcept ey_ = context.Operators.ConvertCodeToConcept(ex_);
-                        CqlBoolean ez_ = context.Operators.Equivalent(ew_, ey_);
-                        return ez_;
-                    }
-
-                    IEnumerable<Observation.ComponentComponent> dy_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)dw_, dx_);
-                    Observation.ComponentComponent dz_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(dy_);
-                    DataType ea_ = dz_?.Value;
-                    object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                    CqlQuantity ec_ = context.Operators.Quantity(90m, "mm[Hg]");
-                    CqlBoolean ed_ = context.Operators.GreaterOrEqual(eb_ as CqlQuantity, ec_);
-                    return ed_;
-                }
-
-                return !((bool?)(cs_
-                    /* CQL 'or' (239:21-247:13) */ || ct_()));
+            object x_(Observation @this) {
+                DataType cw_ = @this?.Effective;
+                object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+                CqlInterval<CqlDateTime> cy_ = QICoreCommon_4_0_000.Instance.toInterval(context, cx_);
+                CqlDateTime cz_ = context.Operators.Start(cy_);
+                return cz_;
             }
 
+            IEnumerable<Observation> y_ = context.Operators.SortBy<Observation>(w_, x_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation z_ = context.Operators.Last<Observation>(y_);
+            List<Observation.ComponentComponent> aa_ = z_?.Component;
+
+            bool? ab_(Observation.ComponentComponent C) {
+                CodeableConcept da_ = C?.Code;
+                CqlConcept db_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, da_);
+                CqlCode dc_ = this.Diastolic_blood_pressure(context);
+                CqlConcept dd_ = context.Operators.ConvertCodeToConcept(dc_);
+                CqlBoolean de_ = context.Operators.Equivalent(db_, dd_);
+                return de_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> ac_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aa_, ab_);
+            Observation.ComponentComponent ad_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ac_);
+            DataType ae_ = ad_?.Value;
+            object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+            CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
+            CqlQuantity ah_ = context.Operators.Quantity(89m, "mm[Hg]");
+            CqlInterval<CqlQuantity> ai_ = context.Operators.Interval(ag_, ah_, true, true);
+            CqlBoolean aj_ = context.Operators.In<CqlQuantity>(af_ as CqlQuantity, ai_, (string)default);
+            CqlBoolean ak_ = aj_;
+
+            bool? al_(Observation BloodPressure) {
+                DataType df_ = BloodPressure?.Effective;
+                object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                CqlInterval<CqlDateTime> dh_ = QICoreCommon_4_0_000.Instance.toInterval(context, dg_);
+                CqlDateTime di_ = context.Operators.End(dh_);
+                Period dj_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dj_);
+                CqlBoolean dl_ = context.Operators.In<CqlDateTime>(di_, dk_, "day");
+                Code<ObservationStatus> dm_ = BloodPressure?.StatusElement;
+                ObservationStatus? dn_ = dm_?.Value;
+                string do_ = context.Operators.Convert<string>(dn_);
+                string[] dp_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean dq_ = context.Operators.In<string>(do_, (IEnumerable<string>)dp_);
+                CqlBoolean dr_ = dq_;
+                return dl_
+                    /* CQL 'and' (226:13-227:77) */ && dr_;
+            }
+
+            IEnumerable<Observation> am_ = context.Operators.Where<Observation>(f_, al_);
+
+            object an_(Observation @this) {
+                DataType ds_ = @this?.Effective;
+                object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
+                CqlInterval<CqlDateTime> du_ = QICoreCommon_4_0_000.Instance.toInterval(context, dt_);
+                CqlDateTime dv_ = context.Operators.Start(du_);
+                return dv_;
+            }
+
+            IEnumerable<Observation> ao_ = context.Operators.SortBy<Observation>(am_, an_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ap_ = context.Operators.Last<Observation>(ao_);
+            List<Observation.ComponentComponent> aq_ = ap_?.Component;
+
+            bool? ar_(Observation.ComponentComponent C) {
+                CodeableConcept dw_ = C?.Code;
+                CqlConcept dx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dw_);
+                CqlCode dy_ = this.Systolic_blood_pressure(context);
+                CqlConcept dz_ = context.Operators.ConvertCodeToConcept(dy_);
+                CqlBoolean ea_ = context.Operators.Equivalent(dx_, dz_);
+                return ea_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> as_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aq_, ar_);
+            Observation.ComponentComponent at_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(as_);
+            DataType au_ = at_?.Value;
+            object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+            CqlQuantity aw_ = context.Operators.Quantity(140m, "mm[Hg]");
+            CqlBoolean ax_ = context.Operators.GreaterOrEqual(av_ as CqlQuantity, aw_);
+
+            bool? ay_(Observation BloodPressure) {
+                DataType eb_ = BloodPressure?.Effective;
+                object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
+                CqlInterval<CqlDateTime> ed_ = QICoreCommon_4_0_000.Instance.toInterval(context, ec_);
+                CqlDateTime ee_ = context.Operators.End(ed_);
+                Period ef_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> eg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ef_);
+                CqlBoolean eh_ = context.Operators.In<CqlDateTime>(ee_, eg_, "day");
+                Code<ObservationStatus> ei_ = BloodPressure?.StatusElement;
+                ObservationStatus? ej_ = ei_?.Value;
+                string ek_ = context.Operators.Convert<string>(ej_);
+                string[] el_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean em_ = context.Operators.In<string>(ek_, (IEnumerable<string>)el_);
+                CqlBoolean en_ = em_;
+                return eh_
+                    /* CQL 'and' (226:13-227:77) */ && en_;
+            }
+
+            IEnumerable<Observation> az_ = context.Operators.Where<Observation>(f_, ay_);
+
+            object ba_(Observation @this) {
+                DataType eo_ = @this?.Effective;
+                object ep_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eo_);
+                CqlInterval<CqlDateTime> eq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ep_);
+                CqlDateTime er_ = context.Operators.Start(eq_);
+                return er_;
+            }
+
+            IEnumerable<Observation> bb_ = context.Operators.SortBy<Observation>(az_, ba_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation bc_ = context.Operators.Last<Observation>(bb_);
+            List<Observation.ComponentComponent> bd_ = bc_?.Component;
+
+            bool? be_(Observation.ComponentComponent C) {
+                CodeableConcept es_ = C?.Code;
+                CqlConcept et_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, es_);
+                CqlCode eu_ = this.Diastolic_blood_pressure(context);
+                CqlConcept ev_ = context.Operators.ConvertCodeToConcept(eu_);
+                CqlBoolean ew_ = context.Operators.Equivalent(et_, ev_);
+                return ew_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> bf_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)bd_, be_);
+            Observation.ComponentComponent bg_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bf_);
+            DataType bh_ = bg_?.Value;
+            object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            CqlQuantity bj_ = context.Operators.Quantity(90m, "mm[Hg]");
+            CqlBoolean bk_ = context.Operators.GreaterOrEqual(bi_ as CqlQuantity, bj_);
+            CqlBoolean bl_ = bk_;
+            CqlBoolean bm_ = (CqlBoolean)(!((bool?)(ax_
+                /* CQL 'or' (239:21-247:13) */ || bl_)));
             return (u_
-                /* CQL 'or' (230:17-238:11) */ || v_())
-                /* CQL 'and' (230:9-248:9) */ && w_();
+                /* CQL 'or' (230:17-238:11) */ || ak_)
+                /* CQL 'and' (230:9-248:9) */ && bm_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1827,17 +1632,12 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlBoolean l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
-
-                CqlBoolean m_() {
-                    FhirDateTime n_ = LabECGIntervention?.AuthoredOnElement;
-                    CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
-                    CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                    CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
-                    return q_;
-                }
-
+                FhirDateTime m_ = LabECGIntervention?.AuthoredOnElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                CqlBoolean o_ = context.Operators.In<CqlDateTime>(n_, k_, "day");
+                CqlBoolean p_ = o_;
                 return l_
-                    /* CQL 'and' (138:17-139:76) */ && m_();
+                    /* CQL 'and' (138:17-139:76) */ && p_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<ServiceRequest>(f_, g_);
@@ -1847,18 +1647,18 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<ServiceRequest> c_ = context.Operators.Where<ServiceRequest>(a_, b_);
 
         bool? d_(ServiceRequest Rescreen2to6) {
-            IEnumerable<ServiceRequest> r_ = this.NonPharmacological_Interventions(context);
+            IEnumerable<ServiceRequest> q_ = this.NonPharmacological_Interventions(context);
 
-            bool? s_(ServiceRequest NonPharmSecondIntervention) {
-                FhirDateTime u_ = NonPharmSecondIntervention?.AuthoredOnElement;
-                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
-                CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                CqlBoolean x_ = context.Operators.In<CqlDateTime>(v_, w_, "day");
-                return x_;
+            bool? r_(ServiceRequest NonPharmSecondIntervention) {
+                FhirDateTime t_ = NonPharmSecondIntervention?.AuthoredOnElement;
+                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
+                CqlInterval<CqlDateTime> v_ = this.Measurement_Period(context);
+                CqlBoolean w_ = context.Operators.In<CqlDateTime>(u_, v_, "day");
+                return w_;
             }
 
-            CqlBoolean t_ = context.Operators.WhereAny<ServiceRequest>(r_, s_);
-            return t_;
+            CqlBoolean s_ = context.Operators.WhereAny<ServiceRequest>(q_, r_);
+            return s_;
         }
 
         IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
@@ -1930,39 +1730,35 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
 
             bool? g_(Observation BloodPressure) {
-                DataType v_ = BloodPressure?.Effective;
-                object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
-                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                CqlDateTime y_ = context.Operators.End(x_);
-                Period z_ = QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(y_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Code<ObservationStatus> ad_ = BloodPressure?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-                return ab_
-                    /* CQL 'and' (197:13-198:77) */ && ac_();
+                DataType bi_ = BloodPressure?.Effective;
+                object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
+                CqlDateTime bl_ = context.Operators.End(bk_);
+                Period bm_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
+                CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bl_, bn_, "day");
+                Code<ObservationStatus> bp_ = BloodPressure?.StatusElement;
+                ObservationStatus? bq_ = bp_?.Value;
+                string br_ = context.Operators.Convert<string>(bq_);
+                string[] bs_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
+                CqlBoolean bu_ = bt_;
+                return bo_
+                    /* CQL 'and' (197:13-198:77) */ && bu_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 
             object i_(Observation @this) {
-                DataType ai_ = @this?.Effective;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlDateTime al_ = context.Operators.Start(ak_);
-                return al_;
+                DataType bv_ = @this?.Effective;
+                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                CqlInterval<CqlDateTime> bx_ = QICoreCommon_4_0_000.Instance.toInterval(context, bw_);
+                CqlDateTime by_ = context.Operators.Start(bx_);
+                return by_;
             }
 
             IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1970,12 +1766,12 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             List<Observation.ComponentComponent> l_ = k_?.Component;
 
             bool? m_(Observation.ComponentComponent C) {
-                CodeableConcept am_ = C?.Code;
-                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
-                CqlCode ao_ = this.Systolic_blood_pressure(context);
-                CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
-                CqlBoolean aq_ = context.Operators.Equivalent(an_, ap_);
-                return aq_;
+                CodeableConcept bz_ = C?.Code;
+                CqlConcept ca_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bz_);
+                CqlCode cb_ = this.Systolic_blood_pressure(context);
+                CqlConcept cc_ = context.Operators.ConvertCodeToConcept(cb_);
+                CqlBoolean cd_ = context.Operators.Equivalent(ca_, cc_);
+                return cd_;
             }
 
             IEnumerable<Observation.ComponentComponent> n_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)l_, m_);
@@ -1985,195 +1781,167 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             CqlQuantity r_ = context.Operators.Quantity(0m, "mm[Hg]");
             CqlBoolean s_ = context.Operators.Greater(q_ as CqlQuantity, r_);
 
-            CqlBoolean t_() {
-                IEnumerable<Observation> ar_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? as_(Observation BloodPressure) {
-                    DataType bf_ = BloodPressure?.Effective;
-                    object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                    CqlInterval<CqlDateTime> bh_ = QICoreCommon_4_0_000.Instance.toInterval(context, bg_);
-                    CqlDateTime bi_ = context.Operators.End(bh_);
-                    Period bj_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bj_);
-                    CqlBoolean bl_ = context.Operators.In<CqlDateTime>(bi_, bk_, "day");
-
-                    CqlBoolean bm_() {
-                        Code<ObservationStatus> bn_ = BloodPressure?.StatusElement;
-                        ObservationStatus? bo_ = bn_?.Value;
-                        string bp_ = context.Operators.Convert<string>(bo_);
-                        string[] bq_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
-                        return br_;
-                    }
-
-                    return bl_
-                        /* CQL 'and' (197:13-198:77) */ && bm_();
-                }
-
-                IEnumerable<Observation> at_ = context.Operators.Where<Observation>(ar_, as_);
-
-                object au_(Observation @this) {
-                    DataType bs_ = @this?.Effective;
-                    object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                    CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, bt_);
-                    CqlDateTime bv_ = context.Operators.Start(bu_);
-                    return bv_;
-                }
-
-                IEnumerable<Observation> av_ = context.Operators.SortBy<Observation>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation aw_ = context.Operators.Last<Observation>(av_);
-                List<Observation.ComponentComponent> ax_ = aw_?.Component;
-
-                bool? ay_(Observation.ComponentComponent C) {
-                    CodeableConcept bw_ = C?.Code;
-                    CqlConcept bx_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bw_);
-                    CqlCode by_ = this.Diastolic_blood_pressure(context);
-                    CqlConcept bz_ = context.Operators.ConvertCodeToConcept(by_);
-                    CqlBoolean ca_ = context.Operators.Equivalent(bx_, bz_);
-                    return ca_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> az_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ax_, ay_);
-                Observation.ComponentComponent ba_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(az_);
-                DataType bb_ = ba_?.Value;
-                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                CqlQuantity bd_ = context.Operators.Quantity(0m, "mm[Hg]");
-                CqlBoolean be_ = context.Operators.Greater(bc_ as CqlQuantity, bd_);
-                return be_;
+            bool? t_(Observation BloodPressure) {
+                DataType ce_ = BloodPressure?.Effective;
+                object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                CqlInterval<CqlDateTime> cg_ = QICoreCommon_4_0_000.Instance.toInterval(context, cf_);
+                CqlDateTime ch_ = context.Operators.End(cg_);
+                Period ci_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ci_);
+                CqlBoolean ck_ = context.Operators.In<CqlDateTime>(ch_, cj_, "day");
+                Code<ObservationStatus> cl_ = BloodPressure?.StatusElement;
+                ObservationStatus? cm_ = cl_?.Value;
+                string cn_ = context.Operators.Convert<string>(cm_);
+                string[] co_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean cp_ = context.Operators.In<string>(cn_, (IEnumerable<string>)co_);
+                CqlBoolean cq_ = cp_;
+                return ck_
+                    /* CQL 'and' (197:13-198:77) */ && cq_;
             }
 
+            IEnumerable<Observation> u_ = context.Operators.Where<Observation>(f_, t_);
 
-            CqlBoolean u_() {
-                IEnumerable<Observation> cb_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                bool? cc_(Observation BloodPressure) {
-                    DataType cq_ = BloodPressure?.Effective;
-                    object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
-                    CqlInterval<CqlDateTime> cs_ = QICoreCommon_4_0_000.Instance.toInterval(context, cr_);
-                    CqlDateTime ct_ = context.Operators.End(cs_);
-                    Period cu_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> cv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cu_);
-                    CqlBoolean cw_ = context.Operators.In<CqlDateTime>(ct_, cv_, "day");
-
-                    CqlBoolean cx_() {
-                        Code<ObservationStatus> cy_ = BloodPressure?.StatusElement;
-                        ObservationStatus? cz_ = cy_?.Value;
-                        string da_ = context.Operators.Convert<string>(cz_);
-                        string[] db_ = [
-                            "final",
-                            "amended",
-                            "corrected",
-                        ];
-                        CqlBoolean dc_ = context.Operators.In<string>(da_, (IEnumerable<string>)db_);
-                        return dc_;
-                    }
-
-                    return cw_
-                        /* CQL 'and' (197:13-198:77) */ && cx_();
-                }
-
-                IEnumerable<Observation> cd_ = context.Operators.Where<Observation>(cb_, cc_);
-
-                object ce_(Observation @this) {
-                    DataType dd_ = @this?.Effective;
-                    object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
-                    CqlInterval<CqlDateTime> df_ = QICoreCommon_4_0_000.Instance.toInterval(context, de_);
-                    CqlDateTime dg_ = context.Operators.Start(df_);
-                    return dg_;
-                }
-
-                IEnumerable<Observation> cf_ = context.Operators.SortBy<Observation>(cd_, ce_, System.ComponentModel.ListSortDirection.Ascending);
-                Observation cg_ = context.Operators.Last<Observation>(cf_);
-                List<Observation.ComponentComponent> ch_ = cg_?.Component;
-
-                bool? ci_(Observation.ComponentComponent C) {
-                    CodeableConcept dh_ = C?.Code;
-                    CqlConcept di_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dh_);
-                    CqlCode dj_ = this.Systolic_blood_pressure(context);
-                    CqlConcept dk_ = context.Operators.ConvertCodeToConcept(dj_);
-                    CqlBoolean dl_ = context.Operators.Equivalent(di_, dk_);
-                    return dl_;
-                }
-
-                IEnumerable<Observation.ComponentComponent> cj_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ch_, ci_);
-                Observation.ComponentComponent ck_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(cj_);
-                DataType cl_ = ck_?.Value;
-                object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                CqlQuantity cn_ = context.Operators.Quantity(140m, "mm[Hg]");
-                CqlBoolean co_ = context.Operators.GreaterOrEqual(cm_ as CqlQuantity, cn_);
-
-                CqlBoolean cp_() {
-                    IEnumerable<Observation> dm_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
-
-                    bool? dn_(Observation BloodPressure) {
-                        DataType ea_ = BloodPressure?.Effective;
-                        object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
-                        CqlInterval<CqlDateTime> ec_ = QICoreCommon_4_0_000.Instance.toInterval(context, eb_);
-                        CqlDateTime ed_ = context.Operators.End(ec_);
-                        Period ee_ = QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ee_);
-                        CqlBoolean eg_ = context.Operators.In<CqlDateTime>(ed_, ef_, "day");
-
-                        CqlBoolean eh_() {
-                            Code<ObservationStatus> ei_ = BloodPressure?.StatusElement;
-                            ObservationStatus? ej_ = ei_?.Value;
-                            string ek_ = context.Operators.Convert<string>(ej_);
-                            string[] el_ = [
-                                "final",
-                                "amended",
-                                "corrected",
-                            ];
-                            CqlBoolean em_ = context.Operators.In<string>(ek_, (IEnumerable<string>)el_);
-                            return em_;
-                        }
-
-                        return eg_
-                            /* CQL 'and' (197:13-198:77) */ && eh_();
-                    }
-
-                    IEnumerable<Observation> do_ = context.Operators.Where<Observation>(dm_, dn_);
-
-                    object dp_(Observation @this) {
-                        DataType en_ = @this?.Effective;
-                        object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
-                        CqlInterval<CqlDateTime> ep_ = QICoreCommon_4_0_000.Instance.toInterval(context, eo_);
-                        CqlDateTime eq_ = context.Operators.Start(ep_);
-                        return eq_;
-                    }
-
-                    IEnumerable<Observation> dq_ = context.Operators.SortBy<Observation>(do_, dp_, System.ComponentModel.ListSortDirection.Ascending);
-                    Observation dr_ = context.Operators.Last<Observation>(dq_);
-                    List<Observation.ComponentComponent> ds_ = dr_?.Component;
-
-                    bool? dt_(Observation.ComponentComponent C) {
-                        CodeableConcept er_ = C?.Code;
-                        CqlConcept es_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, er_);
-                        CqlCode et_ = this.Diastolic_blood_pressure(context);
-                        CqlConcept eu_ = context.Operators.ConvertCodeToConcept(et_);
-                        CqlBoolean ev_ = context.Operators.Equivalent(es_, eu_);
-                        return ev_;
-                    }
-
-                    IEnumerable<Observation.ComponentComponent> du_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ds_, dt_);
-                    Observation.ComponentComponent dv_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(du_);
-                    DataType dw_ = dv_?.Value;
-                    object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
-                    CqlQuantity dy_ = context.Operators.Quantity(90m, "mm[Hg]");
-                    CqlBoolean dz_ = context.Operators.GreaterOrEqual(dx_ as CqlQuantity, dy_);
-                    return dz_;
-                }
-
-                return co_
-                    /* CQL 'or' (209:17-217:13) */ || cp_();
+            object v_(Observation @this) {
+                DataType cr_ = @this?.Effective;
+                object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+                CqlInterval<CqlDateTime> ct_ = QICoreCommon_4_0_000.Instance.toInterval(context, cs_);
+                CqlDateTime cu_ = context.Operators.Start(ct_);
+                return cu_;
             }
 
+            IEnumerable<Observation> w_ = context.Operators.SortBy<Observation>(u_, v_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation x_ = context.Operators.Last<Observation>(w_);
+            List<Observation.ComponentComponent> y_ = x_?.Component;
+
+            bool? z_(Observation.ComponentComponent C) {
+                CodeableConcept cv_ = C?.Code;
+                CqlConcept cw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cv_);
+                CqlCode cx_ = this.Diastolic_blood_pressure(context);
+                CqlConcept cy_ = context.Operators.ConvertCodeToConcept(cx_);
+                CqlBoolean cz_ = context.Operators.Equivalent(cw_, cy_);
+                return cz_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> aa_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)y_, z_);
+            Observation.ComponentComponent ab_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(aa_);
+            DataType ac_ = ab_?.Value;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            CqlBoolean ae_ = context.Operators.Greater(ad_ as CqlQuantity, r_);
+            CqlBoolean af_ = ae_;
+
+            bool? ag_(Observation BloodPressure) {
+                DataType da_ = BloodPressure?.Effective;
+                object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
+                CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_);
+                CqlDateTime dd_ = context.Operators.End(dc_);
+                Period de_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, de_);
+                CqlBoolean dg_ = context.Operators.In<CqlDateTime>(dd_, df_, "day");
+                Code<ObservationStatus> dh_ = BloodPressure?.StatusElement;
+                ObservationStatus? di_ = dh_?.Value;
+                string dj_ = context.Operators.Convert<string>(di_);
+                string[] dk_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean dl_ = context.Operators.In<string>(dj_, (IEnumerable<string>)dk_);
+                CqlBoolean dm_ = dl_;
+                return dg_
+                    /* CQL 'and' (197:13-198:77) */ && dm_;
+            }
+
+            IEnumerable<Observation> ah_ = context.Operators.Where<Observation>(f_, ag_);
+
+            object ai_(Observation @this) {
+                DataType dn_ = @this?.Effective;
+                object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+                CqlInterval<CqlDateTime> dp_ = QICoreCommon_4_0_000.Instance.toInterval(context, do_);
+                CqlDateTime dq_ = context.Operators.Start(dp_);
+                return dq_;
+            }
+
+            IEnumerable<Observation> aj_ = context.Operators.SortBy<Observation>(ah_, ai_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ak_ = context.Operators.Last<Observation>(aj_);
+            List<Observation.ComponentComponent> al_ = ak_?.Component;
+
+            bool? am_(Observation.ComponentComponent C) {
+                CodeableConcept dr_ = C?.Code;
+                CqlConcept ds_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, dr_);
+                CqlCode dt_ = this.Systolic_blood_pressure(context);
+                CqlConcept du_ = context.Operators.ConvertCodeToConcept(dt_);
+                CqlBoolean dv_ = context.Operators.Equivalent(ds_, du_);
+                return dv_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> an_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)al_, am_);
+            Observation.ComponentComponent ao_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(an_);
+            DataType ap_ = ao_?.Value;
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+            CqlQuantity ar_ = context.Operators.Quantity(140m, "mm[Hg]");
+            CqlBoolean as_ = context.Operators.GreaterOrEqual(aq_ as CqlQuantity, ar_);
+
+            bool? at_(Observation BloodPressure) {
+                DataType dw_ = BloodPressure?.Effective;
+                object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                CqlInterval<CqlDateTime> dy_ = QICoreCommon_4_0_000.Instance.toInterval(context, dx_);
+                CqlDateTime dz_ = context.Operators.End(dy_);
+                Period ea_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> eb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ea_);
+                CqlBoolean ec_ = context.Operators.In<CqlDateTime>(dz_, eb_, "day");
+                Code<ObservationStatus> ed_ = BloodPressure?.StatusElement;
+                ObservationStatus? ee_ = ed_?.Value;
+                string ef_ = context.Operators.Convert<string>(ee_);
+                string[] eg_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean eh_ = context.Operators.In<string>(ef_, (IEnumerable<string>)eg_);
+                CqlBoolean ei_ = eh_;
+                return ec_
+                    /* CQL 'and' (197:13-198:77) */ && ei_;
+            }
+
+            IEnumerable<Observation> au_ = context.Operators.Where<Observation>(f_, at_);
+
+            object av_(Observation @this) {
+                DataType ej_ = @this?.Effective;
+                object ek_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ej_);
+                CqlInterval<CqlDateTime> el_ = QICoreCommon_4_0_000.Instance.toInterval(context, ek_);
+                CqlDateTime em_ = context.Operators.Start(el_);
+                return em_;
+            }
+
+            IEnumerable<Observation> aw_ = context.Operators.SortBy<Observation>(au_, av_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ax_ = context.Operators.Last<Observation>(aw_);
+            List<Observation.ComponentComponent> ay_ = ax_?.Component;
+
+            bool? az_(Observation.ComponentComponent C) {
+                CodeableConcept en_ = C?.Code;
+                CqlConcept eo_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, en_);
+                CqlCode ep_ = this.Diastolic_blood_pressure(context);
+                CqlConcept eq_ = context.Operators.ConvertCodeToConcept(ep_);
+                CqlBoolean er_ = context.Operators.Equivalent(eo_, eq_);
+                return er_;
+            }
+
+            IEnumerable<Observation.ComponentComponent> ba_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ay_, az_);
+            Observation.ComponentComponent bb_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ba_);
+            DataType bc_ = bb_?.Value;
+            object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+            CqlQuantity be_ = context.Operators.Quantity(90m, "mm[Hg]");
+            CqlBoolean bf_ = context.Operators.GreaterOrEqual(bd_ as CqlQuantity, be_);
+            CqlBoolean bg_ = bf_;
+            CqlBoolean bh_ = as_
+                /* CQL 'or' (209:17-217:13) */ || bg_;
             return s_
-                /* CQL 'and' (201:17-208:32) */ && t_()
-                /* CQL 'and' (201:9-218:9) */ && u_();
+                /* CQL 'and' (201:17-208:32) */ && af_
+                /* CQL 'and' (201:9-218:9) */ && bh_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -2202,53 +1970,33 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
                 CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
                 CqlBoolean o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
-
-                CqlBoolean p_() {
-                    FhirDateTime s_ = ECGLabTest?.AuthoredOnElement;
-                    CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
-                    CqlInterval<CqlDateTime> u_ = this.Measurement_Period(context);
-                    CqlBoolean v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
-                    return v_;
-                }
-
-
-                CqlBoolean q_() {
-                    Code<RequestIntent> w_ = WeeksRescreen?.IntentElement;
-                    RequestIntent? x_ = w_?.Value;
-                    Code<RequestIntent> y_ = context.Operators.Convert<Code<RequestIntent>>(x_);
-                    string z_ = context.Operators.Convert<string>(y_);
-                    string[] aa_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                    return ab_;
-                }
-
-
-                CqlBoolean r_() {
-                    Code<RequestIntent> ac_ = ECGLabTest?.IntentElement;
-                    RequestIntent? ad_ = ac_?.Value;
-                    Code<RequestIntent> ae_ = context.Operators.Convert<Code<RequestIntent>>(ad_);
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
+                FhirDateTime p_ = ECGLabTest?.AuthoredOnElement;
+                CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+                CqlBoolean r_ = context.Operators.In<CqlDateTime>(q_, n_, "day");
+                CqlBoolean s_ = r_;
+                Code<RequestIntent> t_ = WeeksRescreen?.IntentElement;
+                RequestIntent? u_ = t_?.Value;
+                Code<RequestIntent> v_ = context.Operators.Convert<Code<RequestIntent>>(u_);
+                string w_ = context.Operators.Convert<string>(v_);
+                string[] x_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
+                CqlBoolean z_ = y_;
+                Code<RequestIntent> aa_ = ECGLabTest?.IntentElement;
+                RequestIntent? ab_ = aa_?.Value;
+                Code<RequestIntent> ac_ = context.Operators.Convert<Code<RequestIntent>>(ab_);
+                string ad_ = context.Operators.Convert<string>(ac_);
+                CqlBoolean ae_ = context.Operators.In<string>(ad_, (IEnumerable<string>)x_);
+                CqlBoolean af_ = ae_;
                 return o_
-                    /* CQL 'and' (124:19-125:70) */ && p_()
-                    /* CQL 'and' (124:19-126:117) */ && q_()
-                    /* CQL 'and' (124:19-127:114) */ && r_();
+                    /* CQL 'and' (124:19-125:70) */ && s_
+                    /* CQL 'and' (124:19-126:117) */ && z_
+                    /* CQL 'and' (124:19-127:114) */ && af_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<ServiceRequest>(i_, j_);
@@ -2258,80 +2006,72 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
 
         bool? e_(ServiceRequest WeeksRescreen) {
-            IEnumerable<ServiceRequest> ai_ = this.NonPharmacological_Interventions(context);
+            IEnumerable<ServiceRequest> ag_ = this.NonPharmacological_Interventions(context);
 
-            bool? aj_(ServiceRequest HTNInterventions) {
-                FhirDateTime al_ = HTNInterventions?.AuthoredOnElement;
-                CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
-                CqlInterval<CqlDateTime> an_ = this.Measurement_Period(context);
-                CqlBoolean ao_ = context.Operators.In<CqlDateTime>(am_, an_, "day");
-                return ao_;
+            bool? ah_(ServiceRequest HTNInterventions) {
+                FhirDateTime aj_ = HTNInterventions?.AuthoredOnElement;
+                CqlDateTime ak_ = context.Operators.Convert<CqlDateTime>(aj_);
+                CqlInterval<CqlDateTime> al_ = this.Measurement_Period(context);
+                CqlBoolean am_ = context.Operators.In<CqlDateTime>(ak_, al_, "day");
+                return am_;
             }
 
-            CqlBoolean ak_ = context.Operators.WhereAny<ServiceRequest>(ai_, aj_);
-            return ak_;
+            CqlBoolean ai_ = context.Operators.WhereAny<ServiceRequest>(ag_, ah_);
+            return ai_;
         }
 
         IEnumerable<ServiceRequest> f_ = context.Operators.Where<ServiceRequest>(d_, e_);
 
         bool? g_(ServiceRequest WeeksRescreen) {
-            IEnumerable<MedicationRequest> ap_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> an_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
-            bool? aq_(MedicationRequest MR) {
-                IEnumerable<Medication> ax_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? ao_(MedicationRequest MR) {
+                IEnumerable<Medication> av_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-                bool? ay_(Medication M) {
-                    object ba_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                    object bb_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                    IEnumerable<string> bc_ = context.Operators.Split((string)bb_, "/");
-                    string bd_ = context.Operators.Last<string>(bc_);
-                    CqlBoolean be_ = context.Operators.Equal(ba_, bd_);
-
-                    CqlBoolean bf_() {
-                        CodeableConcept bg_ = M?.Code;
-                        CqlConcept bh_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bg_);
-                        CqlValueSet bi_ = this.Pharmacologic_Therapy_for_Hypertension(context);
-                        CqlBoolean bj_ = context.Operators.ConceptInValueSet(bh_, bi_);
-                        return bj_;
-                    }
-
-                    return be_
-                        /* CQL 'and' */ && bf_();
+                bool? aw_(Medication M) {
+                    object ay_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object az_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> ba_ = context.Operators.Split((string)az_, "/");
+                    string bb_ = context.Operators.Last<string>(ba_);
+                    CqlBoolean bc_ = context.Operators.Equal(ay_, bb_);
+                    CodeableConcept bd_ = M?.Code;
+                    CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_);
+                    CqlValueSet bf_ = this.Pharmacologic_Therapy_for_Hypertension(context);
+                    CqlBoolean bg_ = context.Operators.ConceptInValueSet(be_, bf_);
+                    CqlBoolean bh_ = bg_;
+                    return bc_
+                        /* CQL 'and' */ && bh_;
                 }
 
-                CqlBoolean az_ = context.Operators.WhereAny<Medication>(ax_, ay_);
-                return az_;
+                CqlBoolean ax_ = context.Operators.WhereAny<Medication>(av_, aw_);
+                return ax_;
             }
 
-            IEnumerable<MedicationRequest> ar_ = context.Operators.Where<MedicationRequest>(ap_, aq_);
-            CqlValueSet as_ = this.Pharmacologic_Therapy_for_Hypertension(context);
-            IEnumerable<MedicationRequest> at_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, as_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
-            IEnumerable<MedicationRequest> au_ = context.Operators.Union<MedicationRequest>(ar_, at_);
+            IEnumerable<MedicationRequest> ap_ = context.Operators.Where<MedicationRequest>(an_, ao_);
+            CqlValueSet aq_ = this.Pharmacologic_Therapy_for_Hypertension(context);
+            IEnumerable<MedicationRequest> ar_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> as_ = context.Operators.Union<MedicationRequest>(ap_, ar_);
 
-            bool? av_(MedicationRequest Medications) {
-                FhirDateTime bk_ = Medications?.AuthoredOnElement;
-                CqlDateTime bl_ = context.Operators.Convert<CqlDateTime>(bk_);
-                CqlInterval<CqlDateTime> bm_ = this.Measurement_Period(context);
-                CqlBoolean bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, "day");
-
-                CqlBoolean bo_() {
-                    Code<MedicationRequest.MedicationrequestStatus> bp_ = Medications?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? bq_ = bp_?.Value;
-                    string br_ = context.Operators.Convert<string>(bq_);
-                    string[] bs_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
-                    return bt_;
-                }
-
-                return bn_
-                    /* CQL 'and' (131:19-132:61) */ && bo_();
+            bool? at_(MedicationRequest Medications) {
+                FhirDateTime bi_ = Medications?.AuthoredOnElement;
+                CqlDateTime bj_ = context.Operators.Convert<CqlDateTime>(bi_);
+                CqlInterval<CqlDateTime> bk_ = this.Measurement_Period(context);
+                CqlBoolean bl_ = context.Operators.In<CqlDateTime>(bj_, bk_, "day");
+                Code<MedicationRequest.MedicationrequestStatus> bm_ = Medications?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? bn_ = bm_?.Value;
+                string bo_ = context.Operators.Convert<string>(bn_);
+                string[] bp_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean bq_ = context.Operators.In<string>(bo_, (IEnumerable<string>)bp_);
+                CqlBoolean br_ = bq_;
+                return bl_
+                    /* CQL 'and' (131:19-132:61) */ && br_;
             }
 
-            CqlBoolean aw_ = context.Operators.WhereAny<MedicationRequest>(au_, av_);
-            return aw_;
+            CqlBoolean au_ = context.Operators.WhereAny<MedicationRequest>(as_, at_);
+            return au_;
         }
 
         IEnumerable<ServiceRequest> h_ = context.Operators.Where<ServiceRequest>(f_, g_);
@@ -2441,60 +2181,52 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
                 CqlBoolean v_ = context.Operators.In<CqlDateTime>(s_, u_, "day");
 
-                CqlBoolean w_() {
-
-                    bool? x_(Extension @this) {
-                        FhirUri af_ = @this?.UrlElement;
-                        string ag_ = FHIRHelpers_4_4_000.Instance.ToString(context, af_);
-                        CqlBoolean ah_ = context.Operators.Equal(ag_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                        return ah_;
-                    }
-
-
-                    object y_(Extension @this) {
-                        DataType ai_ = @this?.Value;
-                        return ai_;
-                    }
-
-                    IEnumerable<object> z_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBPScreen is DomainResource
-                        ? (NoBPScreen as DomainResource).Extension
-                        : default), x_, y_);
-                    object aa_ = context.Operators.SingletonFrom<object>(z_);
-                    CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_ as CodeableConcept);
-                    CqlValueSet ac_ = this.Patient_Declined(context);
-                    CqlBoolean ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
-
-                    CqlBoolean ae_() {
-
-                        bool? aj_(Extension @this) {
-                            FhirUri aq_ = @this?.UrlElement;
-                            string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
-                            CqlBoolean as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                            return as_;
-                        }
-
-
-                        object ak_(Extension @this) {
-                            DataType at_ = @this?.Value;
-                            return at_;
-                        }
-
-                        IEnumerable<object> al_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBPScreen is DomainResource
-                            ? (NoBPScreen as DomainResource).Extension
-                            : default), aj_, ak_);
-                        object am_ = context.Operators.SingletonFrom<object>(al_);
-                        CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_ as CodeableConcept);
-                        CqlValueSet ao_ = this.Medical_Reason(context);
-                        CqlBoolean ap_ = context.Operators.ConceptInValueSet(an_, ao_);
-                        return ap_;
-                    }
-
-                    return ad_
-                        /* CQL 'or' (324:13-326:9) */ || ae_();
+                bool? w_(Extension @this) {
+                    FhirUri am_ = @this?.UrlElement;
+                    string an_ = FHIRHelpers_4_4_000.Instance.ToString(context, am_);
+                    CqlBoolean ao_ = context.Operators.Equal(an_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                    return ao_;
                 }
 
+
+                object x_(Extension @this) {
+                    DataType ap_ = @this?.Value;
+                    return ap_;
+                }
+
+                IEnumerable<object> y_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBPScreen is DomainResource
+                    ? (NoBPScreen as DomainResource).Extension
+                    : default), w_, x_);
+                object z_ = context.Operators.SingletonFrom<object>(y_);
+                CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_ as CodeableConcept);
+                CqlValueSet ab_ = this.Patient_Declined(context);
+                CqlBoolean ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+
+                bool? ad_(Extension @this) {
+                    FhirUri aq_ = @this?.UrlElement;
+                    string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                    CqlBoolean as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                    return as_;
+                }
+
+
+                object ae_(Extension @this) {
+                    DataType at_ = @this?.Value;
+                    return at_;
+                }
+
+                IEnumerable<object> af_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBPScreen is DomainResource
+                    ? (NoBPScreen as DomainResource).Extension
+                    : default), ad_, ae_);
+                object ag_ = context.Operators.SingletonFrom<object>(af_);
+                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_ as CodeableConcept);
+                CqlValueSet ai_ = this.Medical_Reason(context);
+                CqlBoolean aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
+                CqlBoolean ak_ = aj_;
+                CqlBoolean al_ = ac_
+                    /* CQL 'or' (324:13-326:9) */ || ak_;
                 return v_
-                    /* CQL 'and' (323:17-326:9) */ && w_();
+                    /* CQL 'and' (323:17-326:9) */ && al_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Observation>(n_, o_);
@@ -2546,33 +2278,29 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             ];
             CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
 
-            CqlBoolean ab_() {
-
-                bool? ac_(Extension @this) {
-                    FhirUri aj_ = @this?.UrlElement;
-                    string ak_ = FHIRHelpers_4_4_000.Instance.ToString(context, aj_);
-                    CqlBoolean al_ = context.Operators.Equal(ak_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                    return al_;
-                }
-
-
-                object ad_(Extension @this) {
-                    DataType am_ = @this?.Value;
-                    return am_;
-                }
-
-                IEnumerable<object> ae_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NonPharmIntervention is DomainResource
-                    ? (NonPharmIntervention as DomainResource).Extension
-                    : default), ac_, ad_);
-                object af_ = context.Operators.SingletonFrom<object>(ae_);
-                CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
-                CqlValueSet ah_ = this.Patient_Declined(context);
-                CqlBoolean ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
-                return ai_;
+            bool? ab_(Extension @this) {
+                FhirUri aj_ = @this?.UrlElement;
+                string ak_ = FHIRHelpers_4_4_000.Instance.ToString(context, aj_);
+                CqlBoolean al_ = context.Operators.Equal(ak_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                return al_;
             }
 
+
+            object ac_(Extension @this) {
+                DataType am_ = @this?.Value;
+                return am_;
+            }
+
+            IEnumerable<object> ad_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NonPharmIntervention is DomainResource
+                ? (NonPharmIntervention as DomainResource).Extension
+                : default), ab_, ac_);
+            object ae_ = context.Operators.SingletonFrom<object>(ad_);
+            CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_ as CodeableConcept);
+            CqlValueSet ag_ = this.Patient_Declined(context);
+            CqlBoolean ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+            CqlBoolean ai_ = ah_;
             return aa_
-                /* CQL 'and' (315:5-316:66) */ && ab_();
+                /* CQL 'and' (315:5-316:66) */ && ai_;
         }
 
         IEnumerable<ServiceRequest> u_ = context.Operators.Where<ServiceRequest>(s_, t_);
@@ -2612,33 +2340,29 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             ];
             CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
 
-            CqlBoolean t_() {
-
-                bool? u_(Extension @this) {
-                    FhirUri ab_ = @this?.UrlElement;
-                    string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
-                    CqlBoolean ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                    return ad_;
-                }
-
-
-                object v_(Extension @this) {
-                    DataType ae_ = @this?.Value;
-                    return ae_;
-                }
-
-                IEnumerable<object> w_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(LabECGNotDone is DomainResource
-                    ? (LabECGNotDone as DomainResource).Extension
-                    : default), u_, v_);
-                object x_ = context.Operators.SingletonFrom<object>(w_);
-                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
-                CqlValueSet z_ = this.Patient_Declined(context);
-                CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                return aa_;
+            bool? t_(Extension @this) {
+                FhirUri ab_ = @this?.UrlElement;
+                string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
+                CqlBoolean ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                return ad_;
             }
 
+
+            object u_(Extension @this) {
+                DataType ae_ = @this?.Value;
+                return ae_;
+            }
+
+            IEnumerable<object> v_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(LabECGNotDone is DomainResource
+                ? (LabECGNotDone as DomainResource).Extension
+                : default), t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlValueSet y_ = this.Patient_Declined(context);
+            CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
+            CqlBoolean aa_ = z_;
             return s_
-                /* CQL 'and' (387:5-388:59) */ && t_();
+                /* CQL 'and' (387:5-388:59) */ && aa_;
         }
 
         IEnumerable<ServiceRequest> m_ = context.Operators.Where<ServiceRequest>(k_, l_);
@@ -2674,33 +2398,29 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             ];
             CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
 
-            CqlBoolean t_() {
-
-                bool? u_(Extension @this) {
-                    FhirUri ab_ = @this?.UrlElement;
-                    string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
-                    CqlBoolean ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                    return ad_;
-                }
-
-
-                object v_(Extension @this) {
-                    DataType ae_ = @this?.Value;
-                    return ae_;
-                }
-
-                IEnumerable<object> w_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(SecondHTNDeclinedReferralAndFollowUp is DomainResource
-                    ? (SecondHTNDeclinedReferralAndFollowUp as DomainResource).Extension
-                    : default), u_, v_);
-                object x_ = context.Operators.SingletonFrom<object>(w_);
-                CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
-                CqlValueSet z_ = this.Patient_Declined(context);
-                CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                return aa_;
+            bool? t_(Extension @this) {
+                FhirUri ab_ = @this?.UrlElement;
+                string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
+                CqlBoolean ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                return ad_;
             }
 
+
+            object u_(Extension @this) {
+                DataType ae_ = @this?.Value;
+                return ae_;
+            }
+
+            IEnumerable<object> v_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(SecondHTNDeclinedReferralAndFollowUp is DomainResource
+                ? (SecondHTNDeclinedReferralAndFollowUp as DomainResource).Extension
+                : default), t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlValueSet y_ = this.Patient_Declined(context);
+            CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
+            CqlBoolean aa_ = z_;
             return s_
-                /* CQL 'and' (364:7-365:84) */ && t_();
+                /* CQL 'and' (364:7-365:84) */ && aa_;
         }
 
         IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(g_, h_);
@@ -2740,33 +2460,29 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
             ];
             CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
 
-            CqlBoolean z_() {
-
-                bool? aa_(Extension @this) {
-                    FhirUri ah_ = @this?.UrlElement;
-                    string ai_ = FHIRHelpers_4_4_000.Instance.ToString(context, ah_);
-                    CqlBoolean aj_ = context.Operators.Equal(ai_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                    return aj_;
-                }
-
-
-                object ab_(Extension @this) {
-                    DataType ak_ = @this?.Value;
-                    return ak_;
-                }
-
-                IEnumerable<object> ac_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(SecondHTN140Over90ReferralFollowUpNotDone is DomainResource
-                    ? (SecondHTN140Over90ReferralFollowUpNotDone as DomainResource).Extension
-                    : default), aa_, ab_);
-                object ad_ = context.Operators.SingletonFrom<object>(ac_);
-                CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_ as CodeableConcept);
-                CqlValueSet af_ = this.Patient_Declined(context);
-                CqlBoolean ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-                return ag_;
+            bool? z_(Extension @this) {
+                FhirUri ah_ = @this?.UrlElement;
+                string ai_ = FHIRHelpers_4_4_000.Instance.ToString(context, ah_);
+                CqlBoolean aj_ = context.Operators.Equal(ai_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                return aj_;
             }
 
+
+            object aa_(Extension @this) {
+                DataType ak_ = @this?.Value;
+                return ak_;
+            }
+
+            IEnumerable<object> ab_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(SecondHTN140Over90ReferralFollowUpNotDone is DomainResource
+                ? (SecondHTN140Over90ReferralFollowUpNotDone as DomainResource).Extension
+                : default), z_, aa_);
+            object ac_ = context.Operators.SingletonFrom<object>(ab_);
+            CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_ as CodeableConcept);
+            CqlValueSet ae_ = this.Patient_Declined(context);
+            CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+            CqlBoolean ag_ = af_;
             return y_
-                /* CQL 'and' (373:9-374:91) */ && z_();
+                /* CQL 'and' (373:9-374:91) */ && ag_;
         }
 
         IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(g_, h_);
@@ -2821,50 +2537,42 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 Period ag_ = ElevatedBPEncounter?.Period;
                 CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
                 CqlBoolean ai_ = context.Operators.In<CqlDateTime>(af_, ah_, "day");
+                Code<RequestStatus> aj_ = ElevatedBPDeclinedInterventions?.StatusElement;
+                RequestStatus? ak_ = aj_?.Value;
+                Code<RequestStatus> al_ = context.Operators.Convert<Code<RequestStatus>>(ak_);
+                string am_ = context.Operators.Convert<string>(al_);
+                string[] an_ = [
+                    "active",
+                    "completed",
+                    "on-hold",
+                ];
+                CqlBoolean ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
+                CqlBoolean ap_ = ao_;
 
-                CqlBoolean aj_() {
-                    Code<RequestStatus> al_ = ElevatedBPDeclinedInterventions?.StatusElement;
-                    RequestStatus? am_ = al_?.Value;
-                    Code<RequestStatus> an_ = context.Operators.Convert<Code<RequestStatus>>(am_);
-                    string ao_ = context.Operators.Convert<string>(an_);
-                    string[] ap_ = [
-                        "active",
-                        "completed",
-                        "on-hold",
-                    ];
-                    CqlBoolean aq_ = context.Operators.In<string>(ao_, (IEnumerable<string>)ap_);
-                    return aq_;
+                bool? aq_(Extension @this) {
+                    FhirUri ay_ = @this?.UrlElement;
+                    string az_ = FHIRHelpers_4_4_000.Instance.ToString(context, ay_);
+                    CqlBoolean ba_ = context.Operators.Equal(az_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                    return ba_;
                 }
 
 
-                CqlBoolean ak_() {
-
-                    bool? ar_(Extension @this) {
-                        FhirUri ay_ = @this?.UrlElement;
-                        string az_ = FHIRHelpers_4_4_000.Instance.ToString(context, ay_);
-                        CqlBoolean ba_ = context.Operators.Equal(az_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                        return ba_;
-                    }
-
-
-                    object as_(Extension @this) {
-                        DataType bb_ = @this?.Value;
-                        return bb_;
-                    }
-
-                    IEnumerable<object> at_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(ElevatedBPDeclinedInterventions is DomainResource
-                        ? (ElevatedBPDeclinedInterventions as DomainResource).Extension
-                        : default), ar_, as_);
-                    object au_ = context.Operators.SingletonFrom<object>(at_);
-                    CqlConcept av_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, au_ as CodeableConcept);
-                    CqlValueSet aw_ = this.Patient_Declined(context);
-                    CqlBoolean ax_ = context.Operators.ConceptInValueSet(av_, aw_);
-                    return ax_;
+                object ar_(Extension @this) {
+                    DataType bb_ = @this?.Value;
+                    return bb_;
                 }
 
+                IEnumerable<object> as_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(ElevatedBPDeclinedInterventions is DomainResource
+                    ? (ElevatedBPDeclinedInterventions as DomainResource).Extension
+                    : default), aq_, ar_);
+                object at_ = context.Operators.SingletonFrom<object>(as_);
+                CqlConcept au_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, at_ as CodeableConcept);
+                CqlValueSet av_ = this.Patient_Declined(context);
+                CqlBoolean aw_ = context.Operators.ConceptInValueSet(au_, av_);
+                CqlBoolean ax_ = aw_;
                 return ai_
-                    /* CQL 'and' (332:21-333:94) */ && aj_()
-                    /* CQL 'and' (332:21-334:83) */ && ak_();
+                    /* CQL 'and' (332:21-333:94) */ && ap_
+                    /* CQL 'and' (332:21-334:83) */ && ax_;
             }
 
             CqlBoolean ad_ = context.Operators.WhereAny<ServiceRequest>(ab_, ac_);
@@ -2908,50 +2616,42 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 Period bv_ = FirstHTNEncounter?.Period;
                 CqlInterval<CqlDateTime> bw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bv_);
                 CqlBoolean bx_ = context.Operators.In<CqlDateTime>(bu_, bw_, "day");
+                Code<RequestStatus> by_ = FirstHTNDeclinedInterventions?.StatusElement;
+                RequestStatus? bz_ = by_?.Value;
+                Code<RequestStatus> ca_ = context.Operators.Convert<Code<RequestStatus>>(bz_);
+                string cb_ = context.Operators.Convert<string>(ca_);
+                string[] cc_ = [
+                    "active",
+                    "completed",
+                    "on-hold",
+                ];
+                CqlBoolean cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
+                CqlBoolean ce_ = cd_;
 
-                CqlBoolean by_() {
-                    Code<RequestStatus> ca_ = FirstHTNDeclinedInterventions?.StatusElement;
-                    RequestStatus? cb_ = ca_?.Value;
-                    Code<RequestStatus> cc_ = context.Operators.Convert<Code<RequestStatus>>(cb_);
-                    string cd_ = context.Operators.Convert<string>(cc_);
-                    string[] ce_ = [
-                        "active",
-                        "completed",
-                        "on-hold",
-                    ];
-                    CqlBoolean cf_ = context.Operators.In<string>(cd_, (IEnumerable<string>)ce_);
-                    return cf_;
+                bool? cf_(Extension @this) {
+                    FhirUri cn_ = @this?.UrlElement;
+                    string co_ = FHIRHelpers_4_4_000.Instance.ToString(context, cn_);
+                    CqlBoolean cp_ = context.Operators.Equal(co_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                    return cp_;
                 }
 
 
-                CqlBoolean bz_() {
-
-                    bool? cg_(Extension @this) {
-                        FhirUri cn_ = @this?.UrlElement;
-                        string co_ = FHIRHelpers_4_4_000.Instance.ToString(context, cn_);
-                        CqlBoolean cp_ = context.Operators.Equal(co_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                        return cp_;
-                    }
-
-
-                    object ch_(Extension @this) {
-                        DataType cq_ = @this?.Value;
-                        return cq_;
-                    }
-
-                    IEnumerable<object> ci_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(FirstHTNDeclinedInterventions is DomainResource
-                        ? (FirstHTNDeclinedInterventions as DomainResource).Extension
-                        : default), cg_, ch_);
-                    object cj_ = context.Operators.SingletonFrom<object>(ci_);
-                    CqlConcept ck_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cj_ as CodeableConcept);
-                    CqlValueSet cl_ = this.Patient_Declined(context);
-                    CqlBoolean cm_ = context.Operators.ConceptInValueSet(ck_, cl_);
-                    return cm_;
+                object cg_(Extension @this) {
+                    DataType cq_ = @this?.Value;
+                    return cq_;
                 }
 
+                IEnumerable<object> ch_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(FirstHTNDeclinedInterventions is DomainResource
+                    ? (FirstHTNDeclinedInterventions as DomainResource).Extension
+                    : default), cf_, cg_);
+                object ci_ = context.Operators.SingletonFrom<object>(ch_);
+                CqlConcept cj_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ci_ as CodeableConcept);
+                CqlValueSet ck_ = this.Patient_Declined(context);
+                CqlBoolean cl_ = context.Operators.ConceptInValueSet(cj_, ck_);
+                CqlBoolean cm_ = cl_;
                 return bx_
-                    /* CQL 'and' (343:23-344:94) */ && by_()
-                    /* CQL 'and' (343:23-345:83) */ && bz_();
+                    /* CQL 'and' (343:23-344:94) */ && ce_
+                    /* CQL 'and' (343:23-345:83) */ && cm_;
             }
 
             CqlBoolean bs_ = context.Operators.WhereAny<ServiceRequest>(bq_, br_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS2FHIRPCSDepScreenAndFollowUp", "1.0.000")]
 public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingleton<CMS2FHIRPCSDepScreenAndFollowUp_1_0_000>
 {
@@ -186,17 +186,13 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
             Period l_ = QualifyingEncounter?.Period;
             CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
             CqlBoolean n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, "day");
-
-            CqlBoolean o_() {
-                Code<Encounter.EncounterStatus> p_ = QualifyingEncounter?.StatusElement;
-                Encounter.EncounterStatus? q_ = p_?.Value;
-                Code<Encounter.EncounterStatus> r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
-                CqlBoolean s_ = context.Operators.Equal(r_, "finished");
-                return s_;
-            }
-
+            Code<Encounter.EncounterStatus> o_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? p_ = o_?.Value;
+            Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
+            CqlBoolean r_ = context.Operators.Equal(q_, "finished");
+            CqlBoolean s_ = r_;
             return n_
-                /* CQL 'and' (212:5-213:49) */ && o_();
+                /* CQL 'and' (212:5-213:49) */ && s_;
         }
 
         IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
@@ -213,15 +209,11 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
     private bool? Initial_Population_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Patient_Age_12_Years_or_Older_at_Start_of_Measurement_Period(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = this.Qualifying_Encounter_During_Measurement_Period(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (37:3-38:67) */ && b_();
+            /* CQL 'and' (37:3-38:67) */ && d_;
     }
 
 
@@ -334,39 +326,24 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime t_ = context.Operators.Subtract(r_, s_);
                 CqlInterval<CqlDateTime> u_ = context.Operators.Interval(t_, r_, true, true);
                 CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, "day");
-
-                CqlBoolean w_() {
-                    Period z_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                    CqlDateTime ab_ = context.Operators.Start(aa_);
-                    return ab_ is not null;
-                }
-
-
-                CqlBoolean x_() {
-                    DataType ac_ = AdolescentDepressionScreening?.Value;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    return ad_ is not null;
-                }
-
-
-                CqlBoolean y_() {
-                    Code<ObservationStatus> ae_ = AdolescentDepressionScreening?.StatusElement;
-                    ObservationStatus? af_ = ae_?.Value;
-                    string ag_ = context.Operators.Convert<string>(af_);
-                    string[] ah_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                    return ai_;
-                }
-
+                CqlBoolean w_ = (CqlBoolean)(r_ is not null);
+                DataType x_ = AdolescentDepressionScreening?.Value;
+                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                CqlBoolean z_ = (CqlBoolean)(y_ is not null);
+                Code<ObservationStatus> aa_ = AdolescentDepressionScreening?.StatusElement;
+                ObservationStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                CqlBoolean af_ = ae_;
                 return v_
-                    /* CQL 'and' (157:19-157:142) */ && w_()
-                    /* CQL 'and' (157:19-158:61) */ && x_()
-                    /* CQL 'and' (157:19-159:89) */ && y_();
+                    /* CQL 'and' (157:19-157:142) */ && w_
+                    /* CQL 'and' (157:19-158:61) */ && z_
+                    /* CQL 'and' (157:19-159:89) */ && af_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Encounter>(i_, j_);
@@ -376,11 +353,11 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         object f_(Observation @this) {
-            DataType aj_ = @this?.Effective;
-            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-            CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
-            CqlDateTime am_ = context.Operators.Start(al_);
-            return am_;
+            DataType ag_ = @this?.Effective;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
+            CqlDateTime aj_ = context.Operators.Start(ai_);
+            return aj_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
@@ -436,17 +413,13 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> x_ = context.Operators.Split((string)w_, "/");
                 string y_ = context.Operators.Last<string>(x_);
                 CqlBoolean z_ = context.Operators.Equal(v_, y_);
-
-                CqlBoolean aa_() {
-                    CodeableConcept ab_ = M?.Code;
-                    CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
-                    CqlValueSet ad_ = this.Adolescent_Depression_Medications(context);
-                    CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
-                    return ae_;
-                }
-
+                CodeableConcept aa_ = M?.Code;
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
+                CqlValueSet ac_ = this.Adolescent_Depression_Medications(context);
+                CqlBoolean ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
+                CqlBoolean ae_ = ad_;
                 return z_
-                    /* CQL 'and' */ && aa_();
+                    /* CQL 'and' */ && ae_;
             }
 
             CqlBoolean u_ = context.Operators.WhereAny<Medication>(s_, t_);
@@ -474,77 +447,51 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
                 CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ar_, ap_, true, true);
                 CqlBoolean at_ = context.Operators.In<CqlDateTime>(am_, as_, "day");
-
-                CqlBoolean au_() {
-                    Period az_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, az_);
-                    CqlDateTime bb_ = context.Operators.Start(ba_);
-                    return bb_ is not null;
-                }
-
-
-                CqlBoolean av_() {
-                    CqlInterval<CqlDate> bc_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdolescentMed);
-                    CqlDate bd_ = (bc_ as CqlInterval<CqlDate>)?.low;
-                    CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
-                    CqlDate bf_ = (bc_ as CqlInterval<CqlDate>)?.high;
-                    CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                    CqlBoolean bh_ = (bc_ as CqlInterval<CqlDate>)?.lowClosed;
-                    CqlBoolean bi_ = (bc_ as CqlInterval<CqlDate>)?.highClosed;
-                    CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(be_, bg_, bh_, bi_);
-                    CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
-                    Period bl_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
-                    CqlBoolean bn_ = context.Operators.OverlapsAfter(bk_, bm_, "day");
-                    return bn_;
-                }
-
-
-                CqlBoolean aw_() {
-                    Observation bo_ = this.Most_Recent_Adolescent_Depression_Screening(context);
-                    DataType bp_ = bo_?.Value;
-                    object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                    CqlCode br_ = this.Depression_screening_positive__finding_(context);
-                    CqlConcept bs_ = context.Operators.ConvertCodeToConcept(br_);
-                    CqlBoolean bt_ = context.Operators.Equivalent(bq_ as CqlConcept, bs_);
-                    return bt_;
-                }
-
-
-                CqlBoolean ax_() {
-                    Code<MedicationRequest.MedicationrequestStatus> bu_ = AdolescentMed?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? bv_ = bu_?.Value;
-                    string bw_ = context.Operators.Convert<string>(bv_);
-                    string[] bx_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
-                    return by_;
-                }
-
-
-                CqlBoolean ay_() {
-                    Code<MedicationRequest.MedicationRequestIntent> bz_ = AdolescentMed?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ca_ = bz_?.Value;
-                    string cb_ = context.Operators.Convert<string>(ca_);
-                    string[] cc_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
-                    return cd_;
-                }
-
+                CqlBoolean au_ = (CqlBoolean)(ap_ is not null);
+                CqlInterval<CqlDate> av_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdolescentMed);
+                CqlDate aw_ = (av_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate ay_ = (av_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime az_ = context.Operators.ConvertDateToDateTime(ay_);
+                CqlBoolean ba_ = (av_ as CqlInterval<CqlDate>)?.lowClosed;
+                CqlBoolean bb_ = (av_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(ax_, az_, ba_, bb_);
+                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
+                CqlBoolean be_ = context.Operators.OverlapsAfter(bd_, ao_, "day");
+                CqlBoolean bf_ = be_;
+                DataType bg_ = ai_?.Value;
+                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                CqlCode bi_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept bj_ = context.Operators.ConvertCodeToConcept(bi_);
+                CqlBoolean bk_ = context.Operators.Equivalent(bh_ as CqlConcept, bj_);
+                CqlBoolean bl_ = bk_;
+                Code<MedicationRequest.MedicationrequestStatus> bm_ = AdolescentMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? bn_ = bm_?.Value;
+                string bo_ = context.Operators.Convert<string>(bn_);
+                string[] bp_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean bq_ = context.Operators.In<string>(bo_, (IEnumerable<string>)bp_);
+                CqlBoolean br_ = bq_;
+                Code<MedicationRequest.MedicationRequestIntent> bs_ = AdolescentMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? bt_ = bs_?.Value;
+                string bu_ = context.Operators.Convert<string>(bt_);
+                string[] bv_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
+                CqlBoolean bx_ = bw_;
                 return at_
-                    /* CQL 'and' (76:21-76:169) */ && au_()
-                    /* CQL 'and' (76:21-77:121) */ && av_()
-                    /* CQL 'and' (76:21-78:111) */ && aw_()
-                    /* CQL 'and' (76:21-79:65) */ && ax_()
-                    /* CQL 'and' (76:21-80:119) */ && ay_();
+                    /* CQL 'and' (76:21-76:169) */ && au_
+                    /* CQL 'and' (76:21-77:121) */ && bf_
+                    /* CQL 'and' (76:21-78:111) */ && bl_
+                    /* CQL 'and' (76:21-79:65) */ && br_
+                    /* CQL 'and' (76:21-80:119) */ && bx_;
             }
 
             CqlBoolean ah_ = context.Operators.WhereAny<Encounter>(af_, ag_);
@@ -556,16 +503,16 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
         bool? k_(ServiceRequest AdolescentReferral) {
-            Code<RequestStatus> ce_ = AdolescentReferral?.StatusElement;
-            RequestStatus? cf_ = ce_?.Value;
-            Code<RequestStatus> cg_ = context.Operators.Convert<Code<RequestStatus>>(cf_);
-            string ch_ = context.Operators.Convert<string>(cg_);
-            string[] ci_ = [
+            Code<RequestStatus> by_ = AdolescentReferral?.StatusElement;
+            RequestStatus? bz_ = by_?.Value;
+            Code<RequestStatus> ca_ = context.Operators.Convert<Code<RequestStatus>>(bz_);
+            string cb_ = context.Operators.Convert<string>(ca_);
+            string[] cc_ = [
                 "active",
                 "completed",
             ];
-            CqlBoolean cj_ = context.Operators.In<string>(ch_, (IEnumerable<string>)ci_);
-            return cj_;
+            CqlBoolean cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
+            return cd_;
         }
 
         IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
@@ -574,11 +521,11 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
         bool? p_(Procedure AdolescentFollowUp) {
-            Code<EventStatus> ck_ = AdolescentFollowUp?.StatusElement;
-            EventStatus? cl_ = ck_?.Value;
-            string cm_ = context.Operators.Convert<string>(cl_);
-            CqlBoolean cn_ = context.Operators.Equal(cm_, "completed");
-            return cn_;
+            Code<EventStatus> ce_ = AdolescentFollowUp?.StatusElement;
+            EventStatus? cf_ = ce_?.Value;
+            string cg_ = context.Operators.Convert<string>(cf_);
+            CqlBoolean ch_ = context.Operators.Equal(cg_, "completed");
+            return ch_;
         }
 
         IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
@@ -621,153 +568,117 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
             CqlDateTime t_ = context.Operators.Subtract(r_, s_);
             CqlInterval<CqlDateTime> u_ = context.Operators.Interval(t_, r_, true, true);
             CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, "day");
-
-            CqlBoolean w_() {
-                Period aa_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                CqlDateTime ac_ = context.Operators.Start(ab_);
-                return ac_ is not null;
+            CqlBoolean w_ = (CqlBoolean)(r_ is not null);
+            DataType x_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Value;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            CqlCode z_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
+            CqlBoolean ab_ = context.Operators.Equivalent(y_ as CqlConcept, aa_);
+            CqlBoolean ac_ = ab_;
+            object ad_;
+            object ax_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+            object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+            bool az_ = ay_ is CqlDateTime;
+            if (az_)
+            {
+                ad_ = ay_ as CqlDateTime;
             }
-
-
-            CqlBoolean x_() {
-                DataType ad_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Value;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                CqlCode af_ = this.Depression_screening_positive__finding_(context);
-                CqlConcept ag_ = context.Operators.ConvertCodeToConcept(af_);
-                CqlBoolean ah_ = context.Operators.Equivalent(ae_ as CqlConcept, ag_);
-                return ah_;
-            }
-
-
-            CqlBoolean y_() {
-                object ai_;
-                object ap_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
-                object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                bool ar_ = aq_ is CqlDateTime;
-                if (ar_)
+            else
+            {
+                bool ba_ = ay_ is CqlQuantity;
+                if (ba_)
                 {
-                    ai_ = aq_ as CqlDateTime;
+                    ad_ = ay_ as CqlQuantity;
                 }
                 else
                 {
-                    bool as_ = aq_ is CqlQuantity;
-                    if (as_)
+                    bool bb_ = ay_ is CqlInterval<CqlDateTime>;
+                    if (bb_)
                     {
-                        ai_ = aq_ as CqlQuantity;
+                        ad_ = ay_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool at_ = aq_ is CqlInterval<CqlDateTime>;
-                        if (at_)
+                        bool bc_ = ay_ is CqlInterval<CqlQuantity>;
+                        if (bc_)
                         {
-                            ai_ = aq_ as CqlInterval<CqlDateTime>;
+                            ad_ = ay_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool au_ = aq_ is CqlInterval<CqlQuantity>;
-                            if (au_)
-                            {
-                                ai_ = aq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ai_ = null;
-                            }
+                            ad_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                CqlDateTime ak_ = context.Operators.Start(aj_);
-                Period al_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                CqlBoolean an_ = context.Operators.In<CqlDateTime>(ak_, am_, (string)default);
-
-                CqlBoolean ao_() {
-                    object av_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "authoredOn");
-                    CqlDateTime aw_ = context.Operators.LateBoundProperty<CqlDateTime>(av_, "value");
-                    Period ax_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
-                    CqlDateTime az_ = context.Operators.End(ay_);
-                    CqlQuantity ba_ = context.Operators.Quantity(2m, "days");
-                    CqlDateTime bb_ = context.Operators.Add(az_, ba_);
-                    CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(az_, bb_, true, true);
-                    CqlBoolean bd_ = context.Operators.In<CqlDateTime>(aw_, bc_, "day");
-
-                    CqlBoolean be_() {
-                        Period bf_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-                        CqlDateTime bh_ = context.Operators.End(bg_);
-                        return bh_ is not null;
-                    }
-
-                    return bd_
-                        /* CQL 'and' (171:14-171:124) */ && be_();
-                }
-
-                return an_
-                    /* CQL 'or' (170:11-172:7) */ || ao_();
             }
-
-
-            CqlBoolean z_() {
-                object bi_;
-                object bp_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
+            CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
+            CqlDateTime af_ = context.Operators.Start(ae_);
+            CqlBoolean ag_ = context.Operators.In<CqlDateTime>(af_, q_, (string)default);
+            object ah_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "authoredOn");
+            CqlDateTime ai_ = context.Operators.LateBoundProperty<CqlDateTime>(ah_, "value");
+            CqlDateTime aj_ = context.Operators.End(q_);
+            CqlQuantity ak_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime al_ = context.Operators.Add(aj_, ak_);
+            CqlInterval<CqlDateTime> am_ = context.Operators.Interval(aj_, al_, true, true);
+            CqlBoolean an_ = context.Operators.In<CqlDateTime>(ai_, am_, "day");
+            CqlBoolean ao_ = (CqlBoolean)(aj_ is not null);
+            CqlBoolean ap_ = an_
+                /* CQL 'and' (171:14-171:124) */ && ao_;
+            CqlBoolean aq_ = ag_
+                /* CQL 'or' (170:11-172:7) */ || ap_;
+            object ar_;
+            object bd_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            bool bf_ = be_ is CqlDateTime;
+            if (bf_)
+            {
+                ar_ = be_ as CqlDateTime;
+            }
+            else
+            {
+                bool bg_ = be_ is CqlQuantity;
+                if (bg_)
                 {
-                    bi_ = bq_ as CqlDateTime;
+                    ar_ = be_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bs_ = bq_ is CqlQuantity;
-                    if (bs_)
+                    bool bh_ = be_ is CqlInterval<CqlDateTime>;
+                    if (bh_)
                     {
-                        bi_ = bq_ as CqlQuantity;
+                        ar_ = be_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bt_)
+                        bool bi_ = be_ is CqlInterval<CqlQuantity>;
+                        if (bi_)
                         {
-                            bi_ = bq_ as CqlInterval<CqlDateTime>;
+                            ar_ = be_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
-                            if (bu_)
-                            {
-                                bi_ = bq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bi_ = null;
-                            }
+                            ar_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
-                CqlDateTime bk_ = context.Operators.Start(bj_);
-                object bl_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "authoredOn");
-                CqlDateTime bm_ = context.Operators.LateBoundProperty<CqlDateTime>(bl_, "value");
-                CqlInterval<CqlDateTime> bn_ = this.Measurement_Period(context);
-                CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bk_ ?? bm_, bn_, "day");
-                return bo_;
             }
-
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.Start(as_);
+            CqlInterval<CqlDateTime> au_ = this.Measurement_Period(context);
+            CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_ ?? ai_, au_, "day");
+            CqlBoolean aw_ = av_;
             return v_
-                /* CQL 'and' (168:11-168:134) */ && w_()
-                /* CQL 'and' (168:11-169:80) */ && x_()
-                /* CQL 'and' (168:11-172:7) */ && y_()
-                /* CQL 'and' (168:5-173:168) */ && z_();
+                /* CQL 'and' (168:11-168:134) */ && w_
+                /* CQL 'and' (168:11-169:80) */ && ac_
+                /* CQL 'and' (168:11-172:7) */ && aq_
+                /* CQL 'and' (168:5-173:168) */ && aw_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> h_ = context.Operators.SelectWhere<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(e_, f_, g_);
 
         (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? i_((CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? tuple_ewmohjtdtinujhphqjvbwmmhh) {
-            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? bv_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter);
-            return bv_;
+            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? bj_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter);
+            return bj_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> j_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(h_, i_);
@@ -823,39 +734,24 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime t_ = context.Operators.Subtract(r_, s_);
                 CqlInterval<CqlDateTime> u_ = context.Operators.Interval(t_, r_, true, true);
                 CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, "day");
-
-                CqlBoolean w_() {
-                    Period z_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                    CqlDateTime ab_ = context.Operators.Start(aa_);
-                    return ab_ is not null;
-                }
-
-
-                CqlBoolean x_() {
-                    DataType ac_ = AdultDepressionScreening?.Value;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    return ad_ is not null;
-                }
-
-
-                CqlBoolean y_() {
-                    Code<ObservationStatus> ae_ = AdultDepressionScreening?.StatusElement;
-                    ObservationStatus? af_ = ae_?.Value;
-                    string ag_ = context.Operators.Convert<string>(af_);
-                    string[] ah_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                    return ai_;
-                }
-
+                CqlBoolean w_ = (CqlBoolean)(r_ is not null);
+                DataType x_ = AdultDepressionScreening?.Value;
+                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                CqlBoolean z_ = (CqlBoolean)(y_ is not null);
+                Code<ObservationStatus> aa_ = AdultDepressionScreening?.StatusElement;
+                ObservationStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                string[] ad_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+                CqlBoolean af_ = ae_;
                 return v_
-                    /* CQL 'and' (178:19-178:137) */ && w_()
-                    /* CQL 'and' (178:19-179:56) */ && x_()
-                    /* CQL 'and' (178:19-180:84) */ && y_();
+                    /* CQL 'and' (178:19-178:137) */ && w_
+                    /* CQL 'and' (178:19-179:56) */ && z_
+                    /* CQL 'and' (178:19-180:84) */ && af_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Encounter>(i_, j_);
@@ -865,11 +761,11 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
         object f_(Observation @this) {
-            DataType aj_ = @this?.Effective;
-            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-            CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
-            CqlDateTime am_ = context.Operators.Start(al_);
-            return am_;
+            DataType ag_ = @this?.Effective;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
+            CqlDateTime aj_ = context.Operators.Start(ai_);
+            return aj_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
@@ -925,17 +821,13 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> x_ = context.Operators.Split((string)w_, "/");
                 string y_ = context.Operators.Last<string>(x_);
                 CqlBoolean z_ = context.Operators.Equal(v_, y_);
-
-                CqlBoolean aa_() {
-                    CodeableConcept ab_ = M?.Code;
-                    CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
-                    CqlValueSet ad_ = this.Adult_Depression_Medications(context);
-                    CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
-                    return ae_;
-                }
-
+                CodeableConcept aa_ = M?.Code;
+                CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
+                CqlValueSet ac_ = this.Adult_Depression_Medications(context);
+                CqlBoolean ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
+                CqlBoolean ae_ = ad_;
                 return z_
-                    /* CQL 'and' */ && aa_();
+                    /* CQL 'and' */ && ae_;
             }
 
             CqlBoolean u_ = context.Operators.WhereAny<Medication>(s_, t_);
@@ -963,77 +855,51 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
                 CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ar_, ap_, true, true);
                 CqlBoolean at_ = context.Operators.In<CqlDateTime>(am_, as_, "day");
-
-                CqlBoolean au_() {
-                    Period az_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, az_);
-                    CqlDateTime bb_ = context.Operators.Start(ba_);
-                    return bb_ is not null;
-                }
-
-
-                CqlBoolean av_() {
-                    CqlInterval<CqlDate> bc_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdultMed);
-                    CqlDate bd_ = (bc_ as CqlInterval<CqlDate>)?.low;
-                    CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
-                    CqlDate bf_ = (bc_ as CqlInterval<CqlDate>)?.high;
-                    CqlDateTime bg_ = context.Operators.ConvertDateToDateTime(bf_);
-                    CqlBoolean bh_ = (bc_ as CqlInterval<CqlDate>)?.lowClosed;
-                    CqlBoolean bi_ = (bc_ as CqlInterval<CqlDate>)?.highClosed;
-                    CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(be_, bg_, bh_, bi_);
-                    CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
-                    Period bl_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
-                    CqlBoolean bn_ = context.Operators.OverlapsAfter(bk_, bm_, "day");
-                    return bn_;
-                }
-
-
-                CqlBoolean aw_() {
-                    Observation bo_ = this.Most_Recent_Adult_Depression_Screening(context);
-                    DataType bp_ = bo_?.Value;
-                    object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                    CqlCode br_ = this.Depression_screening_positive__finding_(context);
-                    CqlConcept bs_ = context.Operators.ConvertCodeToConcept(br_);
-                    CqlBoolean bt_ = context.Operators.Equivalent(bq_ as CqlConcept, bs_);
-                    return bt_;
-                }
-
-
-                CqlBoolean ax_() {
-                    Code<MedicationRequest.MedicationrequestStatus> bu_ = AdultMed?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? bv_ = bu_?.Value;
-                    string bw_ = context.Operators.Convert<string>(bv_);
-                    string[] bx_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
-                    return by_;
-                }
-
-
-                CqlBoolean ay_() {
-                    Code<MedicationRequest.MedicationRequestIntent> bz_ = AdultMed?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ca_ = bz_?.Value;
-                    string cb_ = context.Operators.Convert<string>(ca_);
-                    string[] cc_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
-                    return cd_;
-                }
-
+                CqlBoolean au_ = (CqlBoolean)(ap_ is not null);
+                CqlInterval<CqlDate> av_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdultMed);
+                CqlDate aw_ = (av_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime ax_ = context.Operators.ConvertDateToDateTime(aw_);
+                CqlDate ay_ = (av_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime az_ = context.Operators.ConvertDateToDateTime(ay_);
+                CqlBoolean ba_ = (av_ as CqlInterval<CqlDate>)?.lowClosed;
+                CqlBoolean bb_ = (av_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(ax_, az_, ba_, bb_);
+                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
+                CqlBoolean be_ = context.Operators.OverlapsAfter(bd_, ao_, "day");
+                CqlBoolean bf_ = be_;
+                DataType bg_ = ai_?.Value;
+                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                CqlCode bi_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept bj_ = context.Operators.ConvertCodeToConcept(bi_);
+                CqlBoolean bk_ = context.Operators.Equivalent(bh_ as CqlConcept, bj_);
+                CqlBoolean bl_ = bk_;
+                Code<MedicationRequest.MedicationrequestStatus> bm_ = AdultMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? bn_ = bm_?.Value;
+                string bo_ = context.Operators.Convert<string>(bn_);
+                string[] bp_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean bq_ = context.Operators.In<string>(bo_, (IEnumerable<string>)bp_);
+                CqlBoolean br_ = bq_;
+                Code<MedicationRequest.MedicationRequestIntent> bs_ = AdultMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? bt_ = bs_?.Value;
+                string bu_ = context.Operators.Convert<string>(bt_);
+                string[] bv_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
+                CqlBoolean bx_ = bw_;
                 return at_
-                    /* CQL 'and' (93:21-93:164) */ && au_()
-                    /* CQL 'and' (93:21-94:116) */ && av_()
-                    /* CQL 'and' (93:21-95:106) */ && aw_()
-                    /* CQL 'and' (93:21-96:60) */ && ax_()
-                    /* CQL 'and' (93:21-97:114) */ && ay_();
+                    /* CQL 'and' (93:21-93:164) */ && au_
+                    /* CQL 'and' (93:21-94:116) */ && bf_
+                    /* CQL 'and' (93:21-95:106) */ && bl_
+                    /* CQL 'and' (93:21-96:60) */ && br_
+                    /* CQL 'and' (93:21-97:114) */ && bx_;
             }
 
             CqlBoolean ah_ = context.Operators.WhereAny<Encounter>(af_, ag_);
@@ -1045,16 +911,16 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
 
         bool? k_(ServiceRequest AdultReferral) {
-            Code<RequestStatus> ce_ = AdultReferral?.StatusElement;
-            RequestStatus? cf_ = ce_?.Value;
-            Code<RequestStatus> cg_ = context.Operators.Convert<Code<RequestStatus>>(cf_);
-            string ch_ = context.Operators.Convert<string>(cg_);
-            string[] ci_ = [
+            Code<RequestStatus> by_ = AdultReferral?.StatusElement;
+            RequestStatus? bz_ = by_?.Value;
+            Code<RequestStatus> ca_ = context.Operators.Convert<Code<RequestStatus>>(bz_);
+            string cb_ = context.Operators.Convert<string>(ca_);
+            string[] cc_ = [
                 "active",
                 "completed",
             ];
-            CqlBoolean cj_ = context.Operators.In<string>(ch_, (IEnumerable<string>)ci_);
-            return cj_;
+            CqlBoolean cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
+            return cd_;
         }
 
         IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
@@ -1063,11 +929,11 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
         bool? p_(Procedure AdultFollowUp) {
-            Code<EventStatus> ck_ = AdultFollowUp?.StatusElement;
-            EventStatus? cl_ = ck_?.Value;
-            string cm_ = context.Operators.Convert<string>(cl_);
-            CqlBoolean cn_ = context.Operators.Equal(cm_, "completed");
-            return cn_;
+            Code<EventStatus> ce_ = AdultFollowUp?.StatusElement;
+            EventStatus? cf_ = ce_?.Value;
+            string cg_ = context.Operators.Convert<string>(cf_);
+            CqlBoolean ch_ = context.Operators.Equal(cg_, "completed");
+            return ch_;
         }
 
         IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
@@ -1110,153 +976,117 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
             CqlDateTime t_ = context.Operators.Subtract(r_, s_);
             CqlInterval<CqlDateTime> u_ = context.Operators.Interval(t_, r_, true, true);
             CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, "day");
-
-            CqlBoolean w_() {
-                Period aa_ = tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                CqlDateTime ac_ = context.Operators.Start(ab_);
-                return ac_ is not null;
+            CqlBoolean w_ = (CqlBoolean)(r_ is not null);
+            DataType x_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Value;
+            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+            CqlCode z_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
+            CqlBoolean ab_ = context.Operators.Equivalent(y_ as CqlConcept, aa_);
+            CqlBoolean ac_ = ab_;
+            object ad_;
+            object ax_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+            object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+            bool az_ = ay_ is CqlDateTime;
+            if (az_)
+            {
+                ad_ = ay_ as CqlDateTime;
             }
-
-
-            CqlBoolean x_() {
-                DataType ad_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Value;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                CqlCode af_ = this.Depression_screening_positive__finding_(context);
-                CqlConcept ag_ = context.Operators.ConvertCodeToConcept(af_);
-                CqlBoolean ah_ = context.Operators.Equivalent(ae_ as CqlConcept, ag_);
-                return ah_;
-            }
-
-
-            CqlBoolean y_() {
-                object ai_;
-                object ap_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
-                object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                bool ar_ = aq_ is CqlDateTime;
-                if (ar_)
+            else
+            {
+                bool ba_ = ay_ is CqlQuantity;
+                if (ba_)
                 {
-                    ai_ = aq_ as CqlDateTime;
+                    ad_ = ay_ as CqlQuantity;
                 }
                 else
                 {
-                    bool as_ = aq_ is CqlQuantity;
-                    if (as_)
+                    bool bb_ = ay_ is CqlInterval<CqlDateTime>;
+                    if (bb_)
                     {
-                        ai_ = aq_ as CqlQuantity;
+                        ad_ = ay_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool at_ = aq_ is CqlInterval<CqlDateTime>;
-                        if (at_)
+                        bool bc_ = ay_ is CqlInterval<CqlQuantity>;
+                        if (bc_)
                         {
-                            ai_ = aq_ as CqlInterval<CqlDateTime>;
+                            ad_ = ay_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool au_ = aq_ is CqlInterval<CqlQuantity>;
-                            if (au_)
-                            {
-                                ai_ = aq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ai_ = null;
-                            }
+                            ad_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                CqlDateTime ak_ = context.Operators.Start(aj_);
-                Period al_ = tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter?.Period;
-                CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                CqlBoolean an_ = context.Operators.In<CqlDateTime>(ak_, am_, (string)default);
-
-                CqlBoolean ao_() {
-                    object av_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "authoredOn");
-                    CqlDateTime aw_ = context.Operators.LateBoundProperty<CqlDateTime>(av_, "value");
-                    Period ax_ = tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
-                    CqlDateTime az_ = context.Operators.End(ay_);
-                    CqlQuantity ba_ = context.Operators.Quantity(2m, "days");
-                    CqlDateTime bb_ = context.Operators.Add(az_, ba_);
-                    CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(az_, bb_, true, true);
-                    CqlBoolean bd_ = context.Operators.In<CqlDateTime>(aw_, bc_, "day");
-
-                    CqlBoolean be_() {
-                        Period bf_ = tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter?.Period;
-                        CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-                        CqlDateTime bh_ = context.Operators.End(bg_);
-                        return bh_ is not null;
-                    }
-
-                    return bd_
-                        /* CQL 'and' (192:14-192:119) */ && be_();
-                }
-
-                return an_
-                    /* CQL 'or' (191:11-193:7) */ || ao_();
             }
-
-
-            CqlBoolean z_() {
-                object bi_;
-                object bp_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
+            CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
+            CqlDateTime af_ = context.Operators.Start(ae_);
+            CqlBoolean ag_ = context.Operators.In<CqlDateTime>(af_, q_, (string)default);
+            object ah_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "authoredOn");
+            CqlDateTime ai_ = context.Operators.LateBoundProperty<CqlDateTime>(ah_, "value");
+            CqlDateTime aj_ = context.Operators.End(q_);
+            CqlQuantity ak_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime al_ = context.Operators.Add(aj_, ak_);
+            CqlInterval<CqlDateTime> am_ = context.Operators.Interval(aj_, al_, true, true);
+            CqlBoolean an_ = context.Operators.In<CqlDateTime>(ai_, am_, "day");
+            CqlBoolean ao_ = (CqlBoolean)(aj_ is not null);
+            CqlBoolean ap_ = an_
+                /* CQL 'and' (192:14-192:119) */ && ao_;
+            CqlBoolean aq_ = ag_
+                /* CQL 'or' (191:11-193:7) */ || ap_;
+            object ar_;
+            object bd_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            bool bf_ = be_ is CqlDateTime;
+            if (bf_)
+            {
+                ar_ = be_ as CqlDateTime;
+            }
+            else
+            {
+                bool bg_ = be_ is CqlQuantity;
+                if (bg_)
                 {
-                    bi_ = bq_ as CqlDateTime;
+                    ar_ = be_ as CqlQuantity;
                 }
                 else
                 {
-                    bool bs_ = bq_ is CqlQuantity;
-                    if (bs_)
+                    bool bh_ = be_ is CqlInterval<CqlDateTime>;
+                    if (bh_)
                     {
-                        bi_ = bq_ as CqlQuantity;
+                        ar_ = be_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bt_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bt_)
+                        bool bi_ = be_ is CqlInterval<CqlQuantity>;
+                        if (bi_)
                         {
-                            bi_ = bq_ as CqlInterval<CqlDateTime>;
+                            ar_ = be_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool bu_ = bq_ is CqlInterval<CqlQuantity>;
-                            if (bu_)
-                            {
-                                bi_ = bq_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                bi_ = null;
-                            }
+                            ar_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
-                CqlDateTime bk_ = context.Operators.Start(bj_);
-                object bl_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "authoredOn");
-                CqlDateTime bm_ = context.Operators.LateBoundProperty<CqlDateTime>(bl_, "value");
-                CqlInterval<CqlDateTime> bn_ = this.Measurement_Period(context);
-                CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bk_ ?? bm_, bn_, "day");
-                return bo_;
             }
-
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.Start(as_);
+            CqlInterval<CqlDateTime> au_ = this.Measurement_Period(context);
+            CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_ ?? ai_, au_, "day");
+            CqlBoolean aw_ = av_;
             return v_
-                /* CQL 'and' (189:11-189:129) */ && w_()
-                /* CQL 'and' (189:11-190:75) */ && x_()
-                /* CQL 'and' (189:11-193:7) */ && y_()
-                /* CQL 'and' (189:5-194:158) */ && z_();
+                /* CQL 'and' (189:11-189:129) */ && w_
+                /* CQL 'and' (189:11-190:75) */ && ac_
+                /* CQL 'and' (189:11-193:7) */ && aq_
+                /* CQL 'and' (189:5-194:158) */ && aw_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> h_ = context.Operators.SelectWhere<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(e_, f_, g_);
 
         (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? i_((CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? tuple_cgtoaqsajoehgwcararimqzsa) {
-            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? bv_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter);
-            return bv_;
+            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? bj_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter);
+            return bj_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> j_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(h_, i_);
@@ -1294,75 +1124,32 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
     private bool? Numerator_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Patient_Age_12_to_16_Years_at_Start_of_Measurement_Period(context);
-
-        CqlBoolean b_() {
-            CqlBoolean e_ = this.Has_Most_Recent_Adolescent_Screening_Negative(context);
-
-            CqlBoolean f_() {
-                IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> g_ = this.Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(context);
-                CqlBoolean h_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(g_);
-                return h_;
-            }
-
-            return e_
-                /* CQL 'or' (48:11-50:7) */ || f_();
-        }
-
-
-        CqlBoolean c_() {
-            CqlBoolean i_ = this.Patient_Age_17_Years_at_Start_of_Measurement_Period(context);
-
-            CqlBoolean j_() {
-                CqlBoolean k_ = this.Has_Most_Recent_Adolescent_Screening_Negative(context);
-
-                CqlBoolean l_() {
-                    IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> n_ = this.Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(context);
-                    CqlBoolean o_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(n_);
-                    return o_;
-                }
-
-
-                CqlBoolean m_() {
-                    IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> p_ = this.Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(context);
-                    CqlBoolean q_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(p_);
-                    return q_;
-                }
-
-                return k_
-                    /* CQL 'or' (53:15-54:99) */ || l_()
-                    /* CQL 'or' (53:15-55:57) */ || this.Has_Most_Recent_Adult_Screening_Negative(context)
-                    /* CQL 'or' (53:13-57:9) */ || m_();
-            }
-
-            return i_
-                /* CQL 'and' (52:8-58:5) */ && j_();
-        }
-
-
-        CqlBoolean d_() {
-            CqlBoolean r_ = this.Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(context);
-
-            CqlBoolean s_() {
-                CqlBoolean t_ = this.Has_Most_Recent_Adult_Screening_Negative(context);
-
-                CqlBoolean u_() {
-                    IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> v_ = this.Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(context);
-                    CqlBoolean w_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(v_);
-                    return w_;
-                }
-
-                return t_
-                    /* CQL 'or' (60:13-62:9) */ || u_();
-            }
-
-            return r_
-                /* CQL 'and' (59:8-63:5) */ && s_();
-        }
-
+        CqlBoolean b_ = this.Has_Most_Recent_Adolescent_Screening_Negative(context);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> c_ = this.Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        CqlBoolean d_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(c_);
+        CqlBoolean e_ = d_;
+        CqlBoolean f_ = b_
+            /* CQL 'or' (48:11-50:7) */ || e_;
+        CqlBoolean g_ = this.Patient_Age_17_Years_at_Start_of_Measurement_Period(context);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> h_ = this.Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        CqlBoolean i_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(h_);
+        CqlBoolean j_ = i_;
+        CqlBoolean k_ = b_
+            /* CQL 'or' (53:15-54:99) */ || e_
+            /* CQL 'or' (53:15-55:57) */ || this.Has_Most_Recent_Adult_Screening_Negative(context)
+            /* CQL 'or' (53:13-57:9) */ || j_;
+        CqlBoolean l_ = g_
+            /* CQL 'and' (52:8-58:5) */ && k_;
+        CqlBoolean m_ = this.Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(context);
+        CqlBoolean n_ = this.Has_Most_Recent_Adult_Screening_Negative(context);
+        CqlBoolean o_ = n_
+            /* CQL 'or' (60:13-62:9) */ || j_;
+        CqlBoolean p_ = m_
+            /* CQL 'and' (59:8-63:5) */ && o_;
         return (a_
-            /* CQL 'and' (47:3-51:3) */ && b_())
-            /* CQL 'or' (47:3-58:5) */ || c_()
-            /* CQL 'or' (47:3-63:5) */ || d_();
+            /* CQL 'and' (47:3-51:3) */ && f_)
+            /* CQL 'or' (47:3-58:5) */ || l_
+            /* CQL 'or' (47:3-63:5) */ || p_;
     }
 
 
@@ -1400,16 +1187,16 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         bool? f_(Observation NoAdolescentScreen) {
 
             bool? q_(Extension @this) {
-                FhirUri z_ = @this?.UrlElement;
-                string aa_ = FHIRHelpers_4_4_000.Instance.ToString(context, z_);
-                CqlBoolean ab_ = context.Operators.Equal(aa_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                return ab_;
+                FhirUri ag_ = @this?.UrlElement;
+                string ah_ = FHIRHelpers_4_4_000.Instance.ToString(context, ag_);
+                CqlBoolean ai_ = context.Operators.Equal(ah_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return ai_;
             }
 
 
             object r_(Extension @this) {
-                DataType ac_ = @this?.Value;
-                return ac_;
+                DataType aj_ = @this?.Value;
+                return aj_;
             }
 
             IEnumerable<object> s_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
@@ -1421,33 +1208,29 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
             CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
             CqlBoolean x_ = context.Operators.Equivalent(u_, w_);
 
-            CqlBoolean y_() {
-
-                bool? ad_(Extension @this) {
-                    FhirUri ak_ = @this?.UrlElement;
-                    string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
-                    CqlBoolean am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                    return am_;
-                }
-
-
-                object ae_(Extension @this) {
-                    DataType an_ = @this?.Value;
-                    return an_;
-                }
-
-                IEnumerable<object> af_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
-                    ? (NoAdolescentScreen as DomainResource).Extension
-                    : default), ad_, ae_);
-                object ag_ = context.Operators.SingletonFrom<object>(af_);
-                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_ as CodeableConcept);
-                CqlValueSet ai_ = this.Medical_Reason(context);
-                CqlBoolean aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
-                return aj_;
+            bool? y_(Extension @this) {
+                FhirUri ak_ = @this?.UrlElement;
+                string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
+                CqlBoolean am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return am_;
             }
 
+
+            object z_(Extension @this) {
+                DataType an_ = @this?.Value;
+                return an_;
+            }
+
+            IEnumerable<object> aa_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                ? (NoAdolescentScreen as DomainResource).Extension
+                : default), y_, z_);
+            object ab_ = context.Operators.SingletonFrom<object>(aa_);
+            CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_ as CodeableConcept);
+            CqlValueSet ad_ = this.Medical_Reason(context);
+            CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+            CqlBoolean af_ = ae_;
             return x_
-                /* CQL 'or' (142:5-144:5) */ || y_();
+                /* CQL 'or' (142:5-144:5) */ || af_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
@@ -1482,39 +1265,24 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime q_ = context.Operators.Subtract(o_, p_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(q_, o_, true, true);
                 CqlBoolean s_ = context.Operators.In<CqlDateTime>(l_, r_, "day");
-
-                CqlBoolean t_() {
-                    Period w_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
-                    CqlDateTime y_ = context.Operators.Start(x_);
-                    return y_ is not null;
-                }
-
-
-                CqlBoolean u_() {
-                    DataType z_ = AdolescentScreening?.Value;
-                    object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                    return aa_ is not null;
-                }
-
-
-                CqlBoolean v_() {
-                    Code<ObservationStatus> ab_ = AdolescentScreening?.StatusElement;
-                    ObservationStatus? ac_ = ab_?.Value;
-                    string ad_ = context.Operators.Convert<string>(ac_);
-                    string[] ae_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
-                    return af_;
-                }
-
+                CqlBoolean t_ = (CqlBoolean)(o_ is not null);
+                DataType u_ = AdolescentScreening?.Value;
+                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                CqlBoolean w_ = (CqlBoolean)(v_ is not null);
+                Code<ObservationStatus> x_ = AdolescentScreening?.StatusElement;
+                ObservationStatus? y_ = x_?.Value;
+                string z_ = context.Operators.Convert<string>(y_);
+                string[] aa_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
+                CqlBoolean ac_ = ab_;
                 return s_
-                    /* CQL 'and' (110:19-110:134) */ && t_()
-                    /* CQL 'and' (110:19-111:51) */ && u_()
-                    /* CQL 'and' (110:19-112:79) */ && v_();
+                    /* CQL 'and' (110:19-110:134) */ && t_
+                    /* CQL 'and' (110:19-111:51) */ && w_
+                    /* CQL 'and' (110:19-112:79) */ && ac_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Encounter>(f_, g_);
@@ -1560,16 +1328,16 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
         bool? f_(Observation NoAdultScreen) {
 
             bool? q_(Extension @this) {
-                FhirUri z_ = @this?.UrlElement;
-                string aa_ = FHIRHelpers_4_4_000.Instance.ToString(context, z_);
-                CqlBoolean ab_ = context.Operators.Equal(aa_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                return ab_;
+                FhirUri ag_ = @this?.UrlElement;
+                string ah_ = FHIRHelpers_4_4_000.Instance.ToString(context, ag_);
+                CqlBoolean ai_ = context.Operators.Equal(ah_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return ai_;
             }
 
 
             object r_(Extension @this) {
-                DataType ac_ = @this?.Value;
-                return ac_;
+                DataType aj_ = @this?.Value;
+                return aj_;
             }
 
             IEnumerable<object> s_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
@@ -1581,33 +1349,29 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
             CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
             CqlBoolean x_ = context.Operators.Equivalent(u_, w_);
 
-            CqlBoolean y_() {
-
-                bool? ad_(Extension @this) {
-                    FhirUri ak_ = @this?.UrlElement;
-                    string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
-                    CqlBoolean am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                    return am_;
-                }
-
-
-                object ae_(Extension @this) {
-                    DataType an_ = @this?.Value;
-                    return an_;
-                }
-
-                IEnumerable<object> af_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
-                    ? (NoAdultScreen as DomainResource).Extension
-                    : default), ad_, ae_);
-                object ag_ = context.Operators.SingletonFrom<object>(af_);
-                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_ as CodeableConcept);
-                CqlValueSet ai_ = this.Medical_Reason(context);
-                CqlBoolean aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
-                return aj_;
+            bool? y_(Extension @this) {
+                FhirUri ak_ = @this?.UrlElement;
+                string al_ = FHIRHelpers_4_4_000.Instance.ToString(context, ak_);
+                CqlBoolean am_ = context.Operators.Equal(al_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return am_;
             }
 
+
+            object z_(Extension @this) {
+                DataType an_ = @this?.Value;
+                return an_;
+            }
+
+            IEnumerable<object> aa_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                ? (NoAdultScreen as DomainResource).Extension
+                : default), y_, z_);
+            object ab_ = context.Operators.SingletonFrom<object>(aa_);
+            CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_ as CodeableConcept);
+            CqlValueSet ad_ = this.Medical_Reason(context);
+            CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+            CqlBoolean af_ = ae_;
             return x_
-                /* CQL 'or' (150:5-152:5) */ || y_();
+                /* CQL 'or' (150:5-152:5) */ || af_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
@@ -1642,39 +1406,24 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlDateTime q_ = context.Operators.Subtract(o_, p_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(q_, o_, true, true);
                 CqlBoolean s_ = context.Operators.In<CqlDateTime>(l_, r_, "day");
-
-                CqlBoolean t_() {
-                    Period w_ = QualifyingEncounter?.Period;
-                    CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
-                    CqlDateTime y_ = context.Operators.Start(x_);
-                    return y_ is not null;
-                }
-
-
-                CqlBoolean u_() {
-                    DataType z_ = AdultScreening?.Value;
-                    object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                    return aa_ is not null;
-                }
-
-
-                CqlBoolean v_() {
-                    Code<ObservationStatus> ab_ = AdultScreening?.StatusElement;
-                    ObservationStatus? ac_ = ab_?.Value;
-                    string ad_ = context.Operators.Convert<string>(ac_);
-                    string[] ae_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
-                    return af_;
-                }
-
+                CqlBoolean t_ = (CqlBoolean)(o_ is not null);
+                DataType u_ = AdultScreening?.Value;
+                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                CqlBoolean w_ = (CqlBoolean)(v_ is not null);
+                Code<ObservationStatus> x_ = AdultScreening?.StatusElement;
+                ObservationStatus? y_ = x_?.Value;
+                string z_ = context.Operators.Convert<string>(y_);
+                string[] aa_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
+                CqlBoolean ac_ = ab_;
                 return s_
-                    /* CQL 'and' (118:19-118:129) */ && t_()
-                    /* CQL 'and' (118:19-119:46) */ && u_()
-                    /* CQL 'and' (118:19-120:74) */ && v_();
+                    /* CQL 'and' (118:19-118:129) */ && t_
+                    /* CQL 'and' (118:19-119:46) */ && w_
+                    /* CQL 'and' (118:19-120:74) */ && ac_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Encounter>(f_, g_);
@@ -1696,17 +1445,13 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<Observation> a_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adolescent_for_Depression(context);
         CqlBoolean b_ = context.Operators.Exists<Observation>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> d_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(context);
-            CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
-            return e_
-                /* CQL 'and' (69:8-71:5) */ && !(this.Has_Adult_Depression_Screening(context));
-        }
-
+        IEnumerable<Observation> c_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_
+            /* CQL 'and' (69:8-71:5) */ && !(this.Has_Adult_Depression_Screening(context));
         return (b_
             /* CQL 'and' (66:3-68:3) */ && !(this.Has_Adolescent_Depression_Screening(context)))
-            /* CQL 'or' (66:3-71:5) */ || c_();
+            /* CQL 'or' (66:3-71:5) */ || e_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS314FHIRHIVViralSuppression-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS314FHIRHIVViralSuppression-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS314FHIRHIVViralSuppression", "1.0.000")]
 public partial class CMS314FHIRHIVViralSuppression_1_0_000 : ILibrary, ISingleton<CMS314FHIRHIVViralSuppression_1_0_000>
 {
@@ -136,51 +136,27 @@ public partial class CMS314FHIRHIVViralSuppression_1_0_000 : ILibrary, ISingleto
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (76:54-77:66) */ || i_()
-                /* CQL 'or' (76:54-78:66) */ || j_()
-                /* CQL 'or' (76:52-80:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (76:54-77:66) */ || i_
+            /* CQL 'or' (76:54-78:66) */ || m_
+            /* CQL 'or' (76:52-80:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (76:3-80:3) */ || c_();
+            /* CQL 'implies' (76:3-80:3) */ || r_;
     }
 
 
@@ -264,17 +240,13 @@ public partial class CMS314FHIRHIVViralSuppression_1_0_000 : ILibrary, ISingleto
             Period an_ = QualifyingEncounter?.Period;
             CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
             CqlBoolean ap_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ao_, "day");
-
-            CqlBoolean aq_() {
-                Code<Encounter.EncounterStatus> ar_ = QualifyingEncounter?.StatusElement;
-                Encounter.EncounterStatus? as_ = ar_?.Value;
-                Code<Encounter.EncounterStatus> at_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(as_);
-                CqlBoolean au_ = context.Operators.Equal(at_, "finished");
-                return au_;
-            }
-
+            Code<Encounter.EncounterStatus> aq_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? ar_ = aq_?.Value;
+            Code<Encounter.EncounterStatus> as_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ar_);
+            CqlBoolean at_ = context.Operators.Equal(as_, "finished");
+            CqlBoolean au_ = at_;
             return ap_
-                /* CQL 'and' (67:5-68:49) */ && aq_();
+                /* CQL 'and' (67:5-68:49) */ && au_;
         }
 
         CqlBoolean ah_ = context.Operators.WhereAny<Encounter>(af_, ag_);
@@ -330,43 +302,39 @@ public partial class CMS314FHIRHIVViralSuppression_1_0_000 : ILibrary, ISingleto
                 "corrected",
             ];
             CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-            CqlBoolean m_() {
-                object n_;
-                DataType r_ = ViralLoad?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
+            object m_;
+            DataType r_ = ViralLoad?.Effective;
+            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+            bool t_ = s_ is CqlDateTime;
+            if (t_)
+            {
+                m_ = s_ as CqlDateTime;
+            }
+            else
+            {
                 if (t_)
                 {
-                    n_ = s_ as CqlDateTime;
+                    m_ = s_ as CqlDateTime;
                 }
                 else
                 {
-                    if (t_)
+                    bool u_ = s_ is CqlInterval<CqlDateTime>;
+                    if (u_)
                     {
-                        n_ = s_ as CqlDateTime;
+                        m_ = s_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlInterval<CqlDateTime>;
-                        if (u_)
-                        {
-                            n_ = s_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            n_ = null;
-                        }
+                        m_ = null;
                     }
                 }
-                CqlDateTime o_ = QICoreCommon_4_0_000.Instance.latest(context, n_);
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
-                return q_;
             }
-
+            CqlDateTime n_ = QICoreCommon_4_0_000.Instance.latest(context, m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+            CqlBoolean q_ = p_;
             return l_
-                /* CQL 'and' (48:7-49:75) */ && m_();
+                /* CQL 'and' (48:7-49:75) */ && q_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -422,31 +390,17 @@ public partial class CMS314FHIRHIVViralSuppression_1_0_000 : ILibrary, ISingleto
         object c_ = FHIRHelpers_4_4_000.Instance.ToValue(context, b_);
         CqlQuantity d_ = context.Operators.Quantity(200m, "{copies}/mL");
         CqlBoolean e_ = context.Operators.Less(c_ as CqlQuantity, d_);
-
-        CqlBoolean f_() {
-            Observation h_ = this.Most_Recent_Viral_Load_Test_During_Measurement_Period(context);
-            DataType i_ = h_?.Value;
-            object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-            CqlCode k_ = this.Below_threshold_level__qualifier_value_(context);
-            CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
-            CqlBoolean m_ = context.Operators.Equivalent(j_ as CqlConcept, l_);
-            return m_;
-        }
-
-
-        CqlBoolean g_() {
-            Observation n_ = this.Most_Recent_Viral_Load_Test_During_Measurement_Period(context);
-            DataType o_ = n_?.Value;
-            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-            CqlCode q_ = this.Not_detected__qualifier_value_(context);
-            CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
-            CqlBoolean s_ = context.Operators.Equivalent(p_ as CqlConcept, r_);
-            return s_;
-        }
-
+        CqlCode f_ = this.Below_threshold_level__qualifier_value_(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(c_ as CqlConcept, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = this.Not_detected__qualifier_value_(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(c_ as CqlConcept, k_);
+        CqlBoolean m_ = l_;
         return e_
-            /* CQL 'or' (71:3-72:112) */ || f_()
-            /* CQL 'or' (71:3-73:103) */ || g_();
+            /* CQL 'or' (71:3-72:112) */ || i_
+            /* CQL 'or' (71:3-73:103) */ || m_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS347FHIRStatinPreventionTxCVD", "1.0.000")]
 public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingleton<CMS347FHIRStatinPreventionTxCVD_1_0_000>
 {
@@ -226,51 +226,27 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (250:54-251:66) */ || i_()
-                /* CQL 'or' (250:54-252:66) */ || j_()
-                /* CQL 'or' (250:52-254:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (250:54-251:66) */ || i_
+            /* CQL 'or' (250:54-252:66) */ || m_
+            /* CQL 'or' (250:52-254:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (250:3-254:3) */ || c_();
+            /* CQL 'implies' (250:3-254:3) */ || r_;
     }
 
 
@@ -326,33 +302,33 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
 
         bool? af_(Procedure ASCVDProcedure) {
             object an_;
-            DataType au_ = ASCVDProcedure?.Performed;
-            object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-            bool aw_ = av_ is CqlDateTime;
-            if (aw_)
+            DataType ay_ = ASCVDProcedure?.Performed;
+            object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+            bool ba_ = az_ is CqlDateTime;
+            if (ba_)
             {
-                an_ = av_ as CqlDateTime;
+                an_ = az_ as CqlDateTime;
             }
             else
             {
-                bool ax_ = av_ is CqlQuantity;
-                if (ax_)
+                bool bb_ = az_ is CqlQuantity;
+                if (bb_)
                 {
-                    an_ = av_ as CqlQuantity;
+                    an_ = az_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ay_ = av_ is CqlInterval<CqlDateTime>;
-                    if (ay_)
+                    bool bc_ = az_ is CqlInterval<CqlDateTime>;
+                    if (bc_)
                     {
-                        an_ = av_ as CqlInterval<CqlDateTime>;
+                        an_ = az_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool az_ = av_ is CqlInterval<CqlQuantity>;
-                        if (az_)
+                        bool bd_ = az_ is CqlInterval<CqlQuantity>;
+                        if (bd_)
                         {
-                            an_ = av_ as CqlInterval<CqlQuantity>;
+                            an_ = az_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
@@ -366,17 +342,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             CqlInterval<CqlDateTime> aq_ = this.Measurement_Period(context);
             CqlDateTime ar_ = context.Operators.End(aq_);
             CqlBoolean as_ = context.Operators.SameOrBefore(ap_, ar_, "day");
-
-            CqlBoolean at_() {
-                Code<EventStatus> ba_ = ASCVDProcedure?.StatusElement;
-                EventStatus? bb_ = ba_?.Value;
-                string bc_ = context.Operators.Convert<string>(bb_);
-                CqlBoolean bd_ = context.Operators.Equal(bc_, "completed");
-                return bd_;
-            }
-
+            Code<EventStatus> at_ = ASCVDProcedure?.StatusElement;
+            EventStatus? au_ = at_?.Value;
+            string av_ = context.Operators.Convert<string>(au_);
+            CqlBoolean aw_ = context.Operators.Equal(av_, "completed");
+            CqlBoolean ax_ = aw_;
             return as_
-                /* CQL 'and' (123:9-124:49) */ && at_();
+                /* CQL 'and' (123:9-124:49) */ && ax_;
         }
 
         IEnumerable<Procedure> ag_ = context.Operators.Where<Procedure>(ae_, af_);
@@ -425,17 +397,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             Period ad_ = QualifyingEncounter?.Period;
             CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
             CqlBoolean af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ac_, ae_, "day");
-
-            CqlBoolean ag_() {
-                Code<Encounter.EncounterStatus> ah_ = QualifyingEncounter?.StatusElement;
-                Encounter.EncounterStatus? ai_ = ah_?.Value;
-                Code<Encounter.EncounterStatus> aj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ai_);
-                CqlBoolean ak_ = context.Operators.Equal(aj_, "finished");
-                return ak_;
-            }
-
+            Code<Encounter.EncounterStatus> ag_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? ah_ = ag_?.Value;
+            Code<Encounter.EncounterStatus> ai_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ah_);
+            CqlBoolean aj_ = context.Operators.Equal(ai_, "finished");
+            CqlBoolean ak_ = aj_;
             return af_
-                /* CQL 'and' (230:5-231:49) */ && ag_();
+                /* CQL 'and' (230:5-231:49) */ && ak_;
         }
 
         IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
@@ -453,15 +421,11 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<object> a_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
         CqlBoolean b_ = context.Operators.Exists<object>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
-            CqlBoolean e_ = context.Operators.Exists<Encounter>(d_);
-            return e_;
-        }
-
+        IEnumerable<Encounter> c_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
+        CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'and' (59:3-60:70) */ && c_();
+            /* CQL 'and' (59:3-60:70) */ && e_;
     }
 
 
@@ -503,36 +467,28 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
             CqlQuantity g_ = context.Operators.Quantity(190m, "mg/dL");
             CqlBoolean h_ = context.Operators.GreaterOrEqual(f_ as CqlQuantity, g_);
-
-            CqlBoolean i_() {
-                DataType k_ = LDL190?.Effective;
-                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
-                CqlDateTime p_ = context.Operators.End(o_);
-                CqlBoolean q_ = context.Operators.SameOrBefore(n_, p_, "day");
-                return q_;
-            }
-
-
-            CqlBoolean j_() {
-                Code<ObservationStatus> r_ = LDL190?.StatusElement;
-                ObservationStatus? s_ = r_?.Value;
-                string t_ = context.Operators.Convert<string>(s_);
-                string[] u_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                    "appended",
-                ];
-                CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
-                return v_;
-            }
-
+            DataType i_ = LDL190?.Effective;
+            object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
+            CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
+            CqlDateTime l_ = context.Operators.Start(k_);
+            CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
+            CqlDateTime n_ = context.Operators.End(m_);
+            CqlBoolean o_ = context.Operators.SameOrBefore(l_, n_, "day");
+            CqlBoolean p_ = o_;
+            Code<ObservationStatus> q_ = LDL190?.StatusElement;
+            ObservationStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            string[] t_ = [
+                "final",
+                "amended",
+                "corrected",
+                "appended",
+            ];
+            CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+            CqlBoolean v_ = u_;
             return h_
-                /* CQL 'and' (182:11-183:96) */ && i_()
-                /* CQL 'and' (182:5-184:74) */ && j_();
+                /* CQL 'and' (182:11-183:96) */ && p_
+                /* CQL 'and' (182:5-184:74) */ && v_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -575,25 +531,17 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
     private bool? Patients_Aged_20_to_75_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Patients_Aged_20_to_75_at_Start_of_Measurement_Period(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Observation> d_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
-            IEnumerable<Condition> e_ = this.Hypercholesterolemia_Diagnosis(context);
-            IEnumerable<object> f_ = context.Operators.Union<object>(d_ as IEnumerable<object>, e_ as IEnumerable<object>);
-            CqlBoolean g_ = context.Operators.Exists<object>(f_);
-            return g_;
-        }
-
-
-        CqlBoolean c_() {
-            IEnumerable<object> h_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
-            CqlBoolean i_ = context.Operators.Exists<object>(h_);
-            return !i_;
-        }
-
+        IEnumerable<Observation> b_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
+        IEnumerable<Condition> c_ = this.Hypercholesterolemia_Diagnosis(context);
+        IEnumerable<object> d_ = context.Operators.Union<object>(b_ as IEnumerable<object>, c_ as IEnumerable<object>);
+        CqlBoolean e_ = context.Operators.Exists<object>(d_);
+        CqlBoolean f_ = e_;
+        IEnumerable<object> g_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
+        CqlBoolean h_ = context.Operators.Exists<object>(g_);
+        CqlBoolean i_ = (CqlBoolean)!h_;
         return a_
-            /* CQL 'and' (194:3-197:5) */ && b_()
-            /* CQL 'and' (194:3-198:86) */ && c_();
+            /* CQL 'and' (194:3-197:5) */ && f_
+            /* CQL 'and' (194:3-198:86) */ && i_;
     }
 
 
@@ -606,15 +554,11 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
     private bool? Initial_Population_2_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Patients_Aged_20_to_75_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (63:3-64:70) */ && b_();
+            /* CQL 'and' (63:3-64:70) */ && d_;
     }
 
 
@@ -660,32 +604,20 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(40, 75, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<object> l_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
-            CqlBoolean m_ = context.Operators.Exists<object>(l_);
-
-            CqlBoolean n_() {
-                IEnumerable<Observation> p_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
-                CqlBoolean q_ = context.Operators.Exists<Observation>(p_);
-                return !q_;
-            }
-
-
-            CqlBoolean o_() {
-                IEnumerable<Condition> r_ = this.Hypercholesterolemia_Diagnosis(context);
-                CqlBoolean s_ = context.Operators.Exists<Condition>(r_);
-                return !s_;
-            }
-
-            return (CqlBoolean)!m_
-                /* CQL 'and' (206:11-207:64) */ && n_()
-                /* CQL 'and' (206:9-209:5) */ && o_();
-        }
-
+        IEnumerable<object> k_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
+        CqlBoolean l_ = context.Operators.Exists<object>(k_);
+        IEnumerable<Observation> m_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
+        CqlBoolean n_ = context.Operators.Exists<Observation>(m_);
+        CqlBoolean o_ = (CqlBoolean)!n_;
+        IEnumerable<Condition> p_ = this.Hypercholesterolemia_Diagnosis(context);
+        CqlBoolean q_ = context.Operators.Exists<Condition>(p_);
+        CqlBoolean r_ = (CqlBoolean)!q_;
+        CqlBoolean s_ = (CqlBoolean)!l_
+            /* CQL 'and' (206:11-207:64) */ && o_
+            /* CQL 'and' (206:9-209:5) */ && r_;
         return j_
             /* CQL 'and' (204:3-205:32) */ && this.Has_Diabetes_Diagnosis(context)
-            /* CQL 'and' (204:3-209:5) */ && k_();
+            /* CQL 'and' (204:3-209:5) */ && s_;
     }
 
 
@@ -698,15 +630,11 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
     private bool? Initial_Population_3_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Patients_Aged_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (67:3-68:70) */ && b_();
+            /* CQL 'and' (67:3-68:70) */ && d_;
     }
 
 
@@ -731,33 +659,25 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
             CqlQuantity l_ = context.Operators.Quantity(20m, "%");
             CqlBoolean m_ = context.Operators.GreaterOrEqual(k_ as CqlQuantity, l_);
-
-            CqlBoolean n_() {
-                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                DataType q_ = AtRiskCVD?.Effective;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, "day");
-                return t_;
-            }
-
-
-            CqlBoolean o_() {
-                Code<ObservationStatus> u_ = AtRiskCVD?.StatusElement;
-                ObservationStatus? v_ = u_?.Value;
-                string w_ = context.Operators.Convert<string>(v_);
-                string[] x_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-                return y_;
-            }
-
+            CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
+            DataType o_ = AtRiskCVD?.Effective;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlBoolean r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, "day");
+            CqlBoolean s_ = r_;
+            Code<ObservationStatus> t_ = AtRiskCVD?.StatusElement;
+            ObservationStatus? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
             return m_
-                /* CQL 'and' (244:13-245:81) */ && n_()
-                /* CQL 'and' (244:7-246:67) */ && o_();
+                /* CQL 'and' (244:13-245:81) */ && s_
+                /* CQL 'and' (244:7-246:67) */ && y_;
         }
 
         CqlBoolean i_ = context.Operators.WhereAny<Observation>(g_, h_);
@@ -783,33 +703,21 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(40, 75, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<object> l_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
-            CqlBoolean m_ = context.Operators.Exists<object>(l_);
-
-            CqlBoolean n_() {
-                IEnumerable<Condition> p_ = this.Hypercholesterolemia_Diagnosis(context);
-                CqlBoolean q_ = context.Operators.Exists<Condition>(p_);
-                return q_;
-            }
-
-
-            CqlBoolean o_() {
-                IEnumerable<Observation> r_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
-                CqlBoolean s_ = context.Operators.Exists<Observation>(r_);
-                return s_;
-            }
-
-            return !((bool?)(m_
-                /* CQL 'or' (214:15-215:50) */ || n_()
-                /* CQL 'or' (214:15-216:59) */ || o_()
-                /* CQL 'or' (214:13-218:5) */ || this.Has_Diabetes_Diagnosis(context)));
-        }
-
+        IEnumerable<object> k_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
+        CqlBoolean l_ = context.Operators.Exists<object>(k_);
+        IEnumerable<Condition> m_ = this.Hypercholesterolemia_Diagnosis(context);
+        CqlBoolean n_ = context.Operators.Exists<Condition>(m_);
+        CqlBoolean o_ = n_;
+        IEnumerable<Observation> p_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
+        CqlBoolean q_ = context.Operators.Exists<Observation>(p_);
+        CqlBoolean r_ = q_;
+        CqlBoolean s_ = (CqlBoolean)(!((bool?)(l_
+            /* CQL 'or' (214:15-215:50) */ || o_
+            /* CQL 'or' (214:15-216:59) */ || r_
+            /* CQL 'or' (214:13-218:5) */ || this.Has_Diabetes_Diagnosis(context))));
         return j_
             /* CQL 'and' (212:3-213:35) */ && this.Ten_Year_CVD_Risk_is_High(context)
-            /* CQL 'and' (212:3-218:5) */ && k_();
+            /* CQL 'and' (212:3-218:5) */ && s_;
     }
 
 
@@ -822,15 +730,11 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
     private bool? Initial_Population_4_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Patients_Age_40_to_75_Years_and_have_a_10_Year_CVD_Risk_of_High_without_ASCVD_and_High_LDL_and_Diabetes(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Encounter> c_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
-            CqlBoolean d_ = context.Operators.Exists<Encounter>(c_);
-            return d_;
-        }
-
+        IEnumerable<Encounter> b_ = this.Qualifying_Encounter_During_Day_of_Measurement_Period(context);
+        CqlBoolean c_ = context.Operators.Exists<Encounter>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (71:3-72:70) */ && b_();
+            /* CQL 'and' (71:3-72:70) */ && d_;
     }
 
 
@@ -934,18 +838,14 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             CqlInterval<CqlDateTime> g_ = QICoreCommon_4_0_000.Instance.toInterval(context, f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.Overlaps(g_, h_, "day");
-
-            CqlBoolean j_() {
-                CodeableConcept k_ = StatinAllergy?.ClinicalStatus;
-                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-                CqlCode m_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
-                CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
-                CqlBoolean o_ = context.Operators.Equivalent(l_, n_);
-                return o_;
-            }
-
+            CodeableConcept j_ = StatinAllergy?.ClinicalStatus;
+            CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, j_);
+            CqlCode l_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
+            CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
+            CqlBoolean n_ = context.Operators.Equivalent(k_, m_);
+            CqlBoolean o_ = n_;
             return i_
-                /* CQL 'and' (134:7-135:72) */ && j_();
+                /* CQL 'and' (134:7-135:72) */ && o_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<AllergyIntolerance>(b_, c_);
@@ -1086,37 +986,29 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
                 Period s_ = QualifyingEncounter?.Period;
                 CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
                 CqlBoolean u_ = context.Operators.In<CqlDateTime>(r_, t_, "day");
+                Code<MedicationRequest.MedicationrequestStatus> v_ = NoStatinTherapyOrdered?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? w_ = v_?.Value;
+                string x_ = context.Operators.Convert<string>(w_);
+                string[] y_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
+                CqlBoolean aa_ = z_;
+                List<CodeableConcept> ab_ = NoStatinTherapyOrdered?.ReasonCode;
 
-                CqlBoolean v_() {
-                    Code<MedicationRequest.MedicationrequestStatus> x_ = NoStatinTherapyOrdered?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? y_ = x_?.Value;
-                    string z_ = context.Operators.Convert<string>(y_);
-                    string[] aa_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                    return ab_;
+                CqlConcept ac_(CodeableConcept @this) {
+                    CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ah_;
                 }
 
-
-                CqlBoolean w_() {
-                    List<CodeableConcept> ac_ = NoStatinTherapyOrdered?.ReasonCode;
-
-                    CqlConcept ad_(CodeableConcept @this) {
-                        CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return ah_;
-                    }
-
-                    IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
-                    CqlValueSet af_ = this.Medical_Reason(context);
-                    CqlBoolean ag_ = context.Operators.ConceptsInValueSet(ae_, af_);
-                    return ag_;
-                }
-
+                IEnumerable<CqlConcept> ad_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ab_, ac_);
+                CqlValueSet ae_ = this.Medical_Reason(context);
+                CqlBoolean af_ = context.Operators.ConceptsInValueSet(ad_, ae_);
+                CqlBoolean ag_ = af_;
                 return u_
-                    /* CQL 'and' (163:19-164:72) */ && v_()
-                    /* CQL 'and' (163:19-165:67) */ && w_();
+                    /* CQL 'and' (163:19-164:72) */ && aa_
+                    /* CQL 'and' (163:19-165:67) */ && ag_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Encounter>(n_, o_);
@@ -1167,17 +1059,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
                 string aa_ = context.Operators.Last<string>(z_);
                 CqlBoolean ab_ = context.Operators.Equal(x_, aa_);
-
-                CqlBoolean ac_() {
-                    CodeableConcept ad_ = M?.Code;
-                    CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
-                    CqlValueSet af_ = this.Low_Intensity_Statin_Therapy(context);
-                    CqlBoolean ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-                    return ag_;
-                }
-
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Low_Intensity_Statin_Therapy(context);
+                CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                CqlBoolean ag_ = af_;
                 return ab_
-                    /* CQL 'and' */ && ac_();
+                    /* CQL 'and' */ && ag_;
             }
 
             CqlBoolean w_ = context.Operators.WhereAny<Medication>(u_, v_);
@@ -1198,17 +1086,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> am_ = context.Operators.Split((string)al_, "/");
                 string an_ = context.Operators.Last<string>(am_);
                 CqlBoolean ao_ = context.Operators.Equal(ak_, an_);
-
-                CqlBoolean ap_() {
-                    CodeableConcept aq_ = M?.Code;
-                    CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
-                    CqlValueSet as_ = this.Moderate_Intensity_Statin_Therapy(context);
-                    CqlBoolean at_ = context.Operators.ConceptInValueSet(ar_, as_);
-                    return at_;
-                }
-
+                CodeableConcept ap_ = M?.Code;
+                CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
+                CqlValueSet ar_ = this.Moderate_Intensity_Statin_Therapy(context);
+                CqlBoolean as_ = context.Operators.ConceptInValueSet(aq_, ar_);
+                CqlBoolean at_ = as_;
                 return ao_
-                    /* CQL 'and' */ && ap_();
+                    /* CQL 'and' */ && at_;
             }
 
             CqlBoolean aj_ = context.Operators.WhereAny<Medication>(ah_, ai_);
@@ -1230,17 +1114,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> az_ = context.Operators.Split((string)ay_, "/");
                 string ba_ = context.Operators.Last<string>(az_);
                 CqlBoolean bb_ = context.Operators.Equal(ax_, ba_);
-
-                CqlBoolean bc_() {
-                    CodeableConcept bd_ = M?.Code;
-                    CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_);
-                    CqlValueSet bf_ = this.High_Intensity_Statin_Therapy(context);
-                    CqlBoolean bg_ = context.Operators.ConceptInValueSet(be_, bf_);
-                    return bg_;
-                }
-
+                CodeableConcept bc_ = M?.Code;
+                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_);
+                CqlValueSet be_ = this.High_Intensity_Statin_Therapy(context);
+                CqlBoolean bf_ = context.Operators.ConceptInValueSet(bd_, be_);
+                CqlBoolean bg_ = bf_;
                 return bb_
-                    /* CQL 'and' */ && bc_();
+                    /* CQL 'and' */ && bg_;
             }
 
             CqlBoolean aw_ = context.Operators.WhereAny<Medication>(au_, av_);
@@ -1258,38 +1138,30 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             CqlDateTime bi_ = context.Operators.Convert<CqlDateTime>(bh_);
             CqlInterval<CqlDateTime> bj_ = this.Measurement_Period(context);
             CqlBoolean bk_ = context.Operators.In<CqlDateTime>(bi_, bj_, "day");
-
-            CqlBoolean bl_() {
-                Code<MedicationRequest.MedicationrequestStatus> bn_ = StatinRequest?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? bo_ = bn_?.Value;
-                string bp_ = context.Operators.Convert<string>(bo_);
-                string[] bq_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
-                return br_;
-            }
-
-
-            CqlBoolean bm_() {
-                Code<MedicationRequest.MedicationRequestIntent> bs_ = StatinRequest?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? bt_ = bs_?.Value;
-                string bu_ = context.Operators.Convert<string>(bt_);
-                string[] bv_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filter-order",
-                    "instance-order",
-                ];
-                CqlBoolean bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
-                return bw_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> bl_ = StatinRequest?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? bm_ = bl_?.Value;
+            string bn_ = context.Operators.Convert<string>(bm_);
+            string[] bo_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean bp_ = context.Operators.In<string>(bn_, (IEnumerable<string>)bo_);
+            CqlBoolean bq_ = bp_;
+            Code<MedicationRequest.MedicationRequestIntent> br_ = StatinRequest?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bs_ = br_?.Value;
+            string bt_ = context.Operators.Convert<string>(bs_);
+            string[] bu_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filter-order",
+                "instance-order",
+            ];
+            CqlBoolean bv_ = context.Operators.In<string>(bt_, (IEnumerable<string>)bu_);
+            CqlBoolean bw_ = bv_;
             return bk_
-                /* CQL 'and' (237:11-238:59) */ && bl_()
-                /* CQL 'and' (237:5-239:113) */ && bm_();
+                /* CQL 'and' (237:11-238:59) */ && bq_
+                /* CQL 'and' (237:5-239:113) */ && bw_;
         }
 
         IEnumerable<MedicationRequest> t_ = context.Operators.Where<MedicationRequest>(r_, s_);
@@ -1316,17 +1188,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
                 string aa_ = context.Operators.Last<string>(z_);
                 CqlBoolean ab_ = context.Operators.Equal(x_, aa_);
-
-                CqlBoolean ac_() {
-                    CodeableConcept ad_ = M?.Code;
-                    CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
-                    CqlValueSet af_ = this.Low_Intensity_Statin_Therapy(context);
-                    CqlBoolean ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-                    return ag_;
-                }
-
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Low_Intensity_Statin_Therapy(context);
+                CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                CqlBoolean ag_ = af_;
                 return ab_
-                    /* CQL 'and' */ && ac_();
+                    /* CQL 'and' */ && ag_;
             }
 
             CqlBoolean w_ = context.Operators.WhereAny<Medication>(u_, v_);
@@ -1347,17 +1215,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> am_ = context.Operators.Split((string)al_, "/");
                 string an_ = context.Operators.Last<string>(am_);
                 CqlBoolean ao_ = context.Operators.Equal(ak_, an_);
-
-                CqlBoolean ap_() {
-                    CodeableConcept aq_ = M?.Code;
-                    CqlConcept ar_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aq_);
-                    CqlValueSet as_ = this.Moderate_Intensity_Statin_Therapy(context);
-                    CqlBoolean at_ = context.Operators.ConceptInValueSet(ar_, as_);
-                    return at_;
-                }
-
+                CodeableConcept ap_ = M?.Code;
+                CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
+                CqlValueSet ar_ = this.Moderate_Intensity_Statin_Therapy(context);
+                CqlBoolean as_ = context.Operators.ConceptInValueSet(aq_, ar_);
+                CqlBoolean at_ = as_;
                 return ao_
-                    /* CQL 'and' */ && ap_();
+                    /* CQL 'and' */ && at_;
             }
 
             CqlBoolean aj_ = context.Operators.WhereAny<Medication>(ah_, ai_);
@@ -1379,17 +1243,13 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
                 IEnumerable<string> az_ = context.Operators.Split((string)ay_, "/");
                 string ba_ = context.Operators.Last<string>(az_);
                 CqlBoolean bb_ = context.Operators.Equal(ax_, ba_);
-
-                CqlBoolean bc_() {
-                    CodeableConcept bd_ = M?.Code;
-                    CqlConcept be_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bd_);
-                    CqlValueSet bf_ = this.High_Intensity_Statin_Therapy(context);
-                    CqlBoolean bg_ = context.Operators.ConceptInValueSet(be_, bf_);
-                    return bg_;
-                }
-
+                CodeableConcept bc_ = M?.Code;
+                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_);
+                CqlValueSet be_ = this.High_Intensity_Statin_Therapy(context);
+                CqlBoolean bf_ = context.Operators.ConceptInValueSet(bd_, be_);
+                CqlBoolean bg_ = bf_;
                 return bb_
-                    /* CQL 'and' */ && bc_();
+                    /* CQL 'and' */ && bg_;
             }
 
             CqlBoolean aw_ = context.Operators.WhereAny<Medication>(au_, av_);
@@ -1413,21 +1273,17 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bj_, bl_, bm_, bn_);
             CqlInterval<CqlDateTime> bp_ = this.Measurement_Period(context);
             CqlBoolean bq_ = context.Operators.Overlaps(bo_, bp_, "day");
-
-            CqlBoolean br_() {
-                Code<MedicationRequest.MedicationrequestStatus> bs_ = ActiveStatin?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? bt_ = bs_?.Value;
-                string bu_ = context.Operators.Convert<string>(bt_);
-                string[] bv_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
-                return bw_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> br_ = ActiveStatin?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? bs_ = br_?.Value;
+            string bt_ = context.Operators.Convert<string>(bs_);
+            string[] bu_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean bv_ = context.Operators.In<string>(bt_, (IEnumerable<string>)bu_);
+            CqlBoolean bw_ = bv_;
             return bq_
-                /* CQL 'and' (190:5-191:58) */ && br_();
+                /* CQL 'and' (190:5-191:58) */ && bw_;
         }
 
         IEnumerable<MedicationRequest> t_ = context.Operators.Where<MedicationRequest>(r_, s_);
@@ -1445,15 +1301,11 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
     {
         IEnumerable<MedicationRequest> a_ = this.Statin_Therapy_Ordered_during_Measurement_Period(context);
         CqlBoolean b_ = context.Operators.Exists<MedicationRequest>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<MedicationRequest> d_ = this.Medication_Active_during_the_Measurement_Period(context);
-            CqlBoolean e_ = context.Operators.Exists<MedicationRequest>(d_);
-            return e_;
-        }
-
+        IEnumerable<MedicationRequest> c_ = this.Medication_Active_during_the_Measurement_Period(context);
+        CqlBoolean d_ = context.Operators.Exists<MedicationRequest>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'or' (106:3-107:63) */ || c_();
+            /* CQL 'or' (106:3-107:63) */ || e_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS349FHIRHIVScreening-1.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS349FHIRHIVScreening-1.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS349FHIRHIVScreening", "1.1.000")]
 public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS349FHIRHIVScreening_1_1_000>
 {
@@ -130,17 +130,13 @@ public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS34
             Period r_ = Encounter?.Period;
             CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
             CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, "day");
-
-            CqlBoolean u_() {
-                Code<Encounter.EncounterStatus> v_ = Encounter?.StatusElement;
-                Encounter.EncounterStatus? w_ = v_?.Value;
-                Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "finished");
-                return y_;
-            }
-
+            Code<Encounter.EncounterStatus> u_ = Encounter?.StatusElement;
+            Encounter.EncounterStatus? v_ = u_?.Value;
+            Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+            CqlBoolean x_ = context.Operators.Equal(w_, "finished");
+            CqlBoolean y_ = x_;
             return t_
-                /* CQL 'and' (52:5-53:39) */ && u_();
+                /* CQL 'and' (52:5-53:39) */ && y_;
         }
 
         IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
@@ -166,15 +162,11 @@ public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS34
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(15, 65, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> l_ = this.Qualifying_Encounters(context);
-            CqlBoolean m_ = context.Operators.Exists<Encounter>(l_);
-            return m_;
-        }
-
+        IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
+        CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
+        CqlBoolean m_ = l_;
         return j_
-            /* CQL 'and' (27:3-28:38) */ && k_();
+            /* CQL 'and' (27:3-28:38) */ && m_;
     }
 
 
@@ -209,68 +201,38 @@ public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS34
         bool? g_(Observation HIVTest) {
             DataType i_ = HIVTest?.Value;
             object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-
-            CqlBoolean k_() {
-                Patient n_ = this.Patient(context);
-                Date o_ = n_?.BirthDateElement;
-                string p_ = o_?.Value;
-                CqlDate q_ = context.Operators.ConvertStringToDate(p_);
-                DataType r_ = HIVTest?.Effective;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
-                CqlDateTime u_ = context.Operators.Start(t_);
-                CqlDate v_ = context.Operators.DateFrom(u_);
-                int? w_ = context.Operators.CalculateAgeAt(q_, v_, "year");
-                CqlInterval<int?> x_ = context.Operators.Interval(15, 65, true, true);
-                CqlBoolean y_ = context.Operators.In<int?>(w_, x_, (string)default);
-                return y_;
-            }
-
-
-            CqlBoolean l_() {
-                DataType z_ = HIVTest?.Effective;
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
-                CqlDateTime ac_ = context.Operators.Start(ab_);
-                CqlInterval<CqlDateTime> ad_ = this.Measurement_Period(context);
-                CqlDateTime ae_ = context.Operators.End(ad_);
-                CqlBoolean af_ = context.Operators.Before(ac_, ae_, "day");
-                return af_;
-            }
-
-
-            CqlBoolean m_() {
-                Code<ObservationStatus> ag_ = HIVTest?.StatusElement;
-                ObservationStatus? ah_ = ag_?.Value;
-                string ai_ = context.Operators.Convert<string>(ah_);
-                CqlBoolean aj_ = context.Operators.Equal(ai_, "final");
-
-                CqlBoolean ak_() {
-                    Code<ObservationStatus> am_ = HIVTest?.StatusElement;
-                    ObservationStatus? an_ = am_?.Value;
-                    string ao_ = context.Operators.Convert<string>(an_);
-                    CqlBoolean ap_ = context.Operators.Equal(ao_, "amended");
-                    return ap_;
-                }
-
-
-                CqlBoolean al_() {
-                    Code<ObservationStatus> aq_ = HIVTest?.StatusElement;
-                    ObservationStatus? ar_ = aq_?.Value;
-                    string as_ = context.Operators.Convert<string>(ar_);
-                    CqlBoolean at_ = context.Operators.Equal(as_, "corrected");
-                    return at_;
-                }
-
-                return aj_
-                    /* CQL 'or' (64:13-65:39) */ || ak_()
-                    /* CQL 'or' (64:11-67:7) */ || al_();
-            }
-
+            Patient k_ = this.Patient(context);
+            Date l_ = k_?.BirthDateElement;
+            string m_ = l_?.Value;
+            CqlDate n_ = context.Operators.ConvertStringToDate(m_);
+            DataType o_ = HIVTest?.Effective;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            CqlDateTime r_ = context.Operators.Start(q_);
+            CqlDate s_ = context.Operators.DateFrom(r_);
+            int? t_ = context.Operators.CalculateAgeAt(n_, s_, "year");
+            CqlInterval<int?> u_ = context.Operators.Interval(15, 65, true, true);
+            CqlBoolean v_ = context.Operators.In<int?>(t_, u_, (string)default);
+            CqlBoolean w_ = v_;
+            CqlInterval<CqlDateTime> x_ = this.Measurement_Period(context);
+            CqlDateTime y_ = context.Operators.End(x_);
+            CqlBoolean z_ = context.Operators.Before(r_, y_, "day");
+            CqlBoolean aa_ = z_;
+            Code<ObservationStatus> ab_ = HIVTest?.StatusElement;
+            ObservationStatus? ac_ = ab_?.Value;
+            string ad_ = context.Operators.Convert<string>(ac_);
+            CqlBoolean ae_ = context.Operators.Equal(ad_, "final");
+            CqlBoolean af_ = context.Operators.Equal(ad_, "amended");
+            CqlBoolean ag_ = af_;
+            CqlBoolean ah_ = context.Operators.Equal(ad_, "corrected");
+            CqlBoolean ai_ = ah_;
+            CqlBoolean aj_ = ae_
+                /* CQL 'or' (64:13-65:39) */ || ag_
+                /* CQL 'or' (64:11-67:7) */ || ai_;
             return (CqlBoolean)(j_ is not null)
-                /* CQL 'and' (61:11-62:93) */ && k_()
-                /* CQL 'and' (61:11-63:91) */ && l_()
-                /* CQL 'and' (61:5-67:7) */ && m_();
+                /* CQL 'and' (61:11-62:93) */ && w_
+                /* CQL 'and' (61:11-63:91) */ && aa_
+                /* CQL 'and' (61:5-67:7) */ && aj_;
         }
 
         CqlBoolean h_ = context.Operators.WhereAny<Observation>(f_, g_);
@@ -297,51 +259,27 @@ public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS34
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (87:54-88:66) */ || i_()
-                /* CQL 'or' (87:54-89:66) */ || j_()
-                /* CQL 'or' (87:52-91:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (87:54-88:66) */ || i_
+            /* CQL 'or' (87:54-89:66) */ || m_
+            /* CQL 'or' (87:52-91:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (87:3-91:3) */ || c_();
+            /* CQL 'implies' (87:3-91:3) */ || r_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS506FHIRSafeUseofOpioids", "1.0.000")]
 public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<CMS506FHIRSafeUseofOpioids_1_0_000>
 {
@@ -152,17 +152,13 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Schedule_II__III_and_IV_Opioid_Medications(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Schedule_II__III_and_IV_Opioid_Medications(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -176,39 +172,31 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
 
         bool? g_(MedicationRequest OpioidMedications) {
             CqlBoolean v_ = QICoreCommon_4_0_000.Instance.isCommunity(context, OpioidMedications as MedicationRequest);
-
-            CqlBoolean w_() {
-                Code<MedicationRequest.MedicationrequestStatus> y_ = OpioidMedications?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
-            }
-
-
-            CqlBoolean x_() {
-                Code<MedicationRequest.MedicationRequestIntent> ad_ = OpioidMedications?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
-                string af_ = context.Operators.Convert<string>(ae_);
-                string[] ag_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                return ah_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> w_ = OpioidMedications?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
+            Code<MedicationRequest.MedicationRequestIntent> ac_ = OpioidMedications?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+            string ae_ = context.Operators.Convert<string>(ad_);
+            string[] af_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+            CqlBoolean ah_ = ag_;
             return (v_
                 /* CQL 'or' (59:11-61:5) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, OpioidMedications as MedicationRequest))
-                /* CQL 'and' (59:11-62:63) */ && w_()
-                /* CQL 'and' (59:5-63:117) */ && x_();
+                /* CQL 'and' (59:11-62:63) */ && ab_
+                /* CQL 'and' (59:5-63:117) */ && ah_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -235,17 +223,13 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Schedule_IV_Benzodiazepines(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Schedule_IV_Benzodiazepines(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -259,39 +243,31 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
 
         bool? g_(MedicationRequest BenzoMedications) {
             CqlBoolean v_ = QICoreCommon_4_0_000.Instance.isCommunity(context, BenzoMedications as MedicationRequest);
-
-            CqlBoolean w_() {
-                Code<MedicationRequest.MedicationrequestStatus> y_ = BenzoMedications?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
-            }
-
-
-            CqlBoolean x_() {
-                Code<MedicationRequest.MedicationRequestIntent> ad_ = BenzoMedications?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
-                string af_ = context.Operators.Convert<string>(ae_);
-                string[] ag_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                return ah_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> w_ = BenzoMedications?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
+            Code<MedicationRequest.MedicationRequestIntent> ac_ = BenzoMedications?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+            string ae_ = context.Operators.Convert<string>(ad_);
+            string[] af_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+            CqlBoolean ah_ = ag_;
             return (v_
                 /* CQL 'or' (51:11-53:5) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, BenzoMedications as MedicationRequest))
-                /* CQL 'and' (51:11-54:62) */ && w_()
-                /* CQL 'and' (51:5-55:116) */ && x_();
+                /* CQL 'and' (51:11-54:62) */ && ab_
+                /* CQL 'and' (51:5-55:116) */ && ah_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -374,19 +350,19 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
             IEnumerable<MedicationRequest> d_ = this.Opioid_At_Discharge(context);
 
             bool? e_(MedicationRequest OpioidMedications) {
-                FhirDateTime l_ = OpioidMedications?.AuthoredOnElement;
-                CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
-                Period n_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlBoolean p_ = context.Operators.In<CqlDateTime>(m_, o_, "day");
-                return p_;
+                FhirDateTime n_ = OpioidMedications?.AuthoredOnElement;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlBoolean r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
+                return r_;
             }
 
 
             object f_(MedicationRequest OpioidMedications) {
-                DataType q_ = OpioidMedications?.Medication;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                return r_;
+                DataType s_ = OpioidMedications?.Medication;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                return t_;
             }
 
             IEnumerable<object> g_ = context.Operators.WhereSelect<MedicationRequest, object>(d_, e_, f_);
@@ -394,42 +370,33 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
             int? i_ = context.Operators.Count<object>(h_);
             CqlBoolean j_ = context.Operators.GreaterOrEqual(i_, 2);
 
-            CqlBoolean k_() {
-                IEnumerable<MedicationRequest> s_ = this.Opioid_At_Discharge(context);
+            bool? k_(MedicationRequest OpioidDischargeMedications) {
+                FhirDateTime u_ = OpioidDischargeMedications?.AuthoredOnElement;
+                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                Period w_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
+                CqlBoolean y_ = context.Operators.In<CqlDateTime>(v_, x_, "day");
+                IEnumerable<MedicationRequest> z_ = this.Benzodiazepine_At_Discharge(context);
 
-                bool? t_(MedicationRequest OpioidDischargeMedications) {
-                    FhirDateTime v_ = OpioidDischargeMedications?.AuthoredOnElement;
-                    CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(v_);
-                    Period x_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
-                    CqlBoolean z_ = context.Operators.In<CqlDateTime>(w_, y_, "day");
-
-                    CqlBoolean aa_() {
-                        IEnumerable<MedicationRequest> ab_ = this.Benzodiazepine_At_Discharge(context);
-
-                        bool? ac_(MedicationRequest BenzodiazepineDischargeMedication) {
-                            FhirDateTime ae_ = BenzodiazepineDischargeMedication?.AuthoredOnElement;
-                            CqlDateTime af_ = context.Operators.Convert<CqlDateTime>(ae_);
-                            Period ag_ = InpatientEncounter?.Period;
-                            CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                            CqlBoolean ai_ = context.Operators.In<CqlDateTime>(af_, ah_, "day");
-                            return ai_;
-                        }
-
-                        CqlBoolean ad_ = context.Operators.WhereAny<MedicationRequest>(ab_, ac_);
-                        return ad_;
-                    }
-
-                    return z_
-                        /* CQL 'and' (78:11-81:13) */ && aa_();
+                bool? aa_(MedicationRequest BenzodiazepineDischargeMedication) {
+                    FhirDateTime ad_ = BenzodiazepineDischargeMedication?.AuthoredOnElement;
+                    CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(ad_);
+                    Period af_ = InpatientEncounter?.Period;
+                    CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
+                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, "day");
+                    return ah_;
                 }
 
-                CqlBoolean u_ = context.Operators.WhereAny<MedicationRequest>(s_, t_);
-                return u_;
+                CqlBoolean ab_ = context.Operators.WhereAny<MedicationRequest>(z_, aa_);
+                CqlBoolean ac_ = ab_;
+                return y_
+                    /* CQL 'and' (78:11-81:13) */ && ac_;
             }
 
+            CqlBoolean l_ = context.Operators.WhereAny<MedicationRequest>(d_, k_);
+            CqlBoolean m_ = l_;
             return j_
-                /* CQL 'or' (72:5-82:7) */ || k_();
+                /* CQL 'or' (72:5-82:7) */ || m_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -451,38 +418,33 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
             List<CodeableConcept> d_ = QualifyingEncounter?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Cancer_Related_Pain(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.Cancer_Related_Pain(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'or' (86:5-87:81) */ || i_();
+                /* CQL 'or' (86:5-87:81) */ || n_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -496,51 +458,27 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (165:54-166:66) */ || i_()
-                /* CQL 'or' (165:54-167:66) */ || j_()
-                /* CQL 'or' (165:52-169:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (165:54-166:66) */ || i_
+            /* CQL 'or' (165:54-167:66) */ || m_
+            /* CQL 'or' (165:52-169:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (165:3-169:3) */ || c_();
+            /* CQL 'implies' (165:3-169:3) */ || r_;
     }
 
 
@@ -563,17 +501,13 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Medications_for_Opioid_Use_Disorder__MOUD_(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Medications_for_Opioid_Use_Disorder__MOUD_(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -587,39 +521,31 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
 
         bool? g_(MedicationRequest DischargeMedication) {
             CqlBoolean v_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeMedication as MedicationRequest);
-
-            CqlBoolean w_() {
-                Code<MedicationRequest.MedicationrequestStatus> y_ = DischargeMedication?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
-            }
-
-
-            CqlBoolean x_() {
-                Code<MedicationRequest.MedicationRequestIntent> ad_ = DischargeMedication?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
-                string af_ = context.Operators.Convert<string>(ae_);
-                string[] ag_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                return ah_;
-            }
-
+            Code<MedicationRequest.MedicationrequestStatus> w_ = DischargeMedication?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
+            Code<MedicationRequest.MedicationRequestIntent> ac_ = DischargeMedication?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+            string ae_ = context.Operators.Convert<string>(ad_);
+            string[] af_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+            CqlBoolean ah_ = ag_;
             return (v_
                 /* CQL 'or' (133:11-135:5) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeMedication as MedicationRequest))
-                /* CQL 'and' (133:11-136:65) */ && w_()
-                /* CQL 'and' (133:5-137:119) */ && x_();
+                /* CQL 'and' (133:11-136:65) */ && ab_
+                /* CQL 'and' (133:5-137:119) */ && ah_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -645,33 +571,33 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
                 FhirDateTime k_ = MedicationTreatment?.AuthoredOnElement;
                 CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
                 object m_;
-                DataType r_ = MAT?.Performed;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
-                if (t_)
+                DataType y_ = MAT?.Performed;
+                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                bool aa_ = z_ is CqlDateTime;
+                if (aa_)
                 {
-                    m_ = s_ as CqlDateTime;
+                    m_ = z_ as CqlDateTime;
                 }
                 else
                 {
-                    bool u_ = s_ is CqlQuantity;
-                    if (u_)
+                    bool ab_ = z_ is CqlQuantity;
+                    if (ab_)
                     {
-                        m_ = s_ as CqlQuantity;
+                        m_ = z_ as CqlQuantity;
                     }
                     else
                     {
-                        bool v_ = s_ is CqlInterval<CqlDateTime>;
-                        if (v_)
+                        bool ac_ = z_ is CqlInterval<CqlDateTime>;
+                        if (ac_)
                         {
-                            m_ = s_ as CqlInterval<CqlDateTime>;
+                            m_ = z_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool w_ = s_ is CqlInterval<CqlQuantity>;
-                            if (w_)
+                            bool ad_ = z_ is CqlInterval<CqlQuantity>;
+                            if (ad_)
                             {
-                                m_ = s_ as CqlInterval<CqlQuantity>;
+                                m_ = z_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -682,31 +608,21 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
                 }
                 CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
                 CqlBoolean o_ = context.Operators.In<CqlDateTime>(l_, n_, "day");
-
-                CqlBoolean p_() {
-                    FhirDateTime x_ = MedicationTreatment?.AuthoredOnElement;
-                    CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(x_);
-                    CqlInterval<CqlDateTime> z_ = this.Measurement_Period(context);
-                    CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, "day");
-                    return aa_;
-                }
-
-
-                CqlBoolean q_() {
-                    Code<EventStatus> ab_ = MAT?.StatusElement;
-                    EventStatus? ac_ = ab_?.Value;
-                    string ad_ = context.Operators.Convert<string>(ac_);
-                    string[] ae_ = [
-                        "completed",
-                        "in-progress",
-                    ];
-                    CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
-                    return af_;
-                }
-
+                CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+                CqlBoolean q_ = context.Operators.In<CqlDateTime>(l_, p_, "day");
+                CqlBoolean r_ = q_;
+                Code<EventStatus> s_ = MAT?.StatusElement;
+                EventStatus? t_ = s_?.Value;
+                string u_ = context.Operators.Convert<string>(t_);
+                string[] v_ = [
+                    "completed",
+                    "in-progress",
+                ];
+                CqlBoolean w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
+                CqlBoolean x_ = w_;
                 return o_
-                    /* CQL 'and' (120:19-121:79) */ && p_()
-                    /* CQL 'and' (120:19-122:58) */ && q_();
+                    /* CQL 'and' (120:19-121:79) */ && r_
+                    /* CQL 'and' (120:19-122:58) */ && x_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Procedure>(h_, i_);
@@ -716,29 +632,24 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
         IEnumerable<MedicationRequest> c_ = context.Operators.Where<MedicationRequest>(a_, b_);
 
         bool? d_(MedicationRequest MedicationTreatment) {
-            CqlValueSet ag_ = this.Opioid_Use_Disorder(context);
-            IEnumerable<Condition> ah_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ag_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            CqlValueSet ae_ = this.Opioid_Use_Disorder(context);
+            IEnumerable<Condition> af_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ae_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            bool? ai_(Condition OUD) {
-                FhirDateTime ak_ = MedicationTreatment?.AuthoredOnElement;
-                CqlDateTime al_ = context.Operators.Convert<CqlDateTime>(ak_);
-                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OUD as Condition);
-                CqlBoolean an_ = context.Operators.In<CqlDateTime>(al_, am_, "day");
-
-                CqlBoolean ao_() {
-                    CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OUD as Condition);
-                    CqlInterval<CqlDateTime> aq_ = this.Measurement_Period(context);
-                    CqlBoolean ar_ = context.Operators.Overlaps(ap_, aq_, "day");
-                    return ar_;
-                }
-
-                return an_
-                    /* CQL 'and' (126:21-127:79) */ && ao_()
+            bool? ag_(Condition OUD) {
+                FhirDateTime ai_ = MedicationTreatment?.AuthoredOnElement;
+                CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
+                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OUD as Condition);
+                CqlBoolean al_ = context.Operators.In<CqlDateTime>(aj_, ak_, "day");
+                CqlInterval<CqlDateTime> am_ = this.Measurement_Period(context);
+                CqlBoolean an_ = context.Operators.Overlaps(ak_, am_, "day");
+                CqlBoolean ao_ = an_;
+                return al_
+                    /* CQL 'and' (126:21-127:79) */ && ao_
                     /* CQL 'and' (126:21-128:34) */ && this.isVerified(context, OUD as Condition);
             }
 
-            CqlBoolean aj_ = context.Operators.WhereAny<Condition>(ah_, ai_);
-            return aj_;
+            CqlBoolean ah_ = context.Operators.WhereAny<Condition>(af_, ag_);
+            return ah_;
         }
 
         IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(a_, d_);
@@ -809,160 +720,119 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
             IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? f_(Condition CancerPain) {
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, CancerPain as Condition);
-                Period n_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-                CqlBoolean p_ = context.Operators.Overlaps(m_, o_, "day");
-                return p_
+                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, CancerPain as Condition);
+                Period an_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlBoolean ap_ = context.Operators.Overlaps(am_, ao_, "day");
+                return ap_
                     /* CQL 'and' (97:9-98:39) */ && this.isVerified(context, CancerPain as Condition);
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Condition>(e_, f_);
+            IEnumerable<Encounter> h_ = this.Inpatient_Encounter_With_Encounter_Diagnosis_Of_Cancer_Pain(context);
+            CqlBoolean i_ = context.Operators.Exists<Encounter>(h_);
+            CqlBoolean j_ = i_;
+            CqlValueSet k_ = this.Sickle_Cell_Disease_with_and_without_Crisis(context);
+            IEnumerable<Condition> l_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, k_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            CqlBoolean h_() {
-                IEnumerable<Encounter> q_ = this.Inpatient_Encounter_With_Encounter_Diagnosis_Of_Cancer_Pain(context);
-                CqlBoolean r_ = context.Operators.Exists<Encounter>(q_);
-                return r_;
+            bool? m_(Condition SickleCellDisease) {
+                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SickleCellDisease as Condition);
+                Period ar_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlBoolean at_ = context.Operators.Overlaps(aq_, as_, "day");
+                return at_
+                    /* CQL 'and' (102:11-103:48) */ && this.isVerified(context, SickleCellDisease as Condition);
             }
 
+            CqlBoolean n_ = context.Operators.WhereAny<Condition>(l_, m_);
+            CqlBoolean o_ = n_;
+            IEnumerable<MedicationRequest> p_ = this.Treatment_For_Opioid_Use_Disorders(context);
 
-            CqlBoolean i_() {
-                CqlValueSet s_ = this.Sickle_Cell_Disease_with_and_without_Crisis(context);
-                IEnumerable<Condition> t_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, s_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            bool? q_(MedicationRequest OUDTreatment) {
+                FhirDateTime au_ = OUDTreatment?.AuthoredOnElement;
+                CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(au_);
+                Period aw_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aw_);
+                CqlBoolean ay_ = context.Operators.In<CqlDateTime>(av_, ax_, "day");
+                return ay_;
+            }
 
-                bool? u_(Condition SickleCellDisease) {
-                    CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SickleCellDisease as Condition);
-                    Period x_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
-                    CqlBoolean z_ = context.Operators.Overlaps(w_, y_, "day");
-                    return z_
-                        /* CQL 'and' (102:11-103:48) */ && this.isVerified(context, SickleCellDisease as Condition);
+            CqlBoolean r_ = context.Operators.WhereAny<MedicationRequest>(p_, q_);
+            CqlBoolean s_ = r_;
+            IEnumerable<object> t_ = this.Intervention_Palliative_Or_Hospice_Care(context);
+
+            bool? u_(object PalliativeOrHospiceCare) {
+                object az_;
+                object bg_ = context.Operators.LateBoundProperty<object>(PalliativeOrHospiceCare, "performed");
+                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+                bool bi_ = bh_ is CqlDateTime;
+                if (bi_)
+                {
+                    az_ = bh_ as CqlDateTime;
                 }
-
-                CqlBoolean v_ = context.Operators.WhereAny<Condition>(t_, u_);
-                return v_;
-            }
-
-
-            CqlBoolean j_() {
-                IEnumerable<MedicationRequest> aa_ = this.Treatment_For_Opioid_Use_Disorders(context);
-
-                bool? ab_(MedicationRequest OUDTreatment) {
-                    FhirDateTime ad_ = OUDTreatment?.AuthoredOnElement;
-                    CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(ad_);
-                    Period af_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, "day");
-                    return ah_;
-                }
-
-                CqlBoolean ac_ = context.Operators.WhereAny<MedicationRequest>(aa_, ab_);
-                return ac_;
-            }
-
-
-            CqlBoolean k_() {
-                IEnumerable<object> ai_ = this.Intervention_Palliative_Or_Hospice_Care(context);
-
-                bool? aj_(object PalliativeOrHospiceCare) {
-                    object al_;
-                    object as_ = context.Operators.LateBoundProperty<object>(PalliativeOrHospiceCare, "performed");
-                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                    bool au_ = at_ is CqlDateTime;
-                    if (au_)
+                else
+                {
+                    bool bj_ = bh_ is CqlQuantity;
+                    if (bj_)
                     {
-                        al_ = at_ as CqlDateTime;
+                        az_ = bh_ as CqlQuantity;
                     }
                     else
                     {
-                        bool av_ = at_ is CqlQuantity;
-                        if (av_)
+                        bool bk_ = bh_ is CqlInterval<CqlDateTime>;
+                        if (bk_)
                         {
-                            al_ = at_ as CqlQuantity;
+                            az_ = bh_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool aw_ = at_ is CqlInterval<CqlDateTime>;
-                            if (aw_)
+                            bool bl_ = bh_ is CqlInterval<CqlQuantity>;
+                            if (bl_)
                             {
-                                al_ = at_ as CqlInterval<CqlDateTime>;
+                                az_ = bh_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ax_ = at_ is CqlInterval<CqlQuantity>;
-                                if (ax_)
-                                {
-                                    al_ = at_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    al_ = null;
-                                }
+                                az_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                    CqlDateTime an_ = context.Operators.Start(am_);
-                    object ao_ = context.Operators.LateBoundProperty<object>(PalliativeOrHospiceCare, "authoredOn");
-                    CqlDateTime ap_ = context.Operators.LateBoundProperty<CqlDateTime>(ao_, "value");
-                    CqlInterval<CqlDateTime> aq_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                    CqlBoolean ar_ = context.Operators.In<CqlDateTime>(an_ ?? ap_, aq_, (string)default);
-                    return ar_;
                 }
-
-                CqlBoolean ak_ = context.Operators.WhereAny<object>(ai_, aj_);
-                return ak_;
+                CqlInterval<CqlDateTime> ba_ = QICoreCommon_4_0_000.Instance.toInterval(context, az_);
+                CqlDateTime bb_ = context.Operators.Start(ba_);
+                object bc_ = context.Operators.LateBoundProperty<object>(PalliativeOrHospiceCare, "authoredOn");
+                CqlDateTime bd_ = context.Operators.LateBoundProperty<CqlDateTime>(bc_, "value");
+                CqlInterval<CqlDateTime> be_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+                CqlBoolean bf_ = context.Operators.In<CqlDateTime>(bb_ ?? bd_, be_, (string)default);
+                return bf_;
             }
 
-
-            CqlBoolean l_() {
-                Encounter.HospitalizationComponent ay_ = InpatientEncounter?.Hospitalization;
-                CodeableConcept az_ = ay_?.DischargeDisposition;
-                CqlConcept ba_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, az_);
-                CqlValueSet bb_ = this.Discharge_To_Acute_Care_Facility(context);
-                CqlBoolean bc_ = context.Operators.ConceptInValueSet(ba_, bb_);
-
-                CqlBoolean bd_() {
-                    Encounter.HospitalizationComponent bg_ = InpatientEncounter?.Hospitalization;
-                    CodeableConcept bh_ = bg_?.DischargeDisposition;
-                    CqlConcept bi_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bh_);
-                    CqlValueSet bj_ = this.Hospice_Care_Referral_or_Admission(context);
-                    CqlBoolean bk_ = context.Operators.ConceptInValueSet(bi_, bj_);
-                    return bk_;
-                }
-
-
-                CqlBoolean be_() {
-                    Encounter.HospitalizationComponent bl_ = InpatientEncounter?.Hospitalization;
-                    CodeableConcept bm_ = bl_?.DischargeDisposition;
-                    CqlConcept bn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bm_);
-                    CqlValueSet bo_ = this.Patient_Expired(context);
-                    CqlBoolean bp_ = context.Operators.ConceptInValueSet(bn_, bo_);
-                    return bp_;
-                }
-
-
-                CqlBoolean bf_() {
-                    Encounter.HospitalizationComponent bq_ = InpatientEncounter?.Hospitalization;
-                    CodeableConcept br_ = bq_?.DischargeDisposition;
-                    CqlConcept bs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, br_);
-                    CqlValueSet bt_ = this.Left_Against_Medical_Advice(context);
-                    CqlBoolean bu_ = context.Operators.ConceptInValueSet(bs_, bt_);
-                    return bu_;
-                }
-
-                return bc_
-                    /* CQL 'or' (111:12-112:108) */ || bd_()
-                    /* CQL 'or' (111:12-113:89) */ || be_()
-                    /* CQL 'or' (111:10-115:7) */ || bf_();
-            }
-
+            CqlBoolean v_ = context.Operators.WhereAny<object>(t_, u_);
+            CqlBoolean w_ = v_;
+            Encounter.HospitalizationComponent x_ = InpatientEncounter?.Hospitalization;
+            CodeableConcept y_ = x_?.DischargeDisposition;
+            CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
+            CqlValueSet aa_ = this.Discharge_To_Acute_Care_Facility(context);
+            CqlBoolean ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+            CqlValueSet ac_ = this.Hospice_Care_Referral_or_Admission(context);
+            CqlBoolean ad_ = context.Operators.ConceptInValueSet(z_, ac_);
+            CqlBoolean ae_ = ad_;
+            CqlValueSet af_ = this.Patient_Expired(context);
+            CqlBoolean ag_ = context.Operators.ConceptInValueSet(z_, af_);
+            CqlBoolean ah_ = ag_;
+            CqlValueSet ai_ = this.Left_Against_Medical_Advice(context);
+            CqlBoolean aj_ = context.Operators.ConceptInValueSet(z_, ai_);
+            CqlBoolean ak_ = aj_;
+            CqlBoolean al_ = ab_
+                /* CQL 'or' (111:12-112:108) */ || ae_
+                /* CQL 'or' (111:12-113:89) */ || ah_
+                /* CQL 'or' (111:10-115:7) */ || ak_;
             return g_
-                /* CQL 'or' (96:11-100:81) */ || h_()
-                /* CQL 'or' (96:11-104:7) */ || i_()
-                /* CQL 'or' (96:11-107:7) */ || j_()
-                /* CQL 'or' (96:11-110:7) */ || k_()
-                /* CQL 'or' (96:5-115:7) */ || l_();
+                /* CQL 'or' (96:11-100:81) */ || j_
+                /* CQL 'or' (96:11-104:7) */ || o_
+                /* CQL 'or' (96:11-107:7) */ || s_
+                /* CQL 'or' (96:11-110:7) */ || w_
+                /* CQL 'or' (96:5-115:7) */ || al_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS50FHIRReceiptofSpecialistReport", "1.0.000")]
 public partial class CMS50FHIRReceiptofSpecialistReport_1_0_000 : ILibrary, ISingleton<CMS50FHIRReceiptofSpecialistReport_1_0_000>
 {
@@ -165,17 +165,13 @@ public partial class CMS50FHIRReceiptofSpecialistReport_1_0_000 : ILibrary, ISin
             Encounter.EncounterStatus? u_ = t_?.Value;
             Code<Encounter.EncounterStatus> v_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(u_);
             CqlBoolean w_ = context.Operators.Equal(v_, "finished");
-
-            CqlBoolean x_() {
-                CqlInterval<CqlDateTime> y_ = this.Measurement_Period(context);
-                Period z_ = ValidEncounter?.Period;
-                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                CqlBoolean ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, "day");
-                return ab_;
-            }
-
+            CqlInterval<CqlDateTime> x_ = this.Measurement_Period(context);
+            Period y_ = ValidEncounter?.Period;
+            CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+            CqlBoolean aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, "day");
+            CqlBoolean ab_ = aa_;
             return w_
-                /* CQL 'and' (62:7-63:68) */ && x_();
+                /* CQL 'and' (62:7-63:68) */ && ab_;
         }
 
         CqlBoolean s_ = context.Operators.WhereAny<Encounter>(q_, r_);
@@ -287,32 +283,24 @@ public partial class CMS50FHIRReceiptofSpecialistReport_1_0_000 : ILibrary, ISin
                 "completed",
             ];
             CqlBoolean m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
-
-            CqlBoolean n_() {
-                Code<RequestIntent> p_ = ReferralOrder?.IntentElement;
-                RequestIntent? q_ = p_?.Value;
-                Code<RequestIntent> r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
-                CqlBoolean s_ = context.Operators.Equal(r_, "order");
-                return s_;
-            }
-
-
-            CqlBoolean o_() {
-                FhirDateTime t_ = ReferralOrder?.AuthoredOnElement;
-                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
-                CqlInterval<CqlDateTime> v_ = this.Measurement_Period(context);
-                CqlDateTime w_ = context.Operators.Start(v_);
-                int? x_ = context.Operators.DateTimeComponentFrom(w_, "year");
-                CqlDate y_ = context.Operators.Date(x_, 10, 31);
-                CqlDateTime z_ = context.Operators.ConvertDateToDateTime(y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-                return ab_;
-            }
-
+            Code<RequestIntent> n_ = ReferralOrder?.IntentElement;
+            RequestIntent? o_ = n_?.Value;
+            Code<RequestIntent> p_ = context.Operators.Convert<Code<RequestIntent>>(o_);
+            CqlBoolean q_ = context.Operators.Equal(p_, "order");
+            CqlBoolean r_ = q_;
+            FhirDateTime s_ = ReferralOrder?.AuthoredOnElement;
+            CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
+            CqlInterval<CqlDateTime> u_ = this.Measurement_Period(context);
+            CqlDateTime v_ = context.Operators.Start(u_);
+            int? w_ = context.Operators.DateTimeComponentFrom(v_, "year");
+            CqlDate x_ = context.Operators.Date(w_, 10, 31);
+            CqlDateTime y_ = context.Operators.ConvertDateToDateTime(x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+            CqlBoolean aa_ = context.Operators.In<CqlDateTime>(t_, z_, "day");
+            CqlBoolean ab_ = aa_;
             return m_
-                /* CQL 'and' (80:13-81:42) */ && n_()
-                /* CQL 'and' (80:7-82:145) */ && o_();
+                /* CQL 'and' (80:13-81:42) */ && r_
+                /* CQL 'and' (80:7-82:145) */ && ab_;
         }
 
         IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
@@ -430,58 +418,35 @@ public partial class CMS50FHIRReceiptofSpecialistReport_1_0_000 : ILibrary, ISin
             bool? h_(ServiceRequest FirstReferral) {
                 ResourceReference j_ = ConsultantReportObtained?.Focus;
                 CqlBoolean k_ = QICoreCommon_4_0_000.Instance.references(context, j_, FirstReferral);
-
-                CqlBoolean l_() {
-                    List<ResourceReference> q_ = ConsultantReportObtained?.BasedOn;
-                    CqlBoolean r_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)q_, FirstReferral);
-                    return r_;
-                }
-
-
-                CqlBoolean m_() {
-                    Period s_ = ConsultantReportObtained?.ExecutionPeriod;
-                    CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                    CqlDateTime u_ = context.Operators.End(t_);
-                    FhirDateTime v_ = FirstReferral?.AuthoredOnElement;
-                    CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(v_);
-                    CqlBoolean x_ = context.Operators.After(u_, w_, (string)default);
-                    return x_;
-                }
-
-
-                CqlBoolean n_() {
-                    Period y_ = ConsultantReportObtained?.ExecutionPeriod;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.End(z_);
-                    CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
-                    CqlBoolean ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, "day");
-                    return ac_;
-                }
-
-
-                CqlBoolean o_() {
-                    Code<Task.TaskStatus> ad_ = ConsultantReportObtained?.StatusElement;
-                    Task.TaskStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    CqlBoolean ag_ = context.Operators.Equal(af_, "completed");
-                    return ag_;
-                }
-
-
-                CqlBoolean p_() {
-                    CodeableConcept ah_ = ConsultantReportObtained?.ReasonCode;
-                    CqlConcept ai_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ah_);
-                    CqlValueSet aj_ = this.Consultant_Report(context);
-                    CqlBoolean ak_ = context.Operators.ConceptInValueSet(ai_, aj_);
-                    return ak_;
-                }
-
+                List<ResourceReference> l_ = ConsultantReportObtained?.BasedOn;
+                CqlBoolean m_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)l_, FirstReferral);
+                CqlBoolean n_ = m_;
+                Period o_ = ConsultantReportObtained?.ExecutionPeriod;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                FhirDateTime r_ = FirstReferral?.AuthoredOnElement;
+                CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(r_);
+                CqlBoolean t_ = context.Operators.After(q_, s_, (string)default);
+                CqlBoolean u_ = t_;
+                CqlInterval<CqlDateTime> v_ = this.Measurement_Period(context);
+                CqlBoolean w_ = context.Operators.In<CqlDateTime>(q_, v_, "day");
+                CqlBoolean x_ = w_;
+                Code<Task.TaskStatus> y_ = ConsultantReportObtained?.StatusElement;
+                Task.TaskStatus? z_ = y_?.Value;
+                string aa_ = context.Operators.Convert<string>(z_);
+                CqlBoolean ab_ = context.Operators.Equal(aa_, "completed");
+                CqlBoolean ac_ = ab_;
+                CodeableConcept ad_ = ConsultantReportObtained?.ReasonCode;
+                CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
+                CqlValueSet af_ = this.Consultant_Report(context);
+                CqlBoolean ag_ = context.Operators.ConceptInValueSet(ae_, af_);
+                CqlBoolean ah_ = ag_;
                 return (k_
-                    /* CQL 'or' (94:19-96:9) */ || l_())
-                    /* CQL 'and' (94:19-97:90) */ && m_()
-                    /* CQL 'and' (94:19-98:94) */ && n_()
-                    /* CQL 'and' (94:19-99:59) */ && o_()
-                    /* CQL 'and' (94:19-100:72) */ && p_();
+                    /* CQL 'or' (94:19-96:9) */ || n_)
+                    /* CQL 'and' (94:19-97:90) */ && u_
+                    /* CQL 'and' (94:19-98:94) */ && x_
+                    /* CQL 'and' (94:19-99:59) */ && ac_
+                    /* CQL 'and' (94:19-100:72) */ && ah_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<ServiceRequest>((IEnumerable<ServiceRequest>)g_, h_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS56FHIRFuncStatHipReplacement", "1.0.000")]
 public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingleton<CMS56FHIRFuncStatHipReplacement_1_0_000>
 {
@@ -434,30 +434,22 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
     private bool? Initial_Population_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Has_Qualifying_Encounter(context);
-
-        CqlBoolean b_() {
-            IEnumerable<Procedure> d_ = this.Total_Hip_Arthroplasty_Procedure(context);
-            CqlBoolean e_ = context.Operators.Exists<Procedure>(d_);
-            return e_;
-        }
-
-
-        CqlBoolean c_() {
-            Patient f_ = this.Patient(context);
-            Date g_ = f_?.BirthDateElement;
-            string h_ = g_?.Value;
-            CqlDate i_ = context.Operators.ConvertStringToDate(h_);
-            CqlInterval<CqlDateTime> j_ = this.Measurement_Period(context);
-            CqlDateTime k_ = context.Operators.Start(j_);
-            CqlDate l_ = context.Operators.DateFrom(k_);
-            int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-            CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 19);
-            return n_;
-        }
-
+        IEnumerable<Procedure> b_ = this.Total_Hip_Arthroplasty_Procedure(context);
+        CqlBoolean c_ = context.Operators.Exists<Procedure>(b_);
+        CqlBoolean d_ = c_;
+        Patient e_ = this.Patient(context);
+        Date f_ = e_?.BirthDateElement;
+        string g_ = f_?.Value;
+        CqlDate h_ = context.Operators.ConvertStringToDate(g_);
+        CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
+        CqlDateTime j_ = context.Operators.Start(i_);
+        CqlDate k_ = context.Operators.DateFrom(j_);
+        int? l_ = context.Operators.CalculateAgeAt(h_, k_, "year");
+        CqlBoolean m_ = context.Operators.GreaterOrEqual(l_, 19);
+        CqlBoolean n_ = m_;
         return a_
-            /* CQL 'and' (60:3-61:53) */ && b_()
-            /* CQL 'and' (60:3-62:67) */ && c_();
+            /* CQL 'and' (60:3-61:53) */ && d_
+            /* CQL 'and' (60:3-62:67) */ && n_;
     }
 
 
@@ -507,51 +499,27 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (277:54-278:66) */ || i_()
-                /* CQL 'or' (277:54-279:66) */ || j_()
-                /* CQL 'or' (277:52-281:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (277:54-278:66) */ || i_
+            /* CQL 'or' (277:54-279:66) */ || m_
+            /* CQL 'or' (277:52-281:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (277:3-281:3) */ || c_();
+            /* CQL 'implies' (277:3-281:3) */ || r_;
     }
 
 
@@ -575,33 +543,33 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                 CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LowerBodyFracture);
                 CqlDateTime k_ = context.Operators.Start(j_);
                 object l_;
-                DataType w_ = THAProcedure?.Performed;
-                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                bool y_ = x_ is CqlDateTime;
-                if (y_)
+                DataType z_ = THAProcedure?.Performed;
+                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                bool ab_ = aa_ is CqlDateTime;
+                if (ab_)
                 {
-                    l_ = x_ as CqlDateTime;
+                    l_ = aa_ as CqlDateTime;
                 }
                 else
                 {
-                    bool z_ = x_ is CqlQuantity;
-                    if (z_)
+                    bool ac_ = aa_ is CqlQuantity;
+                    if (ac_)
                     {
-                        l_ = x_ as CqlQuantity;
+                        l_ = aa_ as CqlQuantity;
                     }
                     else
                     {
-                        bool aa_ = x_ is CqlInterval<CqlDateTime>;
-                        if (aa_)
+                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
+                        if (ad_)
                         {
-                            l_ = x_ as CqlInterval<CqlDateTime>;
+                            l_ = aa_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ab_ = x_ is CqlInterval<CqlQuantity>;
-                            if (ab_)
+                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
+                            if (ae_)
                             {
-                                l_ = x_ as CqlInterval<CqlQuantity>;
+                                l_ = aa_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -615,33 +583,33 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                 CqlQuantity o_ = context.Operators.Quantity(48m, "hours");
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 object q_;
-                DataType ac_ = THAProcedure?.Performed;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                bool ae_ = ad_ is CqlDateTime;
-                if (ae_)
+                DataType af_ = THAProcedure?.Performed;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                bool ah_ = ag_ is CqlDateTime;
+                if (ah_)
                 {
-                    q_ = ad_ as CqlDateTime;
+                    q_ = ag_ as CqlDateTime;
                 }
                 else
                 {
-                    bool af_ = ad_ is CqlQuantity;
-                    if (af_)
+                    bool ai_ = ag_ is CqlQuantity;
+                    if (ai_)
                     {
-                        q_ = ad_ as CqlQuantity;
+                        q_ = ag_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool aj_ = ag_ is CqlInterval<CqlDateTime>;
+                        if (aj_)
                         {
-                            q_ = ad_ as CqlInterval<CqlDateTime>;
+                            q_ = ag_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                            if (ah_)
+                            bool ak_ = ag_ is CqlInterval<CqlQuantity>;
+                            if (ak_)
                             {
-                                q_ = ad_ as CqlInterval<CqlQuantity>;
+                                q_ = ag_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -654,51 +622,47 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                 CqlDateTime s_ = context.Operators.Start(r_);
                 CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, true);
                 CqlBoolean u_ = context.Operators.In<CqlDateTime>(k_, t_, (string)default);
-
-                CqlBoolean v_() {
-                    object ai_;
-                    DataType al_ = THAProcedure?.Performed;
-                    object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                    bool an_ = am_ is CqlDateTime;
-                    if (an_)
+                object v_;
+                DataType al_ = THAProcedure?.Performed;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                bool an_ = am_ is CqlDateTime;
+                if (an_)
+                {
+                    v_ = am_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ao_ = am_ is CqlQuantity;
+                    if (ao_)
                     {
-                        ai_ = am_ as CqlDateTime;
+                        v_ = am_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ao_ = am_ is CqlQuantity;
-                        if (ao_)
+                        bool ap_ = am_ is CqlInterval<CqlDateTime>;
+                        if (ap_)
                         {
-                            ai_ = am_ as CqlQuantity;
+                            v_ = am_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ap_ = am_ is CqlInterval<CqlDateTime>;
-                            if (ap_)
+                            bool aq_ = am_ is CqlInterval<CqlQuantity>;
+                            if (aq_)
                             {
-                                ai_ = am_ as CqlInterval<CqlDateTime>;
+                                v_ = am_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aq_ = am_ is CqlInterval<CqlQuantity>;
-                                if (aq_)
-                                {
-                                    ai_ = am_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    ai_ = null;
-                                }
+                                v_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
-                    CqlDateTime ak_ = context.Operators.Start(aj_);
-                    return ak_ is not null;
                 }
-
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                CqlBoolean y_ = (CqlBoolean)(x_ is not null);
                 return u_
-                    /* CQL 'and' (114:19-114:142) */ && v_()
+                    /* CQL 'and' (114:19-114:142) */ && y_
                     /* CQL 'and' (114:19-115:46) */ && this.isVerified(context, LowerBodyFracture);
             }
 
@@ -1076,132 +1040,128 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                 Id k_ = ElectiveTHAProcedure?.IdElement;
                 string l_ = k_?.Value;
                 CqlBoolean m_ = context.Operators.Equivalent(j_, l_);
-
-                CqlBoolean n_() {
-                    object o_;
-                    DataType ac_ = ElectiveTHAProcedure?.Performed;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    bool ae_ = ad_ is CqlDateTime;
-                    if (ae_)
-                    {
-                        o_ = ad_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool af_ = ad_ is CqlQuantity;
-                        if (af_)
-                        {
-                            o_ = ad_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                            if (ag_)
-                            {
-                                o_ = ad_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                                if (ah_)
-                                {
-                                    o_ = ad_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    o_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                    CqlDateTime q_ = context.Operators.Start(p_);
-                    object r_;
-                    DataType ai_ = THAProcedure?.Performed;
-                    object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                    bool ak_ = aj_ is CqlDateTime;
-                    if (ak_)
-                    {
-                        r_ = aj_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool al_ = aj_ is CqlQuantity;
-                        if (al_)
-                        {
-                            r_ = aj_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool am_ = aj_ is CqlInterval<CqlDateTime>;
-                            if (am_)
-                            {
-                                r_ = aj_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool an_ = aj_ is CqlInterval<CqlQuantity>;
-                                if (an_)
-                                {
-                                    r_ = aj_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    r_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.Start(s_);
-                    CqlQuantity u_ = context.Operators.Quantity(1m, "year");
-                    CqlDateTime v_ = context.Operators.Subtract(t_, u_);
-                    object w_;
-                    DataType ao_ = THAProcedure?.Performed;
-                    object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                    bool aq_ = ap_ is CqlDateTime;
-                    if (aq_)
-                    {
-                        w_ = ap_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool ar_ = ap_ is CqlQuantity;
-                        if (ar_)
-                        {
-                            w_ = ap_ as CqlQuantity;
-                        }
-                        else
-                        {
-                            bool as_ = ap_ is CqlInterval<CqlDateTime>;
-                            if (as_)
-                            {
-                                w_ = ap_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bool at_ = ap_ is CqlInterval<CqlQuantity>;
-                                if (at_)
-                                {
-                                    w_ = ap_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    w_ = null;
-                                }
-                            }
-                        }
-                    }
-                    CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                    CqlDateTime y_ = context.Operators.Start(x_);
-                    CqlDateTime z_ = context.Operators.Add(y_, u_);
-                    CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(v_, z_, true, true);
-                    CqlBoolean ab_ = context.Operators.In<CqlDateTime>(q_, aa_, "day");
-                    return ab_;
+                object n_;
+                DataType ac_ = ElectiveTHAProcedure?.Performed;
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                bool ae_ = ad_ is CqlDateTime;
+                if (ae_)
+                {
+                    n_ = ad_ as CqlDateTime;
                 }
-
+                else
+                {
+                    bool af_ = ad_ is CqlQuantity;
+                    if (af_)
+                    {
+                        n_ = ad_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
+                        if (ag_)
+                        {
+                            n_ = ad_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
+                            if (ah_)
+                            {
+                                n_ = ad_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                n_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                object q_;
+                DataType ai_ = THAProcedure?.Performed;
+                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                bool ak_ = aj_ is CqlDateTime;
+                if (ak_)
+                {
+                    q_ = aj_ as CqlDateTime;
+                }
+                else
+                {
+                    bool al_ = aj_ is CqlQuantity;
+                    if (al_)
+                    {
+                        q_ = aj_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool am_ = aj_ is CqlInterval<CqlDateTime>;
+                        if (am_)
+                        {
+                            q_ = aj_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool an_ = aj_ is CqlInterval<CqlQuantity>;
+                            if (an_)
+                            {
+                                q_ = aj_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                q_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlQuantity t_ = context.Operators.Quantity(1m, "year");
+                CqlDateTime u_ = context.Operators.Subtract(s_, t_);
+                object v_;
+                DataType ao_ = THAProcedure?.Performed;
+                object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
+                bool aq_ = ap_ is CqlDateTime;
+                if (aq_)
+                {
+                    v_ = ap_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ar_ = ap_ is CqlQuantity;
+                    if (ar_)
+                    {
+                        v_ = ap_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool as_ = ap_ is CqlInterval<CqlDateTime>;
+                        if (as_)
+                        {
+                            v_ = ap_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool at_ = ap_ is CqlInterval<CqlQuantity>;
+                            if (at_)
+                            {
+                                v_ = ap_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                v_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                CqlDateTime y_ = context.Operators.Add(x_, t_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(u_, y_, true, true);
+                CqlBoolean aa_ = context.Operators.In<CqlDateTime>(p_, z_, "day");
+                CqlBoolean ab_ = aa_;
                 return (CqlBoolean)!m_
-                    /* CQL 'and' (149:19-150:213) */ && n_();
+                    /* CQL 'and' (149:19-150:213) */ && ab_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Procedure>(f_, g_);
@@ -1387,137 +1347,90 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
             CqlDateTime aj_ = context.Operators.Start(ai_);
             CqlDate ak_ = context.Operators.DateFrom(aj_);
             CqlBoolean al_ = context.Operators.SameAs(af_, ak_, "day");
-
-            CqlBoolean am_() {
-                DataType au_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSport as Observation)?.Value;
-                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                return av_ is not null;
-            }
-
-
-            CqlBoolean an_() {
-                DataType aw_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSLifeQuality?.Effective;
-                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
-                CqlDateTime az_ = context.Operators.Start(ay_);
-                CqlDate ba_ = context.Operators.DateFrom(az_);
-                DataType bb_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSActivityScore?.Effective;
-                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-                CqlDateTime be_ = context.Operators.Start(bd_);
-                CqlDate bf_ = context.Operators.DateFrom(be_);
-                CqlBoolean bg_ = context.Operators.SameAs(ba_, bf_, "day");
-                return bg_;
-            }
-
-
-            CqlBoolean ao_() {
-                DataType bh_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSActivityScore as Observation)?.Value;
-                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                return bi_ is not null;
-            }
-
-
-            CqlBoolean ap_() {
-                DataType bj_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSLifeQuality?.Effective;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                CqlInterval<CqlDateTime> bl_ = QICoreCommon_4_0_000.Instance.toInterval(context, bk_);
-                CqlDateTime bm_ = context.Operators.Start(bl_);
-                CqlDate bn_ = context.Operators.DateFrom(bm_);
-                DataType bo_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSymptoms?.Effective;
-                object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
-                CqlInterval<CqlDateTime> bq_ = QICoreCommon_4_0_000.Instance.toInterval(context, bp_);
-                CqlDateTime br_ = context.Operators.Start(bq_);
-                CqlDate bs_ = context.Operators.DateFrom(br_);
-                CqlBoolean bt_ = context.Operators.SameAs(bn_, bs_, "day");
-                return bt_;
-            }
-
-
-            CqlBoolean aq_() {
-                DataType bu_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSymptoms as Observation)?.Value;
-                object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                return bv_ is not null;
-            }
-
-
-            CqlBoolean ar_() {
-                DataType bw_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSLifeQuality?.Effective;
-                object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                CqlInterval<CqlDateTime> by_ = QICoreCommon_4_0_000.Instance.toInterval(context, bx_);
-                CqlDateTime bz_ = context.Operators.Start(by_);
-                CqlDate ca_ = context.Operators.DateFrom(bz_);
-                DataType cb_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSPain?.Effective;
-                object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                CqlInterval<CqlDateTime> cd_ = QICoreCommon_4_0_000.Instance.toInterval(context, cc_);
-                CqlDateTime ce_ = context.Operators.Start(cd_);
-                CqlDate cf_ = context.Operators.DateFrom(ce_);
-                CqlBoolean cg_ = context.Operators.SameAs(ca_, cf_, "day");
-                return cg_;
-            }
-
-
-            CqlBoolean as_() {
-                DataType ch_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSPain as Observation)?.Value;
-                object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                return ci_ is not null;
-            }
-
-
-            CqlBoolean at_() {
-                DataType cj_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSLifeQuality as Observation)?.Value;
-                object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                return ck_ is not null;
-            }
-
+            DataType am_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSport as Observation)?.Value;
+            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            CqlBoolean ao_ = (CqlBoolean)(an_ is not null);
+            DataType ap_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSActivityScore?.Effective;
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.Start(ar_);
+            CqlDate at_ = context.Operators.DateFrom(as_);
+            CqlBoolean au_ = context.Operators.SameAs(af_, at_, "day");
+            CqlBoolean av_ = au_;
+            DataType aw_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSActivityScore as Observation)?.Value;
+            object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+            CqlBoolean ay_ = (CqlBoolean)(ax_ is not null);
+            DataType az_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSymptoms?.Effective;
+            object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+            CqlInterval<CqlDateTime> bb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ba_);
+            CqlDateTime bc_ = context.Operators.Start(bb_);
+            CqlDate bd_ = context.Operators.DateFrom(bc_);
+            CqlBoolean be_ = context.Operators.SameAs(af_, bd_, "day");
+            CqlBoolean bf_ = be_;
+            DataType bg_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSymptoms as Observation)?.Value;
+            object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+            CqlBoolean bi_ = (CqlBoolean)(bh_ is not null);
+            DataType bj_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSPain?.Effective;
+            object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
+            CqlInterval<CqlDateTime> bl_ = QICoreCommon_4_0_000.Instance.toInterval(context, bk_);
+            CqlDateTime bm_ = context.Operators.Start(bl_);
+            CqlDate bn_ = context.Operators.DateFrom(bm_);
+            CqlBoolean bo_ = context.Operators.SameAs(af_, bn_, "day");
+            CqlBoolean bp_ = bo_;
+            DataType bq_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSPain as Observation)?.Value;
+            object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+            CqlBoolean bs_ = (CqlBoolean)(br_ is not null);
+            DataType bt_ = (tuple_eipfmazvhfscjijaofhicpvmb?.HOOSLifeQuality as Observation)?.Value;
+            object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+            CqlBoolean bv_ = (CqlBoolean)(bu_ is not null);
             return al_
-                /* CQL 'and' (185:11-186:75) */ && am_()
-                /* CQL 'and' (185:11-187:63) */ && an_()
-                /* CQL 'and' (185:11-188:83) */ && ao_()
-                /* CQL 'and' (185:11-189:58) */ && ap_()
-                /* CQL 'and' (185:11-190:78) */ && aq_()
-                /* CQL 'and' (185:11-191:54) */ && ar_()
-                /* CQL 'and' (185:11-192:74) */ && as_()
-                /* CQL 'and' (185:5-193:81) */ && at_();
+                /* CQL 'and' (185:11-186:75) */ && ao_
+                /* CQL 'and' (185:11-187:63) */ && av_
+                /* CQL 'and' (185:11-188:83) */ && ay_
+                /* CQL 'and' (185:11-189:58) */ && bf_
+                /* CQL 'and' (185:11-190:78) */ && bi_
+                /* CQL 'and' (185:11-191:54) */ && bp_
+                /* CQL 'and' (185:11-192:74) */ && bs_
+                /* CQL 'and' (185:5-193:81) */ && bv_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation HOOSLifeQuality, Observation HOOSSport, Observation HOOSActivityScore, Observation HOOSSymptoms, Observation HOOSPain)?> x_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation, Observation, Observation, Observation>, (CqlTupleMetadata, Observation HOOSLifeQuality, Observation HOOSSport, Observation HOOSActivityScore, Observation HOOSSymptoms, Observation HOOSPain)?>(u_, v_, w_);
 
         CqlDate y_((CqlTupleMetadata, Observation HOOSLifeQuality, Observation HOOSSport, Observation HOOSActivityScore, Observation HOOSSymptoms, Observation HOOSPain)? tuple_eipfmazvhfscjijaofhicpvmb) {
-            DataType cl_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSLifeQuality?.Effective;
+            DataType bw_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSLifeQuality?.Effective;
+            object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+            CqlInterval<CqlDateTime> by_ = QICoreCommon_4_0_000.Instance.toInterval(context, bx_);
+            CqlDateTime bz_ = context.Operators.Start(by_);
+            CqlDate ca_ = context.Operators.DateFrom(bz_);
+            DataType cb_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSport?.Effective;
+            object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+            CqlInterval<CqlDateTime> cd_ = QICoreCommon_4_0_000.Instance.toInterval(context, cc_);
+            CqlDateTime ce_ = context.Operators.Start(cd_);
+            CqlDate cf_ = context.Operators.DateFrom(ce_);
+            DataType cg_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSActivityScore?.Effective;
+            object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+            CqlInterval<CqlDateTime> ci_ = QICoreCommon_4_0_000.Instance.toInterval(context, ch_);
+            CqlDateTime cj_ = context.Operators.Start(ci_);
+            CqlDate ck_ = context.Operators.DateFrom(cj_);
+            DataType cl_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSymptoms?.Effective;
             object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
             CqlInterval<CqlDateTime> cn_ = QICoreCommon_4_0_000.Instance.toInterval(context, cm_);
             CqlDateTime co_ = context.Operators.Start(cn_);
             CqlDate cp_ = context.Operators.DateFrom(co_);
-            DataType cq_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSport?.Effective;
+            DataType cq_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSPain?.Effective;
             object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
             CqlInterval<CqlDateTime> cs_ = QICoreCommon_4_0_000.Instance.toInterval(context, cr_);
             CqlDateTime ct_ = context.Operators.Start(cs_);
             CqlDate cu_ = context.Operators.DateFrom(ct_);
-            DataType cv_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSActivityScore?.Effective;
-            object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-            CqlInterval<CqlDateTime> cx_ = QICoreCommon_4_0_000.Instance.toInterval(context, cw_);
-            CqlDateTime cy_ = context.Operators.Start(cx_);
-            CqlDate cz_ = context.Operators.DateFrom(cy_);
-            DataType da_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSSymptoms?.Effective;
-            object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-            CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_);
-            CqlDateTime dd_ = context.Operators.Start(dc_);
-            CqlDate de_ = context.Operators.DateFrom(dd_);
-            DataType df_ = tuple_eipfmazvhfscjijaofhicpvmb?.HOOSPain?.Effective;
-            object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
-            CqlInterval<CqlDateTime> dh_ = QICoreCommon_4_0_000.Instance.toInterval(context, dg_);
-            CqlDateTime di_ = context.Operators.Start(dh_);
-            CqlDate dj_ = context.Operators.DateFrom(di_);
-            CqlDate[] dk_ = [
+            CqlDate[] cv_ = [
+                ca_,
+                cf_,
+                ck_,
                 cp_,
                 cu_,
-                cz_,
-                de_,
-                dj_,
             ];
-            CqlDate dl_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)dk_);
-            return dl_;
+            CqlDate cw_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)cv_);
+            return cw_;
         }
 
         IEnumerable<CqlDate> z_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Observation HOOSLifeQuality, Observation HOOSSport, Observation HOOSActivityScore, Observation HOOSSymptoms, Observation HOOSPain)?, CqlDate>(x_, y_);
@@ -1796,23 +1709,15 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10PhysicalScore as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10MentalScore as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10PhysicalScore as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10MentalScore as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (225:11-226:87) */ && aa_()
-                /* CQL 'and' (225:5-227:85) */ && ab_();
+                /* CQL 'and' (225:11-226:87) */ && ac_
+                /* CQL 'and' (225:5-227:85) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)?>(i_, j_, k_);
@@ -1977,23 +1882,15 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (245:11-246:86) */ && aa_()
-                /* CQL 'and' (245:5-247:88) */ && ab_();
+                /* CQL 'and' (245:11-246:86) */ && ac_
+                /* CQL 'and' (245:5-247:88) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?>(i_, j_, k_);
@@ -2158,23 +2055,15 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (265:11-266:86) */ && aa_()
-                /* CQL 'and' (265:5-267:88) */ && ab_();
+                /* CQL 'and' (265:11-266:86) */ && ac_
+                /* CQL 'and' (265:5-267:88) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?>(i_, j_, k_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS645FHIRBoneDensityPCADTherapy", "1.0.000")]
 public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingleton<CMS645FHIRBoneDensityPCADTherapy_1_0_000>
 {
@@ -110,17 +110,13 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
             Period f_ = OfficeVisit?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
-
-            CqlBoolean i_() {
-                Code<Encounter.EncounterStatus> j_ = OfficeVisit?.StatusElement;
-                Encounter.EncounterStatus? k_ = j_?.Value;
-                Code<Encounter.EncounterStatus> l_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(k_);
-                CqlBoolean m_ = context.Operators.Equal(l_, "finished");
-                return m_;
-            }
-
+            Code<Encounter.EncounterStatus> i_ = OfficeVisit?.StatusElement;
+            Encounter.EncounterStatus? j_ = i_?.Value;
+            Code<Encounter.EncounterStatus> k_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(j_);
+            CqlBoolean l_ = context.Operators.Equal(k_, "finished");
+            CqlBoolean m_ = l_;
             return h_
-                /* CQL 'and' (136:7-137:43) */ && i_();
+                /* CQL 'and' (136:7-137:43) */ && m_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Encounter>(b_, c_);
@@ -147,17 +143,13 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
                 string q_ = context.Operators.Last<string>(p_);
                 CqlBoolean r_ = context.Operators.Equal(n_, q_);
-
-                CqlBoolean s_() {
-                    CodeableConcept t_ = M?.Code;
-                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                    CqlValueSet v_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
-                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
-                    return w_;
-                }
-
+                CodeableConcept s_ = M?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                CqlValueSet u_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
+                CqlBoolean w_ = v_;
                 return r_
-                    /* CQL 'and' */ && s_();
+                    /* CQL 'and' */ && w_;
             }
 
             CqlBoolean m_ = context.Operators.WhereAny<Medication>(k_, l_);
@@ -178,24 +170,20 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 "completed",
             ];
             CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-
-            CqlBoolean ac_() {
-                Code<MedicationRequest.MedicationRequestIntent> ad_ = ADTActive?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
-                string af_ = context.Operators.Convert<string>(ae_);
-                string[] ag_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                return ah_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> ac_ = ADTActive?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+            string ae_ = context.Operators.Convert<string>(ad_);
+            string[] af_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+            CqlBoolean ah_ = ag_;
             return ab_
-                /* CQL 'and' (116:5-117:109) */ && ac_();
+                /* CQL 'and' (116:5-117:109) */ && ah_;
         }
 
 
@@ -389,17 +377,13 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
                 string q_ = context.Operators.Last<string>(p_);
                 CqlBoolean r_ = context.Operators.Equal(n_, q_);
-
-                CqlBoolean s_() {
-                    CodeableConcept t_ = M?.Code;
-                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                    CqlValueSet v_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
-                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
-                    return w_;
-                }
-
+                CodeableConcept s_ = M?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                CqlValueSet u_ = this.Androgen_Deprivation_Therapy_for_Urology_Care(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
+                CqlBoolean w_ = v_;
                 return r_
-                    /* CQL 'and' */ && s_();
+                    /* CQL 'and' */ && w_;
             }
 
             CqlBoolean m_ = context.Operators.WhereAny<Medication>(k_, l_);
@@ -420,24 +404,20 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 "completed",
             ];
             CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-
-            CqlBoolean ac_() {
-                Code<MedicationRequest.MedicationRequestIntent> ad_ = ADTOrder?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
-                string af_ = context.Operators.Convert<string>(ae_);
-                string[] ag_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                return ah_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> ac_ = ADTOrder?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+            string ae_ = context.Operators.Convert<string>(ad_);
+            string[] af_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+            CqlBoolean ah_ = ag_;
             return ab_
-                /* CQL 'and' (130:5-131:108) */ && ac_();
+                /* CQL 'and' (130:5-131:108) */ && ah_;
         }
 
 
@@ -582,51 +562,27 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (152:54-153:66) */ || i_()
-                /* CQL 'or' (152:54-154:66) */ || j_()
-                /* CQL 'or' (152:52-156:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (152:54-153:66) */ || i_
+            /* CQL 'or' (152:54-154:66) */ || m_
+            /* CQL 'or' (152:52-156:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (152:3-156:3) */ || c_();
+            /* CQL 'implies' (152:3-156:3) */ || r_;
     }
 
 
@@ -674,21 +630,17 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
             bool? i_(Condition ProstateCancer) {
                 CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ProstateCancer);
                 CqlBoolean l_ = context.Operators.In<CqlDateTime>(ADTDateTime, k_, "day");
-
-                CqlBoolean m_() {
-                    CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
-                    CqlDateTime o_ = context.Operators.Start(n_);
-                    CqlQuantity p_ = context.Operators.Quantity(3m, "months");
-                    CqlDateTime q_ = context.Operators.Subtract(o_, p_);
-                    CqlQuantity r_ = context.Operators.Quantity(9m, "months");
-                    CqlDateTime s_ = context.Operators.Add(o_, r_);
-                    CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-                    CqlBoolean u_ = context.Operators.In<CqlDateTime>(ADTDateTime, t_, "day");
-                    return u_;
-                }
-
+                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlQuantity o_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
+                CqlQuantity q_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime r_ = context.Operators.Add(n_, q_);
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
+                CqlBoolean t_ = context.Operators.In<CqlDateTime>(ADTDateTime, s_, "day");
+                CqlBoolean u_ = t_;
                 return l_
-                    /* CQL 'and' (82:19-83:132) */ && m_();
+                    /* CQL 'and' (82:19-83:132) */ && u_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Condition>(h_, i_);
@@ -724,48 +676,34 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 FhirDateTime j_ = OrderTwelveMonthADT?.AuthoredOnElement;
                 CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
                 CqlBoolean l_ = context.Operators.SameOrAfter(k_, FirstADTMP, "day");
-
-                CqlBoolean m_() {
-                    FhirDateTime p_ = OrderTwelveMonthADT?.AuthoredOnElement;
-                    CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-                    CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
-                    CqlDateTime s_ = context.Operators.Start(r_);
-                    CqlQuantity t_ = context.Operators.Quantity(3m, "months");
-                    CqlDateTime u_ = context.Operators.Subtract(s_, t_);
-                    CqlQuantity v_ = context.Operators.Quantity(9m, "months");
-                    CqlDateTime w_ = context.Operators.Add(s_, v_);
-                    CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
-                    CqlBoolean y_ = context.Operators.In<CqlDateTime>(q_, x_, "day");
-                    return y_;
-                }
-
-
-                CqlBoolean n_() {
-                    Code<RequestStatus> z_ = OrderTwelveMonthADT?.StatusElement;
-                    RequestStatus? aa_ = z_?.Value;
-                    Code<RequestStatus> ab_ = context.Operators.Convert<Code<RequestStatus>>(aa_);
-                    string ac_ = context.Operators.Convert<string>(ab_);
-                    string[] ad_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
-                    return ae_;
-                }
-
-
-                CqlBoolean o_() {
-                    Code<RequestIntent> af_ = OrderTwelveMonthADT?.IntentElement;
-                    RequestIntent? ag_ = af_?.Value;
-                    Code<RequestIntent> ah_ = context.Operators.Convert<Code<RequestIntent>>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-                    return ai_;
-                }
-
+                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlQuantity o_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
+                CqlQuantity q_ = context.Operators.Quantity(9m, "months");
+                CqlDateTime r_ = context.Operators.Add(n_, q_);
+                CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
+                CqlBoolean t_ = context.Operators.In<CqlDateTime>(k_, s_, "day");
+                CqlBoolean u_ = t_;
+                Code<RequestStatus> v_ = OrderTwelveMonthADT?.StatusElement;
+                RequestStatus? w_ = v_?.Value;
+                Code<RequestStatus> x_ = context.Operators.Convert<Code<RequestStatus>>(w_);
+                string y_ = context.Operators.Convert<string>(x_);
+                string[] z_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+                CqlBoolean ab_ = aa_;
+                Code<RequestIntent> ac_ = OrderTwelveMonthADT?.IntentElement;
+                RequestIntent? ad_ = ac_?.Value;
+                Code<RequestIntent> ae_ = context.Operators.Convert<Code<RequestIntent>>(ad_);
+                CqlBoolean af_ = context.Operators.Equal(ae_, "order");
+                CqlBoolean ag_ = af_;
                 return l_
-                    /* CQL 'and' (90:17-91:149) */ && m_()
-                    /* CQL 'and' (90:17-92:67) */ && n_()
-                    /* CQL 'and' (90:17-93:48) */ && o_();
+                    /* CQL 'and' (90:17-91:149) */ && u_
+                    /* CQL 'and' (90:17-92:67) */ && ab_
+                    /* CQL 'and' (90:17-93:48) */ && ag_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<CqlDateTime>((IEnumerable<CqlDateTime>)g_, h_);
@@ -786,15 +724,11 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
     private bool? Initial_Population_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Has_Qualifying_Encounter(context);
-
-        CqlBoolean b_() {
-            IEnumerable<ServiceRequest> c_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
-            CqlBoolean d_ = context.Operators.Exists<ServiceRequest>(c_);
-            return d_;
-        }
-
+        IEnumerable<ServiceRequest> b_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
+        CqlBoolean c_ = context.Operators.Exists<ServiceRequest>(b_);
+        CqlBoolean d_ = c_;
         return a_
-            /* CQL 'and' (25:3-26:108) */ && b_();
+            /* CQL 'and' (25:3-26:108) */ && d_;
     }
 
 
@@ -834,37 +768,16 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime v_ = context.Operators.Add(t_, u_);
                 CqlInterval<CqlDateTime> w_ = context.Operators.Interval(t_, v_, true, true);
                 CqlBoolean x_ = context.Operators.In<CqlDateTime>(r_, w_, "day");
-
-                CqlBoolean y_() {
-                    FhirDateTime aa_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                    CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-                    return ab_ is not null;
-                }
-
-
-                CqlBoolean z_() {
-                    FhirDateTime ac_ = DEXAOrdered?.AuthoredOnElement;
-                    CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(ac_);
-                    FhirDateTime ae_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                    CqlDateTime af_ = context.Operators.Convert<CqlDateTime>(ae_);
-                    CqlQuantity ag_ = context.Operators.Quantity(2m, "years");
-                    CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
-                    CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ah_, af_, true, false);
-                    CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ad_, ai_, "day");
-
-                    CqlBoolean ak_() {
-                        FhirDateTime al_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                        CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
-                        return am_ is not null;
-                    }
-
-                    return aj_
-                        /* CQL 'and' (54:16-54:99) */ && ak_();
-                }
-
+                CqlBoolean y_ = (CqlBoolean)(t_ is not null);
+                CqlQuantity z_ = context.Operators.Quantity(2m, "years");
+                CqlDateTime aa_ = context.Operators.Subtract(t_, z_);
+                CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(aa_, t_, true, false);
+                CqlBoolean ac_ = context.Operators.In<CqlDateTime>(r_, ab_, "day");
+                CqlBoolean ad_ = ac_
+                    /* CQL 'and' (54:16-54:99) */ && y_;
                 return (x_
-                    /* CQL 'and' (53:21-53:110) */ && y_())
-                    /* CQL 'or' (53:21-54:99) */ || z_();
+                    /* CQL 'and' (53:21-53:110) */ && y_)
+                    /* CQL 'or' (53:21-54:99) */ || ad_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<ServiceRequest>(n_, o_);
@@ -874,97 +787,71 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
 
         bool? e_(ServiceRequest DEXAOrdered) {
-            Code<RequestStatus> an_ = DEXAOrdered?.StatusElement;
-            RequestStatus? ao_ = an_?.Value;
-            Code<RequestStatus> ap_ = context.Operators.Convert<Code<RequestStatus>>(ao_);
-            string aq_ = context.Operators.Convert<string>(ap_);
-            string[] ar_ = [
+            Code<RequestStatus> ae_ = DEXAOrdered?.StatusElement;
+            RequestStatus? af_ = ae_?.Value;
+            Code<RequestStatus> ag_ = context.Operators.Convert<Code<RequestStatus>>(af_);
+            string ah_ = context.Operators.Convert<string>(ag_);
+            string[] ai_ = [
                 "active",
                 "completed",
             ];
-            CqlBoolean as_ = context.Operators.In<string>(aq_, (IEnumerable<string>)ar_);
-
-            CqlBoolean at_() {
-                Code<RequestIntent> au_ = DEXAOrdered?.IntentElement;
-                RequestIntent? av_ = au_?.Value;
-                Code<RequestIntent> aw_ = context.Operators.Convert<Code<RequestIntent>>(av_);
-                CqlBoolean ax_ = context.Operators.Equal(aw_, "order");
-                return ax_;
-            }
-
-            return as_
-                /* CQL 'and' (55:9-56:42) */ && at_();
+            CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+            Code<RequestIntent> ak_ = DEXAOrdered?.IntentElement;
+            RequestIntent? al_ = ak_?.Value;
+            Code<RequestIntent> am_ = context.Operators.Convert<Code<RequestIntent>>(al_);
+            CqlBoolean an_ = context.Operators.Equal(am_, "order");
+            CqlBoolean ao_ = an_;
+            return aj_
+                /* CQL 'and' (55:9-56:42) */ && ao_;
         }
 
         IEnumerable<ServiceRequest> f_ = context.Operators.Where<ServiceRequest>(d_, e_);
         IEnumerable<Observation> g_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"));
 
         bool? h_(Observation DEXAPerformed) {
-            IEnumerable<ServiceRequest> ay_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
+            IEnumerable<ServiceRequest> ap_ = this.Order_for_12_Months_of_ADT_in_3_Months_Before_to_9_Months_After_Start_of_Measurement_Period(context);
 
-            bool? az_(ServiceRequest OrderTwelveMonthsADT) {
-                DataType bb_ = DEXAPerformed?.Effective;
-                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-                CqlDateTime be_ = context.Operators.Start(bd_);
-                FhirDateTime bf_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                CqlDateTime bg_ = context.Operators.Convert<CqlDateTime>(bf_);
-                CqlQuantity bh_ = context.Operators.Quantity(3m, "months");
-                CqlDateTime bi_ = context.Operators.Add(bg_, bh_);
-                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bg_, bi_, true, true);
-                CqlBoolean bk_ = context.Operators.In<CqlDateTime>(be_, bj_, "day");
-
-                CqlBoolean bl_() {
-                    FhirDateTime bn_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                    CqlDateTime bo_ = context.Operators.Convert<CqlDateTime>(bn_);
-                    return bo_ is not null;
-                }
-
-
-                CqlBoolean bm_() {
-                    DataType bp_ = DEXAPerformed?.Effective;
-                    object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                    CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
-                    CqlDateTime bs_ = context.Operators.End(br_);
-                    FhirDateTime bt_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                    CqlDateTime bu_ = context.Operators.Convert<CqlDateTime>(bt_);
-                    CqlQuantity bv_ = context.Operators.Quantity(2m, "years");
-                    CqlDateTime bw_ = context.Operators.Subtract(bu_, bv_);
-                    CqlInterval<CqlDateTime> bx_ = context.Operators.Interval(bw_, bu_, true, false);
-                    CqlBoolean by_ = context.Operators.In<CqlDateTime>(bs_, bx_, "day");
-
-                    CqlBoolean bz_() {
-                        FhirDateTime ca_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                        CqlDateTime cb_ = context.Operators.Convert<CqlDateTime>(ca_);
-                        return cb_ is not null;
-                    }
-
-                    return by_
-                        /* CQL 'and' (61:18-61:117) */ && bz_();
-                }
-
-                return (bk_
-                    /* CQL 'and' (60:23-60:128) */ && bl_())
-                    /* CQL 'or' (60:23-61:117) */ || bm_();
+            bool? aq_(ServiceRequest OrderTwelveMonthsADT) {
+                DataType as_ = DEXAPerformed?.Effective;
+                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, at_);
+                CqlDateTime av_ = context.Operators.Start(au_);
+                FhirDateTime aw_ = OrderTwelveMonthsADT?.AuthoredOnElement;
+                CqlDateTime ax_ = context.Operators.Convert<CqlDateTime>(aw_);
+                CqlQuantity ay_ = context.Operators.Quantity(3m, "months");
+                CqlDateTime az_ = context.Operators.Add(ax_, ay_);
+                CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(ax_, az_, true, true);
+                CqlBoolean bb_ = context.Operators.In<CqlDateTime>(av_, ba_, "day");
+                CqlBoolean bc_ = (CqlBoolean)(ax_ is not null);
+                CqlDateTime bd_ = context.Operators.End(au_);
+                CqlQuantity be_ = context.Operators.Quantity(2m, "years");
+                CqlDateTime bf_ = context.Operators.Subtract(ax_, be_);
+                CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(bf_, ax_, true, false);
+                CqlBoolean bh_ = context.Operators.In<CqlDateTime>(bd_, bg_, "day");
+                CqlBoolean bi_ = bh_
+                    /* CQL 'and' (61:18-61:117) */ && bc_;
+                return (bb_
+                    /* CQL 'and' (60:23-60:128) */ && bc_)
+                    /* CQL 'or' (60:23-61:117) */ || bi_;
             }
 
-            CqlBoolean ba_ = context.Operators.WhereAny<ServiceRequest>(ay_, az_);
-            return ba_;
+            CqlBoolean ar_ = context.Operators.WhereAny<ServiceRequest>(ap_, aq_);
+            return ar_;
         }
 
         IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 
         bool? j_(Observation DEXAPerformed) {
-            Code<ObservationStatus> cc_ = DEXAPerformed?.StatusElement;
-            ObservationStatus? cd_ = cc_?.Value;
-            string ce_ = context.Operators.Convert<string>(cd_);
-            string[] cf_ = [
+            Code<ObservationStatus> bj_ = DEXAPerformed?.StatusElement;
+            ObservationStatus? bk_ = bj_?.Value;
+            string bl_ = context.Operators.Convert<string>(bk_);
+            string[] bm_ = [
                 "final",
                 "amended",
                 "corrected",
             ];
-            CqlBoolean cg_ = context.Operators.In<string>(ce_, (IEnumerable<string>)cf_);
-            return cg_;
+            CqlBoolean bn_ = context.Operators.In<string>(bl_, (IEnumerable<string>)bm_);
+            return bn_;
         }
 
         IEnumerable<Observation> k_ = context.Operators.Where<Observation>(i_, j_);
@@ -1011,42 +898,32 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime n_ = context.Operators.Add(l_, m_);
                 CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, true, true);
                 CqlBoolean p_ = context.Operators.In<CqlDateTime>(j_, o_, "day");
+                CqlBoolean q_ = (CqlBoolean)(l_ is not null);
 
-                CqlBoolean q_() {
-                    FhirDateTime s_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                    CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
-                    return t_ is not null;
+                bool? r_(Extension @this) {
+                    FhirUri z_ = @this?.UrlElement;
+                    string aa_ = FHIRHelpers_4_4_000.Instance.ToString(context, z_);
+                    CqlBoolean ab_ = context.Operators.Equal(aa_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                    return ab_;
                 }
 
 
-                CqlBoolean r_() {
-
-                    bool? u_(Extension @this) {
-                        FhirUri ab_ = @this?.UrlElement;
-                        string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
-                        CqlBoolean ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                        return ad_;
-                    }
-
-
-                    object v_(Extension @this) {
-                        DataType ae_ = @this?.Value;
-                        return ae_;
-                    }
-
-                    IEnumerable<object> w_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(DEXANotOrdered is DomainResource
-                        ? (DEXANotOrdered as DomainResource).Extension
-                        : default), u_, v_);
-                    object x_ = context.Operators.SingletonFrom<object>(w_);
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_ as CodeableConcept);
-                    CqlValueSet z_ = this.Patient_Declined(context);
-                    CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    return aa_;
+                object s_(Extension @this) {
+                    DataType ac_ = @this?.Value;
+                    return ac_;
                 }
 
+                IEnumerable<object> t_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(DEXANotOrdered is DomainResource
+                    ? (DEXANotOrdered as DomainResource).Extension
+                    : default), r_, s_);
+                object u_ = context.Operators.SingletonFrom<object>(t_);
+                CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_ as CodeableConcept);
+                CqlValueSet w_ = this.Patient_Declined(context);
+                CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
+                CqlBoolean y_ = x_;
                 return p_
-                    /* CQL 'and' (69:17-69:109) */ && q_()
-                    /* CQL 'and' (69:17-70:62) */ && r_();
+                    /* CQL 'and' (69:17-69:109) */ && q_
+                    /* CQL 'and' (69:17-70:62) */ && y_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<ServiceRequest>(f_, g_);
@@ -1083,42 +960,32 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime o_ = context.Operators.Add(m_, n_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
                 CqlBoolean q_ = context.Operators.In<CqlDateTime>(k_, p_, "day");
+                CqlBoolean r_ = (CqlBoolean)(m_ is not null);
 
-                CqlBoolean r_() {
-                    FhirDateTime t_ = OrderTwelveMonthsADT?.AuthoredOnElement;
-                    CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
-                    return u_ is not null;
+                bool? s_(Extension @this) {
+                    FhirUri aa_ = @this?.UrlElement;
+                    string ab_ = FHIRHelpers_4_4_000.Instance.ToString(context, aa_);
+                    CqlBoolean ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                    return ac_;
                 }
 
 
-                CqlBoolean s_() {
-
-                    bool? v_(Extension @this) {
-                        FhirUri ac_ = @this?.UrlElement;
-                        string ad_ = FHIRHelpers_4_4_000.Instance.ToString(context, ac_);
-                        CqlBoolean ae_ = context.Operators.Equal(ad_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                        return ae_;
-                    }
-
-
-                    object w_(Extension @this) {
-                        DataType af_ = @this?.Value;
-                        return af_;
-                    }
-
-                    IEnumerable<object> x_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(DEXANotPerformed is DomainResource
-                        ? (DEXANotPerformed as DomainResource).Extension
-                        : default), v_, w_);
-                    object y_ = context.Operators.SingletonFrom<object>(x_);
-                    CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_ as CodeableConcept);
-                    CqlValueSet aa_ = this.Patient_Declined(context);
-                    CqlBoolean ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-                    return ab_;
+                object t_(Extension @this) {
+                    DataType ad_ = @this?.Value;
+                    return ad_;
                 }
 
+                IEnumerable<object> u_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(DEXANotPerformed is DomainResource
+                    ? (DEXANotPerformed as DomainResource).Extension
+                    : default), s_, t_);
+                object v_ = context.Operators.SingletonFrom<object>(u_);
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_ as CodeableConcept);
+                CqlValueSet x_ = this.Patient_Declined(context);
+                CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
+                CqlBoolean z_ = y_;
                 return q_
-                    /* CQL 'and' (75:17-75:107) */ && r_()
-                    /* CQL 'and' (75:17-76:64) */ && s_();
+                    /* CQL 'and' (75:17-75:107) */ && r_
+                    /* CQL 'and' (75:17-76:64) */ && z_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<ServiceRequest>(f_, g_);
@@ -1140,15 +1007,11 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<ServiceRequest> a_ = this.No_Bone_Density_Scan_Ordered_Due_to_Patient_Refusal(context);
         CqlBoolean b_ = context.Operators.Exists<ServiceRequest>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> d_ = this.No_Bone_Density_Scan_Performed_Due_to_Patient_Refusal(context);
-            CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
-            return e_;
-        }
-
+        IEnumerable<Observation> c_ = this.No_Bone_Density_Scan_Performed_Due_to_Patient_Refusal(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'or' (35:3-36:73) */ || c_();
+            /* CQL 'or' (35:3-36:73) */ || e_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS646FHIRIntravesicalBCGTherapy", "1.0.000")]
 public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingleton<CMS646FHIRIntravesicalBCGTherapy_1_0_000>
 {
@@ -194,51 +194,27 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (216:54-217:66) */ || i_()
-                /* CQL 'or' (216:54-218:66) */ || j_()
-                /* CQL 'or' (216:52-220:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (216:54-217:66) */ || i_
+            /* CQL 'or' (216:54-218:66) */ || m_
+            /* CQL 'or' (216:52-220:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (216:3-220:3) */ || c_();
+            /* CQL 'implies' (216:3-220:3) */ || r_;
     }
 
 
@@ -261,29 +237,23 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
             CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
             CqlDateTime j_ = context.Operators.End(i_);
             CqlBoolean k_ = context.Operators.Before(h_, j_, "day");
-
-            CqlBoolean l_() {
-                DataType m_ = BladderCancer?.Onset;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
-                CqlInterval<CqlDateTime> p_;
-                CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
-                CqlDateTime s_ = context.Operators.End(r_);
-                if (s_ is null)
-                {
-                    p_ = default;
-                }
-                else
-                {
-                    CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, s_, true, true);
-                    p_ = t_;
-                }
-                CqlBoolean q_ = context.Operators.Before(o_, p_, "day");
-                return q_;
+            DataType l_ = BladderCancer?.Onset;
+            object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+            CqlInterval<CqlDateTime> o_;
+            if (j_ is null)
+            {
+                o_ = default;
             }
-
+            else
+            {
+                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(j_, j_, true, true);
+                o_ = r_;
+            }
+            CqlBoolean p_ = context.Operators.Before(n_, o_, "day");
+            CqlBoolean q_ = p_;
             return (k_
-                /* CQL 'or' (149:11-151:5) */ || l_())
+                /* CQL 'or' (149:11-151:5) */ || q_)
                 /* CQL 'and' (149:5-152:38) */ && this.isVerified(context, BladderCancer);
         }
 
@@ -527,66 +497,40 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
         bool? b_(Observation StagingObservation) {
             IEnumerable<Procedure> d_ = this.getStagingProcedure(context, StagingObservation);
-
-            CqlBoolean e_() {
-                DataType g_ = StagingObservation?.Value;
-                object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
-                CqlCode i_ = this.American_Joint_Committee_on_Cancer_cT1__qualifier_value_(context);
-                CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
-                CqlBoolean k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
-
-                CqlBoolean l_() {
-                    DataType o_ = StagingObservation?.Value;
-                    object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
-                    CqlCode q_ = this.American_Joint_Committee_on_Cancer_cTis__qualifier_value_(context);
-                    CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
-                    CqlBoolean s_ = context.Operators.Equivalent(p_ as CqlConcept, r_);
-                    return s_;
-                }
-
-
-                CqlBoolean m_() {
-                    DataType t_ = StagingObservation?.Value;
-                    object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                    CqlCode v_ = this.American_Joint_Committee_on_Cancer_cTa__qualifier_value_(context);
-                    CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
-                    CqlBoolean x_ = context.Operators.Equivalent(u_ as CqlConcept, w_);
-                    return x_;
-                }
-
-
-                CqlBoolean n_() {
-                    DataType y_ = StagingObservation?.Value;
-                    object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                    CqlCode aa_ = this.Carcinoma_in_situ_of_bladder(context);
-                    CqlConcept ab_ = context.Operators.ConvertCodeToConcept(aa_);
-                    CqlBoolean ac_ = context.Operators.Equivalent(z_ as CqlConcept, ab_);
-                    return ac_;
-                }
-
-                return k_
-                    /* CQL 'or' (179:15-180:112) */ || l_()
-                    /* CQL 'or' (179:15-181:111) */ || m_()
-                    /* CQL 'or' (179:13-183:9) */ || n_();
-            }
-
-
-            CqlBoolean f_() {
-                Code<ObservationStatus> ad_ = StagingObservation?.StatusElement;
-                ObservationStatus? ae_ = ad_?.Value;
-                string af_ = context.Operators.Convert<string>(ae_);
-                string[] ag_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                return ah_;
-            }
-
+            DataType e_ = StagingObservation?.Value;
+            object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
+            CqlCode g_ = this.American_Joint_Committee_on_Cancer_cT1__qualifier_value_(context);
+            CqlConcept h_ = context.Operators.ConvertCodeToConcept(g_);
+            CqlBoolean i_ = context.Operators.Equivalent(f_ as CqlConcept, h_);
+            CqlCode j_ = this.American_Joint_Committee_on_Cancer_cTis__qualifier_value_(context);
+            CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+            CqlBoolean l_ = context.Operators.Equivalent(f_ as CqlConcept, k_);
+            CqlBoolean m_ = l_;
+            CqlCode n_ = this.American_Joint_Committee_on_Cancer_cTa__qualifier_value_(context);
+            CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+            CqlBoolean p_ = context.Operators.Equivalent(f_ as CqlConcept, o_);
+            CqlBoolean q_ = p_;
+            CqlCode r_ = this.Carcinoma_in_situ_of_bladder(context);
+            CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+            CqlBoolean t_ = context.Operators.Equivalent(f_ as CqlConcept, s_);
+            CqlBoolean u_ = t_;
+            CqlBoolean v_ = i_
+                /* CQL 'or' (179:15-180:112) */ || m_
+                /* CQL 'or' (179:15-181:111) */ || q_
+                /* CQL 'or' (179:13-183:9) */ || u_;
+            Code<ObservationStatus> w_ = StagingObservation?.StatusElement;
+            ObservationStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
             return (CqlBoolean)(d_ is not null)
-                /* CQL 'and' (178:13-183:9) */ && e_()
-                /* CQL 'and' (178:7-184:76) */ && f_();
+                /* CQL 'and' (178:13-183:9) */ && v_
+                /* CQL 'and' (178:7-184:76) */ && ab_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Observation>(a_, b_);
@@ -610,27 +554,19 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
             Period f_ = ValidEncounter?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
-
-            CqlBoolean i_() {
-                Coding k_ = ValidEncounter?.Class;
-                CqlCode l_ = FHIRHelpers_4_4_000.Instance.ToCode(context, k_);
-                CqlCode m_ = this.@virtual(context);
-                CqlBoolean n_ = context.Operators.Equivalent(l_, m_);
-                return !n_;
-            }
-
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> o_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? p_ = o_?.Value;
-                Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
-                CqlBoolean r_ = context.Operators.Equal(q_, "finished");
-                return r_;
-            }
-
+            Coding i_ = ValidEncounter?.Class;
+            CqlCode j_ = FHIRHelpers_4_4_000.Instance.ToCode(context, i_);
+            CqlCode k_ = this.@virtual(context);
+            CqlBoolean l_ = context.Operators.Equivalent(j_, k_);
+            CqlBoolean m_ = (CqlBoolean)!l_;
+            Code<Encounter.EncounterStatus> n_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? o_ = n_?.Value;
+            Code<Encounter.EncounterStatus> p_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(o_);
+            CqlBoolean q_ = context.Operators.Equal(p_, "finished");
+            CqlBoolean r_ = q_;
             return h_
-                /* CQL 'and' (141:13-142:45) */ && i_()
-                /* CQL 'and' (141:7-143:46) */ && j_();
+                /* CQL 'and' (141:13-142:45) */ && m_
+                /* CQL 'and' (141:7-143:46) */ && r_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Encounter>(b_, c_);
@@ -687,33 +623,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
             bool? k_(Procedure FirstBladderCancerStaging) {
                 CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveTuberculosis);
                 object n_;
-                DataType r_ = FirstBladderCancerStaging?.Performed;
-                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                bool t_ = s_ is CqlDateTime;
-                if (t_)
+                DataType af_ = FirstBladderCancerStaging?.Performed;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                bool ah_ = ag_ is CqlDateTime;
+                if (ah_)
                 {
-                    n_ = s_ as CqlDateTime;
+                    n_ = ag_ as CqlDateTime;
                 }
                 else
                 {
-                    bool u_ = s_ is CqlQuantity;
-                    if (u_)
+                    bool ai_ = ag_ is CqlQuantity;
+                    if (ai_)
                     {
-                        n_ = s_ as CqlQuantity;
+                        n_ = ag_ as CqlQuantity;
                     }
                     else
                     {
-                        bool v_ = s_ is CqlInterval<CqlDateTime>;
-                        if (v_)
+                        bool aj_ = ag_ is CqlInterval<CqlDateTime>;
+                        if (aj_)
                         {
-                            n_ = s_ as CqlInterval<CqlDateTime>;
+                            n_ = ag_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool w_ = s_ is CqlInterval<CqlQuantity>;
-                            if (w_)
+                            bool ak_ = ag_ is CqlInterval<CqlQuantity>;
+                            if (ak_)
                             {
-                                n_ = s_ as CqlInterval<CqlQuantity>;
+                                n_ = ag_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -724,109 +660,95 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 }
                 CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_);
                 CqlBoolean p_ = context.Operators.OverlapsAfter(m_, o_, "day");
-
-                CqlBoolean q_() {
-                    DataType x_ = ActiveTuberculosis?.Onset;
-                    object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                    CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
-                    object aa_;
-                    DataType ae_ = FirstBladderCancerStaging?.Performed;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    bool ag_ = af_ is CqlDateTime;
-                    if (ag_)
+                DataType q_ = ActiveTuberculosis?.Onset;
+                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
+                object t_;
+                DataType al_ = FirstBladderCancerStaging?.Performed;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                bool an_ = am_ is CqlDateTime;
+                if (an_)
+                {
+                    t_ = am_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ao_ = am_ is CqlQuantity;
+                    if (ao_)
                     {
-                        aa_ = af_ as CqlDateTime;
+                        t_ = am_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ah_ = af_ is CqlQuantity;
-                        if (ah_)
+                        bool ap_ = am_ is CqlInterval<CqlDateTime>;
+                        if (ap_)
                         {
-                            aa_ = af_ as CqlQuantity;
+                            t_ = am_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                            if (ai_)
+                            bool aq_ = am_ is CqlInterval<CqlQuantity>;
+                            if (aq_)
                             {
-                                aa_ = af_ as CqlInterval<CqlDateTime>;
+                                t_ = am_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                                if (aj_)
-                                {
-                                    aa_ = af_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    aa_ = null;
-                                }
+                                t_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
-                    CqlBoolean ac_ = context.Operators.OverlapsAfter(z_, ab_, "day");
-
-                    CqlBoolean ad_() {
-                        DataType ak_ = ActiveTuberculosis?.Abatement;
-                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                        CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                        object an_;
-                        DataType ar_ = FirstBladderCancerStaging?.Performed;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        bool at_ = as_ is CqlDateTime;
-                        if (at_)
-                        {
-                            an_ = as_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool au_ = as_ is CqlQuantity;
-                            if (au_)
-                            {
-                                an_ = as_ as CqlQuantity;
-                            }
-                            else
-                            {
-                                bool av_ = as_ is CqlInterval<CqlDateTime>;
-                                if (av_)
-                                {
-                                    an_ = as_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool aw_ = as_ is CqlInterval<CqlQuantity>;
-                                    if (aw_)
-                                    {
-                                        an_ = as_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        an_ = null;
-                                    }
-                                }
-                            }
-                        }
-                        CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_);
-                        CqlBoolean ap_ = context.Operators.OverlapsAfter(am_, ao_, "day");
-
-                        CqlBoolean aq_() {
-                            DataType ax_ = ActiveTuberculosis?.Abatement;
-                            object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                            return ay_ is null;
-                        }
-
-                        return ap_
-                            /* CQL 'or' (82:19-84:15) */ || aq_();
-                    }
-
-                    return ac_
-                        /* CQL 'and' (81:14-85:11) */ && ad_();
                 }
-
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_);
+                CqlBoolean v_ = context.Operators.OverlapsAfter(s_, u_, "day");
+                DataType w_ = ActiveTuberculosis?.Abatement;
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+                object z_;
+                DataType ar_ = FirstBladderCancerStaging?.Performed;
+                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                bool at_ = as_ is CqlDateTime;
+                if (at_)
+                {
+                    z_ = as_ as CqlDateTime;
+                }
+                else
+                {
+                    bool au_ = as_ is CqlQuantity;
+                    if (au_)
+                    {
+                        z_ = as_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool av_ = as_ is CqlInterval<CqlDateTime>;
+                        if (av_)
+                        {
+                            z_ = as_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool aw_ = as_ is CqlInterval<CqlQuantity>;
+                            if (aw_)
+                            {
+                                z_ = as_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                z_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_);
+                CqlBoolean ab_ = context.Operators.OverlapsAfter(y_, aa_, "day");
+                CqlBoolean ac_ = (CqlBoolean)(x_ is null);
+                CqlBoolean ad_ = ab_
+                    /* CQL 'or' (82:19-84:15) */ || ac_;
+                CqlBoolean ae_ = v_
+                    /* CQL 'and' (81:14-85:11) */ && ad_;
                 return p_
-                    /* CQL 'or' (80:17-86:7) */ || q_();
+                    /* CQL 'or' (80:17-86:7) */ || ae_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)j_, k_);
@@ -836,8 +758,8 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
         bool? g_(Condition ActiveTuberculosis) {
-            CqlBoolean az_ = this.isVerified(context, ActiveTuberculosis);
-            return az_;
+            CqlBoolean ax_ = this.isVerified(context, ActiveTuberculosis);
+            return ax_;
         }
 
         IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
@@ -864,17 +786,13 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
                 string q_ = context.Operators.Last<string>(p_);
                 CqlBoolean r_ = context.Operators.Equal(n_, q_);
-
-                CqlBoolean s_() {
-                    CodeableConcept t_ = M?.Code;
-                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                    CqlValueSet v_ = this.Immunosuppressive_Drugs_for_Urology_Care(context);
-                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
-                    return w_;
-                }
-
+                CodeableConcept s_ = M?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                CqlValueSet u_ = this.Immunosuppressive_Drugs_for_Urology_Care(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_, u_);
+                CqlBoolean w_ = v_;
                 return r_
-                    /* CQL 'and' */ && s_();
+                    /* CQL 'and' */ && w_;
             }
 
             CqlBoolean m_ = context.Operators.WhereAny<Medication>(k_, l_);
@@ -1048,17 +966,13 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 "completed",
             ];
             CqlBoolean cj_ = context.Operators.In<string>(ch_, (IEnumerable<string>)ci_);
-
-            CqlBoolean ck_() {
-                Code<MedicationRequest.MedicationRequestIntent> cl_ = ImmunosuppressiveDrugs?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? cm_ = cl_?.Value;
-                string cn_ = context.Operators.Convert<string>(cm_);
-                CqlBoolean co_ = context.Operators.Equal(cn_, "order");
-                return co_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> ck_ = ImmunosuppressiveDrugs?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? cl_ = ck_?.Value;
+            string cm_ = context.Operators.Convert<string>(cl_);
+            CqlBoolean cn_ = context.Operators.Equal(cm_, "order");
+            CqlBoolean co_ = cn_;
             return cj_
-                /* CQL 'and' (212:5-213:49) */ && ck_();
+                /* CQL 'and' (212:5-213:49) */ && co_;
         }
 
         IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
@@ -1085,33 +999,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
             bool? i_(Procedure FirstBladderCancerStaging) {
                 object k_;
-                DataType y_ = Cystectomy?.Performed;
-                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                bool aa_ = z_ is CqlDateTime;
-                if (aa_)
+                DataType ab_ = Cystectomy?.Performed;
+                object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                bool ad_ = ac_ is CqlDateTime;
+                if (ad_)
                 {
-                    k_ = z_ as CqlDateTime;
+                    k_ = ac_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ab_ = z_ is CqlQuantity;
-                    if (ab_)
+                    bool ae_ = ac_ is CqlQuantity;
+                    if (ae_)
                     {
-                        k_ = z_ as CqlQuantity;
+                        k_ = ac_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ac_ = z_ is CqlInterval<CqlDateTime>;
-                        if (ac_)
+                        bool af_ = ac_ is CqlInterval<CqlDateTime>;
+                        if (af_)
                         {
-                            k_ = z_ as CqlInterval<CqlDateTime>;
+                            k_ = ac_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ad_ = z_ is CqlInterval<CqlQuantity>;
-                            if (ad_)
+                            bool ag_ = ac_ is CqlInterval<CqlQuantity>;
+                            if (ag_)
                             {
-                                k_ = z_ as CqlInterval<CqlQuantity>;
+                                k_ = ac_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1123,33 +1037,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
                 CqlDateTime m_ = context.Operators.End(l_);
                 object n_;
-                DataType ae_ = FirstBladderCancerStaging?.Performed;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                bool ag_ = af_ is CqlDateTime;
-                if (ag_)
+                DataType ah_ = FirstBladderCancerStaging?.Performed;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                bool aj_ = ai_ is CqlDateTime;
+                if (aj_)
                 {
-                    n_ = af_ as CqlDateTime;
+                    n_ = ai_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ah_ = af_ is CqlQuantity;
-                    if (ah_)
+                    bool ak_ = ai_ is CqlQuantity;
+                    if (ak_)
                     {
-                        n_ = af_ as CqlQuantity;
+                        n_ = ai_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                        if (ai_)
+                        bool al_ = ai_ is CqlInterval<CqlDateTime>;
+                        if (al_)
                         {
-                            n_ = af_ as CqlInterval<CqlDateTime>;
+                            n_ = ai_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                            if (aj_)
+                            bool am_ = ai_ is CqlInterval<CqlQuantity>;
+                            if (am_)
                             {
-                                n_ = af_ as CqlInterval<CqlQuantity>;
+                                n_ = ai_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1163,33 +1077,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlQuantity q_ = context.Operators.Quantity(6m, "months");
                 CqlDateTime r_ = context.Operators.Subtract(p_, q_);
                 object s_;
-                DataType ak_ = FirstBladderCancerStaging?.Performed;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                bool am_ = al_ is CqlDateTime;
-                if (am_)
+                DataType an_ = FirstBladderCancerStaging?.Performed;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                bool ap_ = ao_ is CqlDateTime;
+                if (ap_)
                 {
-                    s_ = al_ as CqlDateTime;
+                    s_ = ao_ as CqlDateTime;
                 }
                 else
                 {
-                    bool an_ = al_ is CqlQuantity;
-                    if (an_)
+                    bool aq_ = ao_ is CqlQuantity;
+                    if (aq_)
                     {
-                        s_ = al_ as CqlQuantity;
+                        s_ = ao_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ao_ = al_ is CqlInterval<CqlDateTime>;
-                        if (ao_)
+                        bool ar_ = ao_ is CqlInterval<CqlDateTime>;
+                        if (ar_)
                         {
-                            s_ = al_ as CqlInterval<CqlDateTime>;
+                            s_ = ao_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ap_ = al_ is CqlInterval<CqlQuantity>;
-                            if (ap_)
+                            bool as_ = ao_ is CqlInterval<CqlQuantity>;
+                            if (as_)
                             {
-                                s_ = al_ as CqlInterval<CqlQuantity>;
+                                s_ = ao_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1202,51 +1116,47 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime u_ = context.Operators.Start(t_);
                 CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
                 CqlBoolean w_ = context.Operators.In<CqlDateTime>(m_, v_, "day");
-
-                CqlBoolean x_() {
-                    object aq_;
-                    DataType at_ = FirstBladderCancerStaging?.Performed;
-                    object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                    bool av_ = au_ is CqlDateTime;
-                    if (av_)
+                object x_;
+                DataType at_ = FirstBladderCancerStaging?.Performed;
+                object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+                bool av_ = au_ is CqlDateTime;
+                if (av_)
+                {
+                    x_ = au_ as CqlDateTime;
+                }
+                else
+                {
+                    bool aw_ = au_ is CqlQuantity;
+                    if (aw_)
                     {
-                        aq_ = au_ as CqlDateTime;
+                        x_ = au_ as CqlQuantity;
                     }
                     else
                     {
-                        bool aw_ = au_ is CqlQuantity;
-                        if (aw_)
+                        bool ax_ = au_ is CqlInterval<CqlDateTime>;
+                        if (ax_)
                         {
-                            aq_ = au_ as CqlQuantity;
+                            x_ = au_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ax_ = au_ is CqlInterval<CqlDateTime>;
-                            if (ax_)
+                            bool ay_ = au_ is CqlInterval<CqlQuantity>;
+                            if (ay_)
                             {
-                                aq_ = au_ as CqlInterval<CqlDateTime>;
+                                x_ = au_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ay_ = au_ is CqlInterval<CqlQuantity>;
-                                if (ay_)
-                                {
-                                    aq_ = au_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    aq_ = null;
-                                }
+                                x_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.toInterval(context, aq_);
-                    CqlDateTime as_ = context.Operators.Start(ar_);
-                    return as_ is not null;
                 }
-
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                CqlBoolean aa_ = (CqlBoolean)(z_ is not null);
                 return w_
-                    /* CQL 'and' (92:17-92:142) */ && x_();
+                    /* CQL 'and' (92:17-92:142) */ && aa_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)h_, i_);
@@ -1301,33 +1211,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionDiagnosis);
                 CqlDateTime x_ = context.Operators.Start(w_);
                 object y_;
-                DataType ad_ = FirstBladderCancerStaging?.Performed;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType al_ = FirstBladderCancerStaging?.Performed;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                bool an_ = am_ is CqlDateTime;
+                if (an_)
                 {
-                    y_ = ae_ as CqlDateTime;
+                    y_ = am_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ag_ = ae_ is CqlQuantity;
-                    if (ag_)
+                    bool ao_ = am_ is CqlQuantity;
+                    if (ao_)
                     {
-                        y_ = ae_ as CqlQuantity;
+                        y_ = am_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ah_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ah_)
+                        bool ap_ = am_ is CqlInterval<CqlDateTime>;
+                        if (ap_)
                         {
-                            y_ = ae_ as CqlInterval<CqlDateTime>;
+                            y_ = am_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ai_ = ae_ is CqlInterval<CqlQuantity>;
-                            if (ai_)
+                            bool aq_ = am_ is CqlInterval<CqlQuantity>;
+                            if (aq_)
                             {
-                                y_ = ae_ as CqlInterval<CqlQuantity>;
+                                y_ = am_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1339,56 +1249,52 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
                 CqlDateTime aa_ = context.Operators.Start(z_);
                 CqlBoolean ab_ = context.Operators.SameOrBefore(x_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    DataType aj_ = ExclusionDiagnosis?.Onset;
-                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                    CqlInterval<CqlDateTime> al_ = QICoreCommon_4_0_000.Instance.toInterval(context, ak_);
-                    CqlDateTime am_ = context.Operators.Start(al_);
-                    object an_;
-                    DataType ar_ = FirstBladderCancerStaging?.Performed;
-                    object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                    bool at_ = as_ is CqlDateTime;
-                    if (at_)
+                DataType ac_ = ExclusionDiagnosis?.Onset;
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
+                CqlDateTime af_ = context.Operators.Start(ae_);
+                object ag_;
+                DataType ar_ = FirstBladderCancerStaging?.Performed;
+                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                bool at_ = as_ is CqlDateTime;
+                if (at_)
+                {
+                    ag_ = as_ as CqlDateTime;
+                }
+                else
+                {
+                    bool au_ = as_ is CqlQuantity;
+                    if (au_)
                     {
-                        an_ = as_ as CqlDateTime;
+                        ag_ = as_ as CqlQuantity;
                     }
                     else
                     {
-                        bool au_ = as_ is CqlQuantity;
-                        if (au_)
+                        bool av_ = as_ is CqlInterval<CqlDateTime>;
+                        if (av_)
                         {
-                            an_ = as_ as CqlQuantity;
+                            ag_ = as_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool av_ = as_ is CqlInterval<CqlDateTime>;
-                            if (av_)
+                            bool aw_ = as_ is CqlInterval<CqlQuantity>;
+                            if (aw_)
                             {
-                                an_ = as_ as CqlInterval<CqlDateTime>;
+                                ag_ = as_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool aw_ = as_ is CqlInterval<CqlQuantity>;
-                                if (aw_)
-                                {
-                                    an_ = as_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    an_ = null;
-                                }
+                                ag_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> ao_ = QICoreCommon_4_0_000.Instance.toInterval(context, an_);
-                    CqlDateTime ap_ = context.Operators.Start(ao_);
-                    CqlBoolean aq_ = context.Operators.SameOrBefore(am_, ap_, "day");
-                    return aq_;
                 }
-
+                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
+                CqlDateTime ai_ = context.Operators.Start(ah_);
+                CqlBoolean aj_ = context.Operators.SameOrBefore(af_, ai_, "day");
+                CqlBoolean ak_ = aj_;
                 return ab_
-                    /* CQL 'or' (106:19-108:9) */ || ac_();
+                    /* CQL 'or' (106:19-108:9) */ || ak_;
             }
 
             CqlBoolean v_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)t_, u_);
@@ -1426,17 +1332,13 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 IEnumerable<string> y_ = context.Operators.Split((string)x_, "/");
                 string z_ = context.Operators.Last<string>(y_);
                 CqlBoolean aa_ = context.Operators.Equal(w_, z_);
-
-                CqlBoolean ab_() {
-                    CodeableConcept ac_ = M?.Code;
-                    CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
-                    CqlValueSet ae_ = this.Chemotherapy_Agents_for_Advanced_Cancer(context);
-                    CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
-                    return af_;
-                }
-
+                CodeableConcept ab_ = M?.Code;
+                CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ab_);
+                CqlValueSet ad_ = this.Chemotherapy_Agents_for_Advanced_Cancer(context);
+                CqlBoolean ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+                CqlBoolean af_ = ae_;
                 return aa_
-                    /* CQL 'and' */ && ab_();
+                    /* CQL 'and' */ && af_;
             }
 
             CqlBoolean v_ = context.Operators.WhereAny<Medication>(t_, u_);
@@ -1458,90 +1360,90 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 List<Dosage> ak_ = ExclusionMed?.DosageInstruction;
 
                 bool? al_(Dosage @this) {
-                    Timing bm_ = @this?.Timing;
-                    return bm_ is not null;
+                    Timing bp_ = @this?.Timing;
+                    return bp_ is not null;
                 }
 
 
                 Timing am_(Dosage @this) {
-                    Timing bn_ = @this?.Timing;
-                    return bn_;
+                    Timing bq_ = @this?.Timing;
+                    return bq_;
                 }
 
                 IEnumerable<Timing> an_ = context.Operators.WhereSelect<Dosage, Timing>((IEnumerable<Dosage>)ak_, al_, am_);
 
                 bool? ao_(Timing @this) {
-                    Timing.RepeatComponent bo_ = @this?.Repeat;
-                    return bo_ is not null;
+                    Timing.RepeatComponent br_ = @this?.Repeat;
+                    return br_ is not null;
                 }
 
 
                 Timing.RepeatComponent ap_(Timing @this) {
-                    Timing.RepeatComponent bp_ = @this?.Repeat;
-                    return bp_;
+                    Timing.RepeatComponent bs_ = @this?.Repeat;
+                    return bs_;
                 }
 
                 IEnumerable<Timing.RepeatComponent> aq_ = context.Operators.WhereSelect<Timing, Timing.RepeatComponent>(an_, ao_, ap_);
 
                 bool? ar_(Timing.RepeatComponent @this) {
-                    DataType bq_ = @this?.Bounds;
-                    object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                    return br_ is not null;
+                    DataType bt_ = @this?.Bounds;
+                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                    return bu_ is not null;
                 }
 
 
                 object as_(Timing.RepeatComponent @this) {
-                    DataType bs_ = @this?.Bounds;
-                    object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                    return bt_;
+                    DataType bv_ = @this?.Bounds;
+                    object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                    return bw_;
                 }
 
                 IEnumerable<object> at_ = context.Operators.WhereSelect<Timing.RepeatComponent, object>(aq_, ar_, as_);
 
                 CqlInterval<CqlDateTime> au_(object DoseTime) {
-                    CqlInterval<CqlDateTime> bu_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
-                    return bu_;
+                    CqlInterval<CqlDateTime> bx_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+                    return bx_;
                 }
 
                 IEnumerable<CqlInterval<CqlDateTime>> av_ = context.Operators.SelectDistinct<object, CqlInterval<CqlDateTime>>(at_, au_);
                 IEnumerable<CqlInterval<CqlDateTime>> aw_ = context.Operators.Collapse(av_, (string)default);
 
                 object ax_(CqlInterval<CqlDateTime> @this) {
-                    CqlDateTime bv_ = context.Operators.Start(@this);
-                    return bv_;
+                    CqlDateTime by_ = context.Operators.Start(@this);
+                    return by_;
                 }
 
                 IEnumerable<CqlInterval<CqlDateTime>> ay_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(aw_, ax_, System.ComponentModel.ListSortDirection.Ascending);
                 CqlInterval<CqlDateTime> az_ = context.Operators.First<CqlInterval<CqlDateTime>>(ay_);
                 CqlDateTime ba_ = context.Operators.Start(az_);
                 object bb_;
-                DataType bw_ = FirstBladderCancerStaging?.Performed;
-                object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                bool by_ = bx_ is CqlDateTime;
-                if (by_)
+                DataType bz_ = FirstBladderCancerStaging?.Performed;
+                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                bool cb_ = ca_ is CqlDateTime;
+                if (cb_)
                 {
-                    bb_ = bx_ as CqlDateTime;
+                    bb_ = ca_ as CqlDateTime;
                 }
                 else
                 {
-                    bool bz_ = bx_ is CqlQuantity;
-                    if (bz_)
+                    bool cc_ = ca_ is CqlQuantity;
+                    if (cc_)
                     {
-                        bb_ = bx_ as CqlQuantity;
+                        bb_ = ca_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ca_ = bx_ is CqlInterval<CqlDateTime>;
-                        if (ca_)
+                        bool cd_ = ca_ is CqlInterval<CqlDateTime>;
+                        if (cd_)
                         {
-                            bb_ = bx_ as CqlInterval<CqlDateTime>;
+                            bb_ = ca_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool cb_ = bx_ is CqlInterval<CqlQuantity>;
-                            if (cb_)
+                            bool ce_ = ca_ is CqlInterval<CqlQuantity>;
+                            if (ce_)
                             {
-                                bb_ = bx_ as CqlInterval<CqlQuantity>;
+                                bb_ = ca_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1555,33 +1457,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlQuantity be_ = context.Operators.Quantity(6m, "months");
                 CqlDateTime bf_ = context.Operators.Subtract(bd_, be_);
                 object bg_;
-                DataType cc_ = FirstBladderCancerStaging?.Performed;
-                object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                bool ce_ = cd_ is CqlDateTime;
-                if (ce_)
+                DataType cf_ = FirstBladderCancerStaging?.Performed;
+                object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+                bool ch_ = cg_ is CqlDateTime;
+                if (ch_)
                 {
-                    bg_ = cd_ as CqlDateTime;
+                    bg_ = cg_ as CqlDateTime;
                 }
                 else
                 {
-                    bool cf_ = cd_ is CqlQuantity;
-                    if (cf_)
+                    bool ci_ = cg_ is CqlQuantity;
+                    if (ci_)
                     {
-                        bg_ = cd_ as CqlQuantity;
+                        bg_ = cg_ as CqlQuantity;
                     }
                     else
                     {
-                        bool cg_ = cd_ is CqlInterval<CqlDateTime>;
-                        if (cg_)
+                        bool cj_ = cg_ is CqlInterval<CqlDateTime>;
+                        if (cj_)
                         {
-                            bg_ = cd_ as CqlInterval<CqlDateTime>;
+                            bg_ = cg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ch_ = cd_ is CqlInterval<CqlQuantity>;
-                            if (ch_)
+                            bool ck_ = cg_ is CqlInterval<CqlQuantity>;
+                            if (ck_)
                             {
-                                bg_ = cd_ as CqlInterval<CqlQuantity>;
+                                bg_ = cg_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1594,51 +1496,47 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime bi_ = context.Operators.Start(bh_);
                 CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bf_, bi_, true, false);
                 CqlBoolean bk_ = context.Operators.In<CqlDateTime>(ba_, bj_, (string)default);
-
-                CqlBoolean bl_() {
-                    object ci_;
-                    DataType cl_ = FirstBladderCancerStaging?.Performed;
-                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                    bool cn_ = cm_ is CqlDateTime;
-                    if (cn_)
+                object bl_;
+                DataType cl_ = FirstBladderCancerStaging?.Performed;
+                object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                bool cn_ = cm_ is CqlDateTime;
+                if (cn_)
+                {
+                    bl_ = cm_ as CqlDateTime;
+                }
+                else
+                {
+                    bool co_ = cm_ is CqlQuantity;
+                    if (co_)
                     {
-                        ci_ = cm_ as CqlDateTime;
+                        bl_ = cm_ as CqlQuantity;
                     }
                     else
                     {
-                        bool co_ = cm_ is CqlQuantity;
-                        if (co_)
+                        bool cp_ = cm_ is CqlInterval<CqlDateTime>;
+                        if (cp_)
                         {
-                            ci_ = cm_ as CqlQuantity;
+                            bl_ = cm_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool cp_ = cm_ is CqlInterval<CqlDateTime>;
-                            if (cp_)
+                            bool cq_ = cm_ is CqlInterval<CqlQuantity>;
+                            if (cq_)
                             {
-                                ci_ = cm_ as CqlInterval<CqlDateTime>;
+                                bl_ = cm_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool cq_ = cm_ is CqlInterval<CqlQuantity>;
-                                if (cq_)
-                                {
-                                    ci_ = cm_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    ci_ = null;
-                                }
+                                bl_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> cj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ci_);
-                    CqlDateTime ck_ = context.Operators.Start(cj_);
-                    return ck_ is not null;
                 }
-
+                CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_);
+                CqlDateTime bn_ = context.Operators.Start(bm_);
+                CqlBoolean bo_ = (CqlBoolean)(bn_ is not null);
                 return bk_
-                    /* CQL 'and' (120:21-120:123) */ && bl_();
+                    /* CQL 'and' (120:21-120:123) */ && bo_;
             }
 
             CqlBoolean aj_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)ah_, ai_);
@@ -1656,17 +1554,13 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 "completed",
             ];
             CqlBoolean cv_ = context.Operators.In<string>(ct_, (IEnumerable<string>)cu_);
-
-            CqlBoolean cw_() {
-                Code<MedicationRequest.MedicationRequestIntent> cx_ = ExclusionMed?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? cy_ = cx_?.Value;
-                string cz_ = context.Operators.Convert<string>(cy_);
-                CqlBoolean da_ = context.Operators.Equal(cz_, "order");
-                return da_;
-            }
-
+            Code<MedicationRequest.MedicationRequestIntent> cw_ = ExclusionMed?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? cx_ = cw_?.Value;
+            string cy_ = context.Operators.Convert<string>(cx_);
+            CqlBoolean cz_ = context.Operators.Equal(cy_, "order");
+            CqlBoolean da_ = cz_;
             return cv_
-                /* CQL 'and' (121:9-122:43) */ && cw_();
+                /* CQL 'and' (121:9-122:43) */ && da_;
         }
 
         IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
@@ -1682,33 +1576,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
             bool? dd_(Procedure FirstBladderCancerStaging) {
                 object df_;
-                DataType dt_ = ExclusionProcedure?.Performed;
-                object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
-                bool dv_ = du_ is CqlDateTime;
-                if (dv_)
+                DataType dw_ = ExclusionProcedure?.Performed;
+                object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                bool dy_ = dx_ is CqlDateTime;
+                if (dy_)
                 {
-                    df_ = du_ as CqlDateTime;
+                    df_ = dx_ as CqlDateTime;
                 }
                 else
                 {
-                    bool dw_ = du_ is CqlQuantity;
-                    if (dw_)
+                    bool dz_ = dx_ is CqlQuantity;
+                    if (dz_)
                     {
-                        df_ = du_ as CqlQuantity;
+                        df_ = dx_ as CqlQuantity;
                     }
                     else
                     {
-                        bool dx_ = du_ is CqlInterval<CqlDateTime>;
-                        if (dx_)
+                        bool ea_ = dx_ is CqlInterval<CqlDateTime>;
+                        if (ea_)
                         {
-                            df_ = du_ as CqlInterval<CqlDateTime>;
+                            df_ = dx_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool dy_ = du_ is CqlInterval<CqlQuantity>;
-                            if (dy_)
+                            bool eb_ = dx_ is CqlInterval<CqlQuantity>;
+                            if (eb_)
                             {
-                                df_ = du_ as CqlInterval<CqlQuantity>;
+                                df_ = dx_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1720,33 +1614,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> dg_ = QICoreCommon_4_0_000.Instance.toInterval(context, df_);
                 CqlDateTime dh_ = context.Operators.Start(dg_);
                 object di_;
-                DataType dz_ = FirstBladderCancerStaging?.Performed;
-                object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
-                bool eb_ = ea_ is CqlDateTime;
-                if (eb_)
+                DataType ec_ = FirstBladderCancerStaging?.Performed;
+                object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
+                bool ee_ = ed_ is CqlDateTime;
+                if (ee_)
                 {
-                    di_ = ea_ as CqlDateTime;
+                    di_ = ed_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ec_ = ea_ is CqlQuantity;
-                    if (ec_)
+                    bool ef_ = ed_ is CqlQuantity;
+                    if (ef_)
                     {
-                        di_ = ea_ as CqlQuantity;
+                        di_ = ed_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ed_ = ea_ is CqlInterval<CqlDateTime>;
-                        if (ed_)
+                        bool eg_ = ed_ is CqlInterval<CqlDateTime>;
+                        if (eg_)
                         {
-                            di_ = ea_ as CqlInterval<CqlDateTime>;
+                            di_ = ed_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ee_ = ea_ is CqlInterval<CqlQuantity>;
-                            if (ee_)
+                            bool eh_ = ed_ is CqlInterval<CqlQuantity>;
+                            if (eh_)
                             {
-                                di_ = ea_ as CqlInterval<CqlQuantity>;
+                                di_ = ed_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1760,33 +1654,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlQuantity dl_ = context.Operators.Quantity(6m, "months");
                 CqlDateTime dm_ = context.Operators.Subtract(dk_, dl_);
                 object dn_;
-                DataType ef_ = FirstBladderCancerStaging?.Performed;
-                object eg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ef_);
-                bool eh_ = eg_ is CqlDateTime;
-                if (eh_)
+                DataType ei_ = FirstBladderCancerStaging?.Performed;
+                object ej_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ei_);
+                bool ek_ = ej_ is CqlDateTime;
+                if (ek_)
                 {
-                    dn_ = eg_ as CqlDateTime;
+                    dn_ = ej_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ei_ = eg_ is CqlQuantity;
-                    if (ei_)
+                    bool el_ = ej_ is CqlQuantity;
+                    if (el_)
                     {
-                        dn_ = eg_ as CqlQuantity;
+                        dn_ = ej_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ej_ = eg_ is CqlInterval<CqlDateTime>;
-                        if (ej_)
+                        bool em_ = ej_ is CqlInterval<CqlDateTime>;
+                        if (em_)
                         {
-                            dn_ = eg_ as CqlInterval<CqlDateTime>;
+                            dn_ = ej_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ek_ = eg_ is CqlInterval<CqlQuantity>;
-                            if (ek_)
+                            bool en_ = ej_ is CqlInterval<CqlQuantity>;
+                            if (en_)
                             {
-                                dn_ = eg_ as CqlInterval<CqlQuantity>;
+                                dn_ = ej_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1799,51 +1693,47 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime dp_ = context.Operators.Start(do_);
                 CqlInterval<CqlDateTime> dq_ = context.Operators.Interval(dm_, dp_, true, false);
                 CqlBoolean dr_ = context.Operators.In<CqlDateTime>(dh_, dq_, (string)default);
-
-                CqlBoolean ds_() {
-                    object el_;
-                    DataType eo_ = FirstBladderCancerStaging?.Performed;
-                    object ep_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eo_);
-                    bool eq_ = ep_ is CqlDateTime;
-                    if (eq_)
+                object ds_;
+                DataType eo_ = FirstBladderCancerStaging?.Performed;
+                object ep_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eo_);
+                bool eq_ = ep_ is CqlDateTime;
+                if (eq_)
+                {
+                    ds_ = ep_ as CqlDateTime;
+                }
+                else
+                {
+                    bool er_ = ep_ is CqlQuantity;
+                    if (er_)
                     {
-                        el_ = ep_ as CqlDateTime;
+                        ds_ = ep_ as CqlQuantity;
                     }
                     else
                     {
-                        bool er_ = ep_ is CqlQuantity;
-                        if (er_)
+                        bool es_ = ep_ is CqlInterval<CqlDateTime>;
+                        if (es_)
                         {
-                            el_ = ep_ as CqlQuantity;
+                            ds_ = ep_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool es_ = ep_ is CqlInterval<CqlDateTime>;
-                            if (es_)
+                            bool et_ = ep_ is CqlInterval<CqlQuantity>;
+                            if (et_)
                             {
-                                el_ = ep_ as CqlInterval<CqlDateTime>;
+                                ds_ = ep_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool et_ = ep_ is CqlInterval<CqlQuantity>;
-                                if (et_)
-                                {
-                                    el_ = ep_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    el_ = null;
-                                }
+                                ds_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> em_ = QICoreCommon_4_0_000.Instance.toInterval(context, el_);
-                    CqlDateTime en_ = context.Operators.Start(em_);
-                    return en_ is not null;
                 }
-
+                CqlInterval<CqlDateTime> dt_ = QICoreCommon_4_0_000.Instance.toInterval(context, ds_);
+                CqlDateTime du_ = context.Operators.Start(dt_);
+                CqlBoolean dv_ = (CqlBoolean)(du_ is not null);
                 return dr_
-                    /* CQL 'and' (126:23-126:147) */ && ds_();
+                    /* CQL 'and' (126:23-126:147) */ && dv_;
             }
 
             CqlBoolean de_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)dc_, dd_);
@@ -1881,23 +1771,15 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Condition> a_ = this.Acute_Tuberculosis_Diagnosis(context);
         CqlBoolean b_ = context.Operators.Exists<Condition>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<MedicationRequest> e_ = this.Immunosuppressive_Drugs(context);
-            CqlBoolean f_ = context.Operators.Exists<MedicationRequest>(e_);
-            return f_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Procedure> g_ = this.Cystectomy_Done(context);
-            CqlBoolean h_ = context.Operators.Exists<Procedure>(g_);
-            return h_;
-        }
-
+        IEnumerable<MedicationRequest> c_ = this.Immunosuppressive_Drugs(context);
+        CqlBoolean d_ = context.Operators.Exists<MedicationRequest>(c_);
+        CqlBoolean e_ = d_;
+        IEnumerable<Procedure> f_ = this.Cystectomy_Done(context);
+        CqlBoolean g_ = context.Operators.Exists<Procedure>(f_);
+        CqlBoolean h_ = g_;
         return b_
-            /* CQL 'or' (46:3-47:39) */ || c_()
-            /* CQL 'or' (46:3-48:31) */ || d_()
+            /* CQL 'or' (46:3-47:39) */ || e_
+            /* CQL 'or' (46:3-48:31) */ || h_
             /* CQL 'or' (46:3-49:90) */ || this.Has_Excluding_HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging(context)
             /* CQL 'or' (46:3-50:76) */ || this.Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging(context);
     }
@@ -1924,16 +1806,16 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
             bool? j_(Procedure FirstBladderCancerStaging) {
 
                 bool? l_(Extension @this) {
-                    FhirUri ac_ = @this?.UrlElement;
-                    string ad_ = FHIRHelpers_4_4_000.Instance.ToString(context, ac_);
-                    CqlBoolean ae_ = context.Operators.Equal(ad_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
-                    return ae_;
+                    FhirUri af_ = @this?.UrlElement;
+                    string ag_ = FHIRHelpers_4_4_000.Instance.ToString(context, af_);
+                    CqlBoolean ah_ = context.Operators.Equal(ag_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return ah_;
                 }
 
 
                 DataType m_(Extension @this) {
-                    DataType af_ = @this?.Value;
-                    return af_;
+                    DataType ai_ = @this?.Value;
+                    return ai_;
                 }
 
                 IEnumerable<DataType> n_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(BCGNotGiven is DomainResource
@@ -1943,33 +1825,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 FhirDateTime p_ = context.Operators.Convert<FhirDateTime>(o_);
                 CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
                 object r_;
-                DataType ag_ = FirstBladderCancerStaging?.Performed;
-                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-                bool ai_ = ah_ is CqlDateTime;
-                if (ai_)
+                DataType aj_ = FirstBladderCancerStaging?.Performed;
+                object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                bool al_ = ak_ is CqlDateTime;
+                if (al_)
                 {
-                    r_ = ah_ as CqlDateTime;
+                    r_ = ak_ as CqlDateTime;
                 }
                 else
                 {
-                    bool aj_ = ah_ is CqlQuantity;
-                    if (aj_)
+                    bool am_ = ak_ is CqlQuantity;
+                    if (am_)
                     {
-                        r_ = ah_ as CqlQuantity;
+                        r_ = ak_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ak_ = ah_ is CqlInterval<CqlDateTime>;
-                        if (ak_)
+                        bool an_ = ak_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            r_ = ah_ as CqlInterval<CqlDateTime>;
+                            r_ = ak_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool al_ = ah_ is CqlInterval<CqlQuantity>;
-                            if (al_)
+                            bool ao_ = ak_ is CqlInterval<CqlQuantity>;
+                            if (ao_)
                             {
-                                r_ = ah_ as CqlInterval<CqlQuantity>;
+                                r_ = ak_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1981,33 +1863,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
                 CqlDateTime t_ = context.Operators.Start(s_);
                 object u_;
-                DataType am_ = FirstBladderCancerStaging?.Performed;
-                object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                bool ao_ = an_ is CqlDateTime;
-                if (ao_)
+                DataType ap_ = FirstBladderCancerStaging?.Performed;
+                object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                bool ar_ = aq_ is CqlDateTime;
+                if (ar_)
                 {
-                    u_ = an_ as CqlDateTime;
+                    u_ = aq_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ap_ = an_ is CqlQuantity;
-                    if (ap_)
+                    bool as_ = aq_ is CqlQuantity;
+                    if (as_)
                     {
-                        u_ = an_ as CqlQuantity;
+                        u_ = aq_ as CqlQuantity;
                     }
                     else
                     {
-                        bool aq_ = an_ is CqlInterval<CqlDateTime>;
-                        if (aq_)
+                        bool at_ = aq_ is CqlInterval<CqlDateTime>;
+                        if (at_)
                         {
-                            u_ = an_ as CqlInterval<CqlDateTime>;
+                            u_ = aq_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ar_ = an_ is CqlInterval<CqlQuantity>;
-                            if (ar_)
+                            bool au_ = aq_ is CqlInterval<CqlQuantity>;
+                            if (au_)
                             {
-                                u_ = an_ as CqlInterval<CqlQuantity>;
+                                u_ = aq_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -2022,51 +1904,47 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime y_ = context.Operators.Add(w_, x_);
                 CqlInterval<CqlDateTime> z_ = context.Operators.Interval(t_, y_, false, true);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
-
-                CqlBoolean ab_() {
-                    object as_;
-                    DataType av_ = FirstBladderCancerStaging?.Performed;
-                    object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
-                    bool ax_ = aw_ is CqlDateTime;
-                    if (ax_)
+                object ab_;
+                DataType av_ = FirstBladderCancerStaging?.Performed;
+                object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                bool ax_ = aw_ is CqlDateTime;
+                if (ax_)
+                {
+                    ab_ = aw_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ay_ = aw_ is CqlQuantity;
+                    if (ay_)
                     {
-                        as_ = aw_ as CqlDateTime;
+                        ab_ = aw_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ay_ = aw_ is CqlQuantity;
-                        if (ay_)
+                        bool az_ = aw_ is CqlInterval<CqlDateTime>;
+                        if (az_)
                         {
-                            as_ = aw_ as CqlQuantity;
+                            ab_ = aw_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool az_ = aw_ is CqlInterval<CqlDateTime>;
-                            if (az_)
+                            bool ba_ = aw_ is CqlInterval<CqlQuantity>;
+                            if (ba_)
                             {
-                                as_ = aw_ as CqlInterval<CqlDateTime>;
+                                ab_ = aw_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ba_ = aw_ is CqlInterval<CqlQuantity>;
-                                if (ba_)
-                                {
-                                    as_ = aw_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    as_ = null;
-                                }
+                                ab_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
-                    CqlDateTime au_ = context.Operators.Start(at_);
-                    return au_ is not null;
                 }
-
+                CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                CqlBoolean ae_ = (CqlBoolean)(ad_ is not null);
                 return aa_
-                    /* CQL 'and' (157:17-157:126) */ && ab_();
+                    /* CQL 'and' (157:17-157:126) */ && ae_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)i_, j_);
@@ -2127,17 +2005,13 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
                 string t_ = context.Operators.Last<string>(s_);
                 CqlBoolean u_ = context.Operators.Equal(q_, t_);
-
-                CqlBoolean v_() {
-                    CodeableConcept w_ = M?.Code;
-                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                    CqlValueSet y_ = this.Bacillus_Calmette_Guerin_for_Urology_Care(context);
-                    CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-                    return z_;
-                }
-
+                CodeableConcept v_ = M?.Code;
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                CqlValueSet x_ = this.Bacillus_Calmette_Guerin_for_Urology_Care(context);
+                CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
+                CqlBoolean z_ = y_;
                 return u_
-                    /* CQL 'and' */ && v_();
+                    /* CQL 'and' */ && z_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Medication>(n_, o_);
@@ -2161,33 +2035,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
                 CqlDateTime ah_ = context.Operators.Start(ag_);
                 object ai_;
-                DataType au_ = FirstBladderCancerStaging?.Performed;
-                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                bool aw_ = av_ is CqlDateTime;
-                if (aw_)
+                DataType az_ = FirstBladderCancerStaging?.Performed;
+                object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+                bool bb_ = ba_ is CqlDateTime;
+                if (bb_)
                 {
-                    ai_ = av_ as CqlDateTime;
+                    ai_ = ba_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ax_ = av_ is CqlQuantity;
-                    if (ax_)
+                    bool bc_ = ba_ is CqlQuantity;
+                    if (bc_)
                     {
-                        ai_ = av_ as CqlQuantity;
+                        ai_ = ba_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ay_ = av_ is CqlInterval<CqlDateTime>;
-                        if (ay_)
+                        bool bd_ = ba_ is CqlInterval<CqlDateTime>;
+                        if (bd_)
                         {
-                            ai_ = av_ as CqlInterval<CqlDateTime>;
+                            ai_ = ba_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool az_ = av_ is CqlInterval<CqlQuantity>;
-                            if (az_)
+                            bool be_ = ba_ is CqlInterval<CqlQuantity>;
+                            if (be_)
                             {
-                                ai_ = av_ as CqlInterval<CqlQuantity>;
+                                ai_ = ba_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -2199,33 +2073,33 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
                 CqlDateTime ak_ = context.Operators.Start(aj_);
                 object al_;
-                DataType ba_ = FirstBladderCancerStaging?.Performed;
-                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                bool bc_ = bb_ is CqlDateTime;
-                if (bc_)
+                DataType bf_ = FirstBladderCancerStaging?.Performed;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    al_ = bb_ as CqlDateTime;
+                    al_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    bool bd_ = bb_ is CqlQuantity;
-                    if (bd_)
+                    bool bi_ = bg_ is CqlQuantity;
+                    if (bi_)
                     {
-                        al_ = bb_ as CqlQuantity;
+                        al_ = bg_ as CqlQuantity;
                     }
                     else
                     {
-                        bool be_ = bb_ is CqlInterval<CqlDateTime>;
-                        if (be_)
+                        bool bj_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bj_)
                         {
-                            al_ = bb_ as CqlInterval<CqlDateTime>;
+                            al_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool bf_ = bb_ is CqlInterval<CqlQuantity>;
-                            if (bf_)
+                            bool bk_ = bg_ is CqlInterval<CqlQuantity>;
+                            if (bk_)
                             {
-                                al_ = bb_ as CqlInterval<CqlQuantity>;
+                                al_ = bg_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -2240,63 +2114,51 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                 CqlDateTime ap_ = context.Operators.Add(an_, ao_);
                 CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ak_, ap_, false, true);
                 CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ah_, aq_, "day");
-
-                CqlBoolean as_() {
-                    object bg_;
-                    DataType bj_ = FirstBladderCancerStaging?.Performed;
-                    object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                    bool bl_ = bk_ is CqlDateTime;
-                    if (bl_)
+                object as_;
+                DataType bl_ = FirstBladderCancerStaging?.Performed;
+                object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+                bool bn_ = bm_ is CqlDateTime;
+                if (bn_)
+                {
+                    as_ = bm_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bo_ = bm_ is CqlQuantity;
+                    if (bo_)
                     {
-                        bg_ = bk_ as CqlDateTime;
+                        as_ = bm_ as CqlQuantity;
                     }
                     else
                     {
-                        bool bm_ = bk_ is CqlQuantity;
-                        if (bm_)
+                        bool bp_ = bm_ is CqlInterval<CqlDateTime>;
+                        if (bp_)
                         {
-                            bg_ = bk_ as CqlQuantity;
+                            as_ = bm_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool bn_ = bk_ is CqlInterval<CqlDateTime>;
-                            if (bn_)
+                            bool bq_ = bm_ is CqlInterval<CqlQuantity>;
+                            if (bq_)
                             {
-                                bg_ = bk_ as CqlInterval<CqlDateTime>;
+                                as_ = bm_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool bo_ = bk_ is CqlInterval<CqlQuantity>;
-                                if (bo_)
-                                {
-                                    bg_ = bk_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    bg_ = null;
-                                }
+                                as_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> bh_ = QICoreCommon_4_0_000.Instance.toInterval(context, bg_);
-                    CqlDateTime bi_ = context.Operators.Start(bh_);
-                    return bi_ is not null;
                 }
-
-
-                CqlBoolean at_() {
-                    DataType bp_ = BCG?.Effective;
-                    object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                    CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
-                    CqlDateTime bs_ = context.Operators.Start(br_);
-                    CqlInterval<CqlDateTime> bt_ = this.Measurement_Period(context);
-                    CqlBoolean bu_ = context.Operators.In<CqlDateTime>(bs_, bt_, "day");
-                    return bu_;
-                }
-
+                CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
+                CqlDateTime au_ = context.Operators.Start(at_);
+                CqlBoolean av_ = (CqlBoolean)(au_ is not null);
+                CqlInterval<CqlDateTime> aw_ = this.Measurement_Period(context);
+                CqlBoolean ax_ = context.Operators.In<CqlDateTime>(ah_, aw_, "day");
+                CqlBoolean ay_ = ax_;
                 return ar_
-                    /* CQL 'and' (167:19-167:139) */ && as_()
-                    /* CQL 'and' (167:19-168:82) */ && at_();
+                    /* CQL 'and' (167:19-167:139) */ && av_
+                    /* CQL 'and' (167:19-168:82) */ && ay_;
             }
 
             CqlBoolean ad_ = context.Operators.WhereAny<Procedure>((IEnumerable<Procedure>)ab_, ac_);
@@ -2306,25 +2168,25 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
         IEnumerable<MedicationAdministration> h_ = context.Operators.Where<MedicationAdministration>(f_, g_);
 
         bool? i_(MedicationAdministration BCG) {
-            Code<MedicationAdministration.MedicationAdministrationStatusCodes> bv_ = BCG?.StatusElement;
-            MedicationAdministration.MedicationAdministrationStatusCodes? bw_ = bv_?.Value;
-            string bx_ = context.Operators.Convert<string>(bw_);
-            string[] by_ = [
+            Code<MedicationAdministration.MedicationAdministrationStatusCodes> br_ = BCG?.StatusElement;
+            MedicationAdministration.MedicationAdministrationStatusCodes? bs_ = br_?.Value;
+            string bt_ = context.Operators.Convert<string>(bs_);
+            string[] bu_ = [
                 "in-progress",
                 "completed",
             ];
-            CqlBoolean bz_ = context.Operators.In<string>(bx_, (IEnumerable<string>)by_);
-            return bz_;
+            CqlBoolean bv_ = context.Operators.In<string>(bt_, (IEnumerable<string>)bu_);
+            return bv_;
         }
 
         IEnumerable<MedicationAdministration> j_ = context.Operators.Where<MedicationAdministration>(h_, i_);
 
         object k_(MedicationAdministration @this) {
-            DataType ca_ = @this?.Effective;
-            object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-            CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
-            CqlDateTime cd_ = context.Operators.Start(cc_);
-            return cd_;
+            DataType bw_ = @this?.Effective;
+            object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
+            CqlInterval<CqlDateTime> by_ = QICoreCommon_4_0_000.Instance.toInterval(context, bx_);
+            CqlDateTime bz_ = context.Operators.Start(by_);
+            return bz_;
         }
 
         IEnumerable<MedicationAdministration> l_ = context.Operators.SortBy<MedicationAdministration>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS68FHIRDocumentationCurrentMeds-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS68FHIRDocumentationCurrentMeds-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS68FHIRDocumentationCurrentMeds", "1.0.000")]
 public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISingleton<CMS68FHIRDocumentationCurrentMeds_1_0_000>
 {
@@ -151,17 +151,13 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
             Encounter.EncounterStatus? f_ = e_?.Value;
             Code<Encounter.EncounterStatus> g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
             CqlBoolean h_ = context.Operators.Equal(g_, "finished");
-
-            CqlBoolean i_() {
-                CqlInterval<CqlDateTime> j_ = this.Measurement_Period(context);
-                Period k_ = ValidEncounter?.Period;
-                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                CqlBoolean m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, "day");
-                return m_;
-            }
-
+            CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
+            Period j_ = ValidEncounter?.Period;
+            CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+            CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, k_, "day");
+            CqlBoolean m_ = l_;
             return h_
-                /* CQL 'and' (38:5-39:66) */ && i_();
+                /* CQL 'and' (38:5-39:66) */ && m_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -212,33 +208,33 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
 
             bool? g_(Procedure MedicationsDocumented) {
                 object i_;
-                DataType q_ = MedicationsDocumented?.Performed;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                bool s_ = r_ is CqlDateTime;
-                if (s_)
+                DataType x_ = MedicationsDocumented?.Performed;
+                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                bool z_ = y_ is CqlDateTime;
+                if (z_)
                 {
-                    i_ = r_ as CqlDateTime;
+                    i_ = y_ as CqlDateTime;
                 }
                 else
                 {
-                    bool t_ = r_ is CqlQuantity;
-                    if (t_)
+                    bool aa_ = y_ is CqlQuantity;
+                    if (aa_)
                     {
-                        i_ = r_ as CqlQuantity;
+                        i_ = y_ as CqlQuantity;
                     }
                     else
                     {
-                        bool u_ = r_ is CqlInterval<CqlDateTime>;
-                        if (u_)
+                        bool ab_ = y_ is CqlInterval<CqlDateTime>;
+                        if (ab_)
                         {
-                            i_ = r_ as CqlInterval<CqlDateTime>;
+                            i_ = y_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool v_ = r_ is CqlInterval<CqlQuantity>;
-                            if (v_)
+                            bool ac_ = y_ is CqlInterval<CqlQuantity>;
+                            if (ac_)
                             {
-                                i_ = r_ as CqlInterval<CqlQuantity>;
+                                i_ = y_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -252,61 +248,53 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
                 Period l_ = QualifyingEncounter?.Period;
                 CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
                 CqlBoolean n_ = context.Operators.In<CqlDateTime>(k_, m_, "day");
-
-                CqlBoolean o_() {
-                    object w_;
-                    DataType z_ = MedicationsDocumented?.Performed;
-                    object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                    bool ab_ = aa_ is CqlDateTime;
-                    if (ab_)
+                object o_;
+                DataType ad_ = MedicationsDocumented?.Performed;
+                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                bool af_ = ae_ is CqlDateTime;
+                if (af_)
+                {
+                    o_ = ae_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ag_ = ae_ is CqlQuantity;
+                    if (ag_)
                     {
-                        w_ = aa_ as CqlDateTime;
+                        o_ = ae_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ac_ = aa_ is CqlQuantity;
-                        if (ac_)
+                        bool ah_ = ae_ is CqlInterval<CqlDateTime>;
+                        if (ah_)
                         {
-                            w_ = aa_ as CqlQuantity;
+                            o_ = ae_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                            if (ad_)
+                            bool ai_ = ae_ is CqlInterval<CqlQuantity>;
+                            if (ai_)
                             {
-                                w_ = aa_ as CqlInterval<CqlDateTime>;
+                                o_ = ae_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                                if (ae_)
-                                {
-                                    w_ = aa_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    w_ = null;
-                                }
+                                o_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
-                    CqlBoolean y_ = QICoreCommon_4_0_000.Instance.hasEnd(context, x_);
-                    return y_;
                 }
-
-
-                CqlBoolean p_() {
-                    Code<EventStatus> af_ = MedicationsDocumented?.StatusElement;
-                    EventStatus? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "completed");
-                    return ai_;
-                }
-
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = QICoreCommon_4_0_000.Instance.hasEnd(context, p_);
+                CqlBoolean r_ = q_;
+                Code<EventStatus> s_ = MedicationsDocumented?.StatusElement;
+                EventStatus? t_ = s_?.Value;
+                string u_ = context.Operators.Convert<string>(t_);
+                CqlBoolean v_ = context.Operators.Equal(u_, "completed");
+                CqlBoolean w_ = v_;
                 return n_
-                    /* CQL 'and' (47:17-48:69) */ && o_()
-                    /* CQL 'and' (47:17-49:54) */ && p_();
+                    /* CQL 'and' (47:17-48:69) */ && r_
+                    /* CQL 'and' (47:17-49:54) */ && w_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Procedure>(f_, g_);
@@ -336,16 +324,16 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
             bool? g_(Procedure MedicationsNotDocumented) {
 
                 bool? i_(Extension @this) {
-                    FhirUri t_ = @this?.UrlElement;
-                    string u_ = FHIRHelpers_4_4_000.Instance.ToString(context, t_);
-                    CqlBoolean v_ = context.Operators.Equal(u_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
-                    return v_;
+                    FhirUri ac_ = @this?.UrlElement;
+                    string ad_ = FHIRHelpers_4_4_000.Instance.ToString(context, ac_);
+                    CqlBoolean ae_ = context.Operators.Equal(ad_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return ae_;
                 }
 
 
                 DataType j_(Extension @this) {
-                    DataType w_ = @this?.Value;
-                    return w_;
+                    DataType af_ = @this?.Value;
+                    return af_;
                 }
 
                 IEnumerable<DataType> k_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(MedicationsNotDocumented is DomainResource
@@ -357,40 +345,32 @@ public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISing
                 Period o_ = QualifyingEncounter?.Period;
                 CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
                 CqlBoolean q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+                Code<EventStatus> r_ = MedicationsNotDocumented?.StatusElement;
+                EventStatus? s_ = r_?.Value;
+                string t_ = context.Operators.Convert<string>(s_);
+                CqlBoolean u_ = context.Operators.Equal(t_, "not-done");
+                CqlBoolean v_ = u_;
+                List<CodeableConcept> w_ = MedicationsNotDocumented?.ReasonCode;
 
-                CqlBoolean r_() {
-                    Code<EventStatus> x_ = MedicationsNotDocumented?.StatusElement;
-                    EventStatus? y_ = x_?.Value;
-                    string z_ = context.Operators.Convert<string>(y_);
-                    CqlBoolean aa_ = context.Operators.Equal(z_, "not-done");
-                    return aa_;
+                CqlConcept x_(CodeableConcept @this) {
+                    CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ag_;
                 }
 
 
-                CqlBoolean s_() {
-                    List<CodeableConcept> ab_ = MedicationsNotDocumented?.ReasonCode;
-
-                    CqlConcept ac_(CodeableConcept @this) {
-                        CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return ag_;
-                    }
-
-
-                    bool? ad_(CqlConcept reasonItem) {
-                        CqlCode ah_ = this.Acute_health_crisis__finding_(context);
-                        CqlConcept ai_ = context.Operators.ConvertCodeToConcept(ah_);
-                        CqlBoolean aj_ = context.Operators.Equivalent(reasonItem, ai_);
-                        return aj_;
-                    }
-
-                    IEnumerable<CqlConcept> ae_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ab_, ac_, ad_);
-                    CqlBoolean af_ = context.Operators.Exists<CqlConcept>(ae_);
-                    return af_;
+                bool? y_(CqlConcept reasonItem) {
+                    CqlCode ah_ = this.Acute_health_crisis__finding_(context);
+                    CqlConcept ai_ = context.Operators.ConvertCodeToConcept(ah_);
+                    CqlBoolean aj_ = context.Operators.Equivalent(reasonItem, ai_);
+                    return aj_;
                 }
 
+                IEnumerable<CqlConcept> z_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)w_, x_, y_);
+                CqlBoolean aa_ = context.Operators.Exists<CqlConcept>(z_);
+                CqlBoolean ab_ = aa_;
                 return q_
-                    /* CQL 'and' (54:17-55:56) */ && r_()
-                    /* CQL 'and' (54:17-58:9) */ && s_();
+                    /* CQL 'and' (54:17-55:56) */ && v_
+                    /* CQL 'and' (54:17-58:9) */ && ab_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Procedure>(f_, g_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS69FHIRPCSBMIScreenAndFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS69FHIRPCSBMIScreenAndFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS69FHIRPCSBMIScreenAndFollowUp", "1.0.000")]
 public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingleton<CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000>
 {
@@ -154,27 +154,19 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             Period f_ = BMIEncounter?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
-
-            CqlBoolean i_() {
-                Coding k_ = BMIEncounter?.Class;
-                CqlCode l_ = FHIRHelpers_4_4_000.Instance.ToCode(context, k_);
-                CqlCode m_ = this.@virtual(context);
-                CqlBoolean n_ = context.Operators.Equivalent(l_, m_);
-                return !n_;
-            }
-
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> o_ = BMIEncounter?.StatusElement;
-                Encounter.EncounterStatus? p_ = o_?.Value;
-                Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
-                CqlBoolean r_ = context.Operators.Equal(q_, "finished");
-                return r_;
-            }
-
+            Coding i_ = BMIEncounter?.Class;
+            CqlCode j_ = FHIRHelpers_4_4_000.Instance.ToCode(context, i_);
+            CqlCode k_ = this.@virtual(context);
+            CqlBoolean l_ = context.Operators.Equivalent(j_, k_);
+            CqlBoolean m_ = (CqlBoolean)!l_;
+            Code<Encounter.EncounterStatus> n_ = BMIEncounter?.StatusElement;
+            Encounter.EncounterStatus? o_ = n_?.Value;
+            Code<Encounter.EncounterStatus> p_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(o_);
+            CqlBoolean q_ = context.Operators.Equal(p_, "finished");
+            CqlBoolean r_ = q_;
             return h_
-                /* CQL 'and' (175:11-176:41) */ && i_()
-                /* CQL 'and' (175:5-177:42) */ && j_();
+                /* CQL 'and' (175:11-176:41) */ && m_
+                /* CQL 'and' (175:5-177:42) */ && r_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -238,58 +230,46 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> d_ = context.Operators.Union<Condition>(b_ as IEnumerable<Condition>, c_ as IEnumerable<Condition>);
 
         bool? e_(Condition PregnancyDiagnosis) {
-            CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyDiagnosis);
-            CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
-            CqlBoolean j_ = context.Operators.Overlaps(h_, i_, "day");
-            return j_;
-        }
-
-        CqlBoolean f_ = context.Operators.WhereAny<Condition>(d_, e_);
-
-        CqlBoolean g_() {
-            IEnumerable<Observation> k_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancystatus"));
-
-            bool? l_(Observation PregnantObservation) {
-                DataType n_ = PregnantObservation?.Effective;
-                CqlDateTime o_ = context.Operators.LateBoundProperty<CqlDateTime>(n_, "value");
-                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                CqlBoolean r_ = context.Operators.Overlaps(p_, q_, "day");
-
-                CqlBoolean s_() {
-                    Code<ObservationStatus> u_ = PregnantObservation?.StatusElement;
-                    ObservationStatus? v_ = u_?.Value;
-                    Code<ObservationStatus> w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-                    string x_ = context.Operators.Convert<string>(w_);
-                    string[] y_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
-                    return z_;
-                }
-
-
-                CqlBoolean t_() {
-                    DataType aa_ = PregnantObservation?.Value;
-                    CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_ as CodeableConcept);
-                    CqlValueSet ac_ = this.Pregnancy_or_Other_Related_Diagnoses(context);
-                    CqlBoolean ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
-                    return ad_;
-                }
-
-                return r_
-                    /* CQL 'and' (168:15-169:79) */ && s_()
-                    /* CQL 'and' (168:9-170:85) */ && t_();
-            }
-
-            CqlBoolean m_ = context.Operators.WhereAny<Observation>(k_, l_);
+            CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyDiagnosis);
+            CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+            CqlBoolean m_ = context.Operators.Overlaps(k_, l_, "day");
             return m_;
         }
 
+        CqlBoolean f_ = context.Operators.WhereAny<Condition>(d_, e_);
+        IEnumerable<Observation> g_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancystatus"));
+
+        bool? h_(Observation PregnantObservation) {
+            DataType n_ = PregnantObservation?.Effective;
+            CqlDateTime o_ = context.Operators.LateBoundProperty<CqlDateTime>(n_, "value");
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
+            CqlBoolean r_ = context.Operators.Overlaps(p_, q_, "day");
+            Code<ObservationStatus> s_ = PregnantObservation?.StatusElement;
+            ObservationStatus? t_ = s_?.Value;
+            Code<ObservationStatus> u_ = context.Operators.Convert<Code<ObservationStatus>>(t_);
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
+            DataType z_ = PregnantObservation?.Value;
+            CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_ as CodeableConcept);
+            CqlValueSet ab_ = this.Pregnancy_or_Other_Related_Diagnoses(context);
+            CqlBoolean ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+            CqlBoolean ad_ = ac_;
+            return r_
+                /* CQL 'and' (168:15-169:79) */ && y_
+                /* CQL 'and' (168:9-170:85) */ && ad_;
+        }
+
+        CqlBoolean i_ = context.Operators.WhereAny<Observation>(g_, h_);
+        CqlBoolean j_ = i_;
         return f_
-            /* CQL 'or' (163:3-171:5) */ || g_();
+            /* CQL 'or' (163:3-171:5) */ || j_;
     }
 
 
@@ -324,18 +304,14 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             CqlQuantity f_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, e_ as Quantity);
             CqlQuantity g_ = context.Operators.Quantity(0m, "kg/m2");
             CqlBoolean h_ = context.Operators.Greater(f_, g_);
-
-            CqlBoolean i_() {
-                CqlInterval<CqlDateTime> j_ = this.Measurement_Period(context);
-                DataType k_ = BMI?.Effective;
-                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
-                CqlBoolean n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, "day");
-                return n_;
-            }
-
+            CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
+            DataType j_ = BMI?.Effective;
+            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+            CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
+            CqlBoolean m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, l_, "day");
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'and' (60:5-61:73) */ && i_();
+                /* CQL 'and' (60:5-61:73) */ && n_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -390,17 +366,13 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
                 IEnumerable<string> t_ = context.Operators.Split((string)s_, "/");
                 string u_ = context.Operators.Last<string>(t_);
                 CqlBoolean v_ = context.Operators.Equal(r_, u_);
-
-                CqlBoolean w_() {
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Medications_for_Above_Normal_BMI(context);
-                    CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    return aa_;
-                }
-
+                CodeableConcept w_ = M?.Code;
+                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
+                CqlValueSet y_ = this.Medications_for_Above_Normal_BMI(context);
+                CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
+                CqlBoolean aa_ = z_;
                 return v_
-                    /* CQL 'and' */ && w_();
+                    /* CQL 'and' */ && aa_;
             }
 
             CqlBoolean q_ = context.Operators.WhereAny<Medication>(o_, p_);
@@ -420,8 +392,8 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             ];
 
             CqlConcept ad_(object @this) {
-                CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
-                return ak_;
+                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
+                return ap_;
             }
 
             IEnumerable<CqlConcept> ae_ = context.Operators.Select<object, CqlConcept>((IEnumerable<object>)ac_, ad_);
@@ -431,28 +403,23 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             ];
             CqlValueSet ah_ = this.Overweight_or_Obese(context);
             CqlBoolean ai_ = context.Operators.ConceptsInValueSet((IEnumerable<CqlConcept>)ag_, ah_);
+            IEnumerable<Condition> aj_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            IEnumerable<Condition> ak_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+            IEnumerable<Condition> al_ = context.Operators.Union<Condition>(aj_ as IEnumerable<Condition>, ak_ as IEnumerable<Condition>);
 
-            CqlBoolean aj_() {
-                CqlValueSet al_ = this.Overweight_or_Obese(context);
-                IEnumerable<Condition> am_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, al_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-                IEnumerable<Condition> an_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, al_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-                IEnumerable<Condition> ao_ = context.Operators.Union<Condition>(am_ as IEnumerable<Condition>, an_ as IEnumerable<Condition>);
-
-                bool? ap_(Condition OverweightObese) {
-                    CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OverweightObese);
-                    CqlDateTime as_ = context.Operators.Start(ar_);
-                    object at_ = context.Operators.LateBoundProperty<object>(HighInterventionsOrdered, "authoredOn");
-                    CqlDateTime au_ = context.Operators.LateBoundProperty<CqlDateTime>(at_, "value");
-                    CqlBoolean av_ = context.Operators.SameOrBefore(as_, au_, "day");
-                    return av_;
-                }
-
-                CqlBoolean aq_ = context.Operators.WhereAny<Condition>(ao_, ap_);
-                return aq_;
+            bool? am_(Condition OverweightObese) {
+                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OverweightObese);
+                CqlDateTime ar_ = context.Operators.Start(aq_);
+                object as_ = context.Operators.LateBoundProperty<object>(HighInterventionsOrdered, "authoredOn");
+                CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+                CqlBoolean au_ = context.Operators.SameOrBefore(ar_, at_, "day");
+                return au_;
             }
 
+            CqlBoolean an_ = context.Operators.WhereAny<Condition>(al_, am_);
+            CqlBoolean ao_ = an_;
             return ai_
-                /* CQL 'or' (90:7-94:9) */ || aj_();
+                /* CQL 'or' (90:7-94:9) */ || ao_;
         }
 
         IEnumerable<object> n_ = context.Operators.Where<object>(l_, m_);
@@ -475,116 +442,106 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             List<CodeableConcept> e_ = HighInterventionsPerformed?.ReasonCode;
 
             CqlConcept f_(CodeableConcept @this) {
-                CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return k_;
+                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return n_;
             }
 
             IEnumerable<CqlConcept> g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
             CqlValueSet h_ = this.Overweight_or_Obese(context);
             CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
+            IEnumerable<Condition> j_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            CqlBoolean j_() {
-                CqlValueSet l_ = this.Overweight_or_Obese(context);
-                IEnumerable<Condition> m_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-
-                bool? n_(Condition OverweightObese) {
-                    CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OverweightObese as Condition);
-                    CqlDateTime q_ = context.Operators.Start(p_);
-                    object r_;
-                    DataType w_ = HighInterventionsPerformed?.Performed;
-                    object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                    bool y_ = x_ is CqlDateTime;
-                    if (y_)
+            bool? k_(Condition OverweightObese) {
+                CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OverweightObese as Condition);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                object q_;
+                DataType aa_ = HighInterventionsPerformed?.Performed;
+                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                bool ac_ = ab_ is CqlDateTime;
+                if (ac_)
+                {
+                    q_ = ab_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ad_ = ab_ is CqlQuantity;
+                    if (ad_)
                     {
-                        r_ = x_ as CqlDateTime;
+                        q_ = ab_ as CqlQuantity;
                     }
                     else
                     {
-                        bool z_ = x_ is CqlQuantity;
-                        if (z_)
+                        bool ae_ = ab_ is CqlInterval<CqlDateTime>;
+                        if (ae_)
                         {
-                            r_ = x_ as CqlQuantity;
+                            q_ = ab_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool aa_ = x_ is CqlInterval<CqlDateTime>;
-                            if (aa_)
+                            bool af_ = ab_ is CqlInterval<CqlQuantity>;
+                            if (af_)
                             {
-                                r_ = x_ as CqlInterval<CqlDateTime>;
+                                q_ = ab_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ab_ = x_ is CqlInterval<CqlQuantity>;
-                                if (ab_)
-                                {
-                                    r_ = x_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    r_ = null;
-                                }
+                                q_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlDateTime t_ = context.Operators.Start(s_);
-                    CqlBoolean u_ = context.Operators.SameOrBefore(q_, t_, "day");
-
-                    CqlBoolean v_() {
-                        CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, OverweightObese as Condition);
-                        CqlDateTime ad_ = context.Operators.End(ac_);
-                        object ae_;
-                        DataType ai_ = HighInterventionsPerformed?.Performed;
-                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                        bool ak_ = aj_ is CqlDateTime;
+                }
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlBoolean t_ = context.Operators.SameOrBefore(p_, s_, "day");
+                CqlDateTime u_ = context.Operators.End(o_);
+                object v_;
+                DataType ag_ = HighInterventionsPerformed?.Performed;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                bool ai_ = ah_ is CqlDateTime;
+                if (ai_)
+                {
+                    v_ = ah_ as CqlDateTime;
+                }
+                else
+                {
+                    bool aj_ = ah_ is CqlQuantity;
+                    if (aj_)
+                    {
+                        v_ = ah_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ak_ = ah_ is CqlInterval<CqlDateTime>;
                         if (ak_)
                         {
-                            ae_ = aj_ as CqlDateTime;
+                            v_ = ah_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool al_ = aj_ is CqlQuantity;
+                            bool al_ = ah_ is CqlInterval<CqlQuantity>;
                             if (al_)
                             {
-                                ae_ = aj_ as CqlQuantity;
+                                v_ = ah_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool am_ = aj_ is CqlInterval<CqlDateTime>;
-                                if (am_)
-                                {
-                                    ae_ = aj_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool an_ = aj_ is CqlInterval<CqlQuantity>;
-                                    if (an_)
-                                    {
-                                        ae_ = aj_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        ae_ = null;
-                                    }
-                                }
+                                v_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
-                        CqlDateTime ag_ = context.Operators.Start(af_);
-                        CqlBoolean ah_ = context.Operators.Before(ad_, ag_, "day");
-                        return !ah_;
                     }
-
-                    return u_
-                        /* CQL 'and' (101:13-102:144) */ && v_();
                 }
-
-                CqlBoolean o_ = context.Operators.WhereAny<Condition>(m_, n_);
-                return o_;
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                CqlBoolean y_ = context.Operators.Before(u_, x_, "day");
+                CqlBoolean z_ = (CqlBoolean)!y_;
+                return t_
+                    /* CQL 'and' (101:13-102:144) */ && z_;
             }
 
+            CqlBoolean l_ = context.Operators.WhereAny<Condition>(j_, k_);
+            CqlBoolean m_ = l_;
             return i_
-                /* CQL 'or' (99:7-103:9) */ || j_();
+                /* CQL 'or' (99:7-103:9) */ || m_;
         }
 
         IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
@@ -710,17 +667,13 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
                 IEnumerable<string> t_ = context.Operators.Split((string)s_, "/");
                 string u_ = context.Operators.Last<string>(t_);
                 CqlBoolean v_ = context.Operators.Equal(r_, u_);
-
-                CqlBoolean w_() {
-                    CodeableConcept x_ = M?.Code;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlValueSet z_ = this.Medications_for_Below_Normal_BMI(context);
-                    CqlBoolean aa_ = context.Operators.ConceptInValueSet(y_, z_);
-                    return aa_;
-                }
-
+                CodeableConcept w_ = M?.Code;
+                CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
+                CqlValueSet y_ = this.Medications_for_Below_Normal_BMI(context);
+                CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
+                CqlBoolean aa_ = z_;
                 return v_
-                    /* CQL 'and' */ && w_();
+                    /* CQL 'and' */ && aa_;
             }
 
             CqlBoolean q_ = context.Operators.WhereAny<Medication>(o_, p_);
@@ -740,8 +693,8 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             ];
 
             CqlConcept ad_(object @this) {
-                CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
-                return ak_;
+                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this as CodeableConcept);
+                return ap_;
             }
 
             IEnumerable<CqlConcept> ae_ = context.Operators.Select<object, CqlConcept>((IEnumerable<object>)ac_, ad_);
@@ -751,38 +704,27 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             ];
             CqlValueSet ah_ = this.Underweight(context);
             CqlBoolean ai_ = context.Operators.ConceptsInValueSet((IEnumerable<CqlConcept>)ag_, ah_);
+            IEnumerable<Condition> aj_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            IEnumerable<Condition> ak_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+            IEnumerable<Condition> al_ = context.Operators.Union<Condition>(aj_ as IEnumerable<Condition>, ak_ as IEnumerable<Condition>);
 
-            CqlBoolean aj_() {
-                CqlValueSet al_ = this.Underweight(context);
-                IEnumerable<Condition> am_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, al_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-                IEnumerable<Condition> an_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, al_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-                IEnumerable<Condition> ao_ = context.Operators.Union<Condition>(am_ as IEnumerable<Condition>, an_ as IEnumerable<Condition>);
-
-                bool? ap_(Condition UnderweightDiagnosis) {
-                    CqlInterval<CqlDateTime> ar_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UnderweightDiagnosis);
-                    CqlDateTime as_ = context.Operators.Start(ar_);
-                    object at_ = context.Operators.LateBoundProperty<object>(LowInterventionsOrdered, "authoredOn");
-                    CqlDateTime au_ = context.Operators.LateBoundProperty<CqlDateTime>(at_, "value");
-                    CqlBoolean av_ = context.Operators.SameOrBefore(as_, au_, "day");
-
-                    CqlBoolean aw_() {
-                        object ax_ = context.Operators.LateBoundProperty<object>(LowInterventionsOrdered, "authoredOn");
-                        CqlDateTime ay_ = context.Operators.LateBoundProperty<CqlDateTime>(ax_, "value");
-                        CqlInterval<CqlDateTime> az_ = this.Measurement_Period(context);
-                        CqlBoolean ba_ = context.Operators.In<CqlDateTime>(ay_, az_, "day");
-                        return ba_;
-                    }
-
-                    return av_
-                        /* CQL 'and' (121:13-122:87) */ && aw_();
-                }
-
-                CqlBoolean aq_ = context.Operators.WhereAny<Condition>(ao_, ap_);
-                return aq_;
+            bool? am_(Condition UnderweightDiagnosis) {
+                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UnderweightDiagnosis);
+                CqlDateTime ar_ = context.Operators.Start(aq_);
+                object as_ = context.Operators.LateBoundProperty<object>(LowInterventionsOrdered, "authoredOn");
+                CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+                CqlBoolean au_ = context.Operators.SameOrBefore(ar_, at_, "day");
+                CqlInterval<CqlDateTime> av_ = this.Measurement_Period(context);
+                CqlBoolean aw_ = context.Operators.In<CqlDateTime>(at_, av_, "day");
+                CqlBoolean ax_ = aw_;
+                return au_
+                    /* CQL 'and' (121:13-122:87) */ && ax_;
             }
 
+            CqlBoolean an_ = context.Operators.WhereAny<Condition>(al_, am_);
+            CqlBoolean ao_ = an_;
             return ai_
-                /* CQL 'or' (118:7-123:9) */ || aj_();
+                /* CQL 'or' (118:7-123:9) */ || ao_;
         }
 
         IEnumerable<object> n_ = context.Operators.Where<object>(l_, m_);
@@ -805,178 +747,156 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             List<CodeableConcept> e_ = LowInterventionsPerformed?.ReasonCode;
 
             CqlConcept f_(CodeableConcept @this) {
-                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return l_;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return s_;
             }
 
             IEnumerable<CqlConcept> g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
             CqlValueSet h_ = this.Underweight(context);
             CqlBoolean i_ = context.Operators.ConceptsInValueSet(g_, h_);
+            Code<EventStatus> j_ = LowInterventionsPerformed?.StatusElement;
+            EventStatus? k_ = j_?.Value;
+            string l_ = context.Operators.Convert<string>(k_);
+            CqlBoolean m_ = context.Operators.Equal(l_, "completed");
+            CqlBoolean n_ = m_;
+            IEnumerable<Condition> o_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
-            CqlBoolean j_() {
-                Code<EventStatus> m_ = LowInterventionsPerformed?.StatusElement;
-                EventStatus? n_ = m_?.Value;
-                string o_ = context.Operators.Convert<string>(n_);
-                CqlBoolean p_ = context.Operators.Equal(o_, "completed");
-                return p_;
-            }
-
-
-            CqlBoolean k_() {
-                CqlValueSet q_ = this.Underweight(context);
-                IEnumerable<Condition> r_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, q_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-
-                bool? s_(Condition UnderweightDiagnosis) {
-                    CqlBoolean u_ = QICoreCommon_4_0_000.Instance.isHealthConcern(context, UnderweightDiagnosis as Condition);
-
-                    CqlBoolean v_() {
-                        CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UnderweightDiagnosis as Condition);
-                        CqlDateTime z_ = context.Operators.Start(y_);
-                        object aa_;
-                        DataType ae_ = LowInterventionsPerformed?.Performed;
-                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                        bool ag_ = af_ is CqlDateTime;
-                        if (ag_)
-                        {
-                            aa_ = af_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool ah_ = af_ is CqlQuantity;
-                            if (ah_)
-                            {
-                                aa_ = af_ as CqlQuantity;
-                            }
-                            else
-                            {
-                                bool ai_ = af_ is CqlInterval<CqlDateTime>;
-                                if (ai_)
-                                {
-                                    aa_ = af_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool aj_ = af_ is CqlInterval<CqlQuantity>;
-                                    if (aj_)
-                                    {
-                                        aa_ = af_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        aa_ = null;
-                                    }
-                                }
-                            }
-                        }
-                        CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
-                        CqlDateTime ac_ = context.Operators.Start(ab_);
-                        CqlBoolean ad_ = context.Operators.SameOrBefore(z_, ac_, "day");
-                        return ad_;
+            bool? p_(Condition UnderweightDiagnosis) {
+                CqlBoolean t_ = QICoreCommon_4_0_000.Instance.isHealthConcern(context, UnderweightDiagnosis as Condition);
+                CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UnderweightDiagnosis as Condition);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                object w_;
+                DataType am_ = LowInterventionsPerformed?.Performed;
+                object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                bool ao_ = an_ is CqlDateTime;
+                if (ao_)
+                {
+                    w_ = an_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ap_ = an_ is CqlQuantity;
+                    if (ap_)
+                    {
+                        w_ = an_ as CqlQuantity;
                     }
-
-
-                    CqlBoolean w_() {
-                        CqlInterval<CqlDateTime> ak_ = this.Measurement_Period(context);
-                        object al_;
-                        DataType ao_ = LowInterventionsPerformed?.Performed;
-                        object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ao_);
-                        bool aq_ = ap_ is CqlDateTime;
+                    else
+                    {
+                        bool aq_ = an_ is CqlInterval<CqlDateTime>;
                         if (aq_)
                         {
-                            al_ = ap_ as CqlDateTime;
+                            w_ = an_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ar_ = ap_ is CqlQuantity;
+                            bool ar_ = an_ is CqlInterval<CqlQuantity>;
                             if (ar_)
                             {
-                                al_ = ap_ as CqlQuantity;
+                                w_ = an_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool as_ = ap_ is CqlInterval<CqlDateTime>;
-                                if (as_)
-                                {
-                                    al_ = ap_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool at_ = ap_ is CqlInterval<CqlQuantity>;
-                                    if (at_)
-                                    {
-                                        al_ = ap_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        al_ = null;
-                                    }
-                                }
+                                w_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
-                        CqlBoolean an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ak_, am_, "day");
-                        return an_;
                     }
-
-
-                    CqlBoolean x_() {
-                        CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, UnderweightDiagnosis as Condition);
-                        CqlDateTime av_ = context.Operators.End(au_);
-                        object aw_;
-                        DataType ba_ = LowInterventionsPerformed?.Performed;
-                        object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                        bool bc_ = bb_ is CqlDateTime;
-                        if (bc_)
+                }
+                CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlBoolean z_ = context.Operators.SameOrBefore(v_, y_, "day");
+                CqlBoolean aa_ = z_;
+                CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
+                object ac_;
+                DataType as_ = LowInterventionsPerformed?.Performed;
+                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                bool au_ = at_ is CqlDateTime;
+                if (au_)
+                {
+                    ac_ = at_ as CqlDateTime;
+                }
+                else
+                {
+                    bool av_ = at_ is CqlQuantity;
+                    if (av_)
+                    {
+                        ac_ = at_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool aw_ = at_ is CqlInterval<CqlDateTime>;
+                        if (aw_)
                         {
-                            aw_ = bb_ as CqlDateTime;
+                            ac_ = at_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool bd_ = bb_ is CqlQuantity;
-                            if (bd_)
+                            bool ax_ = at_ is CqlInterval<CqlQuantity>;
+                            if (ax_)
                             {
-                                aw_ = bb_ as CqlQuantity;
+                                ac_ = at_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool be_ = bb_ is CqlInterval<CqlDateTime>;
-                                if (be_)
-                                {
-                                    aw_ = bb_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool bf_ = bb_ is CqlInterval<CqlQuantity>;
-                                    if (bf_)
-                                    {
-                                        aw_ = bb_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        aw_ = null;
-                                    }
-                                }
+                                ac_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_);
-                        CqlDateTime ay_ = context.Operators.Start(ax_);
-                        CqlBoolean az_ = context.Operators.Before(av_, ay_, "day");
-                        return !az_;
                     }
-
-                    return u_
-                        /* CQL 'and' (131:19-132:148) */ && v_()
-                        /* CQL 'and' (131:19-133:103) */ && w_()
-                        /* CQL 'and' (131:13-134:148) */ && x_();
                 }
-
-                CqlBoolean t_ = context.Operators.WhereAny<Condition>(r_, s_);
-                return t_;
+                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
+                CqlBoolean ae_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ab_, ad_, "day");
+                CqlBoolean af_ = ae_;
+                CqlDateTime ag_ = context.Operators.End(u_);
+                object ah_;
+                DataType ay_ = LowInterventionsPerformed?.Performed;
+                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+                bool ba_ = az_ is CqlDateTime;
+                if (ba_)
+                {
+                    ah_ = az_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bb_ = az_ is CqlQuantity;
+                    if (bb_)
+                    {
+                        ah_ = az_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool bc_ = az_ is CqlInterval<CqlDateTime>;
+                        if (bc_)
+                        {
+                            ah_ = az_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool bd_ = az_ is CqlInterval<CqlQuantity>;
+                            if (bd_)
+                            {
+                                ah_ = az_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                ah_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> ai_ = QICoreCommon_4_0_000.Instance.toInterval(context, ah_);
+                CqlDateTime aj_ = context.Operators.Start(ai_);
+                CqlBoolean ak_ = context.Operators.Before(ag_, aj_, "day");
+                CqlBoolean al_ = (CqlBoolean)!ak_;
+                return t_
+                    /* CQL 'and' (131:19-132:148) */ && aa_
+                    /* CQL 'and' (131:19-133:103) */ && af_
+                    /* CQL 'and' (131:13-134:148) */ && al_;
             }
 
+            CqlBoolean q_ = context.Operators.WhereAny<Condition>(o_, p_);
+            CqlBoolean r_ = q_;
             return (i_
-                /* CQL 'and' (128:13-129:58) */ && j_())
-                /* CQL 'or' (128:7-135:9) */ || k_();
+                /* CQL 'and' (128:13-129:58) */ && n_)
+                /* CQL 'or' (128:7-135:9) */ || r_;
         }
 
         IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
@@ -1066,41 +986,27 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         IEnumerable<Observation> a_ = this.BMI_During_Measurement_Period(context);
 
         bool? b_(Observation BMI) {
-            DataType e_ = BMI?.Value;
-            CqlQuantity f_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, e_ as Quantity);
-            CqlQuantity g_ = context.Operators.Quantity(18.5m, "kg/m2");
-            CqlBoolean h_ = context.Operators.GreaterOrEqual(f_, g_);
-
-            CqlBoolean i_() {
-                DataType j_ = BMI?.Value;
-                CqlQuantity k_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, j_ as Quantity);
-                CqlQuantity l_ = context.Operators.Quantity(25m, "kg/m2");
-                CqlBoolean m_ = context.Operators.Less(k_, l_);
-                return m_;
-            }
-
-            return h_
-                /* CQL 'and' (73:7-74:34) */ && i_();
+            DataType j_ = BMI?.Value;
+            CqlQuantity k_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, j_ as Quantity);
+            CqlQuantity l_ = context.Operators.Quantity(18.5m, "kg/m2");
+            CqlBoolean m_ = context.Operators.GreaterOrEqual(k_, l_);
+            CqlQuantity n_ = context.Operators.Quantity(25m, "kg/m2");
+            CqlBoolean o_ = context.Operators.Less(k_, n_);
+            CqlBoolean p_ = o_;
+            return m_
+                /* CQL 'and' (73:7-74:34) */ && p_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Observation>(a_, b_);
-
-        CqlBoolean d_() {
-            IEnumerable<Observation> n_ = this.Documented_High_BMI_During_Measurement_Period(context);
-            CqlBoolean o_ = context.Operators.Exists<Observation>(n_);
-
-            CqlBoolean p_() {
-                IEnumerable<Observation> q_ = this.Documented_Low_BMI_During_Measurement_Period(context);
-                CqlBoolean r_ = context.Operators.Exists<Observation>(q_);
-                return r_;
-            }
-
-            return !((bool?)(o_
-                /* CQL 'or' (76:13-78:5) */ || p_()));
-        }
-
+        IEnumerable<Observation> d_ = this.Documented_High_BMI_During_Measurement_Period(context);
+        CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
+        IEnumerable<Observation> f_ = this.Documented_Low_BMI_During_Measurement_Period(context);
+        CqlBoolean g_ = context.Operators.Exists<Observation>(f_);
+        CqlBoolean h_ = g_;
+        CqlBoolean i_ = (CqlBoolean)(!((bool?)(e_
+            /* CQL 'or' (76:13-78:5) */ || h_)));
         return c_
-            /* CQL 'and' (72:3-78:5) */ && d_();
+            /* CQL 'and' (72:3-78:5) */ && i_;
     }
 
 
@@ -1114,15 +1020,11 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<Observation> a_ = this.High_BMI_And_Follow_Up_Provided(context);
         CqlBoolean b_ = context.Operators.Exists<Observation>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> d_ = this.Low_BMI_And_Follow_Up_Provided(context);
-            CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
-            return e_;
-        }
-
+        IEnumerable<Observation> c_ = this.Low_BMI_And_Follow_Up_Provided(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'or' (50:3-51:46) */ || c_()
+            /* CQL 'or' (50:3-51:46) */ || e_
             /* CQL 'or' (50:3-52:23) */ || this.Has_Normal_BMI(context);
     }
 
@@ -1172,33 +1074,29 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             Code<RequestStatus> am_ = context.Operators.Convert<Code<RequestStatus>>(al_);
             CqlBoolean an_ = context.Operators.Equivalent(am_, "completed");
 
-            CqlBoolean ao_() {
-
-                bool? ap_(Extension @this) {
-                    FhirUri aw_ = @this?.UrlElement;
-                    string ax_ = FHIRHelpers_4_4_000.Instance.ToString(context, aw_);
-                    CqlBoolean ay_ = context.Operators.Equal(ax_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
-                    return ay_;
-                }
-
-
-                object aq_(Extension @this) {
-                    DataType az_ = @this?.Value;
-                    return az_;
-                }
-
-                IEnumerable<object> ar_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBMIFollowUp is DomainResource
-                    ? (NoBMIFollowUp as DomainResource).Extension
-                    : default), ap_, aq_);
-                object as_ = context.Operators.SingletonFrom<object>(ar_);
-                CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, as_ as CodeableConcept);
-                CqlValueSet au_ = this.Medical_Reason(context);
-                CqlBoolean av_ = context.Operators.ConceptInValueSet(at_, au_);
-                return av_;
+            bool? ao_(Extension @this) {
+                FhirUri aw_ = @this?.UrlElement;
+                string ax_ = FHIRHelpers_4_4_000.Instance.ToString(context, aw_);
+                CqlBoolean ay_ = context.Operators.Equal(ax_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+                return ay_;
             }
 
+
+            object ap_(Extension @this) {
+                DataType az_ = @this?.Value;
+                return az_;
+            }
+
+            IEnumerable<object> aq_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBMIFollowUp is DomainResource
+                ? (NoBMIFollowUp as DomainResource).Extension
+                : default), ao_, ap_);
+            object ar_ = context.Operators.SingletonFrom<object>(aq_);
+            CqlConcept as_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ar_ as CodeableConcept);
+            CqlValueSet at_ = this.Medical_Reason(context);
+            CqlBoolean au_ = context.Operators.ConceptInValueSet(as_, at_);
+            CqlBoolean av_ = au_;
             return an_
-                /* CQL 'and' (151:7-152:59) */ && ao_();
+                /* CQL 'and' (151:7-152:59) */ && av_;
         }
 
         IEnumerable<ServiceRequest> o_ = context.Operators.Where<ServiceRequest>(m_, n_);
@@ -1234,23 +1132,19 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             MedicationRequest.MedicationrequestStatus? bk_ = bj_?.Value;
             string bl_ = context.Operators.Convert<string>(bk_);
             CqlBoolean bm_ = context.Operators.Equivalent(bl_, "completed");
+            List<CodeableConcept> bn_ = NoBMIFollowUp?.ReasonCode;
 
-            CqlBoolean bn_() {
-                List<CodeableConcept> bo_ = NoBMIFollowUp?.ReasonCode;
-
-                CqlConcept bp_(CodeableConcept @this) {
-                    CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return bt_;
-                }
-
-                IEnumerable<CqlConcept> bq_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bo_, bp_);
-                CqlValueSet br_ = this.Medical_Reason(context);
-                CqlBoolean bs_ = context.Operators.ConceptsInValueSet(bq_, br_);
-                return bs_;
+            CqlConcept bo_(CodeableConcept @this) {
+                CqlConcept bt_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return bt_;
             }
 
+            IEnumerable<CqlConcept> bp_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bn_, bo_);
+            CqlValueSet bq_ = this.Medical_Reason(context);
+            CqlBoolean br_ = context.Operators.ConceptsInValueSet(bp_, bq_);
+            CqlBoolean bs_ = br_;
             return bm_
-                /* CQL 'and' (158:9-159:58) */ && bn_();
+                /* CQL 'and' (158:9-159:58) */ && bs_;
         }
 
         IEnumerable<MedicationRequest> z_ = context.Operators.Where<MedicationRequest>(x_, y_);
@@ -1295,16 +1189,16 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
         bool? f_(Observation NoBMI) {
 
             bool? s_(Extension @this) {
-                FhirUri aa_ = @this?.UrlElement;
-                string ab_ = FHIRHelpers_4_4_000.Instance.ToString(context, aa_);
-                CqlBoolean ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                return ac_;
+                FhirUri ah_ = @this?.UrlElement;
+                string ai_ = FHIRHelpers_4_4_000.Instance.ToString(context, ah_);
+                CqlBoolean aj_ = context.Operators.Equal(ai_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return aj_;
             }
 
 
             object t_(Extension @this) {
-                DataType ad_ = @this?.Value;
-                return ad_;
+                DataType ak_ = @this?.Value;
+                return ak_;
             }
 
             IEnumerable<object> u_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBMI is DomainResource
@@ -1315,33 +1209,29 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
             CqlValueSet x_ = this.Patient_Declined(context);
             CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
 
-            CqlBoolean z_() {
-
-                bool? ae_(Extension @this) {
-                    FhirUri al_ = @this?.UrlElement;
-                    string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
-                    CqlBoolean an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
-                    return an_;
-                }
-
-
-                object af_(Extension @this) {
-                    DataType ao_ = @this?.Value;
-                    return ao_;
-                }
-
-                IEnumerable<object> ag_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBMI is DomainResource
-                    ? (NoBMI as DomainResource).Extension
-                    : default), ae_, af_);
-                object ah_ = context.Operators.SingletonFrom<object>(ag_);
-                CqlConcept ai_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ah_ as CodeableConcept);
-                CqlValueSet aj_ = this.Medical_Reason(context);
-                CqlBoolean ak_ = context.Operators.ConceptInValueSet(ai_, aj_);
-                return ak_;
+            bool? z_(Extension @this) {
+                FhirUri al_ = @this?.UrlElement;
+                string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
+                CqlBoolean an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+                return an_;
             }
 
+
+            object aa_(Extension @this) {
+                DataType ao_ = @this?.Value;
+                return ao_;
+            }
+
+            IEnumerable<object> ab_ = context.Operators.WhereSelect<Extension, object>((IEnumerable<Extension>)(NoBMI is DomainResource
+                ? (NoBMI as DomainResource).Extension
+                : default), z_, aa_);
+            object ac_ = context.Operators.SingletonFrom<object>(ab_);
+            CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_ as CodeableConcept);
+            CqlValueSet ae_ = this.Medical_Reason(context);
+            CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+            CqlBoolean ag_ = af_;
             return y_
-                /* CQL 'or' (110:5-112:5) */ || z_();
+                /* CQL 'or' (110:5-112:5) */ || ag_;
         }
 
         IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
@@ -1359,15 +1249,11 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingl
     {
         IEnumerable<object> a_ = this.Medical_Reason_For_Not_Documenting_A_Follow_Up_Plan_For_Low_Or_High_BMI(context);
         CqlBoolean b_ = context.Operators.Exists<object>(a_);
-
-        CqlBoolean c_() {
-            IEnumerable<Observation> d_ = this.Medical_Reason_Or_Patient_Reason_For_Not_Performing_BMI_Exam(context);
-            CqlBoolean e_ = context.Operators.Exists<Observation>(d_);
-            return e_;
-        }
-
+        IEnumerable<Observation> c_ = this.Medical_Reason_Or_Patient_Reason_For_Not_Performing_BMI_Exam(context);
+        CqlBoolean d_ = context.Operators.Exists<Observation>(c_);
+        CqlBoolean e_ = d_;
         return b_
-            /* CQL 'or' (55:3-56:76) */ || c_();
+            /* CQL 'or' (55:3-56:76) */ || e_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS71FHIRSTKAnticoagAFFlutter", "1.0.000")]
 public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleton<CMS71FHIRSTKAnticoagAFFlutter_1_0_000>
 {
@@ -132,55 +132,51 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                 EventStatus? r_ = q_?.Value;
                 string s_ = context.Operators.Convert<string>(r_);
                 CqlBoolean t_ = context.Operators.Equal(s_, "completed");
-
-                CqlBoolean u_() {
-                    object v_;
-                    DataType ac_ = AtrialAblationProcedure?.Performed;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    bool ae_ = ad_ is CqlDateTime;
-                    if (ae_)
+                object u_;
+                DataType ac_ = AtrialAblationProcedure?.Performed;
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                bool ae_ = ad_ is CqlDateTime;
+                if (ae_)
+                {
+                    u_ = ad_ as CqlDateTime;
+                }
+                else
+                {
+                    bool af_ = ad_ is CqlQuantity;
+                    if (af_)
                     {
-                        v_ = ad_ as CqlDateTime;
+                        u_ = ad_ as CqlQuantity;
                     }
                     else
                     {
-                        bool af_ = ad_ is CqlQuantity;
-                        if (af_)
+                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
+                        if (ag_)
                         {
-                            v_ = ad_ as CqlQuantity;
+                            u_ = ad_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ag_ = ad_ is CqlInterval<CqlDateTime>;
-                            if (ag_)
+                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
+                            if (ah_)
                             {
-                                v_ = ad_ as CqlInterval<CqlDateTime>;
+                                u_ = ad_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ah_ = ad_ is CqlInterval<CqlQuantity>;
-                                if (ah_)
-                                {
-                                    v_ = ad_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    v_ = null;
-                                }
+                                u_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_);
-                    CqlDateTime x_ = context.Operators.Start(w_);
-                    Period y_ = IschemicStrokeEncounter?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.Start(z_);
-                    CqlBoolean ab_ = context.Operators.Before(x_, aa_, (string)default);
-                    return ab_;
                 }
-
+                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                Period x_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                CqlBoolean aa_ = context.Operators.Before(w_, z_, (string)default);
+                CqlBoolean ab_ = aa_;
                 return t_
-                    /* CQL 'and' (38:11-39:118) */ && u_();
+                    /* CQL 'and' (38:11-39:118) */ && ab_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Procedure>(n_, o_);
@@ -196,43 +192,27 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
             bool? ak_(Condition AtrialAblationDiagnosis) {
                 CodeableConcept am_ = AtrialAblationDiagnosis?.VerificationStatus;
                 CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, am_);
-
-                CqlBoolean ao_() {
-                    CodeableConcept ap_ = AtrialAblationDiagnosis?.VerificationStatus;
-                    CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
-                    CqlCode ar_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
-                    CqlBoolean at_ = context.Operators.Equivalent(aq_, as_);
-
-                    CqlBoolean au_() {
-                        CodeableConcept aw_ = AtrialAblationDiagnosis?.VerificationStatus;
-                        CqlConcept ax_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aw_);
-                        CqlCode ay_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept az_ = context.Operators.ConvertCodeToConcept(ay_);
-                        CqlBoolean ba_ = context.Operators.Equivalent(ax_, az_);
-                        return !ba_;
-                    }
-
-
-                    CqlBoolean av_() {
-                        DataType bb_ = AtrialAblationDiagnosis?.Onset;
-                        object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
-                        CqlInterval<CqlDateTime> bd_ = QICoreCommon_4_0_000.Instance.toInterval(context, bc_);
-                        CqlDateTime be_ = context.Operators.Start(bd_);
-                        Period bf_ = IschemicStrokeEncounter?.Period;
-                        CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-                        CqlDateTime bh_ = context.Operators.Start(bg_);
-                        CqlBoolean bi_ = context.Operators.Before(be_, bh_, (string)default);
-                        return bi_;
-                    }
-
-                    return (CqlBoolean)!at_
-                        /* CQL 'and' (44:84-46:11) */ && au_()
-                        /* CQL 'and' (44:84-47:114) */ && av_();
-                }
-
+                CqlCode ao_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+                CqlBoolean aq_ = context.Operators.Equivalent(an_, ap_);
+                CqlCode ar_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(an_, as_);
+                CqlBoolean au_ = (CqlBoolean)!at_;
+                DataType av_ = AtrialAblationDiagnosis?.Onset;
+                object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+                CqlInterval<CqlDateTime> ax_ = QICoreCommon_4_0_000.Instance.toInterval(context, aw_);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                Period az_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, az_);
+                CqlDateTime bb_ = context.Operators.Start(ba_);
+                CqlBoolean bc_ = context.Operators.Before(ay_, bb_, (string)default);
+                CqlBoolean bd_ = bc_;
+                CqlBoolean be_ = (CqlBoolean)!aq_
+                    /* CQL 'and' (44:84-46:11) */ && au_
+                    /* CQL 'and' (44:84-47:114) */ && bd_;
                 return (CqlBoolean)(an_ is null)
-                    /* CQL 'implies' (44:21-47:114) */ || ao_();
+                    /* CQL 'implies' (44:21-47:114) */ || be_;
             }
 
             CqlBoolean al_ = context.Operators.WhereAny<Condition>(aj_, ak_);
@@ -243,114 +223,94 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
         IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(c_, e_);
 
         bool? g_(Encounter IschemicStrokeEncounter) {
-            CqlValueSet bj_ = this.History_of_Atrial_Ablation(context);
-            IEnumerable<Observation> bk_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, bj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
+            CqlValueSet bf_ = this.History_of_Atrial_Ablation(context);
+            IEnumerable<Observation> bg_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, bf_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-simple-observation"));
 
-            bool? bl_(Observation AtrialAblationObservation) {
-                Code<ObservationStatus> bn_ = AtrialAblationObservation?.StatusElement;
-                ObservationStatus? bo_ = bn_?.Value;
-                string bp_ = context.Operators.Convert<string>(bo_);
-                string[] bq_ = [
+            bool? bh_(Observation AtrialAblationObservation) {
+                Code<ObservationStatus> bj_ = AtrialAblationObservation?.StatusElement;
+                ObservationStatus? bk_ = bj_?.Value;
+                string bl_ = context.Operators.Convert<string>(bk_);
+                string[] bm_ = [
                     "final",
                     "amended",
                     "corrected",
                 ];
-                CqlBoolean br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
-
-                CqlBoolean bs_() {
-                    object bt_;
-                    DataType bz_ = AtrialAblationObservation?.Effective;
-                    object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
-                    bool cb_ = ca_ is CqlDateTime;
-                    if (cb_)
+                CqlBoolean bn_ = context.Operators.In<string>(bl_, (IEnumerable<string>)bm_);
+                object bo_;
+                DataType bv_ = AtrialAblationObservation?.Effective;
+                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                bool bx_ = bw_ is CqlDateTime;
+                if (bx_)
+                {
+                    bo_ = bw_ as CqlDateTime;
+                }
+                else
+                {
+                    if (bx_)
                     {
-                        bt_ = ca_ as CqlDateTime;
+                        bo_ = bw_ as CqlDateTime;
                     }
                     else
                     {
-                        if (cb_)
+                        bool by_ = bw_ is CqlInterval<CqlDateTime>;
+                        if (by_)
                         {
-                            bt_ = ca_ as CqlDateTime;
+                            bo_ = bw_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool cc_ = ca_ is CqlInterval<CqlDateTime>;
-                            if (cc_)
-                            {
-                                bt_ = ca_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bt_ = null;
-                            }
+                            bo_ = null;
                         }
                     }
-                    CqlDateTime bu_ = QICoreCommon_4_0_000.Instance.earliest(context, bt_);
-                    Period bv_ = IschemicStrokeEncounter?.Period;
-                    CqlInterval<CqlDateTime> bw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bv_);
-                    CqlDateTime bx_ = context.Operators.End(bw_);
-                    CqlBoolean by_ = context.Operators.SameOrBefore(bu_, bx_, (string)default);
-                    return by_;
                 }
-
-                return br_
-                    /* CQL 'and' (51:21-52:115) */ && bs_();
+                CqlDateTime bp_ = QICoreCommon_4_0_000.Instance.earliest(context, bo_);
+                Period bq_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bq_);
+                CqlDateTime bs_ = context.Operators.End(br_);
+                CqlBoolean bt_ = context.Operators.SameOrBefore(bp_, bs_, (string)default);
+                CqlBoolean bu_ = bt_;
+                return bn_
+                    /* CQL 'and' (51:21-52:115) */ && bu_;
             }
 
-            CqlBoolean bm_ = context.Operators.WhereAny<Observation>(bk_, bl_);
-            return bm_;
+            CqlBoolean bi_ = context.Operators.WhereAny<Observation>(bg_, bh_);
+            return bi_;
         }
 
         IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(a_, g_);
 
         bool? i_(Encounter IschemicStrokeEncounter) {
-            CqlValueSet cd_ = this.History_of_Atrial_Ablation(context);
-            IEnumerable<Condition> ce_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, cd_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+            CqlValueSet bz_ = this.History_of_Atrial_Ablation(context);
+            IEnumerable<Condition> ca_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, bz_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
 
-            bool? cf_(Condition AtrialAblationEncDiagnosis) {
-                CodeableConcept ch_ = AtrialAblationEncDiagnosis?.VerificationStatus;
-                CqlConcept ci_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ch_);
-
-                CqlBoolean cj_() {
-                    CodeableConcept ck_ = AtrialAblationEncDiagnosis?.VerificationStatus;
-                    CqlConcept cl_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ck_);
-                    CqlCode cm_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept cn_ = context.Operators.ConvertCodeToConcept(cm_);
-                    CqlBoolean co_ = context.Operators.Equivalent(cl_, cn_);
-
-                    CqlBoolean cp_() {
-                        CodeableConcept cr_ = AtrialAblationEncDiagnosis?.VerificationStatus;
-                        CqlConcept cs_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cr_);
-                        CqlCode ct_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept cu_ = context.Operators.ConvertCodeToConcept(ct_);
-                        CqlBoolean cv_ = context.Operators.Equivalent(cs_, cu_);
-                        return !cv_;
-                    }
-
-
-                    CqlBoolean cq_() {
-                        DataType cw_ = AtrialAblationEncDiagnosis?.Onset;
-                        object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                        CqlInterval<CqlDateTime> cy_ = QICoreCommon_4_0_000.Instance.toInterval(context, cx_);
-                        CqlDateTime cz_ = context.Operators.Start(cy_);
-                        Period da_ = IschemicStrokeEncounter?.Period;
-                        CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, da_);
-                        CqlDateTime dc_ = context.Operators.Start(db_);
-                        CqlBoolean dd_ = context.Operators.Before(cz_, dc_, (string)default);
-                        return dd_;
-                    }
-
-                    return (CqlBoolean)!co_
-                        /* CQL 'and' (56:87-58:11) */ && cp_()
-                        /* CQL 'and' (56:87-59:117) */ && cq_();
-                }
-
-                return (CqlBoolean)(ci_ is null)
-                    /* CQL 'implies' (56:21-59:117) */ || cj_();
+            bool? cb_(Condition AtrialAblationEncDiagnosis) {
+                CodeableConcept cd_ = AtrialAblationEncDiagnosis?.VerificationStatus;
+                CqlConcept ce_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cd_);
+                CqlCode cf_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept cg_ = context.Operators.ConvertCodeToConcept(cf_);
+                CqlBoolean ch_ = context.Operators.Equivalent(ce_, cg_);
+                CqlCode ci_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept cj_ = context.Operators.ConvertCodeToConcept(ci_);
+                CqlBoolean ck_ = context.Operators.Equivalent(ce_, cj_);
+                CqlBoolean cl_ = (CqlBoolean)!ck_;
+                DataType cm_ = AtrialAblationEncDiagnosis?.Onset;
+                object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
+                CqlInterval<CqlDateTime> co_ = QICoreCommon_4_0_000.Instance.toInterval(context, cn_);
+                CqlDateTime cp_ = context.Operators.Start(co_);
+                Period cq_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> cr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
+                CqlDateTime cs_ = context.Operators.Start(cr_);
+                CqlBoolean ct_ = context.Operators.Before(cp_, cs_, (string)default);
+                CqlBoolean cu_ = ct_;
+                CqlBoolean cv_ = (CqlBoolean)!ch_
+                    /* CQL 'and' (56:87-58:11) */ && cl_
+                    /* CQL 'and' (56:87-59:117) */ && cu_;
+                return (CqlBoolean)(ce_ is null)
+                    /* CQL 'implies' (56:21-59:117) */ || cv_;
             }
 
-            CqlBoolean cg_ = context.Operators.WhereAny<Condition>(ce_, cf_);
-            return cg_;
+            CqlBoolean cc_ = context.Operators.WhereAny<Condition>(ca_, cb_);
+            return cc_;
         }
 
         IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(a_, i_);
@@ -377,43 +337,27 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
             bool? i_(Condition AtrialFibrillationFlutter) {
                 CodeableConcept k_ = AtrialFibrillationFlutter?.VerificationStatus;
                 CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-
-                CqlBoolean m_() {
-                    CodeableConcept n_ = AtrialFibrillationFlutter?.VerificationStatus;
-                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                    CqlCode p_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                    CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-
-                    CqlBoolean s_() {
-                        CodeableConcept u_ = AtrialFibrillationFlutter?.VerificationStatus;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlCode w_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
-                        CqlBoolean y_ = context.Operators.Equivalent(v_, x_);
-                        return !y_;
-                    }
-
-
-                    CqlBoolean t_() {
-                        DataType z_ = AtrialFibrillationFlutter?.Onset;
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
-                        CqlDateTime ac_ = context.Operators.Start(ab_);
-                        Period ad_ = IschemicStrokeEncounter?.Period;
-                        CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                        CqlDateTime af_ = context.Operators.End(ae_);
-                        CqlBoolean ag_ = context.Operators.SameOrBefore(ac_, af_, (string)default);
-                        return ag_;
-                    }
-
-                    return (CqlBoolean)!r_
-                        /* CQL 'and' (65:84-67:9) */ && s_()
-                        /* CQL 'and' (65:84-68:118) */ && t_();
-                }
-
+                CqlCode m_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
+                CqlBoolean o_ = context.Operators.Equivalent(l_, n_);
+                CqlCode p_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+                CqlBoolean r_ = context.Operators.Equivalent(l_, q_);
+                CqlBoolean s_ = (CqlBoolean)!r_;
+                DataType t_ = AtrialFibrillationFlutter?.Onset;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                Period x_ = IschemicStrokeEncounter?.Period;
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                CqlDateTime z_ = context.Operators.End(y_);
+                CqlBoolean aa_ = context.Operators.SameOrBefore(w_, z_, (string)default);
+                CqlBoolean ab_ = aa_;
+                CqlBoolean ac_ = (CqlBoolean)!o_
+                    /* CQL 'and' (65:84-67:9) */ && s_
+                    /* CQL 'and' (65:84-68:118) */ && ab_;
                 return (CqlBoolean)(l_ is null)
-                    /* CQL 'implies' (65:19-68:118) */ || m_();
+                    /* CQL 'implies' (65:19-68:118) */ || ac_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Condition>(h_, i_);
@@ -423,18 +367,18 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter IschemicStrokeEncounter) {
-            IEnumerable<Condition> ah_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, IschemicStrokeEncounter);
+            IEnumerable<Condition> ad_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, IschemicStrokeEncounter);
 
-            bool? ai_(Condition EncounterDiagnosis) {
-                CodeableConcept ak_ = EncounterDiagnosis?.Code;
-                CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_);
-                CqlValueSet am_ = this.Atrial_Fibrillation_or_Flutter(context);
-                CqlBoolean an_ = context.Operators.ConceptInValueSet(al_, am_);
-                return an_;
+            bool? ae_(Condition EncounterDiagnosis) {
+                CodeableConcept ag_ = EncounterDiagnosis?.Code;
+                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_);
+                CqlValueSet ai_ = this.Atrial_Fibrillation_or_Flutter(context);
+                CqlBoolean aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
+                return aj_;
             }
 
-            CqlBoolean aj_ = context.Operators.WhereAny<Condition>(ah_, ai_);
-            return aj_;
+            CqlBoolean af_ = context.Operators.WhereAny<Condition>(ad_, ae_);
+            return af_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(a_, d_);
@@ -541,62 +485,30 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
             Encounter.EncounterStatus? g_ = f_?.Value;
             Code<Encounter.EncounterStatus> h_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(g_);
             CqlBoolean i_ = context.Operators.Equal(h_, "finished");
-
-            CqlBoolean j_() {
-                Encounter.HospitalizationComponent k_ = Encounter?.Hospitalization;
-                CodeableConcept l_ = k_?.DischargeDisposition;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlValueSet n_ = this.Discharge_To_Acute_Care_Facility(context);
-                CqlBoolean o_ = context.Operators.ConceptInValueSet(m_, n_);
-
-                CqlBoolean p_() {
-                    Encounter.HospitalizationComponent t_ = Encounter?.Hospitalization;
-                    CodeableConcept u_ = t_?.DischargeDisposition;
-                    CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                    CqlValueSet w_ = this.Left_Against_Medical_Advice(context);
-                    CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                    return x_;
-                }
-
-
-                CqlBoolean q_() {
-                    Encounter.HospitalizationComponent y_ = Encounter?.Hospitalization;
-                    CodeableConcept z_ = y_?.DischargeDisposition;
-                    CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
-                    CqlValueSet ab_ = this.Patient_Expired(context);
-                    CqlBoolean ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
-                    return ac_;
-                }
-
-
-                CqlBoolean r_() {
-                    Encounter.HospitalizationComponent ad_ = Encounter?.Hospitalization;
-                    CodeableConcept ae_ = ad_?.DischargeDisposition;
-                    CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_);
-                    CqlValueSet ag_ = this.Discharged_to_Home_for_Hospice_Care(context);
-                    CqlBoolean ah_ = context.Operators.ConceptInValueSet(af_, ag_);
-                    return ah_;
-                }
-
-
-                CqlBoolean s_() {
-                    Encounter.HospitalizationComponent ai_ = Encounter?.Hospitalization;
-                    CodeableConcept aj_ = ai_?.DischargeDisposition;
-                    CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
-                    CqlValueSet al_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care(context);
-                    CqlBoolean am_ = context.Operators.ConceptInValueSet(ak_, al_);
-                    return am_;
-                }
-
-                return o_
-                    /* CQL 'or' (78:15-79:94) */ || p_()
-                    /* CQL 'or' (78:15-80:82) */ || q_()
-                    /* CQL 'or' (78:15-81:102) */ || r_()
-                    /* CQL 'or' (78:13-83:9) */ || s_();
-            }
-
+            Encounter.HospitalizationComponent j_ = Encounter?.Hospitalization;
+            CodeableConcept k_ = j_?.DischargeDisposition;
+            CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
+            CqlValueSet m_ = this.Discharge_To_Acute_Care_Facility(context);
+            CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
+            CqlValueSet o_ = this.Left_Against_Medical_Advice(context);
+            CqlBoolean p_ = context.Operators.ConceptInValueSet(l_, o_);
+            CqlBoolean q_ = p_;
+            CqlValueSet r_ = this.Patient_Expired(context);
+            CqlBoolean s_ = context.Operators.ConceptInValueSet(l_, r_);
+            CqlBoolean t_ = s_;
+            CqlValueSet u_ = this.Discharged_to_Home_for_Hospice_Care(context);
+            CqlBoolean v_ = context.Operators.ConceptInValueSet(l_, u_);
+            CqlBoolean w_ = v_;
+            CqlValueSet x_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care(context);
+            CqlBoolean y_ = context.Operators.ConceptInValueSet(l_, x_);
+            CqlBoolean z_ = y_;
+            CqlBoolean aa_ = n_
+                /* CQL 'or' (78:15-79:94) */ || q_
+                /* CQL 'or' (78:15-80:82) */ || t_
+                /* CQL 'or' (78:15-81:102) */ || w_
+                /* CQL 'or' (78:13-83:9) */ || z_;
             return i_
-                /* CQL 'and' (77:7-83:9) */ && j_();
+                /* CQL 'and' (77:7-83:9) */ && aa_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -628,17 +540,13 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Anticoagulant_Therapy(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Anticoagulant_Therapy(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -659,69 +567,49 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = DischargeAnticoagulant?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                string[] ag_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
+                CqlBoolean ai_ = ah_;
+                CqlBoolean aj_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAnticoagulant as MedicationRequest);
+                CqlBoolean ak_ = aj_
+                    /* CQL 'or' (97:13-99:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAnticoagulant as MedicationRequest);
+                FhirDateTime al_ = DischargeAnticoagulant?.AuthoredOnElement;
+                CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
+                Period an_ = Encounter?.Period;
+                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
+                CqlBoolean ap_ = context.Operators.In<CqlDateTime>(am_, ao_, (string)default);
+                CqlBoolean aq_ = ap_;
+                IEnumerable<Task> ar_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> ah_ = DischargeAnticoagulant?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "order",
-                        "original-order",
-                        "reflex-order",
-                        "filler-order",
-                        "instance-order",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
+                bool? as_(Task TaskReject) {
+                    ResourceReference av_ = TaskReject?.Focus;
+                    CqlBoolean aw_ = QICoreCommon_4_0_000.Instance.references(context, av_, DischargeAnticoagulant);
+                    CodeableConcept ax_ = TaskReject?.Code;
+                    CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
+                    CqlCode az_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                    CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
+                    CqlBoolean bb_ = context.Operators.Equivalent(ay_, ba_);
+                    CqlBoolean bc_ = bb_;
+                    return aw_
+                        /* CQL 'and' (102:13-103:58) */ && bc_;
                 }
 
-
-                CqlBoolean ae_() {
-                    CqlBoolean am_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAnticoagulant as MedicationRequest);
-                    return am_
-                        /* CQL 'or' (97:13-99:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAnticoagulant as MedicationRequest);
-                }
-
-
-                CqlBoolean af_() {
-                    FhirDateTime an_ = DischargeAnticoagulant?.AuthoredOnElement;
-                    CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(an_);
-                    Period ap_ = Encounter?.Period;
-                    CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
-                    CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, (string)default);
-                    return ar_;
-                }
-
-
-                CqlBoolean ag_() {
-                    IEnumerable<Task> as_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
-
-                    bool? at_(Task TaskReject) {
-                        ResourceReference av_ = TaskReject?.Focus;
-                        CqlBoolean aw_ = QICoreCommon_4_0_000.Instance.references(context, av_, DischargeAnticoagulant);
-
-                        CqlBoolean ax_() {
-                            CodeableConcept ay_ = TaskReject?.Code;
-                            CqlConcept az_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ay_);
-                            CqlCode ba_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                            CqlConcept bb_ = context.Operators.ConvertCodeToConcept(ba_);
-                            CqlBoolean bc_ = context.Operators.Equivalent(az_, bb_);
-                            return bc_;
-                        }
-
-                        return aw_
-                            /* CQL 'and' (102:13-103:58) */ && ax_();
-                    }
-
-                    CqlBoolean au_ = context.Operators.WhereAny<Task>(as_, at_);
-                    return !au_;
-                }
-
+                CqlBoolean at_ = context.Operators.WhereAny<Task>(ar_, as_);
+                CqlBoolean au_ = (CqlBoolean)!at_;
                 return ac_
-                    /* CQL 'and' (95:17-96:124) */ && ad_()
-                    /* CQL 'and' (95:17-99:9) */ && ae_()
-                    /* CQL 'and' (95:17-100:69) */ && af_()
-                    /* CQL 'and' (95:17-104:9) */ && ag_();
+                    /* CQL 'and' (95:17-96:124) */ && ai_
+                    /* CQL 'and' (95:17-99:9) */ && ak_
+                    /* CQL 'and' (95:17-100:69) */ && aq_
+                    /* CQL 'and' (95:17-104:9) */ && au_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -749,98 +637,77 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
             List<CodeableConcept> n_ = NoAnticoagulant?.ReasonCode;
 
             CqlConcept o_(CodeableConcept @this) {
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return w_;
+                CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return al_;
             }
 
             IEnumerable<CqlConcept> p_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)n_, o_);
             CqlValueSet q_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
             CqlBoolean r_ = context.Operators.ConceptsInValueSet(p_, q_);
 
-            CqlBoolean s_() {
-                List<CodeableConcept> x_ = NoAnticoagulant?.ReasonCode;
-
-                CqlConcept y_(CodeableConcept @this) {
-                    CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return ac_;
-                }
-
-                IEnumerable<CqlConcept> z_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)x_, y_);
-                CqlValueSet aa_ = this.Patient_Refusal(context);
-                CqlBoolean ab_ = context.Operators.ConceptsInValueSet(z_, aa_);
-                return ab_;
+            CqlConcept s_(CodeableConcept @this) {
+                CqlConcept am_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return am_;
             }
 
-
-            CqlBoolean t_() {
-                CqlBoolean ad_ = QICoreCommon_4_0_000.Instance.isCommunity(context, NoAnticoagulant as MedicationRequest);
-                return ad_
-                    /* CQL 'or' (116:13-118:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, NoAnticoagulant as MedicationRequest);
-            }
-
-
-            CqlBoolean u_() {
-                Code<MedicationRequest.MedicationrequestStatus> ae_ = NoAnticoagulant?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? af_ = ae_?.Value;
-                string ag_ = context.Operators.Convert<string>(af_);
-                string[] ah_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                return ai_;
-            }
-
-
-            CqlBoolean v_() {
-                Code<MedicationRequest.MedicationRequestIntent> aj_ = NoAnticoagulant?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? ak_ = aj_?.Value;
-                string al_ = context.Operators.Convert<string>(ak_);
-                string[] am_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
-                return an_;
-            }
-
+            IEnumerable<CqlConcept> t_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)n_, s_);
+            CqlValueSet u_ = this.Patient_Refusal(context);
+            CqlBoolean v_ = context.Operators.ConceptsInValueSet(t_, u_);
+            CqlBoolean w_ = v_;
+            CqlBoolean x_ = QICoreCommon_4_0_000.Instance.isCommunity(context, NoAnticoagulant as MedicationRequest);
+            CqlBoolean y_ = x_
+                /* CQL 'or' (116:13-118:9) */ || QICoreCommon_4_0_000.Instance.isDischarge(context, NoAnticoagulant as MedicationRequest);
+            Code<MedicationRequest.MedicationrequestStatus> z_ = NoAnticoagulant?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            string[] ac_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
+            CqlBoolean ae_ = ad_;
+            Code<MedicationRequest.MedicationRequestIntent> af_ = NoAnticoagulant?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
+            string ah_ = context.Operators.Convert<string>(ag_);
+            string[] ai_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
+            CqlBoolean ak_ = aj_;
             return (r_
-                /* CQL 'or' (113:13-115:7) */ || s_())
-                /* CQL 'and' (113:13-118:9) */ && t_()
-                /* CQL 'and' (113:13-119:63) */ && u_()
-                /* CQL 'and' (113:7-120:117) */ && v_();
+                /* CQL 'or' (113:13-115:7) */ || w_)
+                /* CQL 'and' (113:13-118:9) */ && y_
+                /* CQL 'and' (113:13-119:63) */ && ae_
+                /* CQL 'and' (113:7-120:117) */ && ak_;
         }
 
         IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
         IEnumerable<MedicationRequest> f_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
         bool? g_(MedicationRequest MR) {
-            IEnumerable<Medication> ao_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            IEnumerable<Medication> an_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? ap_(Medication M) {
-                object ar_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object as_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> at_ = context.Operators.Split((string)as_, "/");
-                string au_ = context.Operators.Last<string>(at_);
-                CqlBoolean av_ = context.Operators.Equal(ar_, au_);
-
-                CqlBoolean aw_() {
-                    CodeableConcept ax_ = M?.Code;
-                    CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
-                    CqlValueSet az_ = this.Anticoagulant_Therapy(context);
-                    CqlBoolean ba_ = context.Operators.ConceptInValueSet(ay_, az_);
-                    return ba_;
-                }
-
-                return av_
-                    /* CQL 'and' */ && aw_();
+            bool? ao_(Medication M) {
+                object aq_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ar_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> as_ = context.Operators.Split((string)ar_, "/");
+                string at_ = context.Operators.Last<string>(as_);
+                CqlBoolean au_ = context.Operators.Equal(aq_, at_);
+                CodeableConcept av_ = M?.Code;
+                CqlConcept aw_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, av_);
+                CqlValueSet ax_ = this.Anticoagulant_Therapy(context);
+                CqlBoolean ay_ = context.Operators.ConceptInValueSet(aw_, ax_);
+                CqlBoolean az_ = ay_;
+                return au_
+                    /* CQL 'and' */ && az_;
             }
 
-            CqlBoolean aq_ = context.Operators.WhereAny<Medication>(ao_, ap_);
-            return aq_;
+            CqlBoolean ap_ = context.Operators.WhereAny<Medication>(an_, ao_);
+            return ap_;
         }
 
         IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
@@ -848,61 +715,43 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
         IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(h_, i_);
 
         bool? k_(MedicationRequest MedReqAntiCoagulant) {
-            IEnumerable<Task> bb_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+            IEnumerable<Task> ba_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            bool? bc_(Task TaskReject) {
-                ResourceReference be_ = TaskReject?.Focus;
-                CqlBoolean bf_ = QICoreCommon_4_0_000.Instance.references(context, be_, MedReqAntiCoagulant);
-
-                CqlBoolean bg_() {
-                    CodeableConcept bj_ = TaskReject?.StatusReason;
-                    CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bj_);
-                    CqlValueSet bl_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
-                    CqlBoolean bm_ = context.Operators.ConceptInValueSet(bk_, bl_);
-
-                    CqlBoolean bn_() {
-                        CodeableConcept bo_ = TaskReject?.StatusReason;
-                        CqlConcept bp_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bo_);
-                        CqlValueSet bq_ = this.Patient_Refusal(context);
-                        CqlBoolean br_ = context.Operators.ConceptInValueSet(bp_, bq_);
-                        return br_;
-                    }
-
-                    return bm_
-                        /* CQL 'or' (125:17-127:13) */ || bn_();
-                }
-
-
-                CqlBoolean bh_() {
-                    Code<MedicationRequest.MedicationrequestStatus> bs_ = MedReqAntiCoagulant?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? bt_ = bs_?.Value;
-                    string bu_ = context.Operators.Convert<string>(bt_);
-                    string[] bv_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean bw_ = context.Operators.In<string>(bu_, (IEnumerable<string>)bv_);
-                    return bw_;
-                }
-
-
-                CqlBoolean bi_() {
-                    CodeableConcept bx_ = TaskReject?.Code;
-                    CqlConcept by_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bx_);
-                    CqlCode bz_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                    CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
-                    CqlBoolean cb_ = context.Operators.Equivalent(by_, ca_);
-                    return cb_;
-                }
-
-                return bf_
-                    /* CQL 'and' (124:21-127:13) */ && bg_()
-                    /* CQL 'and' (124:21-128:71) */ && bh_()
-                    /* CQL 'and' (124:21-129:56) */ && bi_();
+            bool? bb_(Task TaskReject) {
+                ResourceReference bd_ = TaskReject?.Focus;
+                CqlBoolean be_ = QICoreCommon_4_0_000.Instance.references(context, bd_, MedReqAntiCoagulant);
+                CodeableConcept bf_ = TaskReject?.StatusReason;
+                CqlConcept bg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bf_);
+                CqlValueSet bh_ = this.Medical_Reason_For_Not_Providing_Treatment(context);
+                CqlBoolean bi_ = context.Operators.ConceptInValueSet(bg_, bh_);
+                CqlValueSet bj_ = this.Patient_Refusal(context);
+                CqlBoolean bk_ = context.Operators.ConceptInValueSet(bg_, bj_);
+                CqlBoolean bl_ = bk_;
+                CqlBoolean bm_ = bi_
+                    /* CQL 'or' (125:17-127:13) */ || bl_;
+                Code<MedicationRequest.MedicationrequestStatus> bn_ = MedReqAntiCoagulant?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? bo_ = bn_?.Value;
+                string bp_ = context.Operators.Convert<string>(bo_);
+                string[] bq_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
+                CqlBoolean bs_ = br_;
+                CodeableConcept bt_ = TaskReject?.Code;
+                CqlConcept bu_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bt_);
+                CqlCode bv_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept bw_ = context.Operators.ConvertCodeToConcept(bv_);
+                CqlBoolean bx_ = context.Operators.Equivalent(bu_, bw_);
+                CqlBoolean by_ = bx_;
+                return be_
+                    /* CQL 'and' (124:21-127:13) */ && bm_
+                    /* CQL 'and' (124:21-128:71) */ && bs_
+                    /* CQL 'and' (124:21-129:56) */ && by_;
             }
 
-            CqlBoolean bd_ = context.Operators.WhereAny<Task>(bb_, bc_);
-            return bd_;
+            CqlBoolean bc_ = context.Operators.WhereAny<Task>(ba_, bb_);
+            return bc_;
         }
 
         IEnumerable<MedicationRequest> l_ = context.Operators.Where<MedicationRequest>(j_, k_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS72FHIRSTKAntithromboticDay2", "1.0.000")]
 public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISingleton<CMS72FHIRSTKAntithromboticDay2_1_0_000>
 {
@@ -232,17 +232,13 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                 IEnumerable<string> w_ = context.Operators.Split((string)v_, "/");
                 string x_ = context.Operators.Last<string>(w_);
                 CqlBoolean y_ = context.Operators.Equal(u_, x_);
-
-                CqlBoolean z_() {
-                    CodeableConcept aa_ = M?.Code;
-                    CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
-                    CqlValueSet ac_ = this.Thrombolytic_tPA_Therapy(context);
-                    CqlBoolean ad_ = context.Operators.ConceptInValueSet(ab_, ac_);
-                    return ad_;
-                }
-
+                CodeableConcept z_ = M?.Code;
+                CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, z_);
+                CqlValueSet ab_ = this.Thrombolytic_tPA_Therapy(context);
+                CqlBoolean ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+                CqlBoolean ad_ = ac_;
                 return y_
-                    /* CQL 'and' */ && z_();
+                    /* CQL 'and' */ && ad_;
             }
 
             CqlBoolean t_ = context.Operators.WhereAny<Medication>(r_, s_);
@@ -439,37 +435,21 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                 CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
                 CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
                 CqlBoolean n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
-
-                CqlBoolean o_() {
-                    CodeableConcept q_ = PriorTPA?.VerificationStatus;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlBoolean p_() {
-                    CodeableConcept s_ = PriorTPA?.VerificationStatus;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlCode u_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                    CqlBoolean w_ = context.Operators.Equivalent(t_, v_);
-
-                    CqlBoolean x_() {
-                        CodeableConcept y_ = PriorTPA?.VerificationStatus;
-                        CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                        CqlCode aa_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept ab_ = context.Operators.ConvertCodeToConcept(aa_);
-                        CqlBoolean ac_ = context.Operators.Equivalent(z_, ab_);
-                        return !ac_;
-                    }
-
-                    return (CqlBoolean)!w_
-                        /* CQL 'and' (81:63-83:9) */ && x_();
-                }
-
+                CodeableConcept o_ = PriorTPA?.VerificationStatus;
+                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
+                CqlBoolean q_ = (CqlBoolean)(p_ is not null);
+                CqlCode r_ = QICoreCommon_4_0_000.Instance.refuted(context);
+                CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+                CqlBoolean t_ = context.Operators.Equivalent(p_, s_);
+                CqlCode u_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+                CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
+                CqlBoolean w_ = context.Operators.Equivalent(p_, v_);
+                CqlBoolean x_ = (CqlBoolean)!w_;
+                CqlBoolean y_ = (CqlBoolean)!t_
+                    /* CQL 'and' (81:63-83:9) */ && x_;
                 return (CqlBoolean)(!((bool?)(n_
-                    /* CQL 'and' (80:15-81:53) */ && o_())))
-                    /* CQL 'implies' (80:9-83:9) */ || p_();
+                    /* CQL 'and' (80:15-81:53) */ && q_)))
+                    /* CQL 'implies' (80:9-83:9) */ || y_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Condition>(h_, i_);
@@ -479,18 +459,18 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
         bool? d_(Encounter IschemicStrokeEncounter) {
-            IEnumerable<Condition> ad_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, IschemicStrokeEncounter);
+            IEnumerable<Condition> z_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, IschemicStrokeEncounter);
 
-            bool? ae_(Condition EncounterDiagnosis) {
-                CodeableConcept ag_ = EncounterDiagnosis?.Code;
-                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_);
-                CqlValueSet ai_ = this.Intravenous_or_Intraarterial_Thrombolytic_tPA_Therapy_Prior_to_Arrival(context);
-                CqlBoolean aj_ = context.Operators.ConceptInValueSet(ah_, ai_);
-                return aj_;
+            bool? aa_(Condition EncounterDiagnosis) {
+                CodeableConcept ac_ = EncounterDiagnosis?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Intravenous_or_Intraarterial_Thrombolytic_tPA_Therapy_Prior_to_Arrival(context);
+                CqlBoolean af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                return af_;
             }
 
-            CqlBoolean af_ = context.Operators.WhereAny<Condition>(ad_, ae_);
-            return af_;
+            CqlBoolean ab_ = context.Operators.WhereAny<Condition>(z_, aa_);
+            return ab_;
         }
 
         IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(a_, d_);
@@ -555,17 +535,13 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -586,28 +562,24 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    DataType ae_ = Antithrombotic?.Effective;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.Start(ag_);
-                    CqlInterval<CqlDateTime> ai_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                    CqlDateTime aj_ = context.Operators.Start(ai_);
-                    CqlInterval<CqlDate> ak_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aj_);
-                    CqlDate al_ = ak_?.low;
-                    CqlDateTime am_ = context.Operators.ConvertDateToDateTime(al_);
-                    CqlDate an_ = ak_?.high;
-                    CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
-                    CqlBoolean ap_ = ak_?.lowClosed;
-                    CqlBoolean aq_ = ak_?.highClosed;
-                    CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(am_, ao_, ap_, aq_);
-                    CqlBoolean as_ = context.Operators.In<CqlDateTime>(ah_, ar_, "day");
-                    return as_;
-                }
-
+                DataType ad_ = Antithrombotic?.Effective;
+                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+                CqlDateTime ag_ = context.Operators.Start(af_);
+                CqlInterval<CqlDateTime> ah_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                CqlDateTime ai_ = context.Operators.Start(ah_);
+                CqlInterval<CqlDate> aj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ai_);
+                CqlDate ak_ = aj_?.low;
+                CqlDateTime al_ = context.Operators.ConvertDateToDateTime(ak_);
+                CqlDate am_ = aj_?.high;
+                CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+                CqlBoolean ao_ = aj_?.lowClosed;
+                CqlBoolean ap_ = aj_?.highClosed;
+                CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(al_, an_, ao_, ap_);
+                CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ag_, aq_, "day");
+                CqlBoolean as_ = ar_;
                 return ac_
-                    /* CQL 'and' (96:17-97:172) */ && ad_();
+                    /* CQL 'and' (96:17-97:172) */ && as_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationAdministration>(i_, j_);
@@ -648,71 +620,58 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
             List<CodeableConcept> r_ = NoAntithromboticOrder?.ReasonCode;
 
             CqlConcept s_(CodeableConcept @this) {
-                CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return z_;
+                CqlConcept an_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return an_;
             }
 
             IEnumerable<CqlConcept> t_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)r_, s_);
             CqlValueSet u_ = this.Medical_Reason_for_Not_Providing_Treatment(context);
             CqlBoolean v_ = context.Operators.ConceptsInValueSet(t_, u_);
 
-            CqlBoolean w_() {
-                List<CodeableConcept> aa_ = NoAntithromboticOrder?.ReasonCode;
-
-                CqlConcept ab_(CodeableConcept @this) {
-                    CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return af_;
-                }
-
-                IEnumerable<CqlConcept> ac_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)aa_, ab_);
-                CqlValueSet ad_ = this.Patient_Refusal(context);
-                CqlBoolean ae_ = context.Operators.ConceptsInValueSet(ac_, ad_);
-                return ae_;
+            CqlConcept w_(CodeableConcept @this) {
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return ao_;
             }
 
-
-            CqlBoolean x_() {
-                Code<MedicationRequest.MedicationrequestStatus> ag_ = NoAntithromboticOrder?.StatusElement;
-                MedicationRequest.MedicationrequestStatus? ah_ = ag_?.Value;
-                string ai_ = context.Operators.Convert<string>(ah_);
-                string[] aj_ = [
-                    "active",
-                    "completed",
-                ];
-                CqlBoolean ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-                return ak_;
-            }
-
-
-            CqlBoolean y_() {
-                Code<MedicationRequest.MedicationRequestIntent> al_ = NoAntithromboticOrder?.IntentElement;
-                MedicationRequest.MedicationRequestIntent? am_ = al_?.Value;
-                string an_ = context.Operators.Convert<string>(am_);
-                string[] ao_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
-                return ap_;
-            }
-
+            IEnumerable<CqlConcept> x_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)r_, w_);
+            CqlValueSet y_ = this.Patient_Refusal(context);
+            CqlBoolean z_ = context.Operators.ConceptsInValueSet(x_, y_);
+            CqlBoolean aa_ = z_;
+            Code<MedicationRequest.MedicationrequestStatus> ab_ = NoAntithromboticOrder?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ac_ = ab_?.Value;
+            string ad_ = context.Operators.Convert<string>(ac_);
+            string[] ae_ = [
+                "active",
+                "completed",
+            ];
+            CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+            CqlBoolean ag_ = af_;
+            Code<MedicationRequest.MedicationRequestIntent> ah_ = NoAntithromboticOrder?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
+            string aj_ = context.Operators.Convert<string>(ai_);
+            string[] ak_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+            CqlBoolean am_ = al_;
             return (v_
-                /* CQL 'or' (125:13-127:7) */ || w_())
-                /* CQL 'and' (125:13-128:69) */ && x_()
-                /* CQL 'and' (125:7-129:123) */ && y_();
+                /* CQL 'or' (125:13-127:7) */ || aa_)
+                /* CQL 'and' (125:13-128:69) */ && ag_
+                /* CQL 'and' (125:7-129:123) */ && am_;
         }
 
 
         (CqlTupleMetadata, string id, CqlDateTime authoredOn)? e_(MedicationRequest NoAntithromboticOrder) {
-            Id aq_ = NoAntithromboticOrder?.IdElement;
-            string ar_ = aq_?.Value;
-            FhirDateTime as_ = NoAntithromboticOrder?.AuthoredOnElement;
-            CqlDateTime at_ = context.Operators.Convert<CqlDateTime>(as_);
-            (CqlTupleMetadata, string id, CqlDateTime authoredOn)? au_ = (CqlTupleMetadata_DeYYCcJRPXYVddOGVBSgSSNfR, ar_, at_);
-            return au_;
+            Id ap_ = NoAntithromboticOrder?.IdElement;
+            string aq_ = ap_?.Value;
+            FhirDateTime ar_ = NoAntithromboticOrder?.AuthoredOnElement;
+            CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
+            (CqlTupleMetadata, string id, CqlDateTime authoredOn)? at_ = (CqlTupleMetadata_DeYYCcJRPXYVddOGVBSgSSNfR, aq_, as_);
+            return at_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?> f_ = context.Operators.WhereSelect<MedicationRequest, (CqlTupleMetadata, string id, CqlDateTime authoredOn)?>(c_, d_, e_);
@@ -720,29 +679,25 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> h_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
 
         bool? i_(MedicationRequest MR) {
-            IEnumerable<Medication> av_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            IEnumerable<Medication> au_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
 
-            bool? aw_(Medication M) {
-                object ay_ = context.Operators.LateBoundProperty<object>(M, "id.value");
-                object az_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
-                IEnumerable<string> ba_ = context.Operators.Split((string)az_, "/");
-                string bb_ = context.Operators.Last<string>(ba_);
-                CqlBoolean bc_ = context.Operators.Equal(ay_, bb_);
-
-                CqlBoolean bd_() {
-                    CodeableConcept be_ = M?.Code;
-                    CqlConcept bf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, be_);
-                    CqlValueSet bg_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
-                    CqlBoolean bh_ = context.Operators.ConceptInValueSet(bf_, bg_);
-                    return bh_;
-                }
-
-                return bc_
-                    /* CQL 'and' */ && bd_();
+            bool? av_(Medication M) {
+                object ax_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object ay_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> az_ = context.Operators.Split((string)ay_, "/");
+                string ba_ = context.Operators.Last<string>(az_);
+                CqlBoolean bb_ = context.Operators.Equal(ax_, ba_);
+                CodeableConcept bc_ = M?.Code;
+                CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_);
+                CqlValueSet be_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke(context);
+                CqlBoolean bf_ = context.Operators.ConceptInValueSet(bd_, be_);
+                CqlBoolean bg_ = bf_;
+                return bb_
+                    /* CQL 'and' */ && bg_;
             }
 
-            CqlBoolean ax_ = context.Operators.WhereAny<Medication>(av_, aw_);
-            return ax_;
+            CqlBoolean aw_ = context.Operators.WhereAny<Medication>(au_, av_);
+            return aw_;
         }
 
         IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
@@ -750,71 +705,53 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
         IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(j_, k_);
 
         bool? m_(MedicationRequest MedReqAntithrombotic) {
-            IEnumerable<Task> bi_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
+            IEnumerable<Task> bh_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
-            bool? bj_(Task TaskReject) {
-                ResourceReference bl_ = TaskReject?.Focus;
-                CqlBoolean bm_ = QICoreCommon_4_0_000.Instance.references(context, bl_, MedReqAntithrombotic);
-
-                CqlBoolean bn_() {
-                    CodeableConcept bp_ = TaskReject?.StatusReason;
-                    CqlConcept bq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bp_);
-                    CqlValueSet br_ = this.Medical_Reason_for_Not_Providing_Treatment(context);
-                    CqlBoolean bs_ = context.Operators.ConceptInValueSet(bq_, br_);
-
-                    CqlBoolean bt_() {
-                        CodeableConcept bu_ = TaskReject?.StatusReason;
-                        CqlConcept bv_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bu_);
-                        CqlValueSet bw_ = this.Patient_Refusal(context);
-                        CqlBoolean bx_ = context.Operators.ConceptInValueSet(bv_, bw_);
-                        return bx_;
-                    }
-
-                    return bs_
-                        /* CQL 'or' (138:17-140:13) */ || bt_();
-                }
-
-
-                CqlBoolean bo_() {
-                    Code<MedicationRequest.MedicationrequestStatus> by_ = MedReqAntithrombotic?.StatusElement;
-                    MedicationRequest.MedicationrequestStatus? bz_ = by_?.Value;
-                    string ca_ = context.Operators.Convert<string>(bz_);
-                    string[] cb_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean cc_ = context.Operators.In<string>(ca_, (IEnumerable<string>)cb_);
-
-                    CqlBoolean cd_() {
-                        CodeableConcept ce_ = TaskReject?.Code;
-                        CqlConcept cf_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ce_);
-                        CqlCode cg_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
-                        CqlConcept ch_ = context.Operators.ConvertCodeToConcept(cg_);
-                        CqlBoolean ci_ = context.Operators.Equivalent(cf_, ch_);
-                        return ci_;
-                    }
-
-                    return cc_
-                        /* CQL 'and' (141:17-143:13) */ && cd_();
-                }
-
-                return bm_
-                    /* CQL 'and' (137:21-140:13) */ && bn_()
-                    /* CQL 'and' (137:21-143:13) */ && bo_();
+            bool? bi_(Task TaskReject) {
+                ResourceReference bk_ = TaskReject?.Focus;
+                CqlBoolean bl_ = QICoreCommon_4_0_000.Instance.references(context, bk_, MedReqAntithrombotic);
+                CodeableConcept bm_ = TaskReject?.StatusReason;
+                CqlConcept bn_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bm_);
+                CqlValueSet bo_ = this.Medical_Reason_for_Not_Providing_Treatment(context);
+                CqlBoolean bp_ = context.Operators.ConceptInValueSet(bn_, bo_);
+                CqlValueSet bq_ = this.Patient_Refusal(context);
+                CqlBoolean br_ = context.Operators.ConceptInValueSet(bn_, bq_);
+                CqlBoolean bs_ = br_;
+                CqlBoolean bt_ = bp_
+                    /* CQL 'or' (138:17-140:13) */ || bs_;
+                Code<MedicationRequest.MedicationrequestStatus> bu_ = MedReqAntithrombotic?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? bv_ = bu_?.Value;
+                string bw_ = context.Operators.Convert<string>(bv_);
+                string[] bx_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
+                CodeableConcept bz_ = TaskReject?.Code;
+                CqlConcept ca_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bz_);
+                CqlCode cb_ = QICoreCommon_4_0_000.Instance.Fulfill(context);
+                CqlConcept cc_ = context.Operators.ConvertCodeToConcept(cb_);
+                CqlBoolean cd_ = context.Operators.Equivalent(ca_, cc_);
+                CqlBoolean ce_ = cd_;
+                CqlBoolean cf_ = by_
+                    /* CQL 'and' (141:17-143:13) */ && ce_;
+                return bl_
+                    /* CQL 'and' (137:21-140:13) */ && bt_
+                    /* CQL 'and' (137:21-143:13) */ && cf_;
             }
 
-            CqlBoolean bk_ = context.Operators.WhereAny<Task>(bi_, bj_);
-            return bk_;
+            CqlBoolean bj_ = context.Operators.WhereAny<Task>(bh_, bi_);
+            return bj_;
         }
 
 
         (CqlTupleMetadata, string id, CqlDateTime authoredOn)? n_(MedicationRequest MedReqAntithrombotic) {
-            Id cj_ = MedReqAntithrombotic?.IdElement;
-            string ck_ = cj_?.Value;
-            FhirDateTime cl_ = MedReqAntithrombotic?.AuthoredOnElement;
-            CqlDateTime cm_ = context.Operators.Convert<CqlDateTime>(cl_);
-            (CqlTupleMetadata, string id, CqlDateTime authoredOn)? cn_ = (CqlTupleMetadata_DeYYCcJRPXYVddOGVBSgSSNfR, ck_, cm_);
-            return cn_;
+            Id cg_ = MedReqAntithrombotic?.IdElement;
+            string ch_ = cg_?.Value;
+            FhirDateTime ci_ = MedReqAntithrombotic?.AuthoredOnElement;
+            CqlDateTime cj_ = context.Operators.Convert<CqlDateTime>(ci_);
+            (CqlTupleMetadata, string id, CqlDateTime authoredOn)? ck_ = (CqlTupleMetadata_DeYYCcJRPXYVddOGVBSgSSNfR, ch_, cj_);
+            return ck_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, CqlDateTime authoredOn)?> o_ = context.Operators.WhereSelect<MedicationRequest, (CqlTupleMetadata, string id, CqlDateTime authoredOn)?>(l_, m_, n_);
@@ -840,57 +777,52 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
             List<CodeableConcept> h_ = MedicationAdm?.StatusReason;
 
             CqlConcept i_(CodeableConcept @this) {
-                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return n_;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return r_;
             }
 
             IEnumerable<CqlConcept> j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
             CqlValueSet k_ = this.Medical_Reason_for_Not_Providing_Treatment(context);
             CqlBoolean l_ = context.Operators.ConceptsInValueSet(j_, k_);
 
-            CqlBoolean m_() {
-                List<CodeableConcept> o_ = MedicationAdm?.StatusReason;
-
-                CqlConcept p_(CodeableConcept @this) {
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> q_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)o_, p_);
-                CqlValueSet r_ = this.Patient_Refusal(context);
-                CqlBoolean s_ = context.Operators.ConceptsInValueSet(q_, r_);
+            CqlConcept m_(CodeableConcept @this) {
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
                 return s_;
             }
 
+            IEnumerable<CqlConcept> n_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, m_);
+            CqlValueSet o_ = this.Patient_Refusal(context);
+            CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
+            CqlBoolean q_ = p_;
             return l_
-                /* CQL 'or' (115:5-117:5) */ || m_();
+                /* CQL 'or' (115:5-117:5) */ || q_;
         }
 
 
         (CqlTupleMetadata, string id, FhirDateTime authoredOn)? e_(MedicationAdministration MedicationAdm) {
-            Id u_ = MedicationAdm?.IdElement;
-            string v_ = u_?.Value;
+            Id t_ = MedicationAdm?.IdElement;
+            string u_ = t_?.Value;
 
-            bool? w_(Extension @this) {
-                FhirUri ac_ = @this?.UrlElement;
-                string ad_ = FHIRHelpers_4_4_000.Instance.ToString(context, ac_);
-                CqlBoolean ae_ = context.Operators.Equal(ad_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+            bool? v_(Extension @this) {
+                FhirUri ab_ = @this?.UrlElement;
+                string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
+                CqlBoolean ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                return ad_;
+            }
+
+
+            DataType w_(Extension @this) {
+                DataType ae_ = @this?.Value;
                 return ae_;
             }
 
-
-            DataType x_(Extension @this) {
-                DataType af_ = @this?.Value;
-                return af_;
-            }
-
-            IEnumerable<DataType> y_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(MedicationAdm is DomainResource
+            IEnumerable<DataType> x_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(MedicationAdm is DomainResource
                 ? (MedicationAdm as DomainResource).Extension
-                : default), w_, x_);
-            DataType z_ = context.Operators.SingletonFrom<DataType>(y_);
-            FhirDateTime aa_ = context.Operators.Convert<FhirDateTime>(z_);
-            (CqlTupleMetadata, string id, FhirDateTime authoredOn)? ab_ = (CqlTupleMetadata_EOIGQCcgaQBFZACEUUODRVWXI, v_, aa_);
-            return ab_;
+                : default), v_, w_);
+            DataType y_ = context.Operators.SingletonFrom<DataType>(x_);
+            FhirDateTime z_ = context.Operators.Convert<FhirDateTime>(y_);
+            (CqlTupleMetadata, string id, FhirDateTime authoredOn)? aa_ = (CqlTupleMetadata_EOIGQCcgaQBFZACEUUODRVWXI, u_, z_);
+            return aa_;
         }
 
         IEnumerable<(CqlTupleMetadata, string id, FhirDateTime authoredOn)?> f_ = context.Operators.WhereSelect<MedicationAdministration, (CqlTupleMetadata, string id, FhirDateTime authoredOn)?>(c_, d_, e_);
@@ -989,17 +921,13 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -1020,28 +948,24 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    DataType ae_ = PharmacologicalContraindications?.Effective;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.Start(ag_);
-                    CqlInterval<CqlDateTime> ai_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                    CqlDateTime aj_ = context.Operators.Start(ai_);
-                    CqlInterval<CqlDate> ak_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, aj_);
-                    CqlDate al_ = ak_?.low;
-                    CqlDateTime am_ = context.Operators.ConvertDateToDateTime(al_);
-                    CqlDate an_ = ak_?.high;
-                    CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
-                    CqlBoolean ap_ = ak_?.lowClosed;
-                    CqlBoolean aq_ = ak_?.highClosed;
-                    CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(am_, ao_, ap_, aq_);
-                    CqlBoolean as_ = context.Operators.In<CqlDateTime>(ah_, ar_, "day");
-                    return as_;
-                }
-
+                DataType ad_ = PharmacologicalContraindications?.Effective;
+                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
+                CqlDateTime ag_ = context.Operators.Start(af_);
+                CqlInterval<CqlDateTime> ah_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                CqlDateTime ai_ = context.Operators.Start(ah_);
+                CqlInterval<CqlDate> aj_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, ai_);
+                CqlDate ak_ = aj_?.low;
+                CqlDateTime al_ = context.Operators.ConvertDateToDateTime(ak_);
+                CqlDate am_ = aj_?.high;
+                CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+                CqlBoolean ao_ = aj_?.lowClosed;
+                CqlBoolean ap_ = aj_?.highClosed;
+                CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(al_, an_, ao_, ap_);
+                CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ag_, aq_, "day");
+                CqlBoolean as_ = ar_;
                 return ac_
-                    /* CQL 'and' (153:17-154:190) */ && ad_();
+                    /* CQL 'and' (153:17-154:190) */ && as_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationAdministration>(i_, j_);
@@ -1072,42 +996,34 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                 object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
                 CqlQuantity j_ = context.Operators.ConvertDecimalToQuantity(3.5m);
                 CqlBoolean k_ = context.Operators.Greater(i_ as CqlQuantity, j_);
-
-                CqlBoolean l_() {
-                    Code<ObservationStatus> n_ = INR?.StatusElement;
-                    ObservationStatus? o_ = n_?.Value;
-                    string p_ = context.Operators.Convert<string>(o_);
-                    string[] q_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-                    return r_;
-                }
-
-
-                CqlBoolean m_() {
-                    Instant s_ = INR?.IssuedElement;
-                    DateTimeOffset? t_ = s_?.Value;
-                    CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
-                    CqlInterval<CqlDateTime> v_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    CqlInterval<CqlDate> x_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, w_);
-                    CqlDate y_ = x_?.low;
-                    CqlDateTime z_ = context.Operators.ConvertDateToDateTime(y_);
-                    CqlDate aa_ = x_?.high;
-                    CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(aa_);
-                    CqlBoolean ac_ = x_?.lowClosed;
-                    CqlBoolean ad_ = x_?.highClosed;
-                    CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(z_, ab_, ac_, ad_);
-                    CqlBoolean af_ = context.Operators.In<CqlDateTime>(u_, ae_, "day");
-                    return af_;
-                }
-
+                Code<ObservationStatus> l_ = INR?.StatusElement;
+                ObservationStatus? m_ = l_?.Value;
+                string n_ = context.Operators.Convert<string>(m_);
+                string[] o_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
+                CqlBoolean q_ = p_;
+                Instant r_ = INR?.IssuedElement;
+                DateTimeOffset? s_ = r_?.Value;
+                CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(s_);
+                CqlInterval<CqlDateTime> u_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
+                CqlDateTime v_ = context.Operators.Start(u_);
+                CqlInterval<CqlDate> w_ = TJCOverall_8_25_000.Instance.calendarDayOfOrDayAfter(context, v_);
+                CqlDate x_ = w_?.low;
+                CqlDateTime y_ = context.Operators.ConvertDateToDateTime(x_);
+                CqlDate z_ = w_?.high;
+                CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+                CqlBoolean ab_ = w_?.lowClosed;
+                CqlBoolean ac_ = w_?.highClosed;
+                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(y_, aa_, ab_, ac_);
+                CqlBoolean ae_ = context.Operators.In<CqlDateTime>(t_, ad_, "day");
+                CqlBoolean af_ = ae_;
                 return k_
-                    /* CQL 'and' (159:17-160:61) */ && l_()
-                    /* CQL 'and' (159:17-161:136) */ && m_();
+                    /* CQL 'and' (159:17-160:61) */ && q_
+                    /* CQL 'and' (159:17-161:136) */ && af_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS74FHIRDentalCariesPrevention-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS74FHIRDentalCariesPrevention-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS74FHIRDentalCariesPrevention", "1.0.000")]
 public partial class CMS74FHIRDentalCariesPrevention_1_0_000 : ILibrary, ISingleton<CMS74FHIRDentalCariesPrevention_1_0_000>
 {
@@ -119,15 +119,11 @@ public partial class CMS74FHIRDentalCariesPrevention_1_0_000 : ILibrary, ISingle
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> l_ = this.Qualifying_Encounters(context);
-            CqlBoolean m_ = context.Operators.Exists<Encounter>(l_);
-            return m_;
-        }
-
+        IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
+        CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
+        CqlBoolean m_ = l_;
         return j_
-            /* CQL 'and' (23:3-24:42) */ && k_();
+            /* CQL 'and' (23:3-24:42) */ && m_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS75FHIRChildrenDentalDecay-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS75FHIRChildrenDentalDecay-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS75FHIRChildrenDentalDecay", "1.0.000")]
 public partial class CMS75FHIRChildrenDentalDecay_1_0_000 : ILibrary, ISingleton<CMS75FHIRChildrenDentalDecay_1_0_000>
 {
@@ -107,15 +107,11 @@ public partial class CMS75FHIRChildrenDentalDecay_1_0_000 : ILibrary, ISingleton
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
         CqlBoolean j_ = context.Operators.In<int?>(h_, i_, (string)default);
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> l_ = this.Qualifying_Encounters(context);
-            CqlBoolean m_ = context.Operators.Exists<Encounter>(l_);
-            return m_;
-        }
-
+        IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
+        CqlBoolean l_ = context.Operators.Exists<Encounter>(k_);
+        CqlBoolean m_ = l_;
         return j_
-            /* CQL 'and' (20:3-21:42) */ && k_();
+            /* CQL 'and' (20:3-21:42) */ && m_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS771FHIRUrinarySymptomScoreBPH", "1.0.000")]
 public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingleton<CMS771FHIRUrinarySymptomScoreBPH_1_0_000>
 {
@@ -151,27 +151,19 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
             Period f_ = ValidEncounter?.Period;
             CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, f_);
             CqlBoolean h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
-
-            CqlBoolean i_() {
-                Coding k_ = ValidEncounter?.Class;
-                CqlCode l_ = FHIRHelpers_4_4_000.Instance.ToCode(context, k_);
-                CqlCode m_ = this.@virtual(context);
-                CqlBoolean n_ = context.Operators.Equivalent(l_, m_);
-                return !n_;
-            }
-
-
-            CqlBoolean j_() {
-                Code<Encounter.EncounterStatus> o_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? p_ = o_?.Value;
-                Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
-                CqlBoolean r_ = context.Operators.Equal(q_, "finished");
-                return r_;
-            }
-
+            Coding i_ = ValidEncounter?.Class;
+            CqlCode j_ = FHIRHelpers_4_4_000.Instance.ToCode(context, i_);
+            CqlCode k_ = this.@virtual(context);
+            CqlBoolean l_ = context.Operators.Equivalent(j_, k_);
+            CqlBoolean m_ = (CqlBoolean)!l_;
+            Code<Encounter.EncounterStatus> n_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? o_ = n_?.Value;
+            Code<Encounter.EncounterStatus> p_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(o_);
+            CqlBoolean q_ = context.Operators.Equal(p_, "finished");
+            CqlBoolean r_ = q_;
             return h_
-                /* CQL 'and' (107:13-108:45) */ && i_()
-                /* CQL 'and' (107:7-109:46) */ && j_();
+                /* CQL 'and' (107:13-108:45) */ && m_
+                /* CQL 'and' (107:7-109:46) */ && r_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Encounter>(b_, c_);
@@ -184,40 +176,22 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept k_ = condition?.VerificationStatus;
-                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-                CqlCode m_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
-                CqlBoolean o_ = context.Operators.Equivalent(l_, n_);
-                return o_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept p_ = condition?.VerificationStatus;
-                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
-                CqlCode r_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
-                CqlBoolean t_ = context.Operators.Equivalent(q_, s_);
-                return t_;
-            }
-
-            return !((bool?)(h_
-                /* CQL 'or' (177:14-178:64) */ || i_()
-                /* CQL 'or' (177:12-180:5) */ || j_()));
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.refuted(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlBoolean n_ = (CqlBoolean)(!((bool?)(e_
+            /* CQL 'or' (177:14-178:64) */ || i_
+            /* CQL 'or' (177:12-180:5) */ || m_)));
         return (CqlBoolean)(b_ is null)
-            /* CQL 'or' (176:3-180:5) */ || c_();
+            /* CQL 'or' (176:3-180:5) */ || n_;
     }
 
 
@@ -314,15 +288,11 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 "corrected",
             ];
             CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-            CqlBoolean m_() {
-                DataType n_ = IPSSAssessment?.Value;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                return o_ is not null;
-            }
-
+            DataType m_ = IPSSAssessment?.Value;
+            object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+            CqlBoolean o_ = (CqlBoolean)(n_ is not null);
             return l_
-                /* CQL 'and' (83:5-84:42) */ && m_();
+                /* CQL 'and' (83:5-84:42) */ && o_;
         }
 
 
@@ -389,15 +359,11 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 "corrected",
             ];
             CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-            CqlBoolean m_() {
-                DataType n_ = AUASIAssessment?.Value;
-                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                return o_ is not null;
-            }
-
+            DataType m_ = AUASIAssessment?.Value;
+            object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+            CqlBoolean o_ = (CqlBoolean)(n_ is not null);
             return l_
-                /* CQL 'and' (98:5-99:43) */ && m_();
+                /* CQL 'and' (98:5-99:43) */ && o_;
         }
 
 
@@ -438,25 +404,25 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
 
             bool? w_(Observation QOLAssessment) {
                 object aj_;
-                DataType aq_ = QOLAssessment?.Effective;
-                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                bool as_ = ar_ is CqlDateTime;
-                if (as_)
+                DataType ax_ = QOLAssessment?.Effective;
+                object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                bool az_ = ay_ is CqlDateTime;
+                if (az_)
                 {
-                    aj_ = ar_ as CqlDateTime;
+                    aj_ = ay_ as CqlDateTime;
                 }
                 else
                 {
-                    if (as_)
+                    if (az_)
                     {
-                        aj_ = ar_ as CqlDateTime;
+                        aj_ = ay_ as CqlDateTime;
                     }
                     else
                     {
-                        bool at_ = ar_ is CqlInterval<CqlDateTime>;
-                        if (at_)
+                        bool ba_ = ay_ is CqlInterval<CqlDateTime>;
+                        if (ba_)
                         {
-                            aj_ = ar_ as CqlInterval<CqlDateTime>;
+                            aj_ = ay_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -466,25 +432,25 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 }
                 CqlDateTime ak_ = QICoreCommon_4_0_000.Instance.earliest(context, aj_);
                 object al_;
-                DataType au_ = AUASIAssessment?.Effective;
-                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                bool aw_ = av_ is CqlDateTime;
-                if (aw_)
+                DataType bb_ = AUASIAssessment?.Effective;
+                object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                bool bd_ = bc_ is CqlDateTime;
+                if (bd_)
                 {
-                    al_ = av_ as CqlDateTime;
+                    al_ = bc_ as CqlDateTime;
                 }
                 else
                 {
-                    if (aw_)
+                    if (bd_)
                     {
-                        al_ = av_ as CqlDateTime;
+                        al_ = bc_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ax_ = av_ is CqlInterval<CqlDateTime>;
-                        if (ax_)
+                        bool be_ = bc_ is CqlInterval<CqlDateTime>;
+                        if (be_)
                         {
-                            al_ = av_ as CqlInterval<CqlDateTime>;
+                            al_ = bc_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -494,30 +460,22 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 }
                 CqlDateTime am_ = QICoreCommon_4_0_000.Instance.earliest(context, al_);
                 CqlBoolean an_ = context.Operators.SameAs(ak_, am_, "day");
-
-                CqlBoolean ao_() {
-                    Code<ObservationStatus> ay_ = QOLAssessment?.StatusElement;
-                    ObservationStatus? az_ = ay_?.Value;
-                    string ba_ = context.Operators.Convert<string>(az_);
-                    string[] bb_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
-                    return bc_;
-                }
-
-
-                CqlBoolean ap_() {
-                    DataType bd_ = QOLAssessment?.Value;
-                    object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                    return be_ is not null;
-                }
-
+                Code<ObservationStatus> ao_ = QOLAssessment?.StatusElement;
+                ObservationStatus? ap_ = ao_?.Value;
+                string aq_ = context.Operators.Convert<string>(ap_);
+                string[] ar_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean as_ = context.Operators.In<string>(aq_, (IEnumerable<string>)ar_);
+                CqlBoolean at_ = as_;
+                DataType au_ = QOLAssessment?.Value;
+                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                CqlBoolean aw_ = (CqlBoolean)(av_ is not null);
                 return an_
-                    /* CQL 'and' (93:15-94:73) */ && ao_()
-                    /* CQL 'and' (93:9-95:45) */ && ap_();
+                    /* CQL 'and' (93:15-94:73) */ && at_
+                    /* CQL 'and' (93:9-95:45) */ && aw_;
             }
 
             IEnumerable<Observation> x_ = context.Operators.Where<Observation>(v_, w_);
@@ -608,15 +566,9 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 CqlDateTime o_ = context.Operators.Add(m_, n_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
                 CqlBoolean q_ = context.Operators.In<CqlDateTime>(k_, p_, "day");
-
-                CqlBoolean r_() {
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
-                    CqlDateTime t_ = context.Operators.Start(s_);
-                    return t_ is not null;
-                }
-
+                CqlBoolean r_ = (CqlBoolean)(m_ is not null);
                 return q_
-                    /* CQL 'and' (133:19-133:134) */ && r_();
+                    /* CQL 'and' (133:19-133:134) */ && r_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Condition>((IEnumerable<Condition>)h_, i_);
@@ -626,8 +578,8 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
         IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> c_ = context.Operators.Where<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(a_, b_);
 
         object d_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? @this) {
-            CqlDateTime u_ = @this?.effectiveDatetime;
-            return u_;
+            CqlDateTime s_ = @this?.effectiveDatetime;
+            return s_;
         }
 
         IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?> e_ = context.Operators.SortBy<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
@@ -722,15 +674,9 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 CqlDateTime r_ = context.Operators.Add(p_, q_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
                 CqlBoolean t_ = context.Operators.In<CqlDateTime>(n_, s_, "day");
-
-                CqlBoolean u_() {
-                    CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, InitialBPHDiagnosis);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    return w_ is not null;
-                }
-
+                CqlBoolean u_ = (CqlBoolean)(p_ is not null);
                 return t_
-                    /* CQL 'and' (120:17-120:148) */ && u_();
+                    /* CQL 'and' (120:17-120:148) */ && u_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<Condition>((IEnumerable<Condition>)j_, k_);
@@ -740,8 +686,8 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
         bool? g_(Condition UrinaryRetention) {
-            CqlBoolean x_ = this.verificationStatusIsNotInvalid(context, UrinaryRetention);
-            return x_;
+            CqlBoolean v_ = this.verificationStatusIsNotInvalid(context, UrinaryRetention);
+            return v_;
         }
 
         IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
@@ -777,17 +723,13 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 CqlDateTime q_ = context.Operators.Add(o_, p_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(n_, q_, true, true);
                 CqlBoolean s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
-
-                CqlBoolean t_() {
-                    Code<Encounter.EncounterStatus> u_ = UrologyHospitalServices?.StatusElement;
-                    Encounter.EncounterStatus? v_ = u_?.Value;
-                    Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-                    CqlBoolean x_ = context.Operators.Equal(w_, "finished");
-                    return x_;
-                }
-
+                Code<Encounter.EncounterStatus> t_ = UrologyHospitalServices?.StatusElement;
+                Encounter.EncounterStatus? u_ = t_?.Value;
+                Code<Encounter.EncounterStatus> v_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(u_);
+                CqlBoolean w_ = context.Operators.Equal(v_, "finished");
+                CqlBoolean x_ = w_;
                 return s_
-                    /* CQL 'and' (140:17-141:55) */ && t_();
+                    /* CQL 'and' (140:17-141:55) */ && x_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<Encounter>(g_, h_);
@@ -823,17 +765,12 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MorbidObesityDiagnosis);
                 CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
                 CqlBoolean o_ = context.Operators.Overlaps(m_, n_, (string)default);
-
-                CqlBoolean p_() {
-                    CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MorbidObesityDiagnosis);
-                    CqlDateTime r_ = context.Operators.Start(q_);
-                    CqlDateTime s_ = FollowUpUSSAssessment?.effectiveDatetime;
-                    CqlBoolean t_ = context.Operators.SameOrBefore(r_, s_, (string)default);
-                    return t_;
-                }
-
+                CqlDateTime p_ = context.Operators.Start(m_);
+                CqlDateTime q_ = FollowUpUSSAssessment?.effectiveDatetime;
+                CqlBoolean r_ = context.Operators.SameOrBefore(p_, q_, (string)default);
+                CqlBoolean s_ = r_;
                 return o_
-                    /* CQL 'and' (155:17-156:117) */ && p_();
+                    /* CQL 'and' (155:17-156:117) */ && s_;
             }
 
             CqlBoolean l_ = context.Operators.WhereAny<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>((IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>)j_, k_);
@@ -843,8 +780,8 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
         IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
         bool? g_(Condition MorbidObesityDiagnosis) {
-            CqlBoolean u_ = this.verificationStatusIsNotInvalid(context, MorbidObesityDiagnosis);
-            return u_;
+            CqlBoolean t_ = this.verificationStatusIsNotInvalid(context, MorbidObesityDiagnosis);
+            return t_;
         }
 
         IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
@@ -875,44 +812,29 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 CqlQuantity l_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, k_ as Quantity);
                 CqlQuantity m_ = context.Operators.Quantity(40m, "kg/m2");
                 CqlBoolean n_ = context.Operators.GreaterOrEqual(l_, m_);
-
-                CqlBoolean o_() {
-                    Code<ObservationStatus> r_ = BMIExam?.StatusElement;
-                    ObservationStatus? s_ = r_?.Value;
-                    string t_ = context.Operators.Convert<string>(s_);
-                    string[] u_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
-                    return v_;
-                }
-
-
-                CqlBoolean p_() {
-                    DataType w_ = BMIExam?.Effective;
-                    object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-                    CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
-                    CqlInterval<CqlDateTime> z_ = this.Measurement_Period(context);
-                    CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, "day");
-                    return aa_;
-                }
-
-
-                CqlBoolean q_() {
-                    DataType ab_ = BMIExam?.Effective;
-                    object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-                    CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.earliest(context, ac_);
-                    CqlDateTime ae_ = FollowUpUSSAssessment?.effectiveDatetime;
-                    CqlBoolean af_ = context.Operators.SameOrBefore(ad_, ae_, (string)default);
-                    return af_;
-                }
-
+                Code<ObservationStatus> o_ = BMIExam?.StatusElement;
+                ObservationStatus? p_ = o_?.Value;
+                string q_ = context.Operators.Convert<string>(p_);
+                string[] r_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+                CqlBoolean t_ = s_;
+                DataType u_ = BMIExam?.Effective;
+                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
+                CqlInterval<CqlDateTime> x_ = this.Measurement_Period(context);
+                CqlBoolean y_ = context.Operators.In<CqlDateTime>(w_, x_, "day");
+                CqlBoolean z_ = y_;
+                CqlDateTime aa_ = FollowUpUSSAssessment?.effectiveDatetime;
+                CqlBoolean ab_ = context.Operators.SameOrBefore(w_, aa_, (string)default);
+                CqlBoolean ac_ = ab_;
                 return n_
-                    /* CQL 'and' (168:19-169:67) */ && o_()
-                    /* CQL 'and' (168:19-170:79) */ && p_()
-                    /* CQL 'and' (168:19-171:97) */ && q_();
+                    /* CQL 'and' (168:19-169:67) */ && t_
+                    /* CQL 'and' (168:19-170:79) */ && z_
+                    /* CQL 'and' (168:19-171:97) */ && ac_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>((IEnumerable<(CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)?>)h_, i_);
@@ -921,10 +843,10 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
 
 
         CqlDateTime c_(Observation BMIExam) {
-            DataType ag_ = BMIExam?.Effective;
-            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
-            CqlDateTime ai_ = QICoreCommon_4_0_000.Instance.earliest(context, ah_);
-            return ai_;
+            DataType ad_ = BMIExam?.Effective;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlDateTime af_ = QICoreCommon_4_0_000.Instance.earliest(context, ae_);
+            return af_;
         }
 
         IEnumerable<CqlDateTime> d_ = context.Operators.WhereSelect<Observation, CqlDateTime>(a_, b_, c_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS816FHIRHHHypo", "1.0.000")]
 public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRHHHypo_1_0_000>
 {
@@ -94,28 +94,18 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
             CqlDate l_ = context.Operators.DateFrom(k_);
             int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
             CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 18);
-
-            CqlBoolean o_() {
-                Period q_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
-                return u_;
-            }
-
-
-            CqlBoolean p_() {
-                Code<Encounter.EncounterStatus> v_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? w_ = v_?.Value;
-                Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "finished");
-                return y_;
-            }
-
+            CqlDateTime o_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+            CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+            CqlBoolean r_ = q_;
+            Code<Encounter.EncounterStatus> s_ = InpatientEncounter?.StatusElement;
+            Encounter.EncounterStatus? t_ = s_?.Value;
+            Code<Encounter.EncounterStatus> u_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(t_);
+            CqlBoolean v_ = context.Operators.Equal(u_, "finished");
+            CqlBoolean w_ = v_;
             return n_
-                /* CQL 'and' (58:11-59:75) */ && o_()
-                /* CQL 'and' (58:5-60:48) */ && p_();
+                /* CQL 'and' (58:11-59:75) */ && r_
+                /* CQL 'and' (58:5-60:48) */ && w_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -142,17 +132,13 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Hypoglycemics_Severe_Hypoglycemia(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Hypoglycemics_Severe_Hypoglycemia(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -257,25 +243,25 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
 
         bool? g_((CqlTupleMetadata, Encounter InpatientHospitalization, MedicationAdministration HypoglycemicMedication, Observation GlucoseTest)? tuple_fadhmfgiduzpspclbhmqonodh) {
             object l_;
-            DataType s_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
-            object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-            bool u_ = t_ is CqlDateTime;
-            if (u_)
+            DataType aq_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            bool as_ = ar_ is CqlDateTime;
+            if (as_)
             {
-                l_ = t_ as CqlDateTime;
+                l_ = ar_ as CqlDateTime;
             }
             else
             {
-                if (u_)
+                if (as_)
                 {
-                    l_ = t_ as CqlDateTime;
+                    l_ = ar_ as CqlDateTime;
                 }
                 else
                 {
-                    bool v_ = t_ is CqlInterval<CqlDateTime>;
-                    if (v_)
+                    bool at_ = ar_ is CqlInterval<CqlDateTime>;
+                    if (at_)
                     {
-                        l_ = t_ as CqlInterval<CqlDateTime>;
+                        l_ = ar_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -286,136 +272,120 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
             CqlDateTime m_ = QICoreCommon_4_0_000.Instance.earliest(context, l_);
             CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_fadhmfgiduzpspclbhmqonodh?.InpatientHospitalization);
             CqlBoolean o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
-
-            CqlBoolean p_() {
-                Code<ObservationStatus> w_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.StatusElement;
-                ObservationStatus? x_ = w_?.Value;
-                string y_ = context.Operators.Convert<string>(x_);
-                string[] z_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
-                return aa_;
+            Code<ObservationStatus> p_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.StatusElement;
+            ObservationStatus? q_ = p_?.Value;
+            string r_ = context.Operators.Convert<string>(q_);
+            string[] s_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
+            CqlBoolean u_ = t_;
+            DataType v_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Value;
+            object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+            CqlQuantity x_ = context.Operators.Quantity(40m, "mg/dL");
+            CqlBoolean y_ = context.Operators.Less(w_ as CqlQuantity, x_);
+            CqlBoolean z_ = y_;
+            DataType aa_ = tuple_fadhmfgiduzpspclbhmqonodh?.HypoglycemicMedication?.Effective;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_);
+            CqlDateTime ad_ = context.Operators.Start(ac_);
+            object ae_;
+            DataType au_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
+            object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+            bool aw_ = av_ is CqlDateTime;
+            if (aw_)
+            {
+                ae_ = av_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                DataType ab_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Value;
-                object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-                CqlQuantity ad_ = context.Operators.Quantity(40m, "mg/dL");
-                CqlBoolean ae_ = context.Operators.Less(ac_ as CqlQuantity, ad_);
-                return ae_;
-            }
-
-
-            CqlBoolean r_() {
-                DataType af_ = tuple_fadhmfgiduzpspclbhmqonodh?.HypoglycemicMedication?.Effective;
-                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                CqlInterval<CqlDateTime> ah_ = QICoreCommon_4_0_000.Instance.toInterval(context, ag_);
-                CqlDateTime ai_ = context.Operators.Start(ah_);
-                object aj_;
-                DataType as_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
-                object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
-                bool au_ = at_ is CqlDateTime;
-                if (au_)
+            else
+            {
+                if (aw_)
                 {
-                    aj_ = at_ as CqlDateTime;
+                    ae_ = av_ as CqlDateTime;
                 }
                 else
                 {
-                    if (au_)
+                    bool ax_ = av_ is CqlInterval<CqlDateTime>;
+                    if (ax_)
                     {
-                        aj_ = at_ as CqlDateTime;
+                        ae_ = av_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool av_ = at_ is CqlInterval<CqlDateTime>;
-                        if (av_)
-                        {
-                            aj_ = at_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            aj_ = null;
-                        }
+                        ae_ = null;
                     }
                 }
-                CqlDateTime ak_ = QICoreCommon_4_0_000.Instance.earliest(context, aj_);
-                CqlQuantity al_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime am_ = context.Operators.Subtract(ak_, al_);
-                object an_;
-                DataType aw_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
-                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
-                bool ay_ = ax_ is CqlDateTime;
-                if (ay_)
+            }
+            CqlDateTime af_ = QICoreCommon_4_0_000.Instance.earliest(context, ae_);
+            CqlQuantity ag_ = context.Operators.Quantity(24m, "hours");
+            CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+            object ai_;
+            DataType ay_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
+            object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+            bool ba_ = az_ is CqlDateTime;
+            if (ba_)
+            {
+                ai_ = az_ as CqlDateTime;
+            }
+            else
+            {
+                if (ba_)
                 {
-                    an_ = ax_ as CqlDateTime;
+                    ai_ = az_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ay_)
+                    bool bb_ = az_ is CqlInterval<CqlDateTime>;
+                    if (bb_)
                     {
-                        an_ = ax_ as CqlDateTime;
+                        ai_ = az_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool az_ = ax_ is CqlInterval<CqlDateTime>;
-                        if (az_)
-                        {
-                            an_ = ax_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            an_ = null;
-                        }
+                        ai_ = null;
                     }
                 }
-                CqlDateTime ao_ = QICoreCommon_4_0_000.Instance.earliest(context, an_);
-                CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(am_, ao_, true, true);
-                CqlBoolean aq_ = context.Operators.In<CqlDateTime>(ai_, ap_, (string)default);
-
-                CqlBoolean ar_() {
-                    object ba_;
-                    DataType bc_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
-                    object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                    bool be_ = bd_ is CqlDateTime;
-                    if (be_)
-                    {
-                        ba_ = bd_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        if (be_)
-                        {
-                            ba_ = bd_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool bf_ = bd_ is CqlInterval<CqlDateTime>;
-                            if (bf_)
-                            {
-                                ba_ = bd_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                ba_ = null;
-                            }
-                        }
-                    }
-                    CqlDateTime bb_ = QICoreCommon_4_0_000.Instance.earliest(context, ba_);
-                    return bb_ is not null;
-                }
-
-                return aq_
-                    /* CQL 'and' (43:11-43:90) */ && ar_();
             }
-
+            CqlDateTime aj_ = QICoreCommon_4_0_000.Instance.earliest(context, ai_);
+            CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ah_, aj_, true, true);
+            CqlBoolean al_ = context.Operators.In<CqlDateTime>(ad_, ak_, (string)default);
+            object am_;
+            DataType bc_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Effective;
+            object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+            bool be_ = bd_ is CqlDateTime;
+            if (be_)
+            {
+                am_ = bd_ as CqlDateTime;
+            }
+            else
+            {
+                if (be_)
+                {
+                    am_ = bd_ as CqlDateTime;
+                }
+                else
+                {
+                    bool bf_ = bd_ is CqlInterval<CqlDateTime>;
+                    if (bf_)
+                    {
+                        am_ = bd_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        am_ = null;
+                    }
+                }
+            }
+            CqlDateTime an_ = QICoreCommon_4_0_000.Instance.earliest(context, am_);
+            CqlBoolean ao_ = (CqlBoolean)(an_ is not null);
+            CqlBoolean ap_ = al_
+                /* CQL 'and' (43:11-43:90) */ && ao_;
             return o_
-                /* CQL 'and' (40:11-41:67) */ && p_()
-                /* CQL 'and' (40:11-42:40) */ && q_()
-                /* CQL 'and' (40:5-43:90) */ && r_();
+                /* CQL 'and' (40:11-41:67) */ && u_
+                /* CQL 'and' (40:11-42:40) */ && z_
+                /* CQL 'and' (40:5-43:90) */ && ap_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter InpatientHospitalization, MedicationAdministration HypoglycemicMedication, Observation GlucoseTest)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, MedicationAdministration, Observation>, (CqlTupleMetadata, Encounter InpatientHospitalization, MedicationAdministration HypoglycemicMedication, Observation GlucoseTest)?>(e_, f_, g_);
@@ -447,25 +417,25 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
 
         bool? g_((CqlTupleMetadata, Encounter InpatientHospitalization, Observation LowGlucoseTest, Observation FollowupGlucoseTest)? tuple_fcmdncyhjlqsajxzjwdiopqvk) {
             object l_;
-            DataType ab_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Effective;
-            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-            bool ad_ = ac_ is CqlDateTime;
-            if (ad_)
+            DataType ay_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Effective;
+            object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
+            bool ba_ = az_ is CqlDateTime;
+            if (ba_)
             {
-                l_ = ac_ as CqlDateTime;
+                l_ = az_ as CqlDateTime;
             }
             else
             {
-                if (ad_)
+                if (ba_)
                 {
-                    l_ = ac_ as CqlDateTime;
+                    l_ = az_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ae_ = ac_ is CqlInterval<CqlDateTime>;
-                    if (ae_)
+                    bool bb_ = az_ is CqlInterval<CqlDateTime>;
+                    if (bb_)
                     {
-                        l_ = ac_ as CqlInterval<CqlDateTime>;
+                        l_ = az_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -475,25 +445,25 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
             }
             CqlDateTime m_ = QICoreCommon_4_0_000.Instance.earliest(context, l_);
             object n_;
-            DataType af_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
-            object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-            bool ah_ = ag_ is CqlDateTime;
-            if (ah_)
+            DataType bc_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
+            object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+            bool be_ = bd_ is CqlDateTime;
+            if (be_)
             {
-                n_ = ag_ as CqlDateTime;
+                n_ = bd_ as CqlDateTime;
             }
             else
             {
-                if (ah_)
+                if (be_)
                 {
-                    n_ = ag_ as CqlDateTime;
+                    n_ = bd_ as CqlDateTime;
                 }
                 else
                 {
-                    bool ai_ = ag_ is CqlInterval<CqlDateTime>;
-                    if (ai_)
+                    bool bf_ = bd_ is CqlInterval<CqlDateTime>;
+                    if (bf_)
                     {
-                        n_ = ag_ as CqlInterval<CqlDateTime>;
+                        n_ = bd_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -503,25 +473,25 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
             }
             CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_);
             object p_;
-            DataType aj_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
-            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-            bool al_ = ak_ is CqlDateTime;
-            if (al_)
+            DataType bg_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
+            object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
+            bool bi_ = bh_ is CqlDateTime;
+            if (bi_)
             {
-                p_ = ak_ as CqlDateTime;
+                p_ = bh_ as CqlDateTime;
             }
             else
             {
-                if (al_)
+                if (bi_)
                 {
-                    p_ = ak_ as CqlDateTime;
+                    p_ = bh_ as CqlDateTime;
                 }
                 else
                 {
-                    bool am_ = ak_ is CqlInterval<CqlDateTime>;
-                    if (am_)
+                    bool bj_ = bh_ is CqlInterval<CqlDateTime>;
+                    if (bj_)
                     {
-                        p_ = ak_ as CqlInterval<CqlDateTime>;
+                        p_ = bh_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -534,149 +504,124 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
             CqlDateTime s_ = context.Operators.Add(q_, r_);
             CqlInterval<CqlDateTime> t_ = context.Operators.Interval(o_, s_, false, true);
             CqlBoolean u_ = context.Operators.In<CqlDateTime>(m_, t_, (string)default);
-
-            CqlBoolean v_() {
-                object an_;
-                DataType ap_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
-                object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                bool ar_ = aq_ is CqlDateTime;
-                if (ar_)
+            object v_;
+            DataType bk_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
+            object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+            bool bm_ = bl_ is CqlDateTime;
+            if (bm_)
+            {
+                v_ = bl_ as CqlDateTime;
+            }
+            else
+            {
+                if (bm_)
                 {
-                    an_ = aq_ as CqlDateTime;
+                    v_ = bl_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ar_)
+                    bool bn_ = bl_ is CqlInterval<CqlDateTime>;
+                    if (bn_)
                     {
-                        an_ = aq_ as CqlDateTime;
+                        v_ = bl_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool as_ = aq_ is CqlInterval<CqlDateTime>;
-                        if (as_)
-                        {
-                            an_ = aq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            an_ = null;
-                        }
+                        v_ = null;
                     }
                 }
-                CqlDateTime ao_ = QICoreCommon_4_0_000.Instance.earliest(context, an_);
-                return ao_ is not null;
             }
-
-
-            CqlBoolean w_() {
-                object at_;
-                DataType ax_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
-                object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                bool az_ = ay_ is CqlDateTime;
-                if (az_)
+            CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
+            CqlBoolean x_ = (CqlBoolean)(w_ is not null);
+            object y_;
+            DataType bo_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.Effective;
+            object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+            bool bq_ = bp_ is CqlDateTime;
+            if (bq_)
+            {
+                y_ = bp_ as CqlDateTime;
+            }
+            else
+            {
+                if (bq_)
                 {
-                    at_ = ay_ as CqlDateTime;
+                    y_ = bp_ as CqlDateTime;
                 }
                 else
                 {
-                    if (az_)
+                    bool br_ = bp_ is CqlInterval<CqlDateTime>;
+                    if (br_)
                     {
-                        at_ = ay_ as CqlDateTime;
+                        y_ = bp_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ba_ = ay_ is CqlInterval<CqlDateTime>;
-                        if (ba_)
-                        {
-                            at_ = ay_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            at_ = null;
-                        }
+                        y_ = null;
                     }
                 }
-                CqlDateTime au_ = QICoreCommon_4_0_000.Instance.earliest(context, at_);
-                CqlInterval<CqlDateTime> av_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_fcmdncyhjlqsajxzjwdiopqvk?.InpatientHospitalization);
-                CqlBoolean aw_ = context.Operators.In<CqlDateTime>(au_, av_, (string)default);
-                return aw_;
             }
-
-
-            CqlBoolean x_() {
-                object bb_;
-                DataType bf_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Effective;
-                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                bool bh_ = bg_ is CqlDateTime;
-                if (bh_)
+            CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, y_);
+            CqlInterval<CqlDateTime> aa_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_fcmdncyhjlqsajxzjwdiopqvk?.InpatientHospitalization);
+            CqlBoolean ab_ = context.Operators.In<CqlDateTime>(z_, aa_, (string)default);
+            CqlBoolean ac_ = ab_;
+            object ad_;
+            DataType bs_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Effective;
+            object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
+            bool bu_ = bt_ is CqlDateTime;
+            if (bu_)
+            {
+                ad_ = bt_ as CqlDateTime;
+            }
+            else
+            {
+                if (bu_)
                 {
-                    bb_ = bg_ as CqlDateTime;
+                    ad_ = bt_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bh_)
+                    bool bv_ = bt_ is CqlInterval<CqlDateTime>;
+                    if (bv_)
                     {
-                        bb_ = bg_ as CqlDateTime;
+                        ad_ = bt_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
-                        if (bi_)
-                        {
-                            bb_ = bg_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bb_ = null;
-                        }
+                        ad_ = null;
                     }
                 }
-                CqlDateTime bc_ = QICoreCommon_4_0_000.Instance.earliest(context, bb_);
-                CqlInterval<CqlDateTime> bd_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_fcmdncyhjlqsajxzjwdiopqvk?.InpatientHospitalization);
-                CqlBoolean be_ = context.Operators.In<CqlDateTime>(bc_, bd_, (string)default);
-                return be_;
             }
-
-
-            CqlBoolean y_() {
-                Id bj_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.IdElement;
-                string bk_ = bj_?.Value;
-                Id bl_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.IdElement;
-                string bm_ = bl_?.Value;
-                CqlBoolean bn_ = context.Operators.Equivalent(bk_, bm_);
-                return !bn_;
-            }
-
-
-            CqlBoolean z_() {
-                Code<ObservationStatus> bo_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.StatusElement;
-                ObservationStatus? bp_ = bo_?.Value;
-                string bq_ = context.Operators.Convert<string>(bp_);
-                string[] br_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
-                return bs_;
-            }
-
-
-            CqlBoolean aa_() {
-                DataType bt_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Value;
-                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                CqlQuantity bv_ = context.Operators.Quantity(80m, "mg/dL");
-                CqlBoolean bw_ = context.Operators.Greater(bu_ as CqlQuantity, bv_);
-                return bw_;
-            }
-
+            CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
+            CqlBoolean af_ = context.Operators.In<CqlDateTime>(ae_, aa_, (string)default);
+            CqlBoolean ag_ = af_;
+            Id ah_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.IdElement;
+            string ai_ = ah_?.Value;
+            Id aj_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.LowGlucoseTest?.IdElement;
+            string ak_ = aj_?.Value;
+            CqlBoolean al_ = context.Operators.Equivalent(ai_, ak_);
+            CqlBoolean am_ = (CqlBoolean)!al_;
+            Code<ObservationStatus> an_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.StatusElement;
+            ObservationStatus? ao_ = an_?.Value;
+            string ap_ = context.Operators.Convert<string>(ao_);
+            string[] aq_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
+            CqlBoolean as_ = ar_;
+            DataType at_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Value;
+            object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+            CqlQuantity av_ = context.Operators.Quantity(80m, "mg/dL");
+            CqlBoolean aw_ = context.Operators.Greater(au_ as CqlQuantity, av_);
+            CqlBoolean ax_ = aw_;
             return u_
-                /* CQL 'and' (86:11-86:73) */ && v_()
-                /* CQL 'and' (86:11-87:92) */ && w_()
-                /* CQL 'and' (86:11-88:100) */ && x_()
-                /* CQL 'and' (86:11-89:53) */ && y_()
-                /* CQL 'and' (86:11-90:75) */ && z_()
-                /* CQL 'and' (86:5-91:48) */ && aa_();
+                /* CQL 'and' (86:11-86:73) */ && x_
+                /* CQL 'and' (86:11-87:92) */ && ac_
+                /* CQL 'and' (86:11-88:100) */ && ag_
+                /* CQL 'and' (86:11-89:53) */ && am_
+                /* CQL 'and' (86:11-90:75) */ && as_
+                /* CQL 'and' (86:5-91:48) */ && ax_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter InpatientHospitalization, Observation LowGlucoseTest, Observation FollowupGlucoseTest)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter InpatientHospitalization, Observation LowGlucoseTest, Observation FollowupGlucoseTest)?>(e_, f_, g_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS819FHIRHHORAE", "1.0.000")]
 public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRHHORAE_1_0_000>
 {
@@ -107,28 +107,18 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
             CqlDate l_ = context.Operators.DateFrom(k_);
             int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
             CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 18);
-
-            CqlBoolean o_() {
-                Period q_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
-                return u_;
-            }
-
-
-            CqlBoolean p_() {
-                Code<Encounter.EncounterStatus> v_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? w_ = v_?.Value;
-                Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "finished");
-                return y_;
-            }
-
+            CqlDateTime o_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+            CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+            CqlBoolean r_ = q_;
+            Code<Encounter.EncounterStatus> s_ = InpatientEncounter?.StatusElement;
+            Encounter.EncounterStatus? t_ = s_?.Value;
+            Code<Encounter.EncounterStatus> u_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(t_);
+            CqlBoolean v_ = context.Operators.Equal(u_, "finished");
+            CqlBoolean w_ = v_;
             return n_
-                /* CQL 'and' (42:11-43:75) */ && o_()
-                /* CQL 'and' (42:5-44:48) */ && p_();
+                /* CQL 'and' (42:11-43:75) */ && r_
+                /* CQL 'and' (42:5-44:48) */ && w_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -155,17 +145,13 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Opioids__All(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Opioids__All(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -210,45 +196,37 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                 CqlDateTime j_ = context.Operators.Start(i_);
                 CqlInterval<CqlDateTime> k_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
                 CqlBoolean l_ = context.Operators.In<CqlDateTime>(j_, k_, (string)default);
+                List<Encounter.LocationComponent> m_ = InpatientEncounter?.Location;
 
-                CqlBoolean m_() {
-                    List<Encounter.LocationComponent> n_ = InpatientEncounter?.Location;
+                bool? n_(Encounter.LocationComponent EncounterLocation) {
+                    ResourceReference q_ = EncounterLocation?.Location;
+                    Location r_ = CQMCommon_4_1_000.Instance.getLocation(context, q_);
+                    List<CodeableConcept> s_ = r_?.Type;
 
-                    bool? o_(Encounter.LocationComponent EncounterLocation) {
-                        ResourceReference q_ = EncounterLocation?.Location;
-                        Location r_ = CQMCommon_4_1_000.Instance.getLocation(context, q_);
-                        List<CodeableConcept> s_ = r_?.Type;
-
-                        CqlConcept t_(CodeableConcept @this) {
-                            CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                            return y_;
-                        }
-
-                        IEnumerable<CqlConcept> u_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)s_, t_);
-                        CqlValueSet v_ = this.Operating_Room_Suite(context);
-                        CqlBoolean w_ = context.Operators.ConceptsInValueSet(u_, v_);
-
-                        CqlBoolean x_() {
-                            DataType z_ = OpioidGiven?.Effective;
-                            object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                            CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
-                            CqlDateTime ac_ = context.Operators.Start(ab_);
-                            Period ad_ = EncounterLocation?.Period;
-                            CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                            CqlBoolean af_ = context.Operators.In<CqlDateTime>(ac_, ae_, (string)default);
-                            return af_;
-                        }
-
-                        return w_
-                            /* CQL 'and' (63:13-64:93) */ && x_();
+                    CqlConcept t_(CodeableConcept @this) {
+                        CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                        return af_;
                     }
 
-                    CqlBoolean p_ = context.Operators.WhereAny<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)n_, o_);
-                    return !p_;
+                    IEnumerable<CqlConcept> u_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)s_, t_);
+                    CqlValueSet v_ = this.Operating_Room_Suite(context);
+                    CqlBoolean w_ = context.Operators.ConceptsInValueSet(u_, v_);
+                    DataType x_ = OpioidGiven?.Effective;
+                    object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                    CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+                    CqlDateTime aa_ = context.Operators.Start(z_);
+                    Period ab_ = EncounterLocation?.Period;
+                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+                    CqlBoolean ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, (string)default);
+                    CqlBoolean ae_ = ad_;
+                    return w_
+                        /* CQL 'and' (63:13-64:93) */ && ae_;
                 }
 
+                CqlBoolean o_ = context.Operators.WhereAny<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)m_, n_);
+                CqlBoolean p_ = (CqlBoolean)!o_;
                 return l_
-                    /* CQL 'and' (61:17-65:9) */ && m_();
+                    /* CQL 'and' (61:17-65:9) */ && p_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<MedicationAdministration>(d_, e_);
@@ -305,17 +283,13 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                 IEnumerable<string> n_ = context.Operators.Split((string)m_, "/");
                 string o_ = context.Operators.Last<string>(n_);
                 CqlBoolean p_ = context.Operators.Equal(l_, o_);
-
-                CqlBoolean q_() {
-                    CodeableConcept r_ = M?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    CqlValueSet t_ = this.Opioid_Antagonist(context);
-                    CqlBoolean u_ = context.Operators.ConceptInValueSet(s_, t_);
-                    return u_;
-                }
-
+                CodeableConcept q_ = M?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                CqlValueSet s_ = this.Opioid_Antagonist(context);
+                CqlBoolean t_ = context.Operators.ConceptInValueSet(r_, s_);
+                CqlBoolean u_ = t_;
                 return p_
-                    /* CQL 'and' */ && q_();
+                    /* CQL 'and' */ && u_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Medication>(i_, j_);
@@ -366,99 +340,63 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
             List<Encounter.LocationComponent> k_ = tuple_htckrtcfdeaiwittzheehxihp?.InpatientHospitalization?.Location;
 
             bool? l_(Encounter.LocationComponent EncounterLocation) {
-                ResourceReference o_ = EncounterLocation?.Location;
-                Location p_ = CQMCommon_4_1_000.Instance.getLocation(context, o_);
-                List<CodeableConcept> q_ = p_?.Type;
+                ResourceReference an_ = EncounterLocation?.Location;
+                Location ao_ = CQMCommon_4_1_000.Instance.getLocation(context, an_);
+                List<CodeableConcept> ap_ = ao_?.Type;
 
-                CqlConcept r_(CodeableConcept @this) {
-                    CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return w_;
+                CqlConcept aq_(CodeableConcept @this) {
+                    CqlConcept bc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return bc_;
                 }
 
-                IEnumerable<CqlConcept> s_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)q_, r_);
-                CqlValueSet t_ = this.Operating_Room_Suite(context);
-                CqlBoolean u_ = context.Operators.ConceptsInValueSet(s_, t_);
-
-                CqlBoolean v_() {
-                    DataType x_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Effective;
-                    object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                    CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.Start(z_);
-                    Period ab_ = EncounterLocation?.Period;
-                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                    CqlBoolean ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, (string)default);
-                    return ad_;
-                }
-
-                return u_
-                    /* CQL 'and' (81:9-82:109) */ && v_();
+                IEnumerable<CqlConcept> ar_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ap_, aq_);
+                CqlValueSet as_ = this.Operating_Room_Suite(context);
+                CqlBoolean at_ = context.Operators.ConceptsInValueSet(ar_, as_);
+                DataType au_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Effective;
+                object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
+                CqlDateTime ax_ = context.Operators.Start(aw_);
+                Period ay_ = EncounterLocation?.Period;
+                CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
+                CqlBoolean ba_ = context.Operators.In<CqlDateTime>(ax_, az_, (string)default);
+                CqlBoolean bb_ = ba_;
+                return at_
+                    /* CQL 'and' (81:9-82:109) */ && bb_;
             }
 
             CqlBoolean m_ = context.Operators.WhereAny<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)k_, l_);
-
-            CqlBoolean n_() {
-                DataType ae_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Effective;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                CqlDateTime ah_ = context.Operators.Start(ag_);
-                CqlInterval<CqlDateTime> ai_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_htckrtcfdeaiwittzheehxihp?.InpatientHospitalization);
-                CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, (string)default);
-
-                CqlBoolean ak_() {
-                    DataType an_ = tuple_htckrtcfdeaiwittzheehxihp?.OpioidGiven?.Effective;
-                    object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
-                    CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
-                    CqlDateTime aq_ = context.Operators.Start(ap_);
-                    CqlInterval<CqlDateTime> ar_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_htckrtcfdeaiwittzheehxihp?.InpatientHospitalization);
-                    CqlBoolean as_ = context.Operators.In<CqlDateTime>(aq_, ar_, (string)default);
-                    return as_;
-                }
-
-
-                CqlBoolean al_() {
-                    DataType at_ = tuple_htckrtcfdeaiwittzheehxihp?.OpioidGiven?.Effective;
-                    object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
-                    CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.toInterval(context, au_);
-                    CqlDateTime aw_ = context.Operators.End(av_);
-                    DataType ax_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Effective;
-                    object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
-                    CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_);
-                    CqlDateTime ba_ = context.Operators.Start(az_);
-                    CqlQuantity bb_ = context.Operators.Quantity(12m, "hours");
-                    CqlDateTime bc_ = context.Operators.Subtract(ba_, bb_);
-                    CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(bc_, ba_, true, false);
-                    CqlBoolean be_ = context.Operators.In<CqlDateTime>(aw_, bd_, (string)default);
-
-                    CqlBoolean bf_() {
-                        DataType bg_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Effective;
-                        object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                        CqlInterval<CqlDateTime> bi_ = QICoreCommon_4_0_000.Instance.toInterval(context, bh_);
-                        CqlDateTime bj_ = context.Operators.Start(bi_);
-                        return bj_ is not null;
-                    }
-
-                    return be_
-                        /* CQL 'and' (86:15-86:145) */ && bf_();
-                }
-
-
-                CqlBoolean am_() {
-                    MedicationAdministration.DosageComponent bk_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Dosage;
-                    CodeableConcept bl_ = bk_?.Route;
-                    CqlConcept bm_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bl_);
-                    CqlValueSet bn_ = this.Routes_of_Administration_for_Opioid_Antagonists(context);
-                    CqlBoolean bo_ = context.Operators.ConceptInValueSet(bm_, bn_);
-                    return bo_;
-                }
-
-                return aj_
-                    /* CQL 'and' (84:13-85:124) */ && ak_()
-                    /* CQL 'and' (84:13-86:145) */ && al_()
-                    /* CQL 'and' (84:11-88:7) */ && am_();
-            }
-
+            DataType n_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlInterval<CqlDateTime> r_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_htckrtcfdeaiwittzheehxihp?.InpatientHospitalization);
+            CqlBoolean s_ = context.Operators.In<CqlDateTime>(q_, r_, (string)default);
+            DataType t_ = tuple_htckrtcfdeaiwittzheehxihp?.OpioidGiven?.Effective;
+            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+            CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+            CqlDateTime w_ = context.Operators.Start(v_);
+            CqlBoolean x_ = context.Operators.In<CqlDateTime>(w_, r_, (string)default);
+            CqlBoolean y_ = x_;
+            CqlDateTime z_ = context.Operators.End(v_);
+            CqlQuantity aa_ = context.Operators.Quantity(12m, "hours");
+            CqlDateTime ab_ = context.Operators.Subtract(q_, aa_);
+            CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(ab_, q_, true, false);
+            CqlBoolean ad_ = context.Operators.In<CqlDateTime>(z_, ac_, (string)default);
+            CqlBoolean ae_ = (CqlBoolean)(q_ is not null);
+            CqlBoolean af_ = ad_
+                /* CQL 'and' (86:15-86:145) */ && ae_;
+            MedicationAdministration.DosageComponent ag_ = tuple_htckrtcfdeaiwittzheehxihp?.NonEnteralOpioidAntagonistGiven?.Dosage;
+            CodeableConcept ah_ = ag_?.Route;
+            CqlConcept ai_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ah_);
+            CqlValueSet aj_ = this.Routes_of_Administration_for_Opioid_Antagonists(context);
+            CqlBoolean ak_ = context.Operators.ConceptInValueSet(ai_, aj_);
+            CqlBoolean al_ = ak_;
+            CqlBoolean am_ = s_
+                /* CQL 'and' (84:13-85:124) */ && y_
+                /* CQL 'and' (84:13-86:145) */ && af_
+                /* CQL 'and' (84:11-88:7) */ && al_;
             return (CqlBoolean)!m_
-                /* CQL 'and' (80:5-88:7) */ && n_();
+                /* CQL 'and' (80:5-88:7) */ && am_;
         }
 
         IEnumerable<(CqlTupleMetadata, MedicationAdministration NonEnteralOpioidAntagonistGiven, MedicationAdministration OpioidGiven, Encounter InpatientHospitalization)?> g_ = context.Operators.SelectWhere<ValueTuple<MedicationAdministration, MedicationAdministration, Encounter>, (CqlTupleMetadata, MedicationAdministration NonEnteralOpioidAntagonistGiven, MedicationAdministration OpioidGiven, Encounter InpatientHospitalization)?>(d_, e_, f_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS826FHIRHHPI", "1.0.000")]
 public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHPI_1_0_000>
 {
@@ -176,28 +176,18 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
             CqlDate l_ = context.Operators.DateFrom(k_);
             int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
             CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 18);
-
-            CqlBoolean o_() {
-                Period q_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
-                return u_;
-            }
-
-
-            CqlBoolean p_() {
-                Code<Encounter.EncounterStatus> v_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? w_ = v_?.Value;
-                Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "finished");
-                return y_;
-            }
-
+            CqlDateTime o_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+            CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+            CqlBoolean r_ = q_;
+            Code<Encounter.EncounterStatus> s_ = InpatientEncounter?.StatusElement;
+            Encounter.EncounterStatus? t_ = s_?.Value;
+            Code<Encounter.EncounterStatus> u_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(t_);
+            CqlBoolean v_ = context.Operators.Equal(u_, "finished");
+            CqlBoolean w_ = v_;
             return n_
-                /* CQL 'and' (55:11-56:75) */ && o_()
-                /* CQL 'and' (55:5-57:48) */ && p_();
+                /* CQL 'and' (55:11-56:75) */ && r_
+                /* CQL 'and' (55:5-57:48) */ && w_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -265,41 +255,35 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
             "corrected",
         ];
         CqlBoolean e_ = context.Operators.In<string>(c_, (IEnumerable<string>)d_);
-
-        CqlBoolean f_() {
-            CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
-            DataType i_ = observation?.Effective;
-            object j_ = FHIRHelpers_4_4_000.Instance.ToValue(context, i_);
-            CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
-            CqlBoolean l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, (string)default);
-            return l_;
+        CqlInterval<CqlDateTime> f_ = this.Measurement_Period(context);
+        DataType g_ = observation?.Effective;
+        object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+        CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.toInterval(context, h_);
+        CqlBoolean j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, (string)default);
+        CqlBoolean k_ = j_;
+        bool? l_;
+        if (observation is Observation)
+        {
+            DataType n_ = (observation as Observation)?.Value;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlBoolean p_ = context.Operators.ConceptInValueSet(o_ as CqlConcept, vset);
+            l_ = p_;
         }
-
-
-        CqlBoolean g_() {
-            if (observation is Observation)
-            {
-                DataType m_ = (observation as Observation)?.Value;
-                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
-                CqlBoolean o_ = context.Operators.ConceptInValueSet(n_ as CqlConcept, vset);
-                return o_;
-            }
-            else if (observation is Observation)
-            {
-                DataType p_ = (observation as Observation)?.Value;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlBoolean r_ = context.Operators.ConceptInValueSet(q_ as CqlConcept, vset);
-                return r_;
-            }
-            else
-            {
-                return default;
-            }
+        else if (observation is Observation)
+        {
+            DataType q_ = (observation as Observation)?.Value;
+            object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
+            CqlBoolean s_ = context.Operators.ConceptInValueSet(r_ as CqlConcept, vset);
+            l_ = s_;
         }
-
+        else
+        {
+            l_ = default;
+        }
+        CqlBoolean m_ = (CqlBoolean)l_;
         return e_
-            /* CQL 'and' (136:3-137:72) */ && f_()
-            /* CQL 'and' (136:3-141:19) */ && g_();
+            /* CQL 'and' (136:3-137:72) */ && k_
+            /* CQL 'and' (136:3-141:19) */ && m_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS832FHIRHHAKI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS832FHIRHHAKI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS832FHIRHHAKI", "1.0.000")]
 public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHHAKI_1_0_000>
 {
@@ -200,11 +200,11 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
 
         bool? c_(Encounter InpatientEncounter) {
             List<Extension> e_;
-            Patient u_ = this.Patient(context);
-            bool v_ = u_ is DomainResource;
-            if (v_)
+            Patient aq_ = this.Patient(context);
+            bool ar_ = aq_ is DomainResource;
+            if (ar_)
             {
-                e_ = (u_ as DomainResource).Extension;
+                e_ = (aq_ as DomainResource).Extension;
             }
             else
             {
@@ -212,16 +212,16 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             }
 
             bool? f_(Extension @this) {
-                FhirUri w_ = @this?.UrlElement;
-                string x_ = FHIRHelpers_4_4_000.Instance.ToString(context, w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
-                return y_;
+                FhirUri as_ = @this?.UrlElement;
+                string at_ = FHIRHelpers_4_4_000.Instance.ToString(context, as_);
+                CqlBoolean au_ = context.Operators.Equal(at_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+                return au_;
             }
 
 
             DataType g_(Extension @this) {
-                DataType z_ = @this?.Value;
-                return z_;
+                DataType av_ = @this?.Value;
+                return av_;
             }
 
             IEnumerable<DataType> h_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)e_, f_, g_);
@@ -236,55 +236,37 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
                 n_,
             ];
             CqlBoolean p_ = context.Operators.In<string>(j_, (IEnumerable<string>)o_);
-
-            CqlBoolean q_() {
-                Period aa_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                CqlDateTime ac_ = context.Operators.End(ab_);
-                CqlInterval<CqlDateTime> ad_ = this.Measurement_Period(context);
-                CqlBoolean ae_ = context.Operators.In<CqlDateTime>(ac_, ad_, "day");
-                return ae_;
-            }
-
-
-            CqlBoolean r_() {
-                Code<Encounter.EncounterStatus> af_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? ag_ = af_?.Value;
-                Code<Encounter.EncounterStatus> ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
-                CqlBoolean ai_ = context.Operators.Equal(ah_, "finished");
-                return ai_;
-            }
-
-
-            CqlBoolean s_() {
-                Patient aj_ = this.Patient(context);
-                Date ak_ = aj_?.BirthDateElement;
-                string al_ = ak_?.Value;
-                CqlDate am_ = context.Operators.ConvertStringToDate(al_);
-                Period an_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, an_);
-                CqlDateTime ap_ = context.Operators.Start(ao_);
-                CqlDate aq_ = context.Operators.DateFrom(ap_);
-                int? ar_ = context.Operators.CalculateAgeAt(am_, aq_, "year");
-                CqlBoolean as_ = context.Operators.GreaterOrEqual(ar_, 18);
-                return as_;
-            }
-
-
-            CqlBoolean t_() {
-                CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                CqlDateTime au_ = context.Operators.Start(at_);
-                CqlDateTime av_ = context.Operators.End(at_);
-                int? aw_ = context.Operators.DurationBetween(au_, av_, "hour");
-                CqlBoolean ax_ = context.Operators.GreaterOrEqual(aw_, 48);
-                return ax_;
-            }
-
+            Period q_ = InpatientEncounter?.Period;
+            CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
+            CqlDateTime s_ = context.Operators.End(r_);
+            CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
+            CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
+            CqlBoolean v_ = u_;
+            Code<Encounter.EncounterStatus> w_ = InpatientEncounter?.StatusElement;
+            Encounter.EncounterStatus? x_ = w_?.Value;
+            Code<Encounter.EncounterStatus> y_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(x_);
+            CqlBoolean z_ = context.Operators.Equal(y_, "finished");
+            CqlBoolean aa_ = z_;
+            Patient ab_ = this.Patient(context);
+            Date ac_ = ab_?.BirthDateElement;
+            string ad_ = ac_?.Value;
+            CqlDate ae_ = context.Operators.ConvertStringToDate(ad_);
+            CqlDateTime af_ = context.Operators.Start(r_);
+            CqlDate ag_ = context.Operators.DateFrom(af_);
+            int? ah_ = context.Operators.CalculateAgeAt(ae_, ag_, "year");
+            CqlBoolean ai_ = context.Operators.GreaterOrEqual(ah_, 18);
+            CqlBoolean aj_ = ai_;
+            CqlInterval<CqlDateTime> ak_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+            CqlDateTime al_ = context.Operators.Start(ak_);
+            CqlDateTime am_ = context.Operators.End(ak_);
+            int? an_ = context.Operators.DurationBetween(al_, am_, "hour");
+            CqlBoolean ao_ = context.Operators.GreaterOrEqual(an_, 48);
+            CqlBoolean ap_ = ao_;
             return p_
-                /* CQL 'and' (66:11-67:75) */ && q_()
-                /* CQL 'and' (66:11-68:48) */ && r_()
-                /* CQL 'and' (66:11-69:74) */ && s_()
-                /* CQL 'and' (66:5-70:94) */ && t_();
+                /* CQL 'and' (66:11-67:75) */ && v_
+                /* CQL 'and' (66:11-68:48) */ && aa_
+                /* CQL 'and' (66:11-69:74) */ && aj_
+                /* CQL 'and' (66:5-70:94) */ && ap_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -314,63 +296,55 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
         bool? f_((CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)? tuple_bbcfbwcplsbuhefbwpxpvuequ) {
             DataType k_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Value;
             object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-
-            CqlBoolean m_() {
-                object o_;
-                DataType x_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
-                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-                bool z_ = y_ is CqlDateTime;
-                if (z_)
+            object m_;
+            DataType ac_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            bool ae_ = ad_ is CqlDateTime;
+            if (ae_)
+            {
+                m_ = ad_ as CqlDateTime;
+            }
+            else
+            {
+                if (ae_)
                 {
-                    o_ = y_ as CqlDateTime;
+                    m_ = ad_ as CqlDateTime;
                 }
                 else
                 {
-                    if (z_)
+                    bool af_ = ad_ is CqlInterval<CqlDateTime>;
+                    if (af_)
                     {
-                        o_ = y_ as CqlDateTime;
+                        m_ = ad_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool aa_ = y_ is CqlInterval<CqlDateTime>;
-                        if (aa_)
-                        {
-                            o_ = y_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            o_ = null;
-                        }
+                        m_ = null;
                     }
                 }
-                CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_);
-                CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bbcfbwcplsbuhefbwpxpvuequ?.Encounter48Hours);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime t_ = context.Operators.Add(r_, s_);
-                CqlDateTime u_ = context.Operators.End(q_);
-                CqlInterval<CqlDateTime> v_ = context.Operators.Interval(t_, u_, true, true);
-                CqlBoolean w_ = context.Operators.In<CqlDateTime>(p_, v_, (string)default);
-                return w_;
             }
-
-
-            CqlBoolean n_() {
-                Code<ObservationStatus> ab_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.StatusElement;
-                ObservationStatus? ac_ = ab_?.Value;
-                string ad_ = context.Operators.Convert<string>(ac_);
-                string[] ae_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
-                return af_;
-            }
-
+            CqlDateTime n_ = QICoreCommon_4_0_000.Instance.earliest(context, m_);
+            CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bbcfbwcplsbuhefbwpxpvuequ?.Encounter48Hours);
+            CqlDateTime p_ = context.Operators.Start(o_);
+            CqlQuantity q_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime r_ = context.Operators.Add(p_, q_);
+            CqlDateTime s_ = context.Operators.End(o_);
+            CqlInterval<CqlDateTime> t_ = context.Operators.Interval(r_, s_, true, true);
+            CqlBoolean u_ = context.Operators.In<CqlDateTime>(n_, t_, (string)default);
+            CqlBoolean v_ = u_;
+            Code<ObservationStatus> w_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.StatusElement;
+            ObservationStatus? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            CqlBoolean ab_ = aa_;
             return (CqlBoolean)((l_ as CqlQuantity) is not null)
-                /* CQL 'and' (78:11-79:118) */ && m_()
-                /* CQL 'and' (78:5-80:70) */ && n_();
+                /* CQL 'and' (78:11-79:118) */ && v_
+                /* CQL 'and' (78:5-80:70) */ && ab_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)?> g_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation>, (CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)?>(d_, e_, f_);
@@ -394,38 +368,33 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             List<CodeableConcept> d_ = EncounterWithCreatinine?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Obstetrics_and_VTE_Obstetrics(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, EncounterWithCreatinine);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, EncounterWithCreatinine);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.Obstetrics_and_VTE_Obstetrics(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return !((bool?)(h_
-                /* CQL 'or' (85:15-87:5) */ || i_()));
+                /* CQL 'or' (85:15-87:5) */ || n_));
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -468,98 +437,85 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
         bool? c_(Observation CreatinineTest) {
             DataType g_ = CreatinineTest?.Value;
             object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
-
-            CqlBoolean i_() {
-                object l_;
-                DataType t_ = CreatinineTest?.Effective;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                bool v_ = u_ is CqlDateTime;
-                if (v_)
-                {
-                    l_ = u_ as CqlDateTime;
-                }
-                else
-                {
-                    if (v_)
-                    {
-                        l_ = u_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool w_ = u_ is CqlInterval<CqlDateTime>;
-                        if (w_)
-                        {
-                            l_ = u_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            l_ = null;
-                        }
-                    }
-                }
-                CqlDateTime m_ = QICoreCommon_4_0_000.Instance.earliest(context, l_);
-                CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlDateTime o_ = context.Operators.Start(n_);
-                CqlQuantity p_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime q_ = context.Operators.Add(o_, p_);
-                CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-                CqlBoolean s_ = context.Operators.In<CqlDateTime>(m_, r_, (string)default);
-                return s_;
+            object i_;
+            DataType ab_ = CreatinineTest?.Effective;
+            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            bool ad_ = ac_ is CqlDateTime;
+            if (ad_)
+            {
+                i_ = ac_ as CqlDateTime;
             }
-
-
-            CqlBoolean j_() {
-                object x_;
-                DataType ab_ = CreatinineTest?.Effective;
-                object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-                bool ad_ = ac_ is CqlDateTime;
+            else
+            {
                 if (ad_)
                 {
-                    x_ = ac_ as CqlDateTime;
+                    i_ = ac_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ad_)
+                    bool ae_ = ac_ is CqlInterval<CqlDateTime>;
+                    if (ae_)
                     {
-                        x_ = ac_ as CqlDateTime;
+                        i_ = ac_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ae_ = ac_ is CqlInterval<CqlDateTime>;
-                        if (ae_)
-                        {
-                            x_ = ac_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            x_ = null;
-                        }
+                        i_ = null;
                     }
                 }
-                CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
-                CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-                return aa_;
             }
-
-
-            CqlBoolean k_() {
-                Code<ObservationStatus> af_ = CreatinineTest?.StatusElement;
-                ObservationStatus? ag_ = af_?.Value;
-                string ah_ = context.Operators.Convert<string>(ag_);
-                string[] ai_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
-                return aj_;
+            CqlDateTime j_ = QICoreCommon_4_0_000.Instance.earliest(context, i_);
+            CqlInterval<CqlDateTime> k_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlDateTime l_ = context.Operators.Start(k_);
+            CqlQuantity m_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime n_ = context.Operators.Add(l_, m_);
+            CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, true, true);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(j_, o_, (string)default);
+            CqlBoolean q_ = p_;
+            object r_;
+            DataType af_ = CreatinineTest?.Effective;
+            object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+            bool ah_ = ag_ is CqlDateTime;
+            if (ah_)
+            {
+                r_ = ag_ as CqlDateTime;
             }
-
+            else
+            {
+                if (ah_)
+                {
+                    r_ = ag_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ai_ = ag_ is CqlInterval<CqlDateTime>;
+                    if (ai_)
+                    {
+                        r_ = ag_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        r_ = null;
+                    }
+                }
+            }
+            CqlDateTime s_ = QICoreCommon_4_0_000.Instance.earliest(context, r_);
+            CqlBoolean t_ = context.Operators.In<CqlDateTime>(s_, k_, (string)default);
+            CqlBoolean u_ = t_;
+            Code<ObservationStatus> v_ = CreatinineTest?.StatusElement;
+            ObservationStatus? w_ = v_?.Value;
+            string x_ = context.Operators.Convert<string>(w_);
+            string[] y_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
+            CqlBoolean aa_ = z_;
             return (CqlBoolean)((h_ as CqlQuantity) is not null)
-                /* CQL 'and' (282:11-283:204) */ && i_()
-                /* CQL 'and' (282:11-284:109) */ && j_()
-                /* CQL 'and' (282:5-285:70) */ && k_();
+                /* CQL 'and' (282:11-283:204) */ && q_
+                /* CQL 'and' (282:11-284:109) */ && u_
+                /* CQL 'and' (282:5-285:70) */ && aa_;
         }
 
         Observation d_(Observation CreatinineTest) => CreatinineTest;
@@ -683,20 +639,16 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
                 ? (QualifyingEncounter as Resource).IdElement
                 : default)?.Value;
             CqlBoolean j_ = context.Operators.Equal(h_, i_);
-
-            CqlBoolean k_() {
-                CqlDateTime l_ = LabTestsLow?.CrLabTime;
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime p_ = context.Operators.Add(n_, o_);
-                CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                CqlBoolean r_ = context.Operators.In<CqlDateTime>(l_, q_, (string)default);
-                return r_;
-            }
-
+            CqlDateTime k_ = LabTestsLow?.CrLabTime;
+            CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlDateTime m_ = context.Operators.Start(l_);
+            CqlQuantity n_ = context.Operators.Quantity(24m, "hours");
+            CqlDateTime o_ = context.Operators.Add(m_, n_);
+            CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
+            CqlBoolean q_ = context.Operators.In<CqlDateTime>(k_, p_, (string)default);
+            CqlBoolean r_ = q_;
             return j_
-                /* CQL 'and' (303:9-304:188) */ && k_();
+                /* CQL 'and' (303:9-304:188) */ && r_;
         }
 
         IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
@@ -739,25 +691,25 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
 
         bool? f_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)? tuple_ccccqpjvqogtctjhtilehkfoj) {
             object m_;
-            DataType u_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
-            object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-            bool w_ = v_ is CqlDateTime;
-            if (w_)
+            DataType af_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+            object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+            bool ah_ = ag_ is CqlDateTime;
+            if (ah_)
             {
-                m_ = v_ as CqlDateTime;
+                m_ = ag_ as CqlDateTime;
             }
             else
             {
-                if (w_)
+                if (ah_)
                 {
-                    m_ = v_ as CqlDateTime;
+                    m_ = ag_ as CqlDateTime;
                 }
                 else
                 {
-                    bool x_ = v_ is CqlInterval<CqlDateTime>;
-                    if (x_)
+                    bool ai_ = ag_ is CqlInterval<CqlDateTime>;
+                    if (ai_)
                     {
-                        m_ = v_ as CqlInterval<CqlDateTime>;
+                        m_ = ag_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -768,126 +720,106 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             CqlDateTime n_ = QICoreCommon_4_0_000.Instance.earliest(context, m_);
             CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter);
             CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
-
-            CqlBoolean q_() {
-                Code<ObservationStatus> y_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.StatusElement;
-                ObservationStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
-            }
-
-
-            CqlBoolean r_() {
-                DataType ad_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                string af_ = (ae_ as CqlQuantity)?.unit;
-                CqlBoolean ag_ = context.Operators.Equal(af_, "mg/dL");
-                return ag_;
-            }
-
-
-            CqlBoolean s_() {
-                DataType ah_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                return ai_ is not null;
-            }
-
-
-            CqlBoolean t_() {
-                DataType aj_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
-                object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                CqlQuantity al_ = context.Operators.Quantity(0m, "mg/dL");
-                CqlBoolean am_ = context.Operators.Greater(ak_ as CqlQuantity, al_);
-                return am_;
-            }
-
+            Code<ObservationStatus> q_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.StatusElement;
+            ObservationStatus? r_ = q_?.Value;
+            string s_ = context.Operators.Convert<string>(r_);
+            string[] t_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
+            CqlBoolean v_ = u_;
+            DataType w_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
+            object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+            string y_ = (x_ as CqlQuantity)?.unit;
+            CqlBoolean z_ = context.Operators.Equal(y_, "mg/dL");
+            CqlBoolean aa_ = z_;
+            CqlBoolean ab_ = (CqlBoolean)(x_ is not null);
+            CqlQuantity ac_ = context.Operators.Quantity(0m, "mg/dL");
+            CqlBoolean ad_ = context.Operators.Greater(x_ as CqlQuantity, ac_);
+            CqlBoolean ae_ = ad_;
             return p_
                 /* CQL 'and' (233:11-234:47) */ && QICoreCommon_4_0_000.Instance.isLaboratory(context, tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime as Observation)
-                /* CQL 'and' (233:11-235:76) */ && q_()
-                /* CQL 'and' (233:11-236:32) */ && r_()
-                /* CQL 'and' (233:11-237:48) */ && s_()
-                /* CQL 'and' (233:5-238:60) */ && t_();
+                /* CQL 'and' (233:11-235:76) */ && v_
+                /* CQL 'and' (233:11-236:32) */ && aa_
+                /* CQL 'and' (233:11-237:48) */ && ab_
+                /* CQL 'and' (233:5-238:60) */ && ae_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?> g_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?>(d_, e_, f_);
 
         (CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? h_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)? tuple_ccccqpjvqogtctjhtilehkfoj) {
-            Id an_ = tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter?.IdElement;
-            string ao_ = an_?.Value;
-            CqlInterval<CqlDateTime> ap_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter);
-            Id aq_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.IdElement;
-            string ar_ = aq_?.Value;
-            object as_;
+            Id aj_ = tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter?.IdElement;
+            string ak_ = aj_?.Value;
+            CqlInterval<CqlDateTime> al_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter);
+            Id am_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.IdElement;
+            string an_ = am_?.Value;
+            object ao_;
             if ((QICoreCommon_4_0_000.Instance.isLaboratory(context, tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime as Observation)) ?? false)
             {
-                as_ = "laboratory";
+                ao_ = "laboratory";
             }
             else
             {
-                CqlBoolean bj_ = QICoreCommon_4_0_000.Instance.isLaboratory(context, tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime as Observation);
-                as_ = (bool?)bj_;
+                CqlBoolean bf_ = QICoreCommon_4_0_000.Instance.isLaboratory(context, tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime as Observation);
+                ao_ = (bool?)bf_;
             }
-            List<CodeableConcept> at_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Category;
+            List<CodeableConcept> ap_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Category;
 
-            CqlConcept au_(CodeableConcept @this) {
-                CqlConcept bk_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return bk_;
+            CqlConcept aq_(CodeableConcept @this) {
+                CqlConcept bg_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return bg_;
             }
 
-            IEnumerable<CqlConcept> av_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)at_, au_);
-            Code<ObservationStatus> aw_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.StatusElement;
-            ObservationStatus? ax_ = aw_?.Value;
-            string ay_ = context.Operators.Convert<string>(ax_);
-            DataType az_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
-            object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-            string bb_ = (ba_ as CqlQuantity)?.unit;
-            decimal? bc_ = (ba_ as CqlQuantity)?.value;
-            object bd_;
-            DataType bl_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
-            object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
-            bool bn_ = bm_ is CqlDateTime;
-            if (bn_)
+            IEnumerable<CqlConcept> ar_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ap_, aq_);
+            Code<ObservationStatus> as_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.StatusElement;
+            ObservationStatus? at_ = as_?.Value;
+            string au_ = context.Operators.Convert<string>(at_);
+            DataType av_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
+            object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+            string ax_ = (aw_ as CqlQuantity)?.unit;
+            decimal? ay_ = (aw_ as CqlQuantity)?.value;
+            object az_;
+            DataType bh_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+            object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            bool bj_ = bi_ is CqlDateTime;
+            if (bj_)
             {
-                bd_ = bm_ as CqlDateTime;
+                az_ = bi_ as CqlDateTime;
             }
             else
             {
-                if (bn_)
+                if (bj_)
                 {
-                    bd_ = bm_ as CqlDateTime;
+                    az_ = bi_ as CqlDateTime;
                 }
                 else
                 {
-                    bool bo_ = bm_ is CqlInterval<CqlDateTime>;
-                    if (bo_)
+                    bool bk_ = bi_ is CqlInterval<CqlDateTime>;
+                    if (bk_)
                     {
-                        bd_ = bm_ as CqlInterval<CqlDateTime>;
+                        az_ = bi_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bd_ = null;
+                        az_ = null;
                     }
                 }
             }
-            CqlDateTime be_ = QICoreCommon_4_0_000.Instance.earliest(context, bd_);
-            Instant bf_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.IssuedElement;
-            DateTimeOffset? bg_ = bf_?.Value;
-            CqlDateTime bh_ = context.Operators.Convert<CqlDateTime>(bg_);
-            (CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? bi_ = (CqlTupleMetadata_EROdcjJjSdFbfXChfKbYbOdDN, ao_, ap_, ar_, as_, av_, ay_, ba_ as CqlQuantity, bb_, bc_, be_, bh_);
-            return bi_;
+            CqlDateTime ba_ = QICoreCommon_4_0_000.Instance.earliest(context, az_);
+            Instant bb_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.IssuedElement;
+            DateTimeOffset? bc_ = bb_?.Value;
+            CqlDateTime bd_ = context.Operators.Convert<CqlDateTime>(bc_);
+            (CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? be_ = (CqlTupleMetadata_EROdcjJjSdFbfXChfKbYbOdDN, ak_, al_, an_, ao_, ar_, au_, aw_ as CqlQuantity, ax_, ay_, ba_, bd_);
+            return be_;
         }
 
         IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> i_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?, (CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(g_, h_);
 
         object j_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this) {
-            CqlDateTime bp_ = @this?.CrLabTime;
-            return bp_;
+            CqlDateTime bl_ = @this?.CrLabTime;
+            return bl_;
         }
 
         IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> k_ = context.Operators.SortBy<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
@@ -930,20 +862,16 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
                 ? (QualifyingEncounter as Resource).IdElement
                 : default)?.Value;
             CqlBoolean j_ = context.Operators.Equal(h_, i_);
-
-            CqlBoolean k_() {
-                CqlDateTime l_ = LabTests48?.CrLabTime;
-                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                CqlDateTime n_ = context.Operators.Start(m_);
-                CqlQuantity o_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime p_ = context.Operators.Add(n_, o_);
-                CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                CqlBoolean r_ = context.Operators.In<CqlDateTime>(l_, q_, (string)default);
-                return r_;
-            }
-
+            CqlDateTime k_ = LabTests48?.CrLabTime;
+            CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlDateTime m_ = context.Operators.Start(l_);
+            CqlQuantity n_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime o_ = context.Operators.Add(m_, n_);
+            CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
+            CqlBoolean q_ = context.Operators.In<CqlDateTime>(k_, p_, (string)default);
+            CqlBoolean r_ = q_;
             return j_
-                /* CQL 'and' (319:11-320:189) */ && k_();
+                /* CQL 'and' (319:11-320:189) */ && r_;
         }
 
         IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, IEnumerable<CqlConcept> CrLabObsCategory2, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
@@ -977,16 +905,11 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
 
         bool? b_(Encounter QualifyingEncounter) {
             decimal? d_ = this.maleeGFR(context, QualifyingEncounter);
-
-            CqlBoolean e_() {
-                decimal? f_ = this.maleeGFR(context, QualifyingEncounter);
-                decimal? g_ = context.Operators.ConvertIntegerToDecimal(60);
-                CqlBoolean h_ = context.Operators.Less(f_ as decimal?, g_);
-                return h_;
-            }
-
+            decimal? e_ = context.Operators.ConvertIntegerToDecimal(60);
+            CqlBoolean f_ = context.Operators.Less(d_ as decimal?, e_);
+            CqlBoolean g_ = f_;
             return (CqlBoolean)(d_ is not null)
-                /* CQL 'and' (104:5-105:60) */ && e_();
+                /* CQL 'and' (104:5-105:60) */ && g_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1078,16 +1001,11 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
 
         bool? b_(Encounter QualifyingEncounter) {
             decimal? d_ = this.femaleeGFR(context, QualifyingEncounter);
-
-            CqlBoolean e_() {
-                decimal? f_ = this.femaleeGFR(context, QualifyingEncounter);
-                decimal? g_ = context.Operators.ConvertIntegerToDecimal(60);
-                CqlBoolean h_ = context.Operators.Less(f_ as decimal?, g_);
-                return h_;
-            }
-
+            decimal? e_ = context.Operators.ConvertIntegerToDecimal(60);
+            CqlBoolean f_ = context.Operators.Less(d_ as decimal?, e_);
+            CqlBoolean g_ = f_;
             return (CqlBoolean)(d_ is not null)
-                /* CQL 'and' (99:5-100:62) */ && e_();
+                /* CQL 'and' (99:5-100:62) */ && g_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1172,302 +1090,254 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
                 "corrected",
             ];
             CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-
-            CqlBoolean p_() {
-                Code<ObservationStatus> y_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.StatusElement;
-                ObservationStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
+            Code<ObservationStatus> p_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.StatusElement;
+            ObservationStatus? q_ = p_?.Value;
+            string r_ = context.Operators.Convert<string>(q_);
+            CqlBoolean s_ = context.Operators.In<string>(r_, (IEnumerable<string>)n_);
+            CqlBoolean t_ = s_;
+            DataType u_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Value;
+            object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+            DataType w_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
+            object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+            CqlQuantity y_ = context.Operators.Subtract(v_ as CqlQuantity, x_ as CqlQuantity);
+            CqlQuantity z_ = context.Operators.Quantity(0.299m, "mg/dL");
+            CqlBoolean aa_ = context.Operators.Greater(y_, z_);
+            CqlBoolean ab_ = aa_;
+            CqlQuantity ac_ = this.lowestSerumCreatinineResult(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            CqlBoolean ad_ = context.Operators.Equal(x_ as CqlQuantity, ac_);
+            CqlBoolean ae_ = ad_;
+            object af_;
+            DataType bt_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+            object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+            bool bv_ = bu_ is CqlDateTime;
+            if (bv_)
+            {
+                af_ = bu_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                DataType ad_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Value;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                DataType af_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
-                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                CqlQuantity ah_ = context.Operators.Subtract(ae_ as CqlQuantity, ag_ as CqlQuantity);
-                CqlQuantity ai_ = context.Operators.Quantity(0.299m, "mg/dL");
-                CqlBoolean aj_ = context.Operators.Greater(ah_, ai_);
-                return aj_;
-            }
-
-
-            CqlBoolean r_() {
-                DataType ak_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                CqlQuantity am_ = this.lowestSerumCreatinineResult(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlBoolean an_ = context.Operators.Equal(al_ as CqlQuantity, am_);
-                return an_;
-            }
-
-
-            CqlBoolean s_() {
-                object ao_;
-                DataType ay_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+            else
+            {
+                if (bv_)
                 {
-                    ao_ = az_ as CqlDateTime;
+                    af_ = bu_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    bool bw_ = bu_ is CqlInterval<CqlDateTime>;
+                    if (bw_)
                     {
-                        ao_ = az_ as CqlDateTime;
+                        af_ = bu_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
-                        {
-                            ao_ = az_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ao_ = null;
-                        }
+                        af_ = null;
                     }
                 }
-                CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
-                object aq_;
-                DataType bc_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                bool be_ = bd_ is CqlDateTime;
-                if (be_)
+            }
+            CqlDateTime ag_ = QICoreCommon_4_0_000.Instance.earliest(context, af_);
+            object ah_;
+            DataType bx_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+            bool bz_ = by_ is CqlDateTime;
+            if (bz_)
+            {
+                ah_ = by_ as CqlDateTime;
+            }
+            else
+            {
+                if (bz_)
                 {
-                    aq_ = bd_ as CqlDateTime;
+                    ah_ = by_ as CqlDateTime;
                 }
                 else
                 {
-                    if (be_)
+                    bool ca_ = by_ is CqlInterval<CqlDateTime>;
+                    if (ca_)
                     {
-                        aq_ = bd_ as CqlDateTime;
+                        ah_ = by_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bf_ = bd_ is CqlInterval<CqlDateTime>;
-                        if (bf_)
-                        {
-                            aq_ = bd_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            aq_ = null;
-                        }
+                        ah_ = null;
                     }
                 }
-                CqlDateTime ar_ = QICoreCommon_4_0_000.Instance.earliest(context, aq_);
-                CqlQuantity as_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime at_ = context.Operators.Subtract(ar_, as_);
-                object au_;
-                DataType bg_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                bool bi_ = bh_ is CqlDateTime;
-                if (bi_)
+            }
+            CqlDateTime ai_ = QICoreCommon_4_0_000.Instance.earliest(context, ah_);
+            CqlQuantity aj_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime ak_ = context.Operators.Subtract(ai_, aj_);
+            object al_;
+            DataType cb_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+            bool cd_ = cc_ is CqlDateTime;
+            if (cd_)
+            {
+                al_ = cc_ as CqlDateTime;
+            }
+            else
+            {
+                if (cd_)
                 {
-                    au_ = bh_ as CqlDateTime;
+                    al_ = cc_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bi_)
+                    bool ce_ = cc_ is CqlInterval<CqlDateTime>;
+                    if (ce_)
                     {
-                        au_ = bh_ as CqlDateTime;
+                        al_ = cc_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bj_ = bh_ is CqlInterval<CqlDateTime>;
-                        if (bj_)
-                        {
-                            au_ = bh_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            au_ = null;
-                        }
+                        al_ = null;
                     }
                 }
-                CqlDateTime av_ = QICoreCommon_4_0_000.Instance.earliest(context, au_);
-                CqlInterval<CqlDateTime> aw_ = context.Operators.Interval(at_, av_, true, true);
-                CqlBoolean ax_ = context.Operators.In<CqlDateTime>(ap_, aw_, (string)default);
-                return ax_;
             }
-
-
-            CqlBoolean t_() {
-                object bk_;
-                DataType bo_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
-                object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
-                bool bq_ = bp_ is CqlDateTime;
-                if (bq_)
+            CqlDateTime am_ = QICoreCommon_4_0_000.Instance.earliest(context, al_);
+            CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ak_, am_, true, true);
+            CqlBoolean ao_ = context.Operators.In<CqlDateTime>(ag_, an_, (string)default);
+            CqlBoolean ap_ = ao_;
+            object aq_;
+            DataType cf_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+            object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cf_);
+            bool ch_ = cg_ is CqlDateTime;
+            if (ch_)
+            {
+                aq_ = cg_ as CqlDateTime;
+            }
+            else
+            {
+                if (ch_)
                 {
-                    bk_ = bp_ as CqlDateTime;
+                    aq_ = cg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bq_)
+                    bool ci_ = cg_ is CqlInterval<CqlDateTime>;
+                    if (ci_)
                     {
-                        bk_ = bp_ as CqlDateTime;
+                        aq_ = cg_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool br_ = bp_ is CqlInterval<CqlDateTime>;
-                        if (br_)
-                        {
-                            bk_ = bp_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bk_ = null;
-                        }
+                        aq_ = null;
                     }
                 }
-                CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_);
-                CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlBoolean bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
-                return bn_;
             }
-
-
-            CqlBoolean u_() {
-                object bs_;
-                DataType ca_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
-                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                bool cc_ = cb_ is CqlDateTime;
-                if (cc_)
+            CqlDateTime ar_ = QICoreCommon_4_0_000.Instance.earliest(context, aq_);
+            CqlInterval<CqlDateTime> as_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            CqlBoolean at_ = context.Operators.In<CqlDateTime>(ar_, as_, (string)default);
+            CqlBoolean au_ = at_;
+            object av_;
+            DataType cj_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+            object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+            bool cl_ = ck_ is CqlDateTime;
+            if (cl_)
+            {
+                av_ = ck_ as CqlDateTime;
+            }
+            else
+            {
+                if (cl_)
                 {
-                    bs_ = cb_ as CqlDateTime;
+                    av_ = ck_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cc_)
+                    bool cm_ = ck_ is CqlInterval<CqlDateTime>;
+                    if (cm_)
                     {
-                        bs_ = cb_ as CqlDateTime;
+                        av_ = ck_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cd_ = cb_ is CqlInterval<CqlDateTime>;
-                        if (cd_)
-                        {
-                            bs_ = cb_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bs_ = null;
-                        }
+                        av_ = null;
                     }
                 }
-                CqlDateTime bt_ = QICoreCommon_4_0_000.Instance.earliest(context, bs_);
-                CqlInterval<CqlDateTime> bu_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlDateTime bv_ = context.Operators.Start(bu_);
-                CqlQuantity bw_ = context.Operators.Quantity(24m, "hours");
-                CqlDateTime bx_ = context.Operators.Add(bv_, bw_);
-                CqlInterval<CqlDateTime> by_ = context.Operators.Interval(bv_, bx_, true, true);
-                CqlBoolean bz_ = context.Operators.In<CqlDateTime>(bt_, by_, (string)default);
-                return bz_;
             }
-
-
-            CqlBoolean v_() {
-                object ce_;
-                DataType ci_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                bool ck_ = cj_ is CqlDateTime;
-                if (ck_)
+            CqlDateTime aw_ = QICoreCommon_4_0_000.Instance.earliest(context, av_);
+            CqlDateTime ax_ = context.Operators.Start(as_);
+            CqlQuantity ay_ = context.Operators.Quantity(24m, "hours");
+            CqlDateTime az_ = context.Operators.Add(ax_, ay_);
+            CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(ax_, az_, true, true);
+            CqlBoolean bb_ = context.Operators.In<CqlDateTime>(aw_, ba_, (string)default);
+            CqlBoolean bc_ = bb_;
+            object bd_;
+            DataType cn_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+            bool cp_ = co_ is CqlDateTime;
+            if (cp_)
+            {
+                bd_ = co_ as CqlDateTime;
+            }
+            else
+            {
+                if (cp_)
                 {
-                    ce_ = cj_ as CqlDateTime;
+                    bd_ = co_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ck_)
+                    bool cq_ = co_ is CqlInterval<CqlDateTime>;
+                    if (cq_)
                     {
-                        ce_ = cj_ as CqlDateTime;
+                        bd_ = co_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cl_ = cj_ is CqlInterval<CqlDateTime>;
-                        if (cl_)
-                        {
-                            ce_ = cj_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ce_ = null;
-                        }
+                        bd_ = null;
                     }
                 }
-                CqlDateTime cf_ = QICoreCommon_4_0_000.Instance.earliest(context, ce_);
-                CqlInterval<CqlDateTime> cg_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlBoolean ch_ = context.Operators.In<CqlDateTime>(cf_, cg_, (string)default);
-                return ch_;
             }
-
-
-            CqlBoolean w_() {
-                object cm_;
-                DataType cu_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
-                bool cw_ = cv_ is CqlDateTime;
-                if (cw_)
+            CqlDateTime be_ = QICoreCommon_4_0_000.Instance.earliest(context, bd_);
+            CqlBoolean bf_ = context.Operators.In<CqlDateTime>(be_, as_, (string)default);
+            CqlBoolean bg_ = bf_;
+            object bh_;
+            DataType cr_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+            bool ct_ = cs_ is CqlDateTime;
+            if (ct_)
+            {
+                bh_ = cs_ as CqlDateTime;
+            }
+            else
+            {
+                if (ct_)
                 {
-                    cm_ = cv_ as CqlDateTime;
+                    bh_ = cs_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cw_)
+                    bool cu_ = cs_ is CqlInterval<CqlDateTime>;
+                    if (cu_)
                     {
-                        cm_ = cv_ as CqlDateTime;
+                        bh_ = cs_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cx_ = cv_ is CqlInterval<CqlDateTime>;
-                        if (cx_)
-                        {
-                            cm_ = cv_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            cm_ = null;
-                        }
+                        bh_ = null;
                     }
                 }
-                CqlDateTime cn_ = QICoreCommon_4_0_000.Instance.earliest(context, cm_);
-                CqlInterval<CqlDateTime> co_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlDateTime cp_ = context.Operators.Start(co_);
-                CqlQuantity cq_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime cr_ = context.Operators.Add(cp_, cq_);
-                CqlInterval<CqlDateTime> cs_ = context.Operators.Interval(cp_, cr_, true, true);
-                CqlBoolean ct_ = context.Operators.In<CqlDateTime>(cn_, cs_, (string)default);
-                return ct_;
             }
-
-
-            CqlBoolean x_() {
-                Id cy_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.IdElement;
-                string cz_ = cy_?.Value;
-                Id da_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.IdElement;
-                string db_ = da_?.Value;
-                CqlBoolean dc_ = context.Operators.Equal(cz_, db_);
-                return !dc_;
-            }
-
+            CqlDateTime bi_ = QICoreCommon_4_0_000.Instance.earliest(context, bh_);
+            CqlDateTime bj_ = context.Operators.Add(ax_, aj_);
+            CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(ax_, bj_, true, true);
+            CqlBoolean bl_ = context.Operators.In<CqlDateTime>(bi_, bk_, (string)default);
+            CqlBoolean bm_ = bl_;
+            Id bn_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.IdElement;
+            string bo_ = bn_?.Value;
+            Id bp_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.IdElement;
+            string bq_ = bp_?.Value;
+            CqlBoolean br_ = context.Operators.Equal(bo_, bq_);
+            CqlBoolean bs_ = (CqlBoolean)!br_;
             return o_
-                /* CQL 'and' (119:11-120:85) */ && p_()
-                /* CQL 'and' (119:11-121:130) */ && q_()
-                /* CQL 'and' (119:11-122:96) */ && r_()
-                /* CQL 'and' (119:11-123:135) */ && s_()
-                /* CQL 'and' (119:11-124:75) */ && t_()
-                /* CQL 'and' (119:11-125:145) */ && u_()
-                /* CQL 'and' (119:11-126:80) */ && v_()
-                /* CQL 'and' (119:11-127:150) */ && w_()
-                /* CQL 'and' (119:5-128:73) */ && x_();
+                /* CQL 'and' (119:11-120:85) */ && t_
+                /* CQL 'and' (119:11-121:130) */ && ab_
+                /* CQL 'and' (119:11-122:96) */ && ae_
+                /* CQL 'and' (119:11-123:135) */ && ap_
+                /* CQL 'and' (119:11-124:75) */ && au_
+                /* CQL 'and' (119:11-125:145) */ && bc_
+                /* CQL 'and' (119:11-126:80) */ && bg_
+                /* CQL 'and' (119:11-127:150) */ && bm_
+                /* CQL 'and' (119:5-128:73) */ && bs_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?> g_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?>(d_, e_, f_);
@@ -1563,303 +1433,252 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
                 "corrected",
             ];
             CqlBoolean o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
-
-            CqlBoolean p_() {
-                Code<ObservationStatus> y_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.StatusElement;
-                ObservationStatus? z_ = y_?.Value;
-                string aa_ = context.Operators.Convert<string>(z_);
-                string[] ab_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-                return ac_;
+            Code<ObservationStatus> p_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.StatusElement;
+            ObservationStatus? q_ = p_?.Value;
+            string r_ = context.Operators.Convert<string>(q_);
+            CqlBoolean s_ = context.Operators.In<string>(r_, (IEnumerable<string>)n_);
+            CqlBoolean t_ = s_;
+            DataType u_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Value;
+            object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+            DataType w_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
+            object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
+            CqlQuantity y_ = context.Operators.Subtract(v_ as CqlQuantity, x_ as CqlQuantity);
+            CqlQuantity z_ = context.Operators.Quantity(0.299m, "mg/dL");
+            CqlBoolean aa_ = context.Operators.Greater(y_, z_);
+            CqlBoolean ab_ = aa_;
+            IEnumerable<CqlQuantity> ac_ = this.earliestSerumCreatinineResult(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            CqlQuantity ad_ = context.Operators.SingletonFrom<CqlQuantity>(ac_);
+            CqlBoolean ae_ = context.Operators.Equal(x_ as CqlQuantity, ad_);
+            CqlBoolean af_ = ae_;
+            object ag_;
+            DataType br_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+            object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+            bool bt_ = bs_ is CqlDateTime;
+            if (bt_)
+            {
+                ag_ = bs_ as CqlDateTime;
             }
-
-
-            CqlBoolean q_() {
-                DataType ad_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Value;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                DataType af_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
-                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                CqlQuantity ah_ = context.Operators.Subtract(ae_ as CqlQuantity, ag_ as CqlQuantity);
-                CqlQuantity ai_ = context.Operators.Quantity(0.299m, "mg/dL");
-                CqlBoolean aj_ = context.Operators.Greater(ah_, ai_);
-                return aj_;
-            }
-
-
-            CqlBoolean r_() {
-                DataType ak_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                IEnumerable<CqlQuantity> am_ = this.earliestSerumCreatinineResult(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlQuantity an_ = context.Operators.SingletonFrom<CqlQuantity>(am_);
-                CqlBoolean ao_ = context.Operators.Equal(al_ as CqlQuantity, an_);
-                return ao_;
-            }
-
-
-            CqlBoolean s_() {
-                object ap_;
-                DataType az_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
-                object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
-                bool bb_ = ba_ is CqlDateTime;
-                if (bb_)
+            else
+            {
+                if (bt_)
                 {
-                    ap_ = ba_ as CqlDateTime;
+                    ag_ = bs_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bb_)
+                    bool bu_ = bs_ is CqlInterval<CqlDateTime>;
+                    if (bu_)
                     {
-                        ap_ = ba_ as CqlDateTime;
+                        ag_ = bs_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bc_ = ba_ is CqlInterval<CqlDateTime>;
-                        if (bc_)
-                        {
-                            ap_ = ba_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ap_ = null;
-                        }
+                        ag_ = null;
                     }
                 }
-                CqlDateTime aq_ = QICoreCommon_4_0_000.Instance.earliest(context, ap_);
-                object ar_;
-                DataType bd_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
-                bool bf_ = be_ is CqlDateTime;
-                if (bf_)
+            }
+            CqlDateTime ah_ = QICoreCommon_4_0_000.Instance.earliest(context, ag_);
+            object ai_;
+            DataType bv_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            bool bx_ = bw_ is CqlDateTime;
+            if (bx_)
+            {
+                ai_ = bw_ as CqlDateTime;
+            }
+            else
+            {
+                if (bx_)
                 {
-                    ar_ = be_ as CqlDateTime;
+                    ai_ = bw_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bf_)
+                    bool by_ = bw_ is CqlInterval<CqlDateTime>;
+                    if (by_)
                     {
-                        ar_ = be_ as CqlDateTime;
+                        ai_ = bw_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bg_ = be_ is CqlInterval<CqlDateTime>;
-                        if (bg_)
-                        {
-                            ar_ = be_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ar_ = null;
-                        }
+                        ai_ = null;
                     }
                 }
-                CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
-                CqlQuantity at_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime au_ = context.Operators.Subtract(as_, at_);
-                object av_;
-                DataType bh_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                bool bj_ = bi_ is CqlDateTime;
-                if (bj_)
+            }
+            CqlDateTime aj_ = QICoreCommon_4_0_000.Instance.earliest(context, ai_);
+            CqlQuantity ak_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime al_ = context.Operators.Subtract(aj_, ak_);
+            object am_;
+            DataType bz_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+            bool cb_ = ca_ is CqlDateTime;
+            if (cb_)
+            {
+                am_ = ca_ as CqlDateTime;
+            }
+            else
+            {
+                if (cb_)
                 {
-                    av_ = bi_ as CqlDateTime;
+                    am_ = ca_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bj_)
+                    bool cc_ = ca_ is CqlInterval<CqlDateTime>;
+                    if (cc_)
                     {
-                        av_ = bi_ as CqlDateTime;
+                        am_ = ca_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bk_ = bi_ is CqlInterval<CqlDateTime>;
-                        if (bk_)
-                        {
-                            av_ = bi_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            av_ = null;
-                        }
+                        am_ = null;
                     }
                 }
-                CqlDateTime aw_ = QICoreCommon_4_0_000.Instance.earliest(context, av_);
-                CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(au_, aw_, true, true);
-                CqlBoolean ay_ = context.Operators.In<CqlDateTime>(aq_, ax_, (string)default);
-                return ay_;
             }
-
-
-            CqlBoolean t_() {
-                object bl_;
-                DataType bp_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                bool br_ = bq_ is CqlDateTime;
-                if (br_)
+            CqlDateTime an_ = QICoreCommon_4_0_000.Instance.earliest(context, am_);
+            CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(al_, an_, true, true);
+            CqlBoolean ap_ = context.Operators.In<CqlDateTime>(ah_, ao_, (string)default);
+            CqlBoolean aq_ = ap_;
+            object ar_;
+            DataType cd_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+            object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+            bool cf_ = ce_ is CqlDateTime;
+            if (cf_)
+            {
+                ar_ = ce_ as CqlDateTime;
+            }
+            else
+            {
+                if (cf_)
                 {
-                    bl_ = bq_ as CqlDateTime;
+                    ar_ = ce_ as CqlDateTime;
                 }
                 else
                 {
-                    if (br_)
+                    bool cg_ = ce_ is CqlInterval<CqlDateTime>;
+                    if (cg_)
                     {
-                        bl_ = bq_ as CqlDateTime;
+                        ar_ = ce_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bs_ = bq_ is CqlInterval<CqlDateTime>;
-                        if (bs_)
-                        {
-                            bl_ = bq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bl_ = null;
-                        }
+                        ar_ = null;
                     }
                 }
-                CqlDateTime bm_ = QICoreCommon_4_0_000.Instance.earliest(context, bl_);
-                CqlInterval<CqlDateTime> bn_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bm_, bn_, (string)default);
-                return bo_;
             }
-
-
-            CqlBoolean u_() {
-                object bt_;
-                DataType cb_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                bool cd_ = cc_ is CqlDateTime;
-                if (cd_)
+            CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
+            CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            CqlBoolean au_ = context.Operators.In<CqlDateTime>(as_, at_, (string)default);
+            CqlBoolean av_ = au_;
+            object aw_;
+            DataType ch_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+            bool cj_ = ci_ is CqlDateTime;
+            if (cj_)
+            {
+                aw_ = ci_ as CqlDateTime;
+            }
+            else
+            {
+                if (cj_)
                 {
-                    bt_ = cc_ as CqlDateTime;
+                    aw_ = ci_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cd_)
+                    bool ck_ = ci_ is CqlInterval<CqlDateTime>;
+                    if (ck_)
                     {
-                        bt_ = cc_ as CqlDateTime;
+                        aw_ = ci_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ce_ = cc_ is CqlInterval<CqlDateTime>;
-                        if (ce_)
-                        {
-                            bt_ = cc_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bt_ = null;
-                        }
+                        aw_ = null;
                     }
                 }
-                CqlDateTime bu_ = QICoreCommon_4_0_000.Instance.earliest(context, bt_);
-                CqlInterval<CqlDateTime> bv_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlDateTime bw_ = context.Operators.Start(bv_);
-                CqlQuantity bx_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime by_ = context.Operators.Add(bw_, bx_);
-                CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bw_, by_, true, true);
-                CqlBoolean ca_ = context.Operators.In<CqlDateTime>(bu_, bz_, (string)default);
-                return ca_;
             }
-
-
-            CqlBoolean v_() {
-                object cf_;
-                DataType cj_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
-                object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
-                bool cl_ = ck_ is CqlDateTime;
-                if (cl_)
+            CqlDateTime ax_ = QICoreCommon_4_0_000.Instance.earliest(context, aw_);
+            CqlDateTime ay_ = context.Operators.Start(at_);
+            CqlDateTime az_ = context.Operators.Add(ay_, ak_);
+            CqlInterval<CqlDateTime> ba_ = context.Operators.Interval(ay_, az_, true, true);
+            CqlBoolean bb_ = context.Operators.In<CqlDateTime>(ax_, ba_, (string)default);
+            CqlBoolean bc_ = bb_;
+            object bd_;
+            DataType cl_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+            object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+            bool cn_ = cm_ is CqlDateTime;
+            if (cn_)
+            {
+                bd_ = cm_ as CqlDateTime;
+            }
+            else
+            {
+                if (cn_)
                 {
-                    cf_ = ck_ as CqlDateTime;
+                    bd_ = cm_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cl_)
+                    bool co_ = cm_ is CqlInterval<CqlDateTime>;
+                    if (co_)
                     {
-                        cf_ = ck_ as CqlDateTime;
+                        bd_ = cm_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cm_ = ck_ is CqlInterval<CqlDateTime>;
-                        if (cm_)
-                        {
-                            cf_ = ck_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            cf_ = null;
-                        }
+                        bd_ = null;
                     }
                 }
-                CqlDateTime cg_ = QICoreCommon_4_0_000.Instance.earliest(context, cf_);
-                CqlInterval<CqlDateTime> ch_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlBoolean ci_ = context.Operators.In<CqlDateTime>(cg_, ch_, (string)default);
-                return ci_;
             }
-
-
-            CqlBoolean w_() {
-                object cn_;
-                DataType cv_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
-                object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                bool cx_ = cw_ is CqlDateTime;
-                if (cx_)
+            CqlDateTime be_ = QICoreCommon_4_0_000.Instance.earliest(context, bd_);
+            CqlBoolean bf_ = context.Operators.In<CqlDateTime>(be_, at_, (string)default);
+            CqlBoolean bg_ = bf_;
+            object bh_;
+            DataType cp_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+            object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+            bool cr_ = cq_ is CqlDateTime;
+            if (cr_)
+            {
+                bh_ = cq_ as CqlDateTime;
+            }
+            else
+            {
+                if (cr_)
                 {
-                    cn_ = cw_ as CqlDateTime;
+                    bh_ = cq_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cx_)
+                    bool cs_ = cq_ is CqlInterval<CqlDateTime>;
+                    if (cs_)
                     {
-                        cn_ = cw_ as CqlDateTime;
+                        bh_ = cq_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cy_ = cw_ is CqlInterval<CqlDateTime>;
-                        if (cy_)
-                        {
-                            cn_ = cw_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            cn_ = null;
-                        }
+                        bh_ = null;
                     }
                 }
-                CqlDateTime co_ = QICoreCommon_4_0_000.Instance.earliest(context, cn_);
-                CqlInterval<CqlDateTime> cp_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
-                CqlDateTime cq_ = context.Operators.Start(cp_);
-                CqlQuantity cr_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime cs_ = context.Operators.Add(cq_, cr_);
-                CqlInterval<CqlDateTime> ct_ = context.Operators.Interval(cq_, cs_, true, true);
-                CqlBoolean cu_ = context.Operators.In<CqlDateTime>(co_, ct_, (string)default);
-                return cu_;
             }
-
-
-            CqlBoolean x_() {
-                Id cz_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.IdElement;
-                string da_ = cz_?.Value;
-                Id db_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.IdElement;
-                string dc_ = db_?.Value;
-                CqlBoolean dd_ = context.Operators.Equal(da_, dc_);
-                return !dd_;
-            }
-
+            CqlDateTime bi_ = QICoreCommon_4_0_000.Instance.earliest(context, bh_);
+            CqlBoolean bj_ = context.Operators.In<CqlDateTime>(bi_, ba_, (string)default);
+            CqlBoolean bk_ = bj_;
+            Id bl_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.IdElement;
+            string bm_ = bl_?.Value;
+            Id bn_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.IdElement;
+            string bo_ = bn_?.Value;
+            CqlBoolean bp_ = context.Operators.Equal(bm_, bo_);
+            CqlBoolean bq_ = (CqlBoolean)!bp_;
             return o_
-                /* CQL 'and' (139:11-140:85) */ && p_()
-                /* CQL 'and' (139:11-141:130) */ && q_()
-                /* CQL 'and' (139:11-142:125) */ && r_()
-                /* CQL 'and' (139:11-143:135) */ && s_()
-                /* CQL 'and' (139:11-144:75) */ && t_()
-                /* CQL 'and' (139:11-145:150) */ && u_()
-                /* CQL 'and' (139:11-146:80) */ && v_()
-                /* CQL 'and' (139:11-147:145) */ && w_()
-                /* CQL 'and' (139:5-148:73) */ && x_();
+                /* CQL 'and' (139:11-140:85) */ && t_
+                /* CQL 'and' (139:11-141:130) */ && ab_
+                /* CQL 'and' (139:11-142:125) */ && af_
+                /* CQL 'and' (139:11-143:135) */ && aq_
+                /* CQL 'and' (139:11-144:75) */ && av_
+                /* CQL 'and' (139:11-145:150) */ && bc_
+                /* CQL 'and' (139:11-146:80) */ && bg_
+                /* CQL 'and' (139:11-147:145) */ && bk_
+                /* CQL 'and' (139:5-148:73) */ && bq_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?> g_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?>(d_, e_, f_);
@@ -1908,103 +1727,94 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             EventStatus? l_ = k_?.Value;
             string m_ = context.Operators.Convert<string>(l_);
             CqlBoolean n_ = context.Operators.Equal(m_, "completed");
-
-            CqlBoolean o_() {
-                object q_;
-                DataType z_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
-                object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                bool ab_ = aa_ is CqlDateTime;
-                if (ab_)
+            object o_;
+            DataType ad_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            bool af_ = ae_ is CqlDateTime;
+            if (af_)
+            {
+                o_ = ae_ as CqlDateTime;
+            }
+            else
+            {
+                bool ag_ = ae_ is CqlQuantity;
+                if (ag_)
                 {
-                    q_ = aa_ as CqlDateTime;
+                    o_ = ae_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ac_ = aa_ is CqlQuantity;
-                    if (ac_)
+                    bool ah_ = ae_ is CqlInterval<CqlDateTime>;
+                    if (ah_)
                     {
-                        q_ = aa_ as CqlQuantity;
+                        o_ = ae_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ad_ = aa_ is CqlInterval<CqlDateTime>;
-                        if (ad_)
+                        bool ai_ = ae_ is CqlInterval<CqlQuantity>;
+                        if (ai_)
                         {
-                            q_ = aa_ as CqlInterval<CqlDateTime>;
+                            o_ = ae_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool ae_ = aa_ is CqlInterval<CqlQuantity>;
-                            if (ae_)
-                            {
-                                q_ = aa_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                q_ = null;
-                            }
+                            o_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlInterval<CqlDateTime> t_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter);
-                CqlDateTime u_ = context.Operators.Start(t_);
-                CqlQuantity v_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime w_ = context.Operators.Add(u_, v_);
-                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
-                CqlBoolean y_ = context.Operators.In<CqlDateTime>(s_, x_, (string)default);
-                return y_;
             }
-
-
-            CqlBoolean p_() {
-                object af_;
-                DataType ak_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
-                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
-                bool am_ = al_ is CqlDateTime;
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlInterval<CqlDateTime> r_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter);
+            CqlDateTime s_ = context.Operators.Start(r_);
+            CqlQuantity t_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime u_ = context.Operators.Add(s_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(q_, v_, (string)default);
+            CqlBoolean x_ = w_;
+            object y_;
+            DataType aj_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+            bool al_ = ak_ is CqlDateTime;
+            if (al_)
+            {
+                y_ = ak_ as CqlDateTime;
+            }
+            else
+            {
+                bool am_ = ak_ is CqlQuantity;
                 if (am_)
                 {
-                    af_ = al_ as CqlDateTime;
+                    y_ = ak_ as CqlQuantity;
                 }
                 else
                 {
-                    bool an_ = al_ is CqlQuantity;
+                    bool an_ = ak_ is CqlInterval<CqlDateTime>;
                     if (an_)
                     {
-                        af_ = al_ as CqlQuantity;
+                        y_ = ak_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ao_ = al_ is CqlInterval<CqlDateTime>;
+                        bool ao_ = ak_ is CqlInterval<CqlQuantity>;
                         if (ao_)
                         {
-                            af_ = al_ as CqlInterval<CqlDateTime>;
+                            y_ = ak_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool ap_ = al_ is CqlInterval<CqlQuantity>;
-                            if (ap_)
-                            {
-                                af_ = al_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                af_ = null;
-                            }
+                            y_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                CqlDateTime ah_ = context.Operators.Start(ag_);
-                CqlInterval<CqlDateTime> ai_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter);
-                CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, (string)default);
-                return aj_;
             }
-
+            CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+            CqlDateTime aa_ = context.Operators.Start(z_);
+            CqlBoolean ab_ = context.Operators.In<CqlDateTime>(aa_, r_, (string)default);
+            CqlBoolean ac_ = ab_;
             return n_
-                /* CQL 'and' (163:11-164:157) */ && o_()
-                /* CQL 'and' (163:5-165:87) */ && p_();
+                /* CQL 'and' (163:11-164:157) */ && x_
+                /* CQL 'and' (163:5-165:87) */ && ac_;
         }
 
         IEnumerable<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?> g_ = context.Operators.SelectWhere<ValueTuple<Procedure, Encounter>, (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?>(d_, e_, f_);
@@ -2132,309 +1942,258 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
             CqlQuantity m_ = this.Serum_Creatinine_Normal(context);
             CqlBoolean n_ = context.Operators.Greater(l_ as CqlQuantity, m_);
-
-            CqlBoolean o_() {
-                Code<ObservationStatus> x_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.StatusElement;
-                ObservationStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                return ab_;
+            Code<ObservationStatus> o_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.StatusElement;
+            ObservationStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            string[] r_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            CqlBoolean t_ = s_;
+            Code<ObservationStatus> u_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.StatusElement;
+            ObservationStatus? v_ = u_?.Value;
+            string w_ = context.Operators.Convert<string>(v_);
+            CqlBoolean x_ = context.Operators.In<string>(w_, (IEnumerable<string>)r_);
+            CqlBoolean y_ = x_;
+            CqlQuantity z_ = this.highestSerumCreatinineResult(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            CqlBoolean aa_ = context.Operators.Equal(l_ as CqlQuantity, z_);
+            CqlBoolean ab_ = aa_;
+            DataType ac_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Value;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            CqlQuantity ae_ = this.lowestSerumCreatinineResult(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            CqlBoolean af_ = context.Operators.Equal(ad_ as CqlQuantity, ae_);
+            CqlBoolean ag_ = af_;
+            CqlQuantity ah_ = this.oneAndAHalfIncreaseInCreatinine(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            CqlBoolean ai_ = context.Operators.GreaterOrEqual(ah_, ad_ as CqlQuantity);
+            CqlBoolean aj_ = ai_;
+            object ak_;
+            DataType br_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+            object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+            bool bt_ = bs_ is CqlDateTime;
+            if (bt_)
+            {
+                ak_ = bs_ as CqlDateTime;
             }
-
-
-            CqlBoolean p_() {
-                Code<ObservationStatus> ac_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.StatusElement;
-                ObservationStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                return ag_;
-            }
-
-
-            CqlBoolean q_() {
-                DataType ah_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Value;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlQuantity aj_ = this.highestSerumCreatinineResult(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
-                CqlBoolean ak_ = context.Operators.Equal(ai_ as CqlQuantity, aj_);
-                return ak_;
-            }
-
-
-            CqlBoolean r_() {
-                DataType al_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Value;
-                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                CqlQuantity an_ = this.lowestSerumCreatinineResult(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
-                CqlBoolean ao_ = context.Operators.Equal(am_ as CqlQuantity, an_);
-                return ao_;
-            }
-
-
-            CqlBoolean s_() {
-                CqlQuantity ap_ = this.oneAndAHalfIncreaseInCreatinine(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
-                DataType aq_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Value;
-                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
-                CqlBoolean as_ = context.Operators.GreaterOrEqual(ap_, ar_ as CqlQuantity);
-                return as_;
-            }
-
-
-            CqlBoolean t_() {
-                object at_;
-                DataType be_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
-                object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
-                bool bg_ = bf_ is CqlDateTime;
-                if (bg_)
+            else
+            {
+                if (bt_)
                 {
-                    at_ = bf_ as CqlDateTime;
+                    ak_ = bs_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bg_)
-                    {
-                        at_ = bf_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bh_ = bf_ is CqlInterval<CqlDateTime>;
-                        if (bh_)
-                        {
-                            at_ = bf_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            at_ = null;
-                        }
-                    }
-                }
-                CqlDateTime au_ = QICoreCommon_4_0_000.Instance.earliest(context, at_);
-                object av_;
-                DataType bi_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
-                object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                bool bk_ = bj_ is CqlDateTime;
-                if (bk_)
-                {
-                    av_ = bj_ as CqlDateTime;
-                }
-                else
-                {
-                    if (bk_)
-                    {
-                        av_ = bj_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bl_ = bj_ is CqlInterval<CqlDateTime>;
-                        if (bl_)
-                        {
-                            av_ = bj_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            av_ = null;
-                        }
-                    }
-                }
-                CqlDateTime aw_ = QICoreCommon_4_0_000.Instance.earliest(context, av_);
-                CqlQuantity ax_ = context.Operators.Quantity(7m, "days");
-                CqlDateTime ay_ = context.Operators.Subtract(aw_, ax_);
-                object az_;
-                DataType bm_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
-                object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
-                bool bo_ = bn_ is CqlDateTime;
-                if (bo_)
-                {
-                    az_ = bn_ as CqlDateTime;
-                }
-                else
-                {
-                    if (bo_)
-                    {
-                        az_ = bn_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bp_ = bn_ is CqlInterval<CqlDateTime>;
-                        if (bp_)
-                        {
-                            az_ = bn_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            az_ = null;
-                        }
-                    }
-                }
-                CqlDateTime ba_ = QICoreCommon_4_0_000.Instance.earliest(context, az_);
-                CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ay_, ba_, true, false);
-                CqlBoolean bc_ = context.Operators.In<CqlDateTime>(au_, bb_, (string)default);
-
-                CqlBoolean bd_() {
-                    object bq_;
-                    DataType bs_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
-                    object bt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bs_);
-                    bool bu_ = bt_ is CqlDateTime;
+                    bool bu_ = bs_ is CqlInterval<CqlDateTime>;
                     if (bu_)
                     {
-                        bq_ = bt_ as CqlDateTime;
+                        ak_ = bs_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        if (bu_)
-                        {
-                            bq_ = bt_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool bv_ = bt_ is CqlInterval<CqlDateTime>;
-                            if (bv_)
-                            {
-                                bq_ = bt_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                bq_ = null;
-                            }
-                        }
+                        ak_ = null;
                     }
-                    CqlDateTime br_ = QICoreCommon_4_0_000.Instance.earliest(context, bq_);
-                    return br_ is not null;
                 }
-
-                return bc_
-                    /* CQL 'and' (269:11-269:76) */ && bd_();
             }
-
-
-            CqlBoolean u_() {
-                object bw_;
-                DataType ca_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
-                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                bool cc_ = cb_ is CqlDateTime;
-                if (cc_)
+            CqlDateTime al_ = QICoreCommon_4_0_000.Instance.earliest(context, ak_);
+            object am_;
+            DataType bv_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+            object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+            bool bx_ = bw_ is CqlDateTime;
+            if (bx_)
+            {
+                am_ = bw_ as CqlDateTime;
+            }
+            else
+            {
+                if (bx_)
                 {
-                    bw_ = cb_ as CqlDateTime;
+                    am_ = bw_ as CqlDateTime;
                 }
                 else
                 {
+                    bool by_ = bw_ is CqlInterval<CqlDateTime>;
+                    if (by_)
+                    {
+                        am_ = bw_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        am_ = null;
+                    }
+                }
+            }
+            CqlDateTime an_ = QICoreCommon_4_0_000.Instance.earliest(context, am_);
+            CqlQuantity ao_ = context.Operators.Quantity(7m, "days");
+            CqlDateTime ap_ = context.Operators.Subtract(an_, ao_);
+            object aq_;
+            DataType bz_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+            object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+            bool cb_ = ca_ is CqlDateTime;
+            if (cb_)
+            {
+                aq_ = ca_ as CqlDateTime;
+            }
+            else
+            {
+                if (cb_)
+                {
+                    aq_ = ca_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cc_ = ca_ is CqlInterval<CqlDateTime>;
                     if (cc_)
                     {
-                        bw_ = cb_ as CqlDateTime;
+                        aq_ = ca_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cd_ = cb_ is CqlInterval<CqlDateTime>;
-                        if (cd_)
-                        {
-                            bw_ = cb_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bw_ = null;
-                        }
+                        aq_ = null;
                     }
                 }
-                CqlDateTime bx_ = QICoreCommon_4_0_000.Instance.earliest(context, bw_);
-                CqlInterval<CqlDateTime> by_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
-                CqlBoolean bz_ = context.Operators.In<CqlDateTime>(bx_, by_, (string)default);
-                return bz_;
             }
-
-
-            CqlBoolean v_() {
-                object ce_;
-                DataType co_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
-                object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
-                bool cq_ = cp_ is CqlDateTime;
-                if (cq_)
+            CqlDateTime ar_ = QICoreCommon_4_0_000.Instance.earliest(context, aq_);
+            CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ap_, ar_, true, false);
+            CqlBoolean at_ = context.Operators.In<CqlDateTime>(al_, as_, (string)default);
+            object au_;
+            DataType cd_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+            object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+            bool cf_ = ce_ is CqlDateTime;
+            if (cf_)
+            {
+                au_ = ce_ as CqlDateTime;
+            }
+            else
+            {
+                if (cf_)
                 {
-                    ce_ = cp_ as CqlDateTime;
+                    au_ = ce_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cq_)
+                    bool cg_ = ce_ is CqlInterval<CqlDateTime>;
+                    if (cg_)
                     {
-                        ce_ = cp_ as CqlDateTime;
+                        au_ = ce_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cr_ = cp_ is CqlInterval<CqlDateTime>;
-                        if (cr_)
-                        {
-                            ce_ = cp_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ce_ = null;
-                        }
+                        au_ = null;
                     }
                 }
-                CqlDateTime cf_ = QICoreCommon_4_0_000.Instance.earliest(context, ce_);
-                CqlInterval<CqlDateTime> cg_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
-                CqlDateTime ch_ = context.Operators.Start(cg_);
-                CqlQuantity ci_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime cj_ = context.Operators.Add(ch_, ci_);
-                CqlQuantity ck_ = context.Operators.Quantity(30m, "days");
-                CqlDateTime cl_ = context.Operators.Add(ch_, ck_);
-                CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(cj_, cl_, true, true);
-                CqlBoolean cn_ = context.Operators.In<CqlDateTime>(cf_, cm_, (string)default);
-                return cn_;
             }
-
-
-            CqlBoolean w_() {
-                object cs_;
-                DataType cw_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
-                object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
-                bool cy_ = cx_ is CqlDateTime;
-                if (cy_)
+            CqlDateTime av_ = QICoreCommon_4_0_000.Instance.earliest(context, au_);
+            CqlBoolean aw_ = (CqlBoolean)(av_ is not null);
+            CqlBoolean ax_ = at_
+                /* CQL 'and' (269:11-269:76) */ && aw_;
+            object ay_;
+            DataType ch_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+            object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+            bool cj_ = ci_ is CqlDateTime;
+            if (cj_)
+            {
+                ay_ = ci_ as CqlDateTime;
+            }
+            else
+            {
+                if (cj_)
                 {
-                    cs_ = cx_ as CqlDateTime;
+                    ay_ = ci_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cy_)
+                    bool ck_ = ci_ is CqlInterval<CqlDateTime>;
+                    if (ck_)
                     {
-                        cs_ = cx_ as CqlDateTime;
+                        ay_ = ci_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cz_ = cx_ is CqlInterval<CqlDateTime>;
-                        if (cz_)
-                        {
-                            cs_ = cx_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            cs_ = null;
-                        }
+                        ay_ = null;
                     }
                 }
-                CqlDateTime ct_ = QICoreCommon_4_0_000.Instance.earliest(context, cs_);
-                CqlInterval<CqlDateTime> cu_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
-                CqlBoolean cv_ = context.Operators.In<CqlDateTime>(ct_, cu_, (string)default);
-                return cv_;
             }
-
+            CqlDateTime az_ = QICoreCommon_4_0_000.Instance.earliest(context, ay_);
+            CqlInterval<CqlDateTime> ba_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            CqlBoolean bb_ = context.Operators.In<CqlDateTime>(az_, ba_, (string)default);
+            CqlBoolean bc_ = bb_;
+            object bd_;
+            DataType cl_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+            object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+            bool cn_ = cm_ is CqlDateTime;
+            if (cn_)
+            {
+                bd_ = cm_ as CqlDateTime;
+            }
+            else
+            {
+                if (cn_)
+                {
+                    bd_ = cm_ as CqlDateTime;
+                }
+                else
+                {
+                    bool co_ = cm_ is CqlInterval<CqlDateTime>;
+                    if (co_)
+                    {
+                        bd_ = cm_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bd_ = null;
+                    }
+                }
+            }
+            CqlDateTime be_ = QICoreCommon_4_0_000.Instance.earliest(context, bd_);
+            CqlDateTime bf_ = context.Operators.Start(ba_);
+            CqlQuantity bg_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime bh_ = context.Operators.Add(bf_, bg_);
+            CqlQuantity bi_ = context.Operators.Quantity(30m, "days");
+            CqlDateTime bj_ = context.Operators.Add(bf_, bi_);
+            CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(bh_, bj_, true, true);
+            CqlBoolean bl_ = context.Operators.In<CqlDateTime>(be_, bk_, (string)default);
+            CqlBoolean bm_ = bl_;
+            object bn_;
+            DataType cp_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+            object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+            bool cr_ = cq_ is CqlDateTime;
+            if (cr_)
+            {
+                bn_ = cq_ as CqlDateTime;
+            }
+            else
+            {
+                if (cr_)
+                {
+                    bn_ = cq_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cs_ = cq_ is CqlInterval<CqlDateTime>;
+                    if (cs_)
+                    {
+                        bn_ = cq_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bn_ = null;
+                    }
+                }
+            }
+            CqlDateTime bo_ = QICoreCommon_4_0_000.Instance.earliest(context, bn_);
+            CqlBoolean bp_ = context.Operators.In<CqlDateTime>(bo_, ba_, (string)default);
+            CqlBoolean bq_ = bp_;
             return n_
-                /* CQL 'and' (263:11-264:73) */ && o_()
-                /* CQL 'and' (263:11-265:74) */ && p_()
-                /* CQL 'and' (263:11-266:91) */ && q_()
-                /* CQL 'and' (263:11-267:89) */ && r_()
-                /* CQL 'and' (263:11-268:94) */ && s_()
-                /* CQL 'and' (263:11-269:76) */ && t_()
-                /* CQL 'and' (263:11-270:68) */ && u_()
-                /* CQL 'and' (263:11-271:149) */ && v_()
-                /* CQL 'and' (263:5-272:69) */ && w_();
+                /* CQL 'and' (263:11-264:73) */ && t_
+                /* CQL 'and' (263:11-265:74) */ && y_
+                /* CQL 'and' (263:11-266:91) */ && ab_
+                /* CQL 'and' (263:11-267:89) */ && ag_
+                /* CQL 'and' (263:11-268:94) */ && aj_
+                /* CQL 'and' (263:11-269:76) */ && ax_
+                /* CQL 'and' (263:11-270:68) */ && bc_
+                /* CQL 'and' (263:11-271:149) */ && bm_
+                /* CQL 'and' (263:5-272:69) */ && bq_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)?> g_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)?>(d_, e_, f_);
@@ -2468,310 +2227,257 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
             CqlQuantity m_ = this.Serum_Creatinine_Normal(context);
             CqlBoolean n_ = context.Operators.Greater(l_ as CqlQuantity, m_);
-
-            CqlBoolean o_() {
-                Code<ObservationStatus> x_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.StatusElement;
-                ObservationStatus? y_ = x_?.Value;
-                string z_ = context.Operators.Convert<string>(y_);
-                string[] aa_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
-                return ab_;
+            Code<ObservationStatus> o_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.StatusElement;
+            ObservationStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            string[] r_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            CqlBoolean t_ = s_;
+            Code<ObservationStatus> u_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.StatusElement;
+            ObservationStatus? v_ = u_?.Value;
+            string w_ = context.Operators.Convert<string>(v_);
+            CqlBoolean x_ = context.Operators.In<string>(w_, (IEnumerable<string>)r_);
+            CqlBoolean y_ = x_;
+            CqlQuantity z_ = this.highestSerumCreatinineResult(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
+            CqlBoolean aa_ = context.Operators.Equal(l_ as CqlQuantity, z_);
+            CqlBoolean ab_ = aa_;
+            DataType ac_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Value;
+            object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+            CqlQuantity ae_ = this.lowestSerumCreatinineResult(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
+            CqlBoolean af_ = context.Operators.Equal(ad_ as CqlQuantity, ae_);
+            CqlBoolean ag_ = af_;
+            CqlBoolean ah_ = context.Operators.GreaterOrEqual(l_ as CqlQuantity, ad_ as CqlQuantity);
+            CqlBoolean ai_ = ah_;
+            object aj_;
+            DataType bq_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+            object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+            bool bs_ = br_ is CqlDateTime;
+            if (bs_)
+            {
+                aj_ = br_ as CqlDateTime;
             }
-
-
-            CqlBoolean p_() {
-                Code<ObservationStatus> ac_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.StatusElement;
-                ObservationStatus? ad_ = ac_?.Value;
-                string ae_ = context.Operators.Convert<string>(ad_);
-                string[] af_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
-                return ag_;
-            }
-
-
-            CqlBoolean q_() {
-                DataType ah_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Value;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                CqlQuantity aj_ = this.highestSerumCreatinineResult(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
-                CqlBoolean ak_ = context.Operators.Equal(ai_ as CqlQuantity, aj_);
-                return ak_;
-            }
-
-
-            CqlBoolean r_() {
-                DataType al_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Value;
-                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                CqlQuantity an_ = this.lowestSerumCreatinineResult(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
-                CqlBoolean ao_ = context.Operators.Equal(am_ as CqlQuantity, an_);
-                return ao_;
-            }
-
-
-            CqlBoolean s_() {
-                DataType ap_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Value;
-                object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                DataType ar_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Value;
-                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                CqlBoolean at_ = context.Operators.GreaterOrEqual(aq_ as CqlQuantity, as_ as CqlQuantity);
-                return at_;
-            }
-
-
-            CqlBoolean t_() {
-                object au_;
-                DataType bf_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
-                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
-                bool bh_ = bg_ is CqlDateTime;
-                if (bh_)
+            else
+            {
+                if (bs_)
                 {
-                    au_ = bg_ as CqlDateTime;
+                    aj_ = br_ as CqlDateTime;
                 }
                 else
                 {
-                    if (bh_)
+                    bool bt_ = br_ is CqlInterval<CqlDateTime>;
+                    if (bt_)
                     {
-                        au_ = bg_ as CqlDateTime;
+                        aj_ = br_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
-                        if (bi_)
-                        {
-                            au_ = bg_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            au_ = null;
-                        }
+                        aj_ = null;
                     }
                 }
-                CqlDateTime av_ = QICoreCommon_4_0_000.Instance.earliest(context, au_);
-                object aw_;
-                DataType bj_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
-                object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
-                bool bl_ = bk_ is CqlDateTime;
-                if (bl_)
-                {
-                    aw_ = bk_ as CqlDateTime;
-                }
-                else
-                {
-                    if (bl_)
-                    {
-                        aw_ = bk_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bm_ = bk_ is CqlInterval<CqlDateTime>;
-                        if (bm_)
-                        {
-                            aw_ = bk_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            aw_ = null;
-                        }
-                    }
-                }
-                CqlDateTime ax_ = QICoreCommon_4_0_000.Instance.earliest(context, aw_);
-                CqlQuantity ay_ = context.Operators.Quantity(7m, "days");
-                CqlDateTime az_ = context.Operators.Subtract(ax_, ay_);
-                object ba_;
-                DataType bn_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
-                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                bool bp_ = bo_ is CqlDateTime;
-                if (bp_)
-                {
-                    ba_ = bo_ as CqlDateTime;
-                }
-                else
-                {
-                    if (bp_)
-                    {
-                        ba_ = bo_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool bq_ = bo_ is CqlInterval<CqlDateTime>;
-                        if (bq_)
-                        {
-                            ba_ = bo_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ba_ = null;
-                        }
-                    }
-                }
-                CqlDateTime bb_ = QICoreCommon_4_0_000.Instance.earliest(context, ba_);
-                CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(az_, bb_, true, false);
-                CqlBoolean bd_ = context.Operators.In<CqlDateTime>(av_, bc_, (string)default);
-
-                CqlBoolean be_() {
-                    object br_;
-                    DataType bt_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
-                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                    bool bv_ = bu_ is CqlDateTime;
-                    if (bv_)
-                    {
-                        br_ = bu_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        if (bv_)
-                        {
-                            br_ = bu_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool bw_ = bu_ is CqlInterval<CqlDateTime>;
-                            if (bw_)
-                            {
-                                br_ = bu_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                br_ = null;
-                            }
-                        }
-                    }
-                    CqlDateTime bs_ = QICoreCommon_4_0_000.Instance.earliest(context, br_);
-                    return bs_ is not null;
-                }
-
-                return bd_
-                    /* CQL 'and' (182:11-182:76) */ && be_();
             }
-
-
-            CqlBoolean u_() {
-                object bx_;
-                DataType cb_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
-                object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
-                bool cd_ = cc_ is CqlDateTime;
-                if (cd_)
+            CqlDateTime ak_ = QICoreCommon_4_0_000.Instance.earliest(context, aj_);
+            object al_;
+            DataType bu_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+            object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+            bool bw_ = bv_ is CqlDateTime;
+            if (bw_)
+            {
+                al_ = bv_ as CqlDateTime;
+            }
+            else
+            {
+                if (bw_)
                 {
-                    bx_ = cc_ as CqlDateTime;
+                    al_ = bv_ as CqlDateTime;
                 }
                 else
                 {
-                    if (cd_)
+                    bool bx_ = bv_ is CqlInterval<CqlDateTime>;
+                    if (bx_)
                     {
-                        bx_ = cc_ as CqlDateTime;
+                        al_ = bv_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ce_ = cc_ is CqlInterval<CqlDateTime>;
-                        if (ce_)
-                        {
-                            bx_ = cc_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            bx_ = null;
-                        }
+                        al_ = null;
                     }
                 }
-                CqlDateTime by_ = QICoreCommon_4_0_000.Instance.earliest(context, bx_);
-                CqlInterval<CqlDateTime> bz_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
-                CqlBoolean ca_ = context.Operators.In<CqlDateTime>(by_, bz_, (string)default);
-                return ca_;
             }
-
-
-            CqlBoolean v_() {
-                object cf_;
-                DataType cp_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
-                object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
-                bool cr_ = cq_ is CqlDateTime;
-                if (cr_)
+            CqlDateTime am_ = QICoreCommon_4_0_000.Instance.earliest(context, al_);
+            CqlQuantity an_ = context.Operators.Quantity(7m, "days");
+            CqlDateTime ao_ = context.Operators.Subtract(am_, an_);
+            object ap_;
+            DataType by_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+            object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
+            bool ca_ = bz_ is CqlDateTime;
+            if (ca_)
+            {
+                ap_ = bz_ as CqlDateTime;
+            }
+            else
+            {
+                if (ca_)
                 {
-                    cf_ = cq_ as CqlDateTime;
+                    ap_ = bz_ as CqlDateTime;
                 }
                 else
                 {
+                    bool cb_ = bz_ is CqlInterval<CqlDateTime>;
+                    if (cb_)
+                    {
+                        ap_ = bz_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        ap_ = null;
+                    }
+                }
+            }
+            CqlDateTime aq_ = QICoreCommon_4_0_000.Instance.earliest(context, ap_);
+            CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(ao_, aq_, true, false);
+            CqlBoolean as_ = context.Operators.In<CqlDateTime>(ak_, ar_, (string)default);
+            object at_;
+            DataType cc_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+            object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
+            bool ce_ = cd_ is CqlDateTime;
+            if (ce_)
+            {
+                at_ = cd_ as CqlDateTime;
+            }
+            else
+            {
+                if (ce_)
+                {
+                    at_ = cd_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cf_ = cd_ is CqlInterval<CqlDateTime>;
+                    if (cf_)
+                    {
+                        at_ = cd_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        at_ = null;
+                    }
+                }
+            }
+            CqlDateTime au_ = QICoreCommon_4_0_000.Instance.earliest(context, at_);
+            CqlBoolean av_ = (CqlBoolean)(au_ is not null);
+            CqlBoolean aw_ = as_
+                /* CQL 'and' (182:11-182:76) */ && av_;
+            object ax_;
+            DataType cg_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+            object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+            bool ci_ = ch_ is CqlDateTime;
+            if (ci_)
+            {
+                ax_ = ch_ as CqlDateTime;
+            }
+            else
+            {
+                if (ci_)
+                {
+                    ax_ = ch_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cj_ = ch_ is CqlInterval<CqlDateTime>;
+                    if (cj_)
+                    {
+                        ax_ = ch_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        ax_ = null;
+                    }
+                }
+            }
+            CqlDateTime ay_ = QICoreCommon_4_0_000.Instance.earliest(context, ax_);
+            CqlInterval<CqlDateTime> az_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
+            CqlBoolean ba_ = context.Operators.In<CqlDateTime>(ay_, az_, (string)default);
+            CqlBoolean bb_ = ba_;
+            object bc_;
+            DataType ck_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+            object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+            bool cm_ = cl_ is CqlDateTime;
+            if (cm_)
+            {
+                bc_ = cl_ as CqlDateTime;
+            }
+            else
+            {
+                if (cm_)
+                {
+                    bc_ = cl_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cn_ = cl_ is CqlInterval<CqlDateTime>;
+                    if (cn_)
+                    {
+                        bc_ = cl_ as CqlInterval<CqlDateTime>;
+                    }
+                    else
+                    {
+                        bc_ = null;
+                    }
+                }
+            }
+            CqlDateTime bd_ = QICoreCommon_4_0_000.Instance.earliest(context, bc_);
+            CqlDateTime be_ = context.Operators.Start(az_);
+            CqlQuantity bf_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime bg_ = context.Operators.Add(be_, bf_);
+            CqlQuantity bh_ = context.Operators.Quantity(30m, "days");
+            CqlDateTime bi_ = context.Operators.Add(be_, bh_);
+            CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bg_, bi_, true, true);
+            CqlBoolean bk_ = context.Operators.In<CqlDateTime>(bd_, bj_, (string)default);
+            CqlBoolean bl_ = bk_;
+            object bm_;
+            DataType co_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+            object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+            bool cq_ = cp_ is CqlDateTime;
+            if (cq_)
+            {
+                bm_ = cp_ as CqlDateTime;
+            }
+            else
+            {
+                if (cq_)
+                {
+                    bm_ = cp_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cr_ = cp_ is CqlInterval<CqlDateTime>;
                     if (cr_)
                     {
-                        cf_ = cq_ as CqlDateTime;
+                        bm_ = cp_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool cs_ = cq_ is CqlInterval<CqlDateTime>;
-                        if (cs_)
-                        {
-                            cf_ = cq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            cf_ = null;
-                        }
+                        bm_ = null;
                     }
                 }
-                CqlDateTime cg_ = QICoreCommon_4_0_000.Instance.earliest(context, cf_);
-                CqlInterval<CqlDateTime> ch_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
-                CqlDateTime ci_ = context.Operators.Start(ch_);
-                CqlQuantity cj_ = context.Operators.Quantity(48m, "hours");
-                CqlDateTime ck_ = context.Operators.Add(ci_, cj_);
-                CqlQuantity cl_ = context.Operators.Quantity(30m, "days");
-                CqlDateTime cm_ = context.Operators.Add(ci_, cl_);
-                CqlInterval<CqlDateTime> cn_ = context.Operators.Interval(ck_, cm_, true, true);
-                CqlBoolean co_ = context.Operators.In<CqlDateTime>(cg_, cn_, (string)default);
-                return co_;
             }
-
-
-            CqlBoolean w_() {
-                object ct_;
-                DataType cx_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
-                object cy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cx_);
-                bool cz_ = cy_ is CqlDateTime;
-                if (cz_)
-                {
-                    ct_ = cy_ as CqlDateTime;
-                }
-                else
-                {
-                    if (cz_)
-                    {
-                        ct_ = cy_ as CqlDateTime;
-                    }
-                    else
-                    {
-                        bool da_ = cy_ is CqlInterval<CqlDateTime>;
-                        if (da_)
-                        {
-                            ct_ = cy_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ct_ = null;
-                        }
-                    }
-                }
-                CqlDateTime cu_ = QICoreCommon_4_0_000.Instance.earliest(context, ct_);
-                CqlInterval<CqlDateTime> cv_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
-                CqlBoolean cw_ = context.Operators.In<CqlDateTime>(cu_, cv_, (string)default);
-                return cw_;
-            }
-
+            CqlDateTime bn_ = QICoreCommon_4_0_000.Instance.earliest(context, bm_);
+            CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bn_, az_, (string)default);
+            CqlBoolean bp_ = bo_;
             return n_
-                /* CQL 'and' (176:11-177:73) */ && o_()
-                /* CQL 'and' (176:11-178:74) */ && p_()
-                /* CQL 'and' (176:11-179:99) */ && q_()
-                /* CQL 'and' (176:11-180:97) */ && r_()
-                /* CQL 'and' (176:11-181:93) */ && s_()
-                /* CQL 'and' (176:11-182:76) */ && t_()
-                /* CQL 'and' (176:11-183:68) */ && u_()
-                /* CQL 'and' (176:11-184:149) */ && v_()
-                /* CQL 'and' (176:5-185:69) */ && w_();
+                /* CQL 'and' (176:11-177:73) */ && t_
+                /* CQL 'and' (176:11-178:74) */ && y_
+                /* CQL 'and' (176:11-179:99) */ && ab_
+                /* CQL 'and' (176:11-180:97) */ && ag_
+                /* CQL 'and' (176:11-181:93) */ && ai_
+                /* CQL 'and' (176:11-182:76) */ && aw_
+                /* CQL 'and' (176:11-183:68) */ && bb_
+                /* CQL 'and' (176:11-184:149) */ && bl_
+                /* CQL 'and' (176:5-185:69) */ && bp_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)?> g_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)?>(d_, e_, f_);
@@ -2826,38 +2532,33 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             List<CodeableConcept> d_ = QualifyingEncounter?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return o_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.High_Risk_Diagnosis_for_AKI(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
-
-                bool? l_(Condition @this) {
-                    CodeableConcept q_ = @this?.Code;
-                    CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                    return r_ is not null;
-                }
-
-
-                CqlConcept m_(Condition @this) {
-                    CodeableConcept s_ = @this?.Code;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    return t_;
-                }
-
-                IEnumerable<CqlConcept> n_ = context.Operators.WhereSelect<Condition, CqlConcept>(k_, l_, m_);
-                CqlValueSet o_ = this.High_Risk_Diagnosis_for_AKI(context);
-                CqlBoolean p_ = context.Operators.ConceptsInValueSet(n_, o_);
-                return p_;
+            bool? j_(Condition @this) {
+                CodeableConcept p_ = @this?.Code;
+                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
+                return q_ is not null;
             }
 
+
+            CqlConcept k_(Condition @this) {
+                CodeableConcept r_ = @this?.Code;
+                CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
+                return s_;
+            }
+
+            IEnumerable<CqlConcept> l_ = context.Operators.WhereSelect<Condition, CqlConcept>(i_, j_, k_);
+            CqlBoolean m_ = context.Operators.ConceptsInValueSet(l_, g_);
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'or' (194:5-196:5) */ || i_();
+                /* CQL 'or' (194:5-196:5) */ || n_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -2884,53 +2585,49 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
                 EventStatus? i_ = h_?.Value;
                 string j_ = context.Operators.Convert<string>(i_);
                 CqlBoolean k_ = context.Operators.Equal(j_, "completed");
-
-                CqlBoolean l_() {
-                    object m_;
-                    DataType r_ = HighRiskProcedures?.Performed;
-                    object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-                    bool t_ = s_ is CqlDateTime;
-                    if (t_)
+                object l_;
+                DataType r_ = HighRiskProcedures?.Performed;
+                object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
+                bool t_ = s_ is CqlDateTime;
+                if (t_)
+                {
+                    l_ = s_ as CqlDateTime;
+                }
+                else
+                {
+                    bool u_ = s_ is CqlQuantity;
+                    if (u_)
                     {
-                        m_ = s_ as CqlDateTime;
+                        l_ = s_ as CqlQuantity;
                     }
                     else
                     {
-                        bool u_ = s_ is CqlQuantity;
-                        if (u_)
+                        bool v_ = s_ is CqlInterval<CqlDateTime>;
+                        if (v_)
                         {
-                            m_ = s_ as CqlQuantity;
+                            l_ = s_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool v_ = s_ is CqlInterval<CqlDateTime>;
-                            if (v_)
+                            bool w_ = s_ is CqlInterval<CqlQuantity>;
+                            if (w_)
                             {
-                                m_ = s_ as CqlInterval<CqlDateTime>;
+                                l_ = s_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool w_ = s_ is CqlInterval<CqlQuantity>;
-                                if (w_)
-                                {
-                                    m_ = s_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    m_ = null;
-                                }
+                                l_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
-                    CqlDateTime o_ = context.Operators.Start(n_);
-                    CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
-                    return q_;
                 }
-
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
+                CqlBoolean q_ = p_;
                 return k_
-                    /* CQL 'and' (201:17-202:124) */ && l_();
+                    /* CQL 'and' (201:17-202:124) */ && q_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -2986,33 +2683,33 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
 
         bool? f_((CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? tuple_bwwsxdxsfijqjjncdevjkzegj) {
             object k_;
-            DataType w_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
-            object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
-            bool y_ = x_ is CqlDateTime;
-            if (y_)
+            DataType ae_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+            object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+            bool ag_ = af_ is CqlDateTime;
+            if (ag_)
             {
-                k_ = x_ as CqlDateTime;
+                k_ = af_ as CqlDateTime;
             }
             else
             {
-                bool z_ = x_ is CqlQuantity;
-                if (z_)
+                bool ah_ = af_ is CqlQuantity;
+                if (ah_)
                 {
-                    k_ = x_ as CqlQuantity;
+                    k_ = af_ as CqlQuantity;
                 }
                 else
                 {
-                    bool aa_ = x_ is CqlInterval<CqlDateTime>;
-                    if (aa_)
+                    bool ai_ = af_ is CqlInterval<CqlDateTime>;
+                    if (ai_)
                     {
-                        k_ = x_ as CqlInterval<CqlDateTime>;
+                        k_ = af_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ab_ = x_ is CqlInterval<CqlQuantity>;
-                        if (ab_)
+                        bool aj_ = af_ is CqlInterval<CqlQuantity>;
+                        if (aj_)
                         {
-                            k_ = x_ as CqlInterval<CqlQuantity>;
+                            k_ = af_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
@@ -3030,63 +2727,54 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             CqlDateTime r_ = context.Operators.End(n_);
             CqlInterval<CqlDateTime> s_ = context.Operators.Interval(q_, r_, true, true);
             CqlBoolean t_ = context.Operators.In<CqlDateTime>(m_, s_, (string)default);
-
-            CqlBoolean u_() {
-                object ac_;
-                DataType ah_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
-                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                bool aj_ = ai_ is CqlDateTime;
-                if (aj_)
+            object u_;
+            DataType ak_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+            object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+            bool am_ = al_ is CqlDateTime;
+            if (am_)
+            {
+                u_ = al_ as CqlDateTime;
+            }
+            else
+            {
+                bool an_ = al_ is CqlQuantity;
+                if (an_)
                 {
-                    ac_ = ai_ as CqlDateTime;
+                    u_ = al_ as CqlQuantity;
                 }
                 else
                 {
-                    bool ak_ = ai_ is CqlQuantity;
-                    if (ak_)
+                    bool ao_ = al_ is CqlInterval<CqlDateTime>;
+                    if (ao_)
                     {
-                        ac_ = ai_ as CqlQuantity;
+                        u_ = al_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool al_ = ai_ is CqlInterval<CqlDateTime>;
-                        if (al_)
+                        bool ap_ = al_ is CqlInterval<CqlQuantity>;
+                        if (ap_)
                         {
-                            ac_ = ai_ as CqlInterval<CqlDateTime>;
+                            u_ = al_ as CqlInterval<CqlQuantity>;
                         }
                         else
                         {
-                            bool am_ = ai_ is CqlInterval<CqlQuantity>;
-                            if (am_)
-                            {
-                                ac_ = ai_ as CqlInterval<CqlQuantity>;
-                            }
-                            else
-                            {
-                                ac_ = null;
-                            }
+                            u_ = null;
                         }
                     }
                 }
-                CqlInterval<CqlDateTime> ad_ = QICoreCommon_4_0_000.Instance.toInterval(context, ac_);
-                CqlDateTime ae_ = context.Operators.Start(ad_);
-                CqlInterval<CqlDateTime> af_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter);
-                CqlBoolean ag_ = context.Operators.In<CqlDateTime>(ae_, af_, (string)default);
-                return ag_;
             }
-
-
-            CqlBoolean v_() {
-                Code<EventStatus> an_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.StatusElement;
-                EventStatus? ao_ = an_?.Value;
-                string ap_ = context.Operators.Convert<string>(ao_);
-                CqlBoolean aq_ = context.Operators.Equal(ap_, "completed");
-                return aq_;
-            }
-
+            CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
+            CqlDateTime w_ = context.Operators.Start(v_);
+            CqlBoolean x_ = context.Operators.In<CqlDateTime>(w_, n_, (string)default);
+            CqlBoolean y_ = x_;
+            Code<EventStatus> z_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.StatusElement;
+            EventStatus? aa_ = z_?.Value;
+            string ab_ = context.Operators.Convert<string>(aa_);
+            CqlBoolean ac_ = context.Operators.Equal(ab_, "completed");
+            CqlBoolean ad_ = ac_;
             return t_
-                /* CQL 'and' (216:11-217:87) */ && u_()
-                /* CQL 'and' (216:5-218:39) */ && v_();
+                /* CQL 'and' (216:11-217:87) */ && y_
+                /* CQL 'and' (216:5-218:39) */ && ad_;
         }
 
         IEnumerable<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?> g_ = context.Operators.SelectWhere<ValueTuple<Procedure, Encounter>, (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?>(d_, e_, f_);
@@ -3235,87 +2923,71 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             FinancialResourceStatusCodes? k_ = j_?.Value;
             Code<FinancialResourceStatusCodes> l_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(k_);
             CqlBoolean m_ = context.Operators.Equal(l_, "active");
+            Code<ClaimUseCode> n_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.UseElement;
+            ClaimUseCode? o_ = n_?.Value;
+            Code<ClaimUseCode> p_ = context.Operators.Convert<Code<ClaimUseCode>>(o_);
+            CqlBoolean q_ = context.Operators.Equal(p_, "claim");
+            CqlBoolean r_ = q_;
+            List<Claim.ItemComponent> s_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.Item;
 
-            CqlBoolean n_() {
-                Code<ClaimUseCode> p_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.UseElement;
-                ClaimUseCode? q_ = p_?.Value;
-                Code<ClaimUseCode> r_ = context.Operators.Convert<Code<ClaimUseCode>>(q_);
-                CqlBoolean s_ = context.Operators.Equal(r_, "claim");
-                return s_;
-            }
+            bool? t_(Claim.ItemComponent ClaimItem) {
+                List<ResourceReference> w_ = ClaimItem?.Encounter;
+                CqlBoolean x_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)w_, tuple_epwvnljjfhnvfarkifgamtzks?.QualifyingEncounter);
+                List<Claim.DiagnosisComponent> y_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.Diagnosis;
 
+                bool? z_(Claim.DiagnosisComponent Dx) {
+                    PositiveInt ac_ = Dx?.SequenceElement;
+                    int? ad_ = ac_?.Value;
+                    List<Claim.ItemComponent> ae_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.Item;
 
-            CqlBoolean o_() {
-                List<Claim.ItemComponent> t_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.Item;
+                    bool? af_(Claim.ItemComponent @this) {
+                        List<PositiveInt> ap_ = @this?.DiagnosisSequenceElement;
 
-                bool? u_(Claim.ItemComponent ClaimItem) {
-                    List<ResourceReference> w_ = ClaimItem?.Encounter;
-                    CqlBoolean x_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)w_, tuple_epwvnljjfhnvfarkifgamtzks?.QualifyingEncounter);
-
-                    CqlBoolean y_() {
-                        List<Claim.DiagnosisComponent> z_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.Diagnosis;
-
-                        bool? aa_(Claim.DiagnosisComponent Dx) {
-                            PositiveInt ac_ = Dx?.SequenceElement;
-                            int? ad_ = ac_?.Value;
-                            List<Claim.ItemComponent> ae_ = tuple_epwvnljjfhnvfarkifgamtzks?.clm?.Item;
-
-                            bool? af_(Claim.ItemComponent @this) {
-                                List<PositiveInt> al_ = @this?.DiagnosisSequenceElement;
-
-                                int? am_(PositiveInt @this) {
-                                    int? ao_ = @this?.Value;
-                                    return ao_;
-                                }
-
-                                IEnumerable<int?> an_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)al_, am_);
-                                return an_ is not null;
-                            }
-
-
-                            IEnumerable<int?> ag_(Claim.ItemComponent @this) {
-                                List<PositiveInt> ap_ = @this?.DiagnosisSequenceElement;
-
-                                int? aq_(PositiveInt @this) {
-                                    int? as_ = @this?.Value;
-                                    return as_;
-                                }
-
-                                IEnumerable<int?> ar_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)ap_, aq_);
-                                return ar_;
-                            }
-
-                            IEnumerable<IEnumerable<int?>> ah_ = context.Operators.WhereSelect<Claim.ItemComponent, IEnumerable<int?>>((IEnumerable<Claim.ItemComponent>)ae_, af_, ag_);
-                            IEnumerable<int?> ai_ = context.Operators.Flatten<int?>(ah_);
-                            CqlBoolean aj_ = context.Operators.In<int?>(ad_, ai_);
-
-                            CqlBoolean ak_() {
-                                CodeableConcept at_ = Dx?.OnAdmission;
-                                CqlConcept au_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, at_);
-                                CqlValueSet av_ = this.Present_on_Admission_or_Clinically_Undetermined(context);
-                                CqlBoolean aw_ = context.Operators.ConceptInValueSet(au_, av_);
-                                return aw_;
-                            }
-
-                            return aj_
-                                /* CQL 'and' (385:17-386:89) */ && ak_();
+                        int? aq_(PositiveInt @this) {
+                            int? as_ = @this?.Value;
+                            return as_;
                         }
 
-                        CqlBoolean ab_ = context.Operators.WhereAny<Claim.DiagnosisComponent>((IEnumerable<Claim.DiagnosisComponent>)z_, aa_);
-                        return ab_;
+                        IEnumerable<int?> ar_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)ap_, aq_);
+                        return ar_ is not null;
                     }
 
-                    return x_
-                        /* CQL 'and' (383:11-387:13) */ && y_();
+
+                    IEnumerable<int?> ag_(Claim.ItemComponent @this) {
+                        List<PositiveInt> at_ = @this?.DiagnosisSequenceElement;
+
+                        int? au_(PositiveInt @this) {
+                            int? aw_ = @this?.Value;
+                            return aw_;
+                        }
+
+                        IEnumerable<int?> av_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)at_, au_);
+                        return av_;
+                    }
+
+                    IEnumerable<IEnumerable<int?>> ah_ = context.Operators.WhereSelect<Claim.ItemComponent, IEnumerable<int?>>((IEnumerable<Claim.ItemComponent>)ae_, af_, ag_);
+                    IEnumerable<int?> ai_ = context.Operators.Flatten<int?>(ah_);
+                    CqlBoolean aj_ = context.Operators.In<int?>(ad_, ai_);
+                    CodeableConcept ak_ = Dx?.OnAdmission;
+                    CqlConcept al_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ak_);
+                    CqlValueSet am_ = this.Present_on_Admission_or_Clinically_Undetermined(context);
+                    CqlBoolean an_ = context.Operators.ConceptInValueSet(al_, am_);
+                    CqlBoolean ao_ = an_;
+                    return aj_
+                        /* CQL 'and' (385:17-386:89) */ && ao_;
                 }
 
-                CqlBoolean v_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)t_, u_);
-                return v_;
+                CqlBoolean aa_ = context.Operators.WhereAny<Claim.DiagnosisComponent>((IEnumerable<Claim.DiagnosisComponent>)y_, z_);
+                CqlBoolean ab_ = aa_;
+                return x_
+                    /* CQL 'and' (383:11-387:13) */ && ab_;
             }
 
+            CqlBoolean u_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)s_, t_);
+            CqlBoolean v_ = u_;
             return m_
-                /* CQL 'and' (380:11-381:27) */ && n_()
-                /* CQL 'and' (380:5-388:7) */ && o_();
+                /* CQL 'and' (380:11-381:27) */ && r_
+                /* CQL 'and' (380:5-388:7) */ && v_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim clm)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, Claim>, (CqlTupleMetadata, Encounter QualifyingEncounter, Claim clm)?>(c_, d_, e_);
@@ -3341,15 +3013,11 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             CqlDateTime k_ = QICoreCommon_4_0_000.Instance.earliest(context, j_);
             CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
             CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
-
-            CqlBoolean n_() {
-                DataType o_ = FirstHeartBeats?.Value;
-                CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_ as Quantity);
-                return p_ is not null;
-            }
-
+            DataType n_ = FirstHeartBeats?.Value;
+            CqlQuantity o_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, n_ as Quantity);
+            CqlBoolean p_ = (CqlBoolean)(o_ is not null);
             return m_
-                /* CQL 'and' (427:7-428:45) */ && n_();
+                /* CQL 'and' (427:7-428:45) */ && p_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
@@ -3403,15 +3071,11 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             CqlDateTime k_ = QICoreCommon_4_0_000.Instance.earliest(context, j_);
             CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
             CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
-
-            CqlBoolean n_() {
-                DataType o_ = FirstRespiration?.Value;
-                CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_ as Quantity);
-                return p_ is not null;
-            }
-
+            DataType n_ = FirstRespiration?.Value;
+            CqlQuantity o_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, n_ as Quantity);
+            CqlBoolean p_ = (CqlBoolean)(o_ is not null);
             return m_
-                /* CQL 'and' (434:7-435:46) */ && n_();
+                /* CQL 'and' (434:7-435:46) */ && p_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
@@ -3535,15 +3199,11 @@ public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHH
             CqlDateTime k_ = QICoreCommon_4_0_000.Instance.earliest(context, j_);
             CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
             CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
-
-            CqlBoolean n_() {
-                DataType o_ = FirstTemperature?.Value;
-                CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_ as Quantity);
-                return p_ is not null;
-            }
-
+            DataType n_ = FirstTemperature?.Value;
+            CqlQuantity o_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, n_ as Quantity);
+            CqlBoolean p_ = (CqlBoolean)(o_ is not null);
             return m_
-                /* CQL 'and' (420:7-421:46) */ && n_();
+                /* CQL 'and' (420:7-421:46) */ && p_;
         }
 
         IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS871FHIRHHHyper", "1.0.000")]
 public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIRHHHyper_1_0_000>
 {
@@ -147,28 +147,18 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
             CqlDate l_ = context.Operators.DateFrom(k_);
             int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
             CqlBoolean n_ = context.Operators.GreaterOrEqual(m_, 18);
-
-            CqlBoolean o_() {
-                Period q_ = InpatientEncounter?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.End(r_);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlBoolean u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
-                return u_;
-            }
-
-
-            CqlBoolean p_() {
-                Code<Encounter.EncounterStatus> v_ = InpatientEncounter?.StatusElement;
-                Encounter.EncounterStatus? w_ = v_?.Value;
-                Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
-                CqlBoolean y_ = context.Operators.Equal(x_, "finished");
-                return y_;
-            }
-
+            CqlDateTime o_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
+            CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+            CqlBoolean r_ = q_;
+            Code<Encounter.EncounterStatus> s_ = InpatientEncounter?.StatusElement;
+            Encounter.EncounterStatus? t_ = s_?.Value;
+            Code<Encounter.EncounterStatus> u_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(t_);
+            CqlBoolean v_ = context.Operators.Equal(u_, "finished");
+            CqlBoolean w_ = v_;
             return n_
-                /* CQL 'and' (212:11-213:75) */ && o_()
-                /* CQL 'and' (212:5-214:48) */ && p_();
+                /* CQL 'and' (212:11-213:75) */ && r_
+                /* CQL 'and' (212:5-214:48) */ && w_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -215,114 +205,77 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 Encounter p_ = Hospitalization?.encounter;
                 List<ResourceReference> q_ = p_?.ReasonReference;
                 CqlBoolean r_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)q_, DiabetesEncounter);
+                List<CodeableConcept> s_ = p_?.ReasonCode;
 
-                CqlBoolean s_() {
-                    Encounter u_ = Hospitalization?.encounter;
-                    List<CodeableConcept> v_ = u_?.ReasonCode;
-
-                    CqlConcept w_(CodeableConcept @this) {
-                        CqlConcept aa_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return aa_;
-                    }
-
-                    IEnumerable<CqlConcept> x_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)v_, w_);
-                    CqlValueSet y_ = this.Diabetes(context);
-                    CqlBoolean z_ = context.Operators.ConceptsInValueSet(x_, y_);
-                    return z_;
+                CqlConcept t_(CodeableConcept @this) {
+                    CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ae_;
                 }
 
-
-                CqlBoolean t_() {
-                    CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesEncounter as Condition);
-                    CqlDateTime ac_ = context.Operators.Start(ab_);
-                    CqlInterval<CqlDateTime> ad_ = Hospitalization?.hospitalizationPeriod;
-                    CqlDateTime ae_ = context.Operators.End(ad_);
-                    CqlBoolean af_ = context.Operators.Before(ac_, ae_, (string)default);
-                    return af_;
-                }
-
+                IEnumerable<CqlConcept> u_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)s_, t_);
+                CqlValueSet v_ = this.Diabetes(context);
+                CqlBoolean w_ = context.Operators.ConceptsInValueSet(u_, v_);
+                CqlBoolean x_ = w_;
+                CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesEncounter as Condition);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                CqlInterval<CqlDateTime> aa_ = Hospitalization?.hospitalizationPeriod;
+                CqlDateTime ab_ = context.Operators.End(aa_);
+                CqlBoolean ac_ = context.Operators.Before(z_, ab_, (string)default);
+                CqlBoolean ad_ = ac_;
                 return (r_
-                    /* CQL 'or' (121:15-123:9) */ || s_())
-                    /* CQL 'and' (121:9-124:113) */ && t_();
+                    /* CQL 'or' (121:15-123:9) */ || x_)
+                    /* CQL 'and' (121:9-124:113) */ && ad_;
             }
 
             IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
             IEnumerable<Condition> j_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
 
             bool? k_(Condition DiabetesProblem) {
-                CodeableConcept ag_ = DiabetesProblem?.VerificationStatus;
-                CqlConcept ah_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ag_);
-
-                CqlBoolean ai_() {
-                    CodeableConcept aj_ = DiabetesProblem?.VerificationStatus;
-                    CqlConcept ak_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aj_);
-                    CqlCode al_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-                    CqlConcept am_ = context.Operators.ConvertCodeToConcept(al_);
-                    CqlBoolean an_ = context.Operators.Equivalent(ak_, am_);
-
-                    CqlBoolean ao_() {
-                        CodeableConcept as_ = DiabetesProblem?.VerificationStatus;
-                        CqlConcept at_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, as_);
-                        CqlCode au_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                        CqlConcept av_ = context.Operators.ConvertCodeToConcept(au_);
-                        CqlBoolean aw_ = context.Operators.Equivalent(at_, av_);
-                        return aw_;
-                    }
-
-
-                    CqlBoolean ap_() {
-                        CodeableConcept ax_ = DiabetesProblem?.VerificationStatus;
-                        CqlConcept ay_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ax_);
-                        CqlCode az_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                        CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
-                        CqlBoolean bb_ = context.Operators.Equivalent(ay_, ba_);
-                        return bb_;
-                    }
-
-
-                    CqlBoolean aq_() {
-                        CodeableConcept bc_ = DiabetesProblem?.VerificationStatus;
-                        CqlConcept bd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, bc_);
-                        CqlCode be_ = QICoreCommon_4_0_000.Instance.differential(context);
-                        CqlConcept bf_ = context.Operators.ConvertCodeToConcept(be_);
-                        CqlBoolean bg_ = context.Operators.Equivalent(bd_, bf_);
-                        return bg_;
-                    }
-
-
-                    CqlBoolean ar_() {
-                        CqlInterval<CqlDateTime> bh_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesProblem as Condition);
-                        CqlDateTime bi_ = context.Operators.Start(bh_);
-                        CqlInterval<CqlDateTime> bj_ = Hospitalization?.hospitalizationPeriod;
-                        CqlDateTime bk_ = context.Operators.End(bj_);
-                        CqlBoolean bl_ = context.Operators.Before(bi_, bk_, (string)default);
-                        return bl_;
-                    }
-
-                    return (an_
-                        /* CQL 'or' (127:74-128:80) */ || ao_()
-                        /* CQL 'or' (127:74-129:80) */ || ap_()
-                        /* CQL 'or' (127:72-131:11) */ || aq_())
-                        /* CQL 'and' (127:72-132:113) */ && ar_();
-                }
-
-                return (CqlBoolean)(ah_ is null)
-                    /* CQL 'implies' (127:11-132:113) */ || ai_();
+                CodeableConcept af_ = DiabetesProblem?.VerificationStatus;
+                CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_);
+                CqlCode ah_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+                CqlConcept ai_ = context.Operators.ConvertCodeToConcept(ah_);
+                CqlBoolean aj_ = context.Operators.Equivalent(ag_, ai_);
+                CqlCode ak_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+                CqlConcept al_ = context.Operators.ConvertCodeToConcept(ak_);
+                CqlBoolean am_ = context.Operators.Equivalent(ag_, al_);
+                CqlBoolean an_ = am_;
+                CqlCode ao_ = QICoreCommon_4_0_000.Instance.provisional(context);
+                CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+                CqlBoolean aq_ = context.Operators.Equivalent(ag_, ap_);
+                CqlBoolean ar_ = aq_;
+                CqlCode as_ = QICoreCommon_4_0_000.Instance.differential(context);
+                CqlConcept at_ = context.Operators.ConvertCodeToConcept(as_);
+                CqlBoolean au_ = context.Operators.Equivalent(ag_, at_);
+                CqlBoolean av_ = au_;
+                CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesProblem as Condition);
+                CqlDateTime ax_ = context.Operators.Start(aw_);
+                CqlInterval<CqlDateTime> ay_ = Hospitalization?.hospitalizationPeriod;
+                CqlDateTime az_ = context.Operators.End(ay_);
+                CqlBoolean ba_ = context.Operators.Before(ax_, az_, (string)default);
+                CqlBoolean bb_ = ba_;
+                CqlBoolean bc_ = (aj_
+                    /* CQL 'or' (127:74-128:80) */ || an_
+                    /* CQL 'or' (127:74-129:80) */ || ar_
+                    /* CQL 'or' (127:72-131:11) */ || av_)
+                    /* CQL 'and' (127:72-132:113) */ && bb_;
+                return (CqlBoolean)(ag_ is null)
+                    /* CQL 'implies' (127:11-132:113) */ || bc_;
             }
 
             IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
             IEnumerable<Condition> m_ = context.Operators.Union<Condition>(i_ as IEnumerable<Condition>, l_ as IEnumerable<Condition>);
 
             bool? n_(Condition DiabetesCondition) {
-                ResourceReference bm_ = DiabetesCondition?.Subject;
-                FhirString bn_ = bm_?.ReferenceElement;
-                string bo_ = bn_?.Value;
-                Encounter bp_ = Hospitalization?.encounter;
-                ResourceReference bq_ = bp_?.Subject;
-                FhirString br_ = bq_?.ReferenceElement;
-                string bs_ = br_?.Value;
-                CqlBoolean bt_ = context.Operators.Equal(bo_, bs_);
-                return bt_;
+                ResourceReference bd_ = DiabetesCondition?.Subject;
+                FhirString be_ = bd_?.ReferenceElement;
+                string bf_ = be_?.Value;
+                Encounter bg_ = Hospitalization?.encounter;
+                ResourceReference bh_ = bg_?.Subject;
+                FhirString bi_ = bh_?.ReferenceElement;
+                string bj_ = bi_?.Value;
+                CqlBoolean bk_ = context.Operators.Equal(bf_, bj_);
+                return bk_;
             }
 
             CqlBoolean o_ = context.Operators.WhereAny<Condition>(m_, n_);
@@ -331,8 +284,8 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
 
         Encounter c_((CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization) {
-            Encounter bu_ = Hospitalization?.encounter;
-            return bu_;
+            Encounter bl_ = Hospitalization?.encounter;
+            return bl_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.WhereSelect<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, Encounter>(a_, b_, c_);
@@ -361,17 +314,13 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 IEnumerable<string> s_ = context.Operators.Split((string)r_, "/");
                 string t_ = context.Operators.Last<string>(s_);
                 CqlBoolean u_ = context.Operators.Equal(q_, t_);
-
-                CqlBoolean v_() {
-                    CodeableConcept w_ = M?.Code;
-                    CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_);
-                    CqlValueSet y_ = this.Hypoglycemics_Treatment_Medications(context);
-                    CqlBoolean z_ = context.Operators.ConceptInValueSet(x_, y_);
-                    return z_;
-                }
-
+                CodeableConcept v_ = M?.Code;
+                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
+                CqlValueSet x_ = this.Hypoglycemics_Treatment_Medications(context);
+                CqlBoolean y_ = context.Operators.ConceptInValueSet(w_, x_);
+                CqlBoolean z_ = y_;
                 return u_
-                    /* CQL 'and' */ && v_();
+                    /* CQL 'and' */ && z_;
             }
 
             CqlBoolean p_ = context.Operators.WhereAny<Medication>(n_, o_);
@@ -399,18 +348,14 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 "in-progress",
             ];
             CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
-
-            CqlBoolean ag_() {
-                CqlInterval<CqlDateTime> ah_ = tuple_brdbxsuhdqixbcfmgdsacwig?.Hospitalization?.hospitalizationPeriod;
-                DataType ai_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.Effective;
-                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
-                CqlInterval<CqlDateTime> ak_ = QICoreCommon_4_0_000.Instance.toInterval(context, aj_);
-                CqlBoolean al_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ah_, ak_, (string)default);
-                return al_;
-            }
-
+            CqlInterval<CqlDateTime> ag_ = tuple_brdbxsuhdqixbcfmgdsacwig?.Hospitalization?.hospitalizationPeriod;
+            DataType ah_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.Effective;
+            object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+            CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+            CqlBoolean ak_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ag_, aj_, (string)default);
+            CqlBoolean al_ = ak_;
             return af_
-                /* CQL 'and' (164:5-165:95) */ && ag_();
+                /* CQL 'and' (164:5-165:95) */ && al_;
         }
 
         IEnumerable<(CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)?> k_ = context.Operators.SelectWhere<ValueTuple<(CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>, (CqlTupleMetadata, (CqlTupleMetadata, Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? Hospitalization, MedicationAdministration HypoglycemicMed)?>(h_, i_, j_);
@@ -441,25 +386,25 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
             bool? h_(Observation GlucoseTest) {
                 object j_;
-                DataType p_ = GlucoseTest?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                bool r_ = q_ is CqlDateTime;
-                if (r_)
+                DataType y_ = GlucoseTest?.Effective;
+                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                bool aa_ = z_ is CqlDateTime;
+                if (aa_)
                 {
-                    j_ = q_ as CqlDateTime;
+                    j_ = z_ as CqlDateTime;
                 }
                 else
                 {
-                    if (r_)
+                    if (aa_)
                     {
-                        j_ = q_ as CqlDateTime;
+                        j_ = z_ as CqlDateTime;
                     }
                     else
                     {
-                        bool s_ = q_ is CqlInterval<CqlDateTime>;
-                        if (s_)
+                        bool ab_ = z_ is CqlInterval<CqlDateTime>;
+                        if (ab_)
                         {
-                            j_ = q_ as CqlInterval<CqlDateTime>;
+                            j_ = z_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -470,32 +415,24 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 CqlDateTime k_ = QICoreCommon_4_0_000.Instance.earliest(context, j_);
                 CqlInterval<CqlDateTime> l_ = Hospitalization?.hospitalizationPeriod;
                 CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
-
-                CqlBoolean n_() {
-                    Code<ObservationStatus> t_ = GlucoseTest?.StatusElement;
-                    ObservationStatus? u_ = t_?.Value;
-                    string v_ = context.Operators.Convert<string>(u_);
-                    string[] w_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
-                    return x_;
-                }
-
-
-                CqlBoolean o_() {
-                    DataType y_ = GlucoseTest?.Value;
-                    object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
-                    CqlQuantity aa_ = context.Operators.Quantity(200m, "mg/dL");
-                    CqlBoolean ab_ = context.Operators.GreaterOrEqual(z_ as CqlQuantity, aa_);
-                    return ab_;
-                }
-
+                Code<ObservationStatus> n_ = GlucoseTest?.StatusElement;
+                ObservationStatus? o_ = n_?.Value;
+                string p_ = context.Operators.Convert<string>(o_);
+                string[] q_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
+                CqlBoolean s_ = r_;
+                DataType t_ = GlucoseTest?.Value;
+                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+                CqlQuantity v_ = context.Operators.Quantity(200m, "mg/dL");
+                CqlBoolean w_ = context.Operators.GreaterOrEqual(u_ as CqlQuantity, v_);
+                CqlBoolean x_ = w_;
                 return m_
-                    /* CQL 'and' (113:17-114:69) */ && n_()
-                    /* CQL 'and' (113:17-115:44) */ && o_();
+                    /* CQL 'and' (113:17-114:69) */ && s_
+                    /* CQL 'and' (113:17-115:44) */ && x_;
             }
 
             CqlBoolean i_ = context.Operators.WhereAny<Observation>(g_, h_);
@@ -628,53 +565,45 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                         "corrected",
                     ];
                     CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-
-                    CqlBoolean z_() {
-                        DataType ab_ = GlucoseTest?.Value;
-                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
-                        CqlQuantity ad_ = context.Operators.Quantity(300m, "mg/dL");
-                        CqlBoolean ae_ = context.Operators.Greater(ac_ as CqlQuantity, ad_);
-                        return ae_;
+                    DataType z_ = GlucoseTest?.Value;
+                    object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                    CqlQuantity ab_ = context.Operators.Quantity(300m, "mg/dL");
+                    CqlBoolean ac_ = context.Operators.Greater(aa_ as CqlQuantity, ab_);
+                    CqlBoolean ad_ = ac_;
+                    object ae_;
+                    DataType aj_ = GlucoseTest?.Effective;
+                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                    bool al_ = ak_ is CqlDateTime;
+                    if (al_)
+                    {
+                        ae_ = ak_ as CqlDateTime;
                     }
-
-
-                    CqlBoolean aa_() {
-                        object af_;
-                        DataType aj_ = GlucoseTest?.Effective;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        bool al_ = ak_ is CqlDateTime;
+                    else
+                    {
                         if (al_)
                         {
-                            af_ = ak_ as CqlDateTime;
+                            ae_ = ak_ as CqlDateTime;
                         }
                         else
                         {
-                            if (al_)
+                            bool am_ = ak_ is CqlInterval<CqlDateTime>;
+                            if (am_)
                             {
-                                af_ = ak_ as CqlDateTime;
+                                ae_ = ak_ as CqlInterval<CqlDateTime>;
                             }
                             else
                             {
-                                bool am_ = ak_ is CqlInterval<CqlDateTime>;
-                                if (am_)
-                                {
-                                    af_ = ak_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    af_ = null;
-                                }
+                                ae_ = null;
                             }
                         }
-                        CqlDateTime ag_ = QICoreCommon_4_0_000.Instance.earliest(context, af_);
-                        CqlInterval<CqlDateTime> ah_ = EncounterDay?.dayPeriod;
-                        CqlBoolean ai_ = context.Operators.In<CqlDateTime>(ag_, ah_, (string)default);
-                        return ai_;
                     }
-
+                    CqlDateTime af_ = QICoreCommon_4_0_000.Instance.earliest(context, ae_);
+                    CqlInterval<CqlDateTime> ag_ = EncounterDay?.dayPeriod;
+                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(af_, ag_, (string)default);
+                    CqlBoolean ai_ = ah_;
                     return y_
-                        /* CQL 'and' (52:23-53:53) */ && z_()
-                        /* CQL 'and' (52:17-54:86) */ && aa_();
+                        /* CQL 'and' (52:23-53:53) */ && ad_
+                        /* CQL 'and' (52:17-54:86) */ && ai_;
                 }
 
                 CqlBoolean o_ = context.Operators.WhereAny<Observation>(m_, n_);
@@ -689,53 +618,45 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                         "corrected",
                     ];
                     CqlBoolean ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
-
-                    CqlBoolean as_() {
-                        DataType au_ = GlucoseTest?.Value;
-                        object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
-                        CqlQuantity aw_ = context.Operators.Quantity(200m, "mg/dL");
-                        CqlBoolean ax_ = context.Operators.GreaterOrEqual(av_ as CqlQuantity, aw_);
-                        return ax_;
+                    DataType as_ = GlucoseTest?.Value;
+                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+                    CqlQuantity au_ = context.Operators.Quantity(200m, "mg/dL");
+                    CqlBoolean av_ = context.Operators.GreaterOrEqual(at_ as CqlQuantity, au_);
+                    CqlBoolean aw_ = av_;
+                    object ax_;
+                    DataType bc_ = GlucoseTest?.Effective;
+                    object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                    bool be_ = bd_ is CqlDateTime;
+                    if (be_)
+                    {
+                        ax_ = bd_ as CqlDateTime;
                     }
-
-
-                    CqlBoolean at_() {
-                        object ay_;
-                        DataType bc_ = GlucoseTest?.Effective;
-                        object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                        bool be_ = bd_ is CqlDateTime;
+                    else
+                    {
                         if (be_)
                         {
-                            ay_ = bd_ as CqlDateTime;
+                            ax_ = bd_ as CqlDateTime;
                         }
                         else
                         {
-                            if (be_)
+                            bool bf_ = bd_ is CqlInterval<CqlDateTime>;
+                            if (bf_)
                             {
-                                ay_ = bd_ as CqlDateTime;
+                                ax_ = bd_ as CqlInterval<CqlDateTime>;
                             }
                             else
                             {
-                                bool bf_ = bd_ is CqlInterval<CqlDateTime>;
-                                if (bf_)
-                                {
-                                    ay_ = bd_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    ay_ = null;
-                                }
+                                ax_ = null;
                             }
                         }
-                        CqlDateTime az_ = QICoreCommon_4_0_000.Instance.earliest(context, ay_);
-                        CqlInterval<CqlDateTime> ba_ = EncounterDay?.dayPeriod;
-                        CqlBoolean bb_ = context.Operators.In<CqlDateTime>(az_, ba_, (string)default);
-                        return bb_;
                     }
-
+                    CqlDateTime ay_ = QICoreCommon_4_0_000.Instance.earliest(context, ax_);
+                    CqlInterval<CqlDateTime> az_ = EncounterDay?.dayPeriod;
+                    CqlBoolean ba_ = context.Operators.In<CqlDateTime>(ay_, az_, (string)default);
+                    CqlBoolean bb_ = ba_;
                     return ar_
-                        /* CQL 'and' (57:23-58:54) */ && as_()
-                        /* CQL 'and' (57:17-59:86) */ && at_();
+                        /* CQL 'and' (57:23-58:54) */ && aw_
+                        /* CQL 'and' (57:17-59:86) */ && bb_;
                 }
 
                 CqlBoolean q_ = context.Operators.WhereAny<Observation>(m_, p_);
@@ -750,43 +671,39 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                         "corrected",
                     ];
                     CqlBoolean bk_ = context.Operators.In<string>(bi_, (IEnumerable<string>)bj_);
-
-                    CqlBoolean bl_() {
-                        object bm_;
-                        DataType bq_ = GlucoseTest?.Effective;
-                        object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
-                        bool bs_ = br_ is CqlDateTime;
+                    object bl_;
+                    DataType bq_ = GlucoseTest?.Effective;
+                    object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
+                    bool bs_ = br_ is CqlDateTime;
+                    if (bs_)
+                    {
+                        bl_ = br_ as CqlDateTime;
+                    }
+                    else
+                    {
                         if (bs_)
                         {
-                            bm_ = br_ as CqlDateTime;
+                            bl_ = br_ as CqlDateTime;
                         }
                         else
                         {
-                            if (bs_)
+                            bool bt_ = br_ is CqlInterval<CqlDateTime>;
+                            if (bt_)
                             {
-                                bm_ = br_ as CqlDateTime;
+                                bl_ = br_ as CqlInterval<CqlDateTime>;
                             }
                             else
                             {
-                                bool bt_ = br_ is CqlInterval<CqlDateTime>;
-                                if (bt_)
-                                {
-                                    bm_ = br_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bm_ = null;
-                                }
+                                bl_ = null;
                             }
                         }
-                        CqlDateTime bn_ = QICoreCommon_4_0_000.Instance.earliest(context, bm_);
-                        CqlInterval<CqlDateTime> bo_ = EncounterDay?.dayPeriod;
-                        CqlBoolean bp_ = context.Operators.In<CqlDateTime>(bn_, bo_, (string)default);
-                        return bp_;
                     }
-
+                    CqlDateTime bm_ = QICoreCommon_4_0_000.Instance.earliest(context, bl_);
+                    CqlInterval<CqlDateTime> bn_ = EncounterDay?.dayPeriod;
+                    CqlBoolean bo_ = context.Operators.In<CqlDateTime>(bm_, bn_, (string)default);
+                    CqlBoolean bp_ = bo_;
                     return bk_
-                        /* CQL 'and' (62:17-63:86) */ && bl_();
+                        /* CQL 'and' (62:17-63:86) */ && bp_;
                 }
 
                 CqlBoolean s_ = context.Operators.WhereAny<Observation>(m_, r_);
@@ -830,37 +747,22 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 int? n_ = EncounterDay?.dayNumber;
                 CqlInterval<CqlDateTime> o_ = EncounterDay?.dayPeriod;
                 CqlBoolean p_ = EncounterDay?.hasSevereResult;
-
-                CqlBoolean q_() {
-                    CqlBoolean s_ = EncounterDay?.hasNoGlucoseTest;
-
-                    CqlBoolean t_() {
-                        IEnumerable<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?> v_ = EncounterWithResultDays?.relevantDays;
-                        int? w_ = EncounterDay?.dayNumber;
-                        int? x_ = context.Operators.Subtract(w_, 2);
-                        (CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)? y_ = context.Operators.Indexer<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?>(v_, x_);
-                        CqlBoolean z_ = y_?.hasElevatedResult;
-                        return z_;
-                    }
-
-
-                    CqlBoolean u_() {
-                        IEnumerable<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?> aa_ = EncounterWithResultDays?.relevantDays;
-                        int? ab_ = EncounterDay?.dayNumber;
-                        int? ac_ = context.Operators.Subtract(ab_, 3);
-                        (CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)? ad_ = context.Operators.Indexer<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?>(aa_, ac_);
-                        CqlBoolean ae_ = ad_?.hasElevatedResult;
-                        return ae_;
-                    }
-
-                    return s_
-                        /* CQL 'and' (77:18-78:102) */ && t_()
-                        /* CQL 'and' (77:16-80:13) */ && u_();
-                }
-
-                (CqlTupleMetadata, int? dayIndex, CqlInterval<CqlDateTime> dayPeriod, bool? hasHyperglycemicEvent)? r_ = (CqlTupleMetadata_FNeERNKXWKJeEjWXREHDLePdY, n_, o_, (bool?)(p_
-                    /* CQL 'or' (76:32-81:9) */ || q_()));
-                return r_;
+                CqlBoolean q_ = EncounterDay?.hasNoGlucoseTest;
+                IEnumerable<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?> r_ = EncounterWithResultDays?.relevantDays;
+                int? s_ = context.Operators.Subtract(n_, 2);
+                (CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)? t_ = context.Operators.Indexer<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?>(r_, s_);
+                CqlBoolean u_ = t_?.hasElevatedResult;
+                CqlBoolean v_ = u_;
+                int? w_ = context.Operators.Subtract(n_, 3);
+                (CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)? x_ = context.Operators.Indexer<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?>(r_, w_);
+                CqlBoolean y_ = x_?.hasElevatedResult;
+                CqlBoolean z_ = y_;
+                CqlBoolean aa_ = q_
+                    /* CQL 'and' (77:18-78:102) */ && v_
+                    /* CQL 'and' (77:16-80:13) */ && z_;
+                (CqlTupleMetadata, int? dayIndex, CqlInterval<CqlDateTime> dayPeriod, bool? hasHyperglycemicEvent)? ab_ = (CqlTupleMetadata_FNeERNKXWKJeEjWXREHDLePdY, n_, o_, (bool?)(p_
+                    /* CQL 'or' (76:32-81:9) */ || aa_));
+                return ab_;
             }
 
             IEnumerable<(CqlTupleMetadata, int? dayIndex, CqlInterval<CqlDateTime> dayPeriod, bool? hasHyperglycemicEvent)?> i_ = context.Operators.WhereSelect<(CqlTupleMetadata, int? dayNumber, CqlInterval<CqlDateTime> dayPeriod, bool? hasSevereResult, bool? hasElevatedResult, bool? hasNoGlucoseTest)?, (CqlTupleMetadata, int? dayIndex, CqlInterval<CqlDateTime> dayPeriod, bool? hasHyperglycemicEvent)?>(f_, g_, h_);
@@ -898,64 +800,56 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
             object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
             CqlQuantity m_ = context.Operators.Quantity(600m, "mg/dL");
             CqlBoolean n_ = context.Operators.Greater(l_ as CqlQuantity, m_);
-
-            CqlBoolean o_() {
-                Code<ObservationStatus> q_ = tuple_gldtpgaqprrprerabeflfanwh?.GlucoseTest?.StatusElement;
-                ObservationStatus? r_ = q_?.Value;
-                string s_ = context.Operators.Convert<string>(r_);
-                string[] t_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
-                return u_;
+            Code<ObservationStatus> o_ = tuple_gldtpgaqprrprerabeflfanwh?.GlucoseTest?.StatusElement;
+            ObservationStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            string[] r_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            CqlBoolean t_ = s_;
+            object u_;
+            DataType af_ = tuple_gldtpgaqprrprerabeflfanwh?.GlucoseTest?.Effective;
+            object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+            bool ah_ = ag_ is CqlDateTime;
+            if (ah_)
+            {
+                u_ = ag_ as CqlDateTime;
             }
-
-
-            CqlBoolean p_() {
-                object v_;
-                DataType af_ = tuple_gldtpgaqprrprerabeflfanwh?.GlucoseTest?.Effective;
-                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
-                bool ah_ = ag_ is CqlDateTime;
+            else
+            {
                 if (ah_)
                 {
-                    v_ = ag_ as CqlDateTime;
+                    u_ = ag_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ah_)
+                    bool ai_ = ag_ is CqlInterval<CqlDateTime>;
+                    if (ai_)
                     {
-                        v_ = ag_ as CqlDateTime;
+                        u_ = ag_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ai_ = ag_ is CqlInterval<CqlDateTime>;
-                        if (ai_)
-                        {
-                            v_ = ag_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            v_ = null;
-                        }
+                        u_ = null;
                     }
                 }
-                CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
-                CqlInterval<CqlDateTime> x_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_gldtpgaqprrprerabeflfanwh?.InpatientHospitalization);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                CqlQuantity z_ = context.Operators.Quantity(1m, "hour");
-                CqlDateTime aa_ = context.Operators.Subtract(y_, z_);
-                CqlQuantity ab_ = context.Operators.Quantity(6m, "hours");
-                CqlDateTime ac_ = context.Operators.Add(y_, ab_);
-                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(aa_, ac_, true, true);
-                CqlBoolean ae_ = context.Operators.In<CqlDateTime>(w_, ad_, (string)default);
-                return ae_;
             }
-
+            CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
+            CqlInterval<CqlDateTime> w_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_gldtpgaqprrprerabeflfanwh?.InpatientHospitalization);
+            CqlDateTime x_ = context.Operators.Start(w_);
+            CqlQuantity y_ = context.Operators.Quantity(1m, "hour");
+            CqlDateTime z_ = context.Operators.Subtract(x_, y_);
+            CqlQuantity aa_ = context.Operators.Quantity(6m, "hours");
+            CqlDateTime ab_ = context.Operators.Add(x_, aa_);
+            CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_, true, true);
+            CqlBoolean ad_ = context.Operators.In<CqlDateTime>(v_, ac_, (string)default);
+            CqlBoolean ae_ = ad_;
             return n_
-                /* CQL 'and' (174:11-175:67) */ && o_()
-                /* CQL 'and' (174:5-176:136) */ && p_();
+                /* CQL 'and' (174:11-175:67) */ && t_
+                /* CQL 'and' (174:5-176:136) */ && ae_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter InpatientHospitalization, Observation GlucoseTest)?> g_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation>, (CqlTupleMetadata, Encounter InpatientHospitalization, Observation GlucoseTest)?>(d_, e_, f_);
@@ -987,25 +881,25 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
         bool? g_((CqlTupleMetadata, Encounter InpatientHospitalization, Observation GlucoseResult600, Observation EarlierGlucoseTest)? tuple_ghpnfyjsiaqamntcrzhgtgped) {
             object l_;
-            DataType x_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.GlucoseResult600?.Effective;
-            object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
-            bool z_ = y_ is CqlDateTime;
-            if (z_)
+            DataType ai_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.GlucoseResult600?.Effective;
+            object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+            bool ak_ = aj_ is CqlDateTime;
+            if (ak_)
             {
-                l_ = y_ as CqlDateTime;
+                l_ = aj_ as CqlDateTime;
             }
             else
             {
-                if (z_)
+                if (ak_)
                 {
-                    l_ = y_ as CqlDateTime;
+                    l_ = aj_ as CqlDateTime;
                 }
                 else
                 {
-                    bool aa_ = y_ is CqlInterval<CqlDateTime>;
-                    if (aa_)
+                    bool al_ = aj_ is CqlInterval<CqlDateTime>;
+                    if (al_)
                     {
-                        l_ = y_ as CqlInterval<CqlDateTime>;
+                        l_ = aj_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
@@ -1022,86 +916,74 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
             CqlDateTime s_ = context.Operators.Add(o_, r_);
             CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
             CqlBoolean u_ = context.Operators.In<CqlDateTime>(m_, t_, (string)default);
-
-            CqlBoolean v_() {
-                object ab_;
-                DataType al_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.EarlierGlucoseTest?.Effective;
-                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
-                bool an_ = am_ is CqlDateTime;
-                if (an_)
+            object v_;
+            DataType am_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.EarlierGlucoseTest?.Effective;
+            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            bool ao_ = an_ is CqlDateTime;
+            if (ao_)
+            {
+                v_ = an_ as CqlDateTime;
+            }
+            else
+            {
+                if (ao_)
                 {
-                    ab_ = am_ as CqlDateTime;
+                    v_ = an_ as CqlDateTime;
                 }
                 else
                 {
-                    if (an_)
+                    bool ap_ = an_ is CqlInterval<CqlDateTime>;
+                    if (ap_)
                     {
-                        ab_ = am_ as CqlDateTime;
+                        v_ = an_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ao_ = am_ is CqlInterval<CqlDateTime>;
-                        if (ao_)
-                        {
-                            ab_ = am_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ab_ = null;
-                        }
+                        v_ = null;
                     }
                 }
-                CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_);
-                CqlInterval<CqlDateTime> ad_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_ghpnfyjsiaqamntcrzhgtgped?.InpatientHospitalization);
-                CqlDateTime ae_ = context.Operators.Start(ad_);
-                CqlQuantity af_ = context.Operators.Quantity(1m, "hour");
-                CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
-                object ah_;
-                DataType ap_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.GlucoseResult600?.Effective;
-                object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                bool ar_ = aq_ is CqlDateTime;
-                if (ar_)
+            }
+            CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
+            object x_;
+            DataType aq_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.GlucoseResult600?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            bool as_ = ar_ is CqlDateTime;
+            if (as_)
+            {
+                x_ = ar_ as CqlDateTime;
+            }
+            else
+            {
+                if (as_)
                 {
-                    ah_ = aq_ as CqlDateTime;
+                    x_ = ar_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ar_)
+                    bool at_ = ar_ is CqlInterval<CqlDateTime>;
+                    if (at_)
                     {
-                        ah_ = aq_ as CqlDateTime;
+                        x_ = ar_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool as_ = aq_ is CqlInterval<CqlDateTime>;
-                        if (as_)
-                        {
-                            ah_ = aq_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            ah_ = null;
-                        }
+                        x_ = null;
                     }
                 }
-                CqlDateTime ai_ = QICoreCommon_4_0_000.Instance.earliest(context, ah_);
-                CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ag_, ai_, true, false);
-                CqlBoolean ak_ = context.Operators.In<CqlDateTime>(ac_, aj_, (string)default);
-                return ak_;
             }
-
-
-            CqlBoolean w_() {
-                Id at_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.EarlierGlucoseTest?.IdElement;
-                string au_ = at_?.Value;
-                Id av_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.GlucoseResult600?.IdElement;
-                string aw_ = av_?.Value;
-                CqlBoolean ax_ = context.Operators.Equivalent(au_, aw_);
-                return !ax_;
-            }
-
+            CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(q_, y_, true, false);
+            CqlBoolean aa_ = context.Operators.In<CqlDateTime>(w_, z_, (string)default);
+            CqlBoolean ab_ = aa_;
+            Id ac_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.EarlierGlucoseTest?.IdElement;
+            string ad_ = ac_?.Value;
+            Id ae_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.GlucoseResult600?.IdElement;
+            string af_ = ae_?.Value;
+            CqlBoolean ag_ = context.Operators.Equivalent(ad_, af_);
+            CqlBoolean ah_ = (CqlBoolean)!ag_;
             return u_
-                /* CQL 'and' (187:11-188:116) */ && v_()
-                /* CQL 'and' (187:5-189:54) */ && w_();
+                /* CQL 'and' (187:11-188:116) */ && ab_
+                /* CQL 'and' (187:5-189:54) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter InpatientHospitalization, Observation GlucoseResult600, Observation EarlierGlucoseTest)?> h_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter InpatientHospitalization, Observation GlucoseResult600, Observation EarlierGlucoseTest)?>(e_, f_, g_);
@@ -1174,64 +1056,56 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
             object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
             CqlQuantity l_ = context.Operators.Quantity(600m, "mg/dL");
             CqlBoolean m_ = context.Operators.Greater(k_ as CqlQuantity, l_);
-
-            CqlBoolean n_() {
-                Code<ObservationStatus> p_ = tuple_olaiqtwvfyenjplsytlpsbjd?.EarlyGlucoseResult?.StatusElement;
-                ObservationStatus? q_ = p_?.Value;
-                string r_ = context.Operators.Convert<string>(q_);
-                string[] s_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
-                return t_;
+            Code<ObservationStatus> n_ = tuple_olaiqtwvfyenjplsytlpsbjd?.EarlyGlucoseResult?.StatusElement;
+            ObservationStatus? o_ = n_?.Value;
+            string p_ = context.Operators.Convert<string>(o_);
+            string[] q_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
+            CqlBoolean s_ = r_;
+            object t_;
+            DataType ae_ = tuple_olaiqtwvfyenjplsytlpsbjd?.EarlyGlucoseResult?.Effective;
+            object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+            bool ag_ = af_ is CqlDateTime;
+            if (ag_)
+            {
+                t_ = af_ as CqlDateTime;
             }
-
-
-            CqlBoolean o_() {
-                object u_;
-                DataType ae_ = tuple_olaiqtwvfyenjplsytlpsbjd?.EarlyGlucoseResult?.Effective;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                bool ag_ = af_ is CqlDateTime;
+            else
+            {
                 if (ag_)
                 {
-                    u_ = af_ as CqlDateTime;
+                    t_ = af_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ag_)
+                    bool ah_ = af_ is CqlInterval<CqlDateTime>;
+                    if (ah_)
                     {
-                        u_ = af_ as CqlDateTime;
+                        t_ = af_ as CqlInterval<CqlDateTime>;
                     }
                     else
                     {
-                        bool ah_ = af_ is CqlInterval<CqlDateTime>;
-                        if (ah_)
-                        {
-                            u_ = af_ as CqlInterval<CqlDateTime>;
-                        }
-                        else
-                        {
-                            u_ = null;
-                        }
+                        t_ = null;
                     }
                 }
-                CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
-                CqlInterval<CqlDateTime> w_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_olaiqtwvfyenjplsytlpsbjd?.InpatientHospitalization);
-                CqlDateTime x_ = context.Operators.Start(w_);
-                CqlQuantity y_ = context.Operators.Quantity(1m, "hour");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlQuantity aa_ = context.Operators.Quantity(6m, "hours");
-                CqlDateTime ab_ = context.Operators.Add(x_, aa_);
-                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_, true, true);
-                CqlBoolean ad_ = context.Operators.In<CqlDateTime>(v_, ac_, (string)default);
-                return ad_;
             }
-
+            CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
+            CqlInterval<CqlDateTime> v_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_olaiqtwvfyenjplsytlpsbjd?.InpatientHospitalization);
+            CqlDateTime w_ = context.Operators.Start(v_);
+            CqlQuantity x_ = context.Operators.Quantity(1m, "hour");
+            CqlDateTime y_ = context.Operators.Subtract(w_, x_);
+            CqlQuantity z_ = context.Operators.Quantity(6m, "hours");
+            CqlDateTime aa_ = context.Operators.Add(w_, z_);
+            CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(y_, aa_, true, true);
+            CqlBoolean ac_ = context.Operators.In<CqlDateTime>(u_, ab_, (string)default);
+            CqlBoolean ad_ = ac_;
             return m_
-                /* CQL 'and' (141:11-142:74) */ && n_()
-                /* CQL 'and' (141:5-143:234) */ && o_();
+                /* CQL 'and' (141:11-142:74) */ && s_
+                /* CQL 'and' (141:5-143:234) */ && ad_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter InpatientHospitalization, Observation EarlyGlucoseResult)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, Observation>, (CqlTupleMetadata, Encounter InpatientHospitalization, Observation EarlyGlucoseResult)?>(c_, d_, e_);
@@ -1326,18 +1200,11 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
             CqlConcept f_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, e_);
             CqlValueSet g_ = this.Discharged_to_Home_for_Hospice_Care(context);
             CqlBoolean h_ = context.Operators.ConceptInValueSet(f_, g_);
-
-            CqlBoolean i_() {
-                Encounter.HospitalizationComponent j_ = InpatientHospitalization?.Hospitalization;
-                CodeableConcept k_ = j_?.DischargeDisposition;
-                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-                CqlValueSet m_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care(context);
-                CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
-                return n_;
-            }
-
+            CqlValueSet i_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care(context);
+            CqlBoolean j_ = context.Operators.ConceptInValueSet(f_, i_);
+            CqlBoolean k_ = j_;
             return h_
-                /* CQL 'or' (102:5-103:127) */ || i_();
+                /* CQL 'or' (102:5-103:127) */ || k_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS90FHIRFSAforHeartFailure-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS90FHIRFSAforHeartFailure-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS90FHIRFSAforHeartFailure", "1.0.000")]
 public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<CMS90FHIRFSAforHeartFailure_1_0_000>
 {
@@ -370,35 +370,27 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
         CqlDate g_ = context.Operators.DateFrom(f_);
         int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
         CqlBoolean i_ = context.Operators.GreaterOrEqual(h_, 18);
+        CqlValueSet j_ = this.Heart_Failure(context);
+        IEnumerable<Condition> k_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, j_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> l_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, j_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> m_ = context.Operators.Union<Condition>(k_ as IEnumerable<Condition>, l_ as IEnumerable<Condition>);
+        IEnumerable<Condition> n_ = Status_1_15_000.Instance.verified(context, m_);
 
-        CqlBoolean j_() {
-            CqlValueSet l_ = this.Heart_Failure(context);
-            IEnumerable<Condition> m_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> n_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> o_ = context.Operators.Union<Condition>(m_ as IEnumerable<Condition>, n_ as IEnumerable<Condition>);
-            IEnumerable<Condition> p_ = Status_1_15_000.Instance.verified(context, o_);
-
-            bool? q_(Condition HeartFailure) {
-                CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HeartFailure);
-                CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                CqlBoolean u_ = context.Operators.OverlapsBefore(s_, t_, "day");
-                return u_;
-            }
-
-            CqlBoolean r_ = context.Operators.WhereAny<Condition>(p_, q_);
-            return r_;
-        }
-
-
-        CqlBoolean k_() {
-            IEnumerable<Encounter> v_ = this.Outpatient_Encounters_with_at_least_one_subsequent_Outpatient_Encounter_during_Measurement_Period(context);
-            CqlBoolean w_ = context.Operators.Exists<Encounter>(v_);
+        bool? o_(Condition HeartFailure) {
+            CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HeartFailure);
+            CqlInterval<CqlDateTime> v_ = this.Measurement_Period(context);
+            CqlBoolean w_ = context.Operators.OverlapsBefore(u_, v_, "day");
             return w_;
         }
 
+        CqlBoolean p_ = context.Operators.WhereAny<Condition>(n_, o_);
+        CqlBoolean q_ = p_;
+        IEnumerable<Encounter> r_ = this.Outpatient_Encounters_with_at_least_one_subsequent_Outpatient_Encounter_during_Measurement_Period(context);
+        CqlBoolean s_ = context.Operators.Exists<Encounter>(r_);
+        CqlBoolean t_ = s_;
         return i_
-            /* CQL 'and' (67:3-72:5) */ && j_()
-            /* CQL 'and' (67:3-73:118) */ && k_();
+            /* CQL 'and' (67:3-72:5) */ && q_
+            /* CQL 'and' (67:3-73:118) */ && t_;
     }
 
 
@@ -424,28 +416,24 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
     private bool? Denominator_Exclusions_Compute(CqlContext context)
     {
         CqlBoolean a_ = Hospice_6_18_000.Instance.Has_Hospice_Services(context);
+        CqlCode b_ = this.Severe_cognitive_impairment__finding_(context);
+        IEnumerable<CqlCode> c_ = context.Operators.ToList<CqlCode>(b_);
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, default, c_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, default, c_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+        IEnumerable<Condition> f_ = context.Operators.Union<Condition>(d_ as IEnumerable<Condition>, e_ as IEnumerable<Condition>);
+        IEnumerable<Condition> g_ = Status_1_15_000.Instance.verified(context, f_);
 
-        CqlBoolean b_() {
-            CqlCode c_ = this.Severe_cognitive_impairment__finding_(context);
-            IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
-            IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, default, d_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-            IEnumerable<Condition> f_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, default, d_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-            IEnumerable<Condition> g_ = context.Operators.Union<Condition>(e_ as IEnumerable<Condition>, f_ as IEnumerable<Condition>);
-            IEnumerable<Condition> h_ = Status_1_15_000.Instance.verified(context, g_);
-
-            bool? i_(Condition SevereCognitiveImpairment) {
-                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SevereCognitiveImpairment);
-                CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
-                CqlBoolean m_ = context.Operators.Overlaps(k_, l_, "day");
-                return m_;
-            }
-
-            CqlBoolean j_ = context.Operators.WhereAny<Condition>(h_, i_);
-            return j_;
+        bool? h_(Condition SevereCognitiveImpairment) {
+            CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SevereCognitiveImpairment);
+            CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+            CqlBoolean m_ = context.Operators.Overlaps(k_, l_, "day");
+            return m_;
         }
 
+        CqlBoolean i_ = context.Operators.WhereAny<Condition>(g_, h_);
+        CqlBoolean j_ = i_;
         return a_
-            /* CQL 'or' (79:3-84:5) */ || b_();
+            /* CQL 'or' (79:3-84:5) */ || j_;
     }
 
 
@@ -485,23 +473,15 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10MentalScore as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10PhysicalScore as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10MentalScore as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_ddtaodcfiesjbggrllzpybgqb?.PROMIS10PhysicalScore as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (128:11-129:85) */ && aa_()
-                /* CQL 'and' (128:5-130:87) */ && ab_();
+                /* CQL 'and' (128:11-129:85) */ && ac_
+                /* CQL 'and' (128:5-130:87) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)?>(i_, j_, k_);
@@ -547,46 +527,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj?.InitialPROMIS10Date);
-                Period v_ = tuple_dzhwgxhmbfavmzfaszbeksohj?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_dzhwgxhmbfavmzfaszbeksohj?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (117:13-117:97) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj?.FollowupPROMIS10Date);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj?.InitialPROMIS10Date);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj?.InitialPROMIS10Date);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (117:13-117:97) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj?.FollowupPROMIS10Date);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (116:13-117:97) */ && s_()
-                /* CQL 'and' (116:7-118:148) */ && t_();
+                /* CQL 'and' (116:13-117:97) */ && y_
+                /* CQL 'and' (116:7-118:148) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialPROMIS10Date, CqlDate FollowupPROMIS10Date)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialPROMIS10Date, CqlDate FollowupPROMIS10Date)?>(c_, d_, e_);
@@ -653,159 +613,86 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime ar_ = context.Operators.Start(aq_);
             CqlDate as_ = context.Operators.DateFrom(ar_);
             CqlBoolean at_ = context.Operators.SameAs(an_, as_, "day");
-
-            CqlBoolean au_() {
-                DataType bg_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29SocialRoles?.Value;
-                object bh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bg_);
-                return bh_ is not null;
-            }
-
-
-            CqlBoolean av_() {
-                DataType bi_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Effective;
-                object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
-                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
-                CqlDateTime bl_ = context.Operators.Start(bk_);
-                CqlDate bm_ = context.Operators.DateFrom(bl_);
-                DataType bn_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Physical?.Effective;
-                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_);
-                CqlDateTime bq_ = context.Operators.Start(bp_);
-                CqlDate br_ = context.Operators.DateFrom(bq_);
-                CqlBoolean bs_ = context.Operators.SameAs(bm_, br_, "day");
-                return bs_;
-            }
-
-
-            CqlBoolean aw_() {
-                DataType bt_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Physical?.Value;
-                object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                return bu_ is not null;
-            }
-
-
-            CqlBoolean ax_() {
-                DataType bv_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Effective;
-                object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                CqlInterval<CqlDateTime> bx_ = QICoreCommon_4_0_000.Instance.toInterval(context, bw_);
-                CqlDateTime by_ = context.Operators.Start(bx_);
-                CqlDate bz_ = context.Operators.DateFrom(by_);
-                DataType ca_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Pain?.Effective;
-                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                CqlInterval<CqlDateTime> cc_ = QICoreCommon_4_0_000.Instance.toInterval(context, cb_);
-                CqlDateTime cd_ = context.Operators.Start(cc_);
-                CqlDate ce_ = context.Operators.DateFrom(cd_);
-                CqlBoolean cf_ = context.Operators.SameAs(bz_, ce_, "day");
-                return cf_;
-            }
-
-
-            CqlBoolean ay_() {
-                DataType cg_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Pain?.Value;
-                object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
-                return ch_ is not null;
-            }
-
-
-            CqlBoolean az_() {
-                DataType ci_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Effective;
-                object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
-                CqlInterval<CqlDateTime> ck_ = QICoreCommon_4_0_000.Instance.toInterval(context, cj_);
-                CqlDateTime cl_ = context.Operators.Start(ck_);
-                CqlDate cm_ = context.Operators.DateFrom(cl_);
-                DataType cn_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Fatigue?.Effective;
-                object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                CqlInterval<CqlDateTime> cp_ = QICoreCommon_4_0_000.Instance.toInterval(context, co_);
-                CqlDateTime cq_ = context.Operators.Start(cp_);
-                CqlDate cr_ = context.Operators.DateFrom(cq_);
-                CqlBoolean cs_ = context.Operators.SameAs(cm_, cr_, "day");
-                return cs_;
-            }
-
-
-            CqlBoolean ba_() {
-                DataType ct_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Fatigue?.Value;
-                object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
-                return cu_ is not null;
-            }
-
-
-            CqlBoolean bb_() {
-                DataType cv_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Effective;
-                object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
-                CqlInterval<CqlDateTime> cx_ = QICoreCommon_4_0_000.Instance.toInterval(context, cw_);
-                CqlDateTime cy_ = context.Operators.Start(cx_);
-                CqlDate cz_ = context.Operators.DateFrom(cy_);
-                DataType da_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Depression?.Effective;
-                object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-                CqlInterval<CqlDateTime> dc_ = QICoreCommon_4_0_000.Instance.toInterval(context, db_);
-                CqlDateTime dd_ = context.Operators.Start(dc_);
-                CqlDate de_ = context.Operators.DateFrom(dd_);
-                CqlBoolean df_ = context.Operators.SameAs(cz_, de_, "day");
-                return df_;
-            }
-
-
-            CqlBoolean bc_() {
-                DataType dg_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Depression?.Value;
-                object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
-                return dh_ is not null;
-            }
-
-
-            CqlBoolean bd_() {
-                DataType di_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Effective;
-                object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
-                CqlInterval<CqlDateTime> dk_ = QICoreCommon_4_0_000.Instance.toInterval(context, dj_);
-                CqlDateTime dl_ = context.Operators.Start(dk_);
-                CqlDate dm_ = context.Operators.DateFrom(dl_);
-                DataType dn_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Anxiety?.Effective;
-                object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
-                CqlInterval<CqlDateTime> dp_ = QICoreCommon_4_0_000.Instance.toInterval(context, do_);
-                CqlDateTime dq_ = context.Operators.Start(dp_);
-                CqlDate dr_ = context.Operators.DateFrom(dq_);
-                CqlBoolean ds_ = context.Operators.SameAs(dm_, dr_, "day");
-                return ds_;
-            }
-
-
-            CqlBoolean be_() {
-                DataType dt_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Anxiety?.Value;
-                object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
-                return du_ is not null;
-            }
-
-
-            CqlBoolean bf_() {
-                DataType dv_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Value;
-                object dw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dv_);
-                return dw_ is not null;
-            }
-
+            DataType au_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29SocialRoles?.Value;
+            object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+            CqlBoolean aw_ = (CqlBoolean)(av_ is not null);
+            DataType ax_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Physical?.Effective;
+            object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+            CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_);
+            CqlDateTime ba_ = context.Operators.Start(az_);
+            CqlDate bb_ = context.Operators.DateFrom(ba_);
+            CqlBoolean bc_ = context.Operators.SameAs(an_, bb_, "day");
+            CqlBoolean bd_ = bc_;
+            DataType be_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Physical?.Value;
+            object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+            CqlBoolean bg_ = (CqlBoolean)(bf_ is not null);
+            DataType bh_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Pain?.Effective;
+            object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+            CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
+            CqlDateTime bk_ = context.Operators.Start(bj_);
+            CqlDate bl_ = context.Operators.DateFrom(bk_);
+            CqlBoolean bm_ = context.Operators.SameAs(an_, bl_, "day");
+            CqlBoolean bn_ = bm_;
+            DataType bo_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Pain?.Value;
+            object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+            CqlBoolean bq_ = (CqlBoolean)(bp_ is not null);
+            DataType br_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Fatigue?.Effective;
+            object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+            CqlInterval<CqlDateTime> bt_ = QICoreCommon_4_0_000.Instance.toInterval(context, bs_);
+            CqlDateTime bu_ = context.Operators.Start(bt_);
+            CqlDate bv_ = context.Operators.DateFrom(bu_);
+            CqlBoolean bw_ = context.Operators.SameAs(an_, bv_, "day");
+            CqlBoolean bx_ = bw_;
+            DataType by_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Fatigue?.Value;
+            object bz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, by_);
+            CqlBoolean ca_ = (CqlBoolean)(bz_ is not null);
+            DataType cb_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Depression?.Effective;
+            object cc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cb_);
+            CqlInterval<CqlDateTime> cd_ = QICoreCommon_4_0_000.Instance.toInterval(context, cc_);
+            CqlDateTime ce_ = context.Operators.Start(cd_);
+            CqlDate cf_ = context.Operators.DateFrom(ce_);
+            CqlBoolean cg_ = context.Operators.SameAs(an_, cf_, "day");
+            CqlBoolean ch_ = cg_;
+            DataType ci_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Depression?.Value;
+            object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+            CqlBoolean ck_ = (CqlBoolean)(cj_ is not null);
+            DataType cl_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Anxiety?.Effective;
+            object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+            CqlInterval<CqlDateTime> cn_ = QICoreCommon_4_0_000.Instance.toInterval(context, cm_);
+            CqlDateTime co_ = context.Operators.Start(cn_);
+            CqlDate cp_ = context.Operators.DateFrom(co_);
+            CqlBoolean cq_ = context.Operators.SameAs(an_, cp_, "day");
+            CqlBoolean cr_ = cq_;
+            DataType cs_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Anxiety?.Value;
+            object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
+            CqlBoolean cu_ = (CqlBoolean)(ct_ is not null);
+            DataType cv_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Value;
+            object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+            CqlBoolean cx_ = (CqlBoolean)(cw_ is not null);
             return at_
-                /* CQL 'and' (160:11-161:47) */ && au_()
-                /* CQL 'and' (160:11-162:60) */ && av_()
-                /* CQL 'and' (160:11-163:44) */ && aw_()
-                /* CQL 'and' (160:11-164:56) */ && ax_()
-                /* CQL 'and' (160:11-165:40) */ && ay_()
-                /* CQL 'and' (160:11-166:59) */ && az_()
-                /* CQL 'and' (160:11-167:43) */ && ba_()
-                /* CQL 'and' (160:11-168:62) */ && bb_()
-                /* CQL 'and' (160:11-169:46) */ && bc_()
-                /* CQL 'and' (160:11-170:59) */ && bd_()
-                /* CQL 'and' (160:11-171:43) */ && be_()
-                /* CQL 'and' (160:5-172:41) */ && bf_();
+                /* CQL 'and' (160:11-161:47) */ && aw_
+                /* CQL 'and' (160:11-162:60) */ && bd_
+                /* CQL 'and' (160:11-163:44) */ && bg_
+                /* CQL 'and' (160:11-164:56) */ && bn_
+                /* CQL 'and' (160:11-165:40) */ && bq_
+                /* CQL 'and' (160:11-166:59) */ && bx_
+                /* CQL 'and' (160:11-167:43) */ && ca_
+                /* CQL 'and' (160:11-168:62) */ && ch_
+                /* CQL 'and' (160:11-169:46) */ && ck_
+                /* CQL 'and' (160:11-170:59) */ && cr_
+                /* CQL 'and' (160:11-171:43) */ && cu_
+                /* CQL 'and' (160:5-172:41) */ && cx_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation Promis29Sleep, Observation Promis29SocialRoles, Observation Promis29Physical, Observation Promis29Pain, Observation Promis29Fatigue, Observation Promis29Depression, Observation Promis29Anxiety)?> af_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation>, (CqlTupleMetadata, Observation Promis29Sleep, Observation Promis29SocialRoles, Observation Promis29Physical, Observation Promis29Pain, Observation Promis29Fatigue, Observation Promis29Depression, Observation Promis29Anxiety)?>(ac_, ad_, ae_);
 
         CqlDate ag_((CqlTupleMetadata, Observation Promis29Sleep, Observation Promis29SocialRoles, Observation Promis29Physical, Observation Promis29Pain, Observation Promis29Fatigue, Observation Promis29Depression, Observation Promis29Anxiety)? tuple_cbgpsarvwrsewlglehinjanim) {
-            DataType dx_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Effective;
-            object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
-            CqlInterval<CqlDateTime> dz_ = QICoreCommon_4_0_000.Instance.toInterval(context, dy_);
-            CqlDateTime ea_ = context.Operators.Start(dz_);
-            CqlDate eb_ = context.Operators.DateFrom(ea_);
-            return eb_;
+            DataType cy_ = tuple_cbgpsarvwrsewlglehinjanim?.Promis29Sleep?.Effective;
+            object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+            CqlInterval<CqlDateTime> da_ = QICoreCommon_4_0_000.Instance.toInterval(context, cz_);
+            CqlDateTime db_ = context.Operators.Start(da_);
+            CqlDate dc_ = context.Operators.DateFrom(db_);
+            return dc_;
         }
 
         IEnumerable<CqlDate> ah_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Observation Promis29Sleep, Observation Promis29SocialRoles, Observation Promis29Physical, Observation Promis29Pain, Observation Promis29Fatigue, Observation Promis29Depression, Observation Promis29Anxiety)?, CqlDate>(af_, ag_);
@@ -840,46 +727,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao?.InitialPROMIS29Date);
-                Period v_ = tuple_kmpntxjuhkpbcwgftqigieao?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_kmpntxjuhkpbcwgftqigieao?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (139:13-139:97) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao?.FollowupPROMIS29Date);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao?.InitialPROMIS29Date);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao?.InitialPROMIS29Date);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (139:13-139:97) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao?.FollowupPROMIS29Date);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (138:13-139:97) */ && s_()
-                /* CQL 'and' (138:7-140:148) */ && t_();
+                /* CQL 'and' (138:13-139:97) */ && y_
+                /* CQL 'and' (138:7-140:148) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialPROMIS29Date, CqlDate FollowupPROMIS29Date)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialPROMIS29Date, CqlDate FollowupPROMIS29Date)?>(c_, d_, e_);
@@ -926,23 +793,15 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (192:11-193:86) */ && aa_()
-                /* CQL 'and' (192:5-194:88) */ && ab_();
+                /* CQL 'and' (192:11-193:86) */ && ac_
+                /* CQL 'and' (192:5-194:88) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?>(i_, j_, k_);
@@ -988,46 +847,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh?.InitialVR12ObliqueDate);
-                Period v_ = tuple_fppktdiagiekhptnsbacpswh?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_fppktdiagiekhptnsbacpswh?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (181:13-181:100) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh?.FollowupVR12ObliqueDate);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh?.InitialVR12ObliqueDate);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh?.InitialVR12ObliqueDate);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (181:13-181:100) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh?.FollowupVR12ObliqueDate);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (180:13-181:100) */ && s_()
-                /* CQL 'and' (180:7-182:157) */ && t_();
+                /* CQL 'and' (180:13-181:100) */ && y_
+                /* CQL 'and' (180:7-182:157) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR12ObliqueDate, CqlDate FollowupVR12ObliqueDate)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR12ObliqueDate, CqlDate FollowupVR12ObliqueDate)?>(c_, d_, e_);
@@ -1074,23 +913,15 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12MentalAssessment as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_gadrfkrahuugjcvhwqwrujhrh?.VR12PhysicalAssessment as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (214:11-215:86) */ && aa_()
-                /* CQL 'and' (214:5-216:88) */ && ab_();
+                /* CQL 'and' (214:11-215:86) */ && ac_
+                /* CQL 'and' (214:5-216:88) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)?>(i_, j_, k_);
@@ -1136,46 +967,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai?.InitialVR12OrthogonalDate);
-                Period v_ = tuple_fansvmjaedmvsdoyrozxdlsai?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_fansvmjaedmvsdoyrozxdlsai?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (203:13-203:103) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai?.FollowupVR12OrthogonalDate);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai?.InitialVR12OrthogonalDate);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai?.InitialVR12OrthogonalDate);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (203:13-203:103) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai?.FollowupVR12OrthogonalDate);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (202:13-203:103) */ && s_()
-                /* CQL 'and' (202:7-204:166) */ && t_();
+                /* CQL 'and' (202:13-203:103) */ && y_
+                /* CQL 'and' (202:7-204:166) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR12OrthogonalDate, CqlDate FollowupVR12OrthogonalDate)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR12OrthogonalDate, CqlDate FollowupVR12OrthogonalDate)?>(c_, d_, e_);
@@ -1222,23 +1033,15 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36MentalAssessment as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36PhysicalAssessment as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36MentalAssessment as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36PhysicalAssessment as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (236:11-237:86) */ && aa_()
-                /* CQL 'and' (236:5-238:88) */ && ab_();
+                /* CQL 'and' (236:11-237:86) */ && ac_
+                /* CQL 'and' (236:5-238:88) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)?>(i_, j_, k_);
@@ -1284,46 +1087,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga?.InitialVR36ObliqueDate);
-                Period v_ = tuple_elxicyhrdpyzpqyjphdifbiga?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_elxicyhrdpyzpqyjphdifbiga?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (225:13-225:100) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga?.FollowupVR36ObliqueDate);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga?.InitialVR36ObliqueDate);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga?.InitialVR36ObliqueDate);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (225:13-225:100) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga?.FollowupVR36ObliqueDate);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (224:13-225:100) */ && s_()
-                /* CQL 'and' (224:7-226:157) */ && t_();
+                /* CQL 'and' (224:13-225:100) */ && y_
+                /* CQL 'and' (224:7-226:157) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR36ObliqueDate, CqlDate FollowupVR36ObliqueDate)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR36ObliqueDate, CqlDate FollowupVR36ObliqueDate)?>(c_, d_, e_);
@@ -1370,23 +1153,15 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36MentalAssessment as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36PhysicalAssessment as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36MentalAssessment as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_ducftclcqewdggqdfcwthfauk?.VR36PhysicalAssessment as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (258:11-259:86) */ && aa_()
-                /* CQL 'and' (258:5-260:88) */ && ab_();
+                /* CQL 'and' (258:11-259:86) */ && ac_
+                /* CQL 'and' (258:5-260:88) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)?>(i_, j_, k_);
@@ -1432,46 +1207,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht?.InitialVR36OrthogonalDate);
-                Period v_ = tuple_fucqujadjizabihdffformht?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_fucqujadjizabihdffformht?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (247:13-247:103) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht?.FollowupVR36OrthogonalDate);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht?.InitialVR36OrthogonalDate);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht?.InitialVR36OrthogonalDate);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (247:13-247:103) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht?.FollowupVR36OrthogonalDate);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (246:13-247:103) */ && s_()
-                /* CQL 'and' (246:7-248:166) */ && t_();
+                /* CQL 'and' (246:13-247:103) */ && y_
+                /* CQL 'and' (246:7-248:166) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR36OrthogonalDate, CqlDate FollowupVR36OrthogonalDate)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialVR36OrthogonalDate, CqlDate FollowupVR36OrthogonalDate)?>(c_, d_, e_);
@@ -1518,23 +1273,15 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_fnofxckadaeusjerhbdqfoshe?.MLHFQPhysical as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_fnofxckadaeusjerhbdqfoshe?.MLHFQEmotional as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_fnofxckadaeusjerhbdqfoshe?.MLHFQPhysical as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_fnofxckadaeusjerhbdqfoshe?.MLHFQEmotional as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (280:11-281:79) */ && aa_()
-                /* CQL 'and' (280:5-282:80) */ && ab_();
+                /* CQL 'and' (280:11-281:79) */ && ac_
+                /* CQL 'and' (280:5-282:80) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation MLHFQPhysical, Observation MLHFQEmotional)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation MLHFQPhysical, Observation MLHFQEmotional)?>(i_, j_, k_);
@@ -1580,46 +1327,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig?.InitialMLHFQDate);
-                Period v_ = tuple_ncdawctnmbfmtibmihsfbaig?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_ncdawctnmbfmtibmihsfbaig?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (269:13-269:94) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig?.FollowupMLHFQDate);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig?.InitialMLHFQDate);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig?.InitialMLHFQDate);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (269:13-269:94) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig?.FollowupMLHFQDate);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (268:13-269:94) */ && s_()
-                /* CQL 'and' (268:7-270:139) */ && t_();
+                /* CQL 'and' (268:13-269:94) */ && y_
+                /* CQL 'and' (268:7-270:139) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialMLHFQDate, CqlDate FollowupMLHFQDate)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialMLHFQDate, CqlDate FollowupMLHFQDate)?>(c_, d_, e_);
@@ -1666,23 +1393,15 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime x_ = context.Operators.Start(w_);
             CqlDate y_ = context.Operators.DateFrom(x_);
             CqlBoolean z_ = context.Operators.SameAs(t_, y_, "day");
-
-            CqlBoolean aa_() {
-                DataType ac_ = (tuple_dfkxorghhyafccusbqamfntdj?.KCCQ12Item as Observation)?.Value;
-                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                return ad_ is not null;
-            }
-
-
-            CqlBoolean ab_() {
-                DataType ae_ = (tuple_dfkxorghhyafccusbqamfntdj?.KCCQ12Summary as Observation)?.Value;
-                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                return af_ is not null;
-            }
-
+            DataType aa_ = (tuple_dfkxorghhyafccusbqamfntdj?.KCCQ12Item as Observation)?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
+            DataType ad_ = (tuple_dfkxorghhyafccusbqamfntdj?.KCCQ12Summary as Observation)?.Value;
+            object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+            CqlBoolean af_ = (CqlBoolean)(ae_ is not null);
             return z_
-                /* CQL 'and' (302:11-303:76) */ && aa_()
-                /* CQL 'and' (302:5-304:79) */ && ab_();
+                /* CQL 'and' (302:11-303:76) */ && ac_
+                /* CQL 'and' (302:5-304:79) */ && af_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation KCCQ12Item, Observation KCCQ12Summary)?> l_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation>, (CqlTupleMetadata, Observation KCCQ12Item, Observation KCCQ12Summary)?>(i_, j_, k_);
@@ -1728,46 +1447,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo?.InitialKCCQ12Date);
-                Period v_ = tuple_eoahgtwwdfqijhcjzqnvidvuo?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_eoahgtwwdfqijhcjzqnvidvuo?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (291:13-291:95) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo?.FollowupKCCQ12Date);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo?.InitialKCCQ12Date);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo?.InitialKCCQ12Date);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (291:13-291:95) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo?.FollowupKCCQ12Date);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (290:13-291:95) */ && s_()
-                /* CQL 'and' (290:7-292:142) */ && t_();
+                /* CQL 'and' (290:13-291:95) */ && y_
+                /* CQL 'and' (290:7-292:142) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialKCCQ12Date, CqlDate FollowupKCCQ12Date)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialKCCQ12Date, CqlDate FollowupKCCQ12Date)?>(c_, d_, e_);
@@ -1830,134 +1529,74 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlDateTime an_ = context.Operators.Start(am_);
             CqlDate ao_ = context.Operators.DateFrom(an_);
             CqlBoolean ap_ = context.Operators.SameAs(aj_, ao_, "day");
-
-            CqlBoolean aq_() {
-                DataType ba_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSymptomStability as Observation)?.Value;
-                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
-                return bb_ is not null;
-            }
-
-
-            CqlBoolean ar_() {
-                DataType bc_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality?.Effective;
-                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
-                CqlInterval<CqlDateTime> be_ = QICoreCommon_4_0_000.Instance.toInterval(context, bd_);
-                CqlDateTime bf_ = context.Operators.Start(be_);
-                CqlDate bg_ = context.Operators.DateFrom(bf_);
-                DataType bh_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSelfEfficacy?.Effective;
-                object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
-                CqlDateTime bk_ = context.Operators.Start(bj_);
-                CqlDate bl_ = context.Operators.DateFrom(bk_);
-                CqlBoolean bm_ = context.Operators.SameAs(bg_, bl_, "day");
-                return bm_;
-            }
-
-
-            CqlBoolean as_() {
-                DataType bn_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSelfEfficacy as Observation)?.Value;
-                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
-                return bo_ is not null;
-            }
-
-
-            CqlBoolean at_() {
-                DataType bp_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality?.Effective;
-                object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
-                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
-                CqlDateTime bs_ = context.Operators.Start(br_);
-                CqlDate bt_ = context.Operators.DateFrom(bs_);
-                DataType bu_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSymptoms?.Effective;
-                object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                CqlInterval<CqlDateTime> bw_ = QICoreCommon_4_0_000.Instance.toInterval(context, bv_);
-                CqlDateTime bx_ = context.Operators.Start(bw_);
-                CqlDate by_ = context.Operators.DateFrom(bx_);
-                CqlBoolean bz_ = context.Operators.SameAs(bt_, by_, "day");
-                return bz_;
-            }
-
-
-            CqlBoolean au_() {
-                DataType ca_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSymptoms as Observation)?.Value;
-                object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
-                return cb_ is not null;
-            }
-
-
-            CqlBoolean av_() {
-                DataType cc_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality?.Effective;
-                object cd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cc_);
-                CqlInterval<CqlDateTime> ce_ = QICoreCommon_4_0_000.Instance.toInterval(context, cd_);
-                CqlDateTime cf_ = context.Operators.Start(ce_);
-                CqlDate cg_ = context.Operators.DateFrom(cf_);
-                DataType ch_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQPhysicalLimits?.Effective;
-                object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
-                CqlInterval<CqlDateTime> cj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ci_);
-                CqlDateTime ck_ = context.Operators.Start(cj_);
-                CqlDate cl_ = context.Operators.DateFrom(ck_);
-                CqlBoolean cm_ = context.Operators.SameAs(cg_, cl_, "day");
-                return cm_;
-            }
-
-
-            CqlBoolean aw_() {
-                DataType cn_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQPhysicalLimits as Observation)?.Value;
-                object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
-                return co_ is not null;
-            }
-
-
-            CqlBoolean ax_() {
-                DataType cp_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality?.Effective;
-                object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
-                CqlInterval<CqlDateTime> cr_ = QICoreCommon_4_0_000.Instance.toInterval(context, cq_);
-                CqlDateTime cs_ = context.Operators.Start(cr_);
-                CqlDate ct_ = context.Operators.DateFrom(cs_);
-                DataType cu_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSocialLimits?.Effective;
-                object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
-                CqlInterval<CqlDateTime> cw_ = QICoreCommon_4_0_000.Instance.toInterval(context, cv_);
-                CqlDateTime cx_ = context.Operators.Start(cw_);
-                CqlDate cy_ = context.Operators.DateFrom(cx_);
-                CqlBoolean cz_ = context.Operators.SameAs(ct_, cy_, "day");
-                return cz_;
-            }
-
-
-            CqlBoolean ay_() {
-                DataType da_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSocialLimits as Observation)?.Value;
-                object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
-                return db_ is not null;
-            }
-
-
-            CqlBoolean az_() {
-                DataType dc_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality as Observation)?.Value;
-                object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
-                return dd_ is not null;
-            }
-
+            DataType aq_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSymptomStability as Observation)?.Value;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            CqlBoolean as_ = (CqlBoolean)(ar_ is not null);
+            DataType at_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSelfEfficacy?.Effective;
+            object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+            CqlInterval<CqlDateTime> av_ = QICoreCommon_4_0_000.Instance.toInterval(context, au_);
+            CqlDateTime aw_ = context.Operators.Start(av_);
+            CqlDate ax_ = context.Operators.DateFrom(aw_);
+            CqlBoolean ay_ = context.Operators.SameAs(aj_, ax_, "day");
+            CqlBoolean az_ = ay_;
+            DataType ba_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSelfEfficacy as Observation)?.Value;
+            object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+            CqlBoolean bc_ = (CqlBoolean)(bb_ is not null);
+            DataType bd_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSymptoms?.Effective;
+            object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+            CqlInterval<CqlDateTime> bf_ = QICoreCommon_4_0_000.Instance.toInterval(context, be_);
+            CqlDateTime bg_ = context.Operators.Start(bf_);
+            CqlDate bh_ = context.Operators.DateFrom(bg_);
+            CqlBoolean bi_ = context.Operators.SameAs(aj_, bh_, "day");
+            CqlBoolean bj_ = bi_;
+            DataType bk_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSymptoms as Observation)?.Value;
+            object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+            CqlBoolean bm_ = (CqlBoolean)(bl_ is not null);
+            DataType bn_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQPhysicalLimits?.Effective;
+            object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bn_);
+            CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_);
+            CqlDateTime bq_ = context.Operators.Start(bp_);
+            CqlDate br_ = context.Operators.DateFrom(bq_);
+            CqlBoolean bs_ = context.Operators.SameAs(aj_, br_, "day");
+            CqlBoolean bt_ = bs_;
+            DataType bu_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQPhysicalLimits as Observation)?.Value;
+            object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
+            CqlBoolean bw_ = (CqlBoolean)(bv_ is not null);
+            DataType bx_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSocialLimits?.Effective;
+            object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+            CqlInterval<CqlDateTime> bz_ = QICoreCommon_4_0_000.Instance.toInterval(context, by_);
+            CqlDateTime ca_ = context.Operators.Start(bz_);
+            CqlDate cb_ = context.Operators.DateFrom(ca_);
+            CqlBoolean cc_ = context.Operators.SameAs(aj_, cb_, "day");
+            CqlBoolean cd_ = cc_;
+            DataType ce_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQSocialLimits as Observation)?.Value;
+            object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+            CqlBoolean cg_ = (CqlBoolean)(cf_ is not null);
+            DataType ch_ = (tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality as Observation)?.Value;
+            object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+            CqlBoolean cj_ = (CqlBoolean)(ci_ is not null);
             return ap_
-                /* CQL 'and' (332:11-333:86) */ && aq_()
-                /* CQL 'and' (332:11-334:62) */ && ar_()
-                /* CQL 'and' (332:11-335:82) */ && as_()
-                /* CQL 'and' (332:11-336:58) */ && at_()
-                /* CQL 'and' (332:11-337:78) */ && au_()
-                /* CQL 'and' (332:11-338:64) */ && av_()
-                /* CQL 'and' (332:11-339:84) */ && aw_()
-                /* CQL 'and' (332:11-340:62) */ && ax_()
-                /* CQL 'and' (332:11-341:82) */ && ay_()
-                /* CQL 'and' (332:5-342:81) */ && az_();
+                /* CQL 'and' (332:11-333:86) */ && as_
+                /* CQL 'and' (332:11-334:62) */ && az_
+                /* CQL 'and' (332:11-335:82) */ && bc_
+                /* CQL 'and' (332:11-336:58) */ && bj_
+                /* CQL 'and' (332:11-337:78) */ && bm_
+                /* CQL 'and' (332:11-338:64) */ && bt_
+                /* CQL 'and' (332:11-339:84) */ && bw_
+                /* CQL 'and' (332:11-340:62) */ && cd_
+                /* CQL 'and' (332:11-341:82) */ && cg_
+                /* CQL 'and' (332:5-342:81) */ && cj_;
         }
 
         IEnumerable<(CqlTupleMetadata, Observation KCCQLifeQuality, Observation KCCQSymptomStability, Observation KCCQSelfEfficacy, Observation KCCQSymptoms, Observation KCCQPhysicalLimits, Observation KCCQSocialLimits)?> ab_ = context.Operators.SelectWhere<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation>, (CqlTupleMetadata, Observation KCCQLifeQuality, Observation KCCQSymptomStability, Observation KCCQSelfEfficacy, Observation KCCQSymptoms, Observation KCCQPhysicalLimits, Observation KCCQSocialLimits)?>(y_, z_, aa_);
 
         CqlDate ac_((CqlTupleMetadata, Observation KCCQLifeQuality, Observation KCCQSymptomStability, Observation KCCQSelfEfficacy, Observation KCCQSymptoms, Observation KCCQPhysicalLimits, Observation KCCQSocialLimits)? tuple_etfcawdpmcqfbnayqdmdqqsdn) {
-            DataType de_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality?.Effective;
-            object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
-            CqlInterval<CqlDateTime> dg_ = QICoreCommon_4_0_000.Instance.toInterval(context, df_);
-            CqlDateTime dh_ = context.Operators.Start(dg_);
-            CqlDate di_ = context.Operators.DateFrom(dh_);
-            return di_;
+            DataType ck_ = tuple_etfcawdpmcqfbnayqdmdqqsdn?.KCCQLifeQuality?.Effective;
+            object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+            CqlInterval<CqlDateTime> cm_ = QICoreCommon_4_0_000.Instance.toInterval(context, cl_);
+            CqlDateTime cn_ = context.Operators.Start(cm_);
+            CqlDate co_ = context.Operators.DateFrom(cn_);
+            return co_;
         }
 
         IEnumerable<CqlDate> ad_ = context.Operators.SelectDistinct<(CqlTupleMetadata, Observation KCCQLifeQuality, Observation KCCQSymptomStability, Observation KCCQSelfEfficacy, Observation KCCQSymptoms, Observation KCCQPhysicalLimits, Observation KCCQSocialLimits)?, CqlDate>(ab_, ac_);
@@ -1992,46 +1631,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea?.InitialKCCQAssessmentDate);
-                Period v_ = tuple_hrluhbcfcsvnvrrnjajahdcea?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_hrluhbcfcsvnvrrnjajahdcea?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (313:13-313:103) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea?.FollowupKCCQAssessmentDate);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea?.InitialKCCQAssessmentDate);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea?.InitialKCCQAssessmentDate);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (313:13-313:103) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea?.FollowupKCCQAssessmentDate);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (312:13-313:103) */ && s_()
-                /* CQL 'and' (312:7-314:166) */ && t_();
+                /* CQL 'and' (312:13-313:103) */ && y_
+                /* CQL 'and' (312:7-314:166) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialKCCQAssessmentDate, CqlDate FollowupKCCQAssessmentDate)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialKCCQAssessmentDate, CqlDate FollowupKCCQAssessmentDate)?>(c_, d_, e_);
@@ -2104,46 +1723,26 @@ public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<
             CqlQuantity p_ = context.Operators.Quantity(180m, "days");
             CqlDateTime q_ = context.Operators.Subtract(o_, p_);
             CqlBoolean r_ = context.Operators.SameOrBefore(m_, q_, "day");
-
-            CqlBoolean s_() {
-                CqlDateTime u_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj?.InitialKCCQTotalScore);
-                Period v_ = tuple_dgrojeekdvizsvyisepdjhjgj?.ValidEncounters?.Period;
-                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
-                CqlDateTime x_ = context.Operators.End(w_);
-                CqlQuantity y_ = context.Operators.Quantity(14m, "days");
-                CqlDateTime z_ = context.Operators.Subtract(x_, y_);
-                CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(z_, x_, true, true);
-                CqlBoolean ab_ = context.Operators.In<CqlDateTime>(u_, aa_, "day");
-
-                CqlBoolean ac_() {
-                    Period ad_ = tuple_dgrojeekdvizsvyisepdjhjgj?.ValidEncounters?.Period;
-                    CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.End(ae_);
-                    return af_ is not null;
-                }
-
-                return ab_
-                    /* CQL 'and' (356:13-356:99) */ && ac_();
-            }
-
-
-            CqlBoolean t_() {
-                CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj?.FollowupKCCQTotalScore);
-                CqlDate ah_ = context.Operators.DateFrom(ag_);
-                CqlDateTime ai_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj?.InitialKCCQTotalScore);
-                CqlDate aj_ = context.Operators.DateFrom(ai_);
-                CqlQuantity ak_ = context.Operators.Quantity(30m, "days");
-                CqlDate al_ = context.Operators.Add(aj_, ak_);
-                CqlQuantity am_ = context.Operators.Quantity(180m, "days");
-                CqlDate an_ = context.Operators.Add(aj_, am_);
-                CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-                CqlBoolean ap_ = context.Operators.In<CqlDate>(ah_, ao_, "day");
-                return ap_;
-            }
-
+            CqlDateTime s_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj?.InitialKCCQTotalScore);
+            CqlQuantity t_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime u_ = context.Operators.Subtract(m_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(u_, m_, true, true);
+            CqlBoolean w_ = context.Operators.In<CqlDateTime>(s_, v_, "day");
+            CqlBoolean x_ = (CqlBoolean)(m_ is not null);
+            CqlBoolean y_ = w_
+                /* CQL 'and' (356:13-356:99) */ && x_;
+            CqlDateTime z_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj?.FollowupKCCQTotalScore);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            CqlDate ab_ = context.Operators.DateFrom(s_);
+            CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+            CqlDate ad_ = context.Operators.Add(ab_, ac_);
+            CqlDate ae_ = context.Operators.Add(ab_, p_);
+            CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, ae_, true, true);
+            CqlBoolean ag_ = context.Operators.In<CqlDate>(aa_, af_, "day");
+            CqlBoolean ah_ = ag_;
             return r_
-                /* CQL 'and' (355:13-356:99) */ && s_()
-                /* CQL 'and' (355:7-357:154) */ && t_();
+                /* CQL 'and' (355:13-356:99) */ && y_
+                /* CQL 'and' (355:7-357:154) */ && ah_;
         }
 
         IEnumerable<(CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialKCCQTotalScore, CqlDate FollowupKCCQTotalScore)?> f_ = context.Operators.SelectWhere<ValueTuple<Encounter, CqlDate, CqlDate>, (CqlTupleMetadata, Encounter ValidEncounters, CqlDate InitialKCCQTotalScore, CqlDate FollowupKCCQTotalScore)?>(c_, d_, e_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS951FHIRKidneyHealthEval-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS951FHIRKidneyHealthEval-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS951FHIRKidneyHealthEval", "1.0.000")]
 public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<CMS951FHIRKidneyHealthEval_1_0_000>
 {
@@ -185,37 +185,21 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             CqlInterval<CqlDateTime> g_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DiabetesDiagnosis);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.OverlapsBefore(g_, h_, "day");
-
-            CqlBoolean j_() {
-                CodeableConcept k_ = DiabetesDiagnosis?.VerificationStatus;
-                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-
-                CqlBoolean m_() {
-                    CodeableConcept n_ = DiabetesDiagnosis?.VerificationStatus;
-                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, n_);
-                    CqlCode p_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
-                    CqlBoolean r_ = context.Operators.Equivalent(o_, q_);
-
-                    CqlBoolean s_() {
-                        CodeableConcept t_ = DiabetesDiagnosis?.VerificationStatus;
-                        CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                        CqlCode v_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
-                        CqlBoolean x_ = context.Operators.Equivalent(u_, w_);
-                        return !x_;
-                    }
-
-                    return (CqlBoolean)!r_
-                        /* CQL 'and' (64:70-66:9) */ && s_();
-                }
-
-                return (CqlBoolean)(l_ is null)
-                    /* CQL 'implies' (64:11-67:7) */ || m_();
-            }
-
+            CodeableConcept j_ = DiabetesDiagnosis?.VerificationStatus;
+            CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, j_);
+            CqlCode l_ = QICoreCommon_4_0_000.Instance.refuted(context);
+            CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
+            CqlBoolean n_ = context.Operators.Equivalent(k_, m_);
+            CqlCode o_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+            CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
+            CqlBoolean q_ = context.Operators.Equivalent(k_, p_);
+            CqlBoolean r_ = (CqlBoolean)!q_;
+            CqlBoolean s_ = (CqlBoolean)!n_
+                /* CQL 'and' (64:70-66:9) */ && r_;
+            CqlBoolean t_ = (CqlBoolean)(k_ is null)
+                /* CQL 'implies' (64:11-67:7) */ || s_;
             return i_
-                /* CQL 'and' (63:5-67:7) */ && j_();
+                /* CQL 'and' (63:5-67:7) */ && t_;
         }
 
         CqlBoolean f_ = context.Operators.WhereAny<Condition>(d_, e_);
@@ -257,17 +241,13 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             Period x_ = ValidEncounter?.Period;
             CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
             CqlBoolean z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, y_, "day");
-
-            CqlBoolean aa_() {
-                Code<Encounter.EncounterStatus> ab_ = ValidEncounter?.StatusElement;
-                Encounter.EncounterStatus? ac_ = ab_?.Value;
-                Code<Encounter.EncounterStatus> ad_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ac_);
-                CqlBoolean ae_ = context.Operators.Equal(ad_, "finished");
-                return ae_;
-            }
-
+            Code<Encounter.EncounterStatus> aa_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? ab_ = aa_?.Value;
+            Code<Encounter.EncounterStatus> ac_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ab_);
+            CqlBoolean ad_ = context.Operators.Equal(ac_, "finished");
+            CqlBoolean ae_ = ad_;
             return z_
-                /* CQL 'and' (90:7-91:46) */ && aa_();
+                /* CQL 'and' (90:7-91:46) */ && ae_;
         }
 
         CqlBoolean v_ = context.Operators.WhereAny<Encounter>(t_, u_);
@@ -334,37 +314,21 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, CKDOrESRD);
             CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
             CqlBoolean n_ = context.Operators.Overlaps(l_, m_, "day");
-
-            CqlBoolean o_() {
-                CodeableConcept p_ = CKDOrESRD?.VerificationStatus;
-                CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_);
-
-                CqlBoolean r_() {
-                    CodeableConcept s_ = CKDOrESRD?.VerificationStatus;
-                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
-                    CqlCode u_ = QICoreCommon_4_0_000.Instance.refuted(context);
-                    CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                    CqlBoolean w_ = context.Operators.Equivalent(t_, v_);
-
-                    CqlBoolean x_() {
-                        CodeableConcept y_ = CKDOrESRD?.VerificationStatus;
-                        CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                        CqlCode aa_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
-                        CqlConcept ab_ = context.Operators.ConvertCodeToConcept(aa_);
-                        CqlBoolean ac_ = context.Operators.Equivalent(z_, ab_);
-                        return !ac_;
-                    }
-
-                    return (CqlBoolean)!w_
-                        /* CQL 'and' (77:62-79:9) */ && x_();
-                }
-
-                return (CqlBoolean)(q_ is null)
-                    /* CQL 'implies' (77:11-80:7) */ || r_();
-            }
-
+            CodeableConcept o_ = CKDOrESRD?.VerificationStatus;
+            CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
+            CqlCode q_ = QICoreCommon_4_0_000.Instance.refuted(context);
+            CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+            CqlBoolean s_ = context.Operators.Equivalent(p_, r_);
+            CqlCode t_ = QICoreCommon_4_0_000.Instance.entered_in_error(context);
+            CqlConcept u_ = context.Operators.ConvertCodeToConcept(t_);
+            CqlBoolean v_ = context.Operators.Equivalent(p_, u_);
+            CqlBoolean w_ = (CqlBoolean)!v_;
+            CqlBoolean x_ = (CqlBoolean)!s_
+                /* CQL 'and' (77:62-79:9) */ && w_;
+            CqlBoolean y_ = (CqlBoolean)(p_ is null)
+                /* CQL 'implies' (77:11-80:7) */ || x_;
             return n_
-                /* CQL 'and' (76:5-80:7) */ && o_();
+                /* CQL 'and' (76:5-80:7) */ && y_;
         }
 
         CqlBoolean k_ = context.Operators.WhereAny<Condition>(i_, j_);
@@ -404,30 +368,22 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                DataType l_ = eGFRTest?.Value;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                return m_ is not null;
-            }
-
-
-            CqlBoolean k_() {
-                Code<ObservationStatus> n_ = eGFRTest?.StatusElement;
-                ObservationStatus? o_ = n_?.Value;
-                string p_ = context.Operators.Convert<string>(o_);
-                string[] q_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-                return r_;
-            }
-
+            DataType j_ = eGFRTest?.Value;
+            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
+            Code<ObservationStatus> m_ = eGFRTest?.StatusElement;
+            ObservationStatus? n_ = m_?.Value;
+            string o_ = context.Operators.Convert<string>(n_);
+            string[] p_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+            CqlBoolean r_ = q_;
             return i_
-                /* CQL 'and' (102:13-103:38) */ && j_()
-                /* CQL 'and' (102:7-104:66) */ && k_();
+                /* CQL 'and' (102:13-103:38) */ && l_
+                /* CQL 'and' (102:7-104:66) */ && r_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Observation>(b_, c_);
@@ -452,41 +408,27 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                Code<ObservationStatus> l_ = uACRTest?.StatusElement;
-                ObservationStatus? m_ = l_?.Value;
-                string n_ = context.Operators.Convert<string>(m_);
-                string[] o_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
-                return p_;
-            }
-
-
-            CqlBoolean k_() {
-                DataType q_ = uACRTest?.Value;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                bool s_ = r_ is CqlQuantity;
-
-                CqlBoolean t_() {
-                    DataType u_ = uACRTest?.Value;
-                    object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                    CqlValueSet w_ = this.Undetectable_Lab_Result_Value(context);
-                    CqlBoolean x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                    return x_;
-                }
-
-                return (CqlBoolean)s_
-                    /* CQL 'or' (111:13-113:9) */ || t_();
-            }
-
+            Code<ObservationStatus> j_ = uACRTest?.StatusElement;
+            ObservationStatus? k_ = j_?.Value;
+            string l_ = context.Operators.Convert<string>(k_);
+            string[] m_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+            CqlBoolean o_ = n_;
+            DataType p_ = uACRTest?.Value;
+            object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
+            bool r_ = q_ is CqlQuantity;
+            CqlValueSet s_ = this.Undetectable_Lab_Result_Value(context);
+            CqlBoolean t_ = context.Operators.ConceptInValueSet(q_ as CqlConcept, s_);
+            CqlBoolean u_ = t_;
+            CqlBoolean v_ = (CqlBoolean)r_
+                /* CQL 'or' (111:13-113:9) */ || u_;
             return i_
-                /* CQL 'and' (109:13-110:66) */ && j_()
-                /* CQL 'and' (109:7-113:9) */ && k_();
+                /* CQL 'and' (109:13-110:66) */ && o_
+                /* CQL 'and' (109:7-113:9) */ && v_;
         }
 
         CqlBoolean d_ = context.Operators.WhereAny<Observation>(b_, c_);
@@ -511,30 +453,22 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                DataType l_ = AlbuminTest?.Value;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                return m_ is not null;
-            }
-
-
-            CqlBoolean k_() {
-                Code<ObservationStatus> n_ = AlbuminTest?.StatusElement;
-                ObservationStatus? o_ = n_?.Value;
-                string p_ = context.Operators.Convert<string>(o_);
-                string[] q_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-                return r_;
-            }
-
+            DataType j_ = AlbuminTest?.Value;
+            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
+            Code<ObservationStatus> m_ = AlbuminTest?.StatusElement;
+            ObservationStatus? n_ = m_?.Value;
+            string o_ = context.Operators.Convert<string>(n_);
+            string[] p_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+            CqlBoolean r_ = q_;
             return i_
-                /* CQL 'and' (127:11-128:39) */ && j_()
-                /* CQL 'and' (127:5-129:67) */ && k_();
+                /* CQL 'and' (127:11-128:39) */ && l_
+                /* CQL 'and' (127:5-129:67) */ && r_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -559,30 +493,22 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
             CqlBoolean i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-
-            CqlBoolean j_() {
-                DataType l_ = CreatinineTest?.Value;
-                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                return m_ is not null;
-            }
-
-
-            CqlBoolean k_() {
-                Code<ObservationStatus> n_ = CreatinineTest?.StatusElement;
-                ObservationStatus? o_ = n_?.Value;
-                string p_ = context.Operators.Convert<string>(o_);
-                string[] q_ = [
-                    "final",
-                    "amended",
-                    "corrected",
-                ];
-                CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-                return r_;
-            }
-
+            DataType j_ = CreatinineTest?.Value;
+            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+            CqlBoolean l_ = (CqlBoolean)(k_ is not null);
+            Code<ObservationStatus> m_ = CreatinineTest?.StatusElement;
+            ObservationStatus? n_ = m_?.Value;
+            string o_ = context.Operators.Convert<string>(n_);
+            string[] p_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            CqlBoolean q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
+            CqlBoolean r_ = q_;
             return i_
-                /* CQL 'and' (133:11-134:42) */ && j_()
-                /* CQL 'and' (133:5-135:70) */ && k_();
+                /* CQL 'and' (133:11-134:42) */ && l_
+                /* CQL 'and' (133:5-135:70) */ && r_;
         }
 
         IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
@@ -647,15 +573,11 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
     private bool? Kidney_Panel_Performed_During_Measurement_Period_Compute(CqlContext context)
     {
         CqlBoolean a_ = this.Has_Estimated_Glomerular_Filtration_Rate_Performed_During_Measurement_Period(context);
-
-        CqlBoolean b_() {
-            CqlBoolean c_ = this.Has_Urine_Albumin_Creatinine_Ratio_Test_Performed_During_Measurement_Period(context);
-            return c_
-                /* CQL 'or' (96:9-98:5) */ || this.Has_Urine_Albumin_Test_And_Urine_Creatine_Test_Less_Than_Or_Equal_To_Four_Days_Apart(context);
-        }
-
+        CqlBoolean b_ = this.Has_Urine_Albumin_Creatinine_Ratio_Test_Performed_During_Measurement_Period(context);
+        CqlBoolean c_ = b_
+            /* CQL 'or' (96:9-98:5) */ || this.Has_Urine_Albumin_Test_And_Urine_Creatine_Test_Less_Than_Or_Equal_To_Four_Days_Apart(context);
         return a_
-            /* CQL 'and' (95:3-98:5) */ && b_();
+            /* CQL 'and' (95:3-98:5) */ && c_;
     }
 
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS986FHIRMalnutritionScore", "1.0.000")]
 public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<CMS986FHIRMalnutritionScore_1_0_000>
 {
@@ -177,45 +177,27 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-
-            CqlBoolean j_() {
-                Patient m_ = this.Patient(context);
-                Date n_ = m_?.BirthDateElement;
-                string o_ = n_?.Value;
-                CqlDate p_ = context.Operators.ConvertStringToDate(o_);
-                Period q_ = EncounterInpatient?.Period;
-                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, q_);
-                CqlDateTime s_ = context.Operators.Start(r_);
-                CqlDate t_ = context.Operators.DateFrom(s_);
-                int? u_ = context.Operators.CalculateAgeAt(p_, t_, "year");
-                CqlBoolean v_ = context.Operators.GreaterOrEqual(u_, 18);
-                return v_;
-            }
-
-
-            CqlBoolean k_() {
-                Period w_ = EncounterInpatient?.Period;
-                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, w_);
-                CqlDateTime y_ = context.Operators.Start(x_);
-                CqlDateTime z_ = context.Operators.End(x_);
-                int? aa_ = context.Operators.DurationBetween(y_, z_, "hour");
-                CqlBoolean ab_ = context.Operators.GreaterOrEqual(aa_, 24);
-                return ab_;
-            }
-
-
-            CqlBoolean l_() {
-                Code<Encounter.EncounterStatus> ac_ = EncounterInpatient?.StatusElement;
-                Encounter.EncounterStatus? ad_ = ac_?.Value;
-                Code<Encounter.EncounterStatus> ae_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ad_);
-                CqlBoolean af_ = context.Operators.Equal(ae_, "finished");
-                return af_;
-            }
-
+            Patient j_ = this.Patient(context);
+            Date k_ = j_?.BirthDateElement;
+            string l_ = k_?.Value;
+            CqlDate m_ = context.Operators.ConvertStringToDate(l_);
+            CqlDateTime n_ = context.Operators.Start(f_);
+            CqlDate o_ = context.Operators.DateFrom(n_);
+            int? p_ = context.Operators.CalculateAgeAt(m_, o_, "year");
+            CqlBoolean q_ = context.Operators.GreaterOrEqual(p_, 18);
+            CqlBoolean r_ = q_;
+            int? s_ = context.Operators.DurationBetween(n_, g_, "hour");
+            CqlBoolean t_ = context.Operators.GreaterOrEqual(s_, 24);
+            CqlBoolean u_ = t_;
+            Code<Encounter.EncounterStatus> v_ = EncounterInpatient?.StatusElement;
+            Encounter.EncounterStatus? w_ = v_?.Value;
+            Code<Encounter.EncounterStatus> x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(w_);
+            CqlBoolean y_ = context.Operators.Equal(x_, "finished");
+            CqlBoolean z_ = y_;
             return i_
-                /* CQL 'and' (47:11-48:74) */ && j_()
-                /* CQL 'and' (47:11-49:66) */ && k_()
-                /* CQL 'and' (47:5-50:48) */ && l_();
+                /* CQL 'and' (47:11-48:74) */ && r_
+                /* CQL 'and' (47:11-49:66) */ && u_
+                /* CQL 'and' (47:5-50:48) */ && z_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -282,25 +264,21 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                 "on-hold",
             ];
             CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-
-            CqlBoolean s_() {
-                Code<RequestIntent> t_ = HospiceStatusOrder?.IntentElement;
-                RequestIntent? u_ = t_?.Value;
-                Code<RequestIntent> v_ = context.Operators.Convert<Code<RequestIntent>>(u_);
-                string w_ = context.Operators.Convert<string>(v_);
-                string[] x_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-                return y_;
-            }
-
+            Code<RequestIntent> s_ = HospiceStatusOrder?.IntentElement;
+            RequestIntent? t_ = s_?.Value;
+            Code<RequestIntent> u_ = context.Operators.Convert<Code<RequestIntent>>(t_);
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
             return r_
-                /* CQL 'and' (80:7-81:120) */ && s_();
+                /* CQL 'and' (80:7-81:120) */ && y_;
         }
 
 
@@ -441,25 +419,21 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                 "on-hold",
             ];
             CqlBoolean r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
-
-            CqlBoolean s_() {
-                Code<RequestIntent> t_ = DietitianReferralOrder?.IntentElement;
-                RequestIntent? u_ = t_?.Value;
-                Code<RequestIntent> v_ = context.Operators.Convert<Code<RequestIntent>>(u_);
-                string w_ = context.Operators.Convert<string>(v_);
-                string[] x_ = [
-                    "order",
-                    "original-order",
-                    "reflex-order",
-                    "filler-order",
-                    "instance-order",
-                ];
-                CqlBoolean y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
-                return y_;
-            }
-
+            Code<RequestIntent> s_ = DietitianReferralOrder?.IntentElement;
+            RequestIntent? t_ = s_?.Value;
+            Code<RequestIntent> u_ = context.Operators.Convert<Code<RequestIntent>>(t_);
+            string v_ = context.Operators.Convert<string>(u_);
+            string[] w_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            CqlBoolean x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
+            CqlBoolean y_ = x_;
             return r_
-                /* CQL 'and' (115:7-116:124) */ && s_();
+                /* CQL 'and' (115:7-116:124) */ && y_;
         }
 
 
@@ -587,28 +561,20 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     "corrected",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    DataType p_ = MalnutritionRiskScreening?.Effective;
-                    object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                    CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                    return s_;
-                }
-
-
-                CqlBoolean n_() {
-                    DataType t_ = MalnutritionRiskScreening?.Value;
-                    object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                    CqlValueSet v_ = this.Malnutrition_Screening_Finding_of_Not_At_Risk_Result(context);
-                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
-                    return w_;
-                }
-
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType n_ = MalnutritionRiskScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
+                CqlBoolean r_ = q_;
+                DataType s_ = MalnutritionRiskScreening?.Value;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                CqlValueSet u_ = this.Malnutrition_Screening_Finding_of_Not_At_Risk_Result(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, u_);
+                CqlBoolean w_ = v_;
                 return l_
-                    /* CQL 'and' (140:17-141:124) */ && m_()
-                    /* CQL 'and' (140:17-142:116) */ && n_();
+                    /* CQL 'and' (140:17-141:124) */ && r_
+                    /* CQL 'and' (140:17-142:116) */ && w_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);
@@ -644,28 +610,20 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     "corrected",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    DataType p_ = MalnutritionRiskScreening?.Effective;
-                    object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                    CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                    return s_;
-                }
-
-
-                CqlBoolean n_() {
-                    DataType t_ = MalnutritionRiskScreening?.Value;
-                    object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                    CqlValueSet v_ = this.Malnutrition_Screening_Finding_of_At_Risk_Result(context);
-                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_ as CqlConcept, v_);
-                    return w_;
-                }
-
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType n_ = MalnutritionRiskScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
+                CqlBoolean r_ = q_;
+                DataType s_ = MalnutritionRiskScreening?.Value;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                CqlValueSet u_ = this.Malnutrition_Screening_Finding_of_At_Risk_Result(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, u_);
+                CqlBoolean w_ = v_;
                 return l_
-                    /* CQL 'and' (151:17-152:124) */ && m_()
-                    /* CQL 'and' (151:17-153:112) */ && n_();
+                    /* CQL 'and' (151:17-152:124) */ && r_
+                    /* CQL 'and' (151:17-153:112) */ && w_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);
@@ -753,26 +711,18 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                 "corrected",
             ];
             CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-            CqlBoolean m_() {
-                CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                DataType p_ = NutritionAssessment?.Effective;
-                object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
-                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                CqlBoolean s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
-                return s_;
-            }
-
-
-            CqlBoolean n_() {
-                DataType t_ = NutritionAssessment?.Value;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                return u_ is not null;
-            }
-
+            CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            DataType n_ = NutritionAssessment?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
+            CqlBoolean r_ = q_;
+            DataType s_ = NutritionAssessment?.Value;
+            object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+            CqlBoolean u_ = (CqlBoolean)(t_ is not null);
             return l_
-                /* CQL 'and' (184:13-185:114) */ && m_()
-                /* CQL 'and' (184:7-186:49) */ && n_();
+                /* CQL 'and' (184:13-185:114) */ && r_
+                /* CQL 'and' (184:7-186:49) */ && u_;
         }
 
 
@@ -839,84 +789,58 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     "corrected",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    DataType q_ = NutritionAssessment?.Effective;
-                    object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, (string)default);
-                    return t_;
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType n_ = NutritionAssessment?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
+                CqlBoolean r_ = q_;
+                DataType s_ = NutritionAssessment?.Value;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                CqlValueSet u_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, u_);
+                CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
+                CqlBoolean x_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, w_);
+                CqlBoolean y_ = x_;
+                CqlValueSet z_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
+                CqlBoolean aa_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, z_);
+                CqlBoolean ab_ = aa_;
+                CqlBoolean ac_ = v_
+                    /* CQL 'or' (195:17-196:125) */ || y_
+                    /* CQL 'or' (195:15-198:11) */ || ab_;
+                object ad_;
+                bool ai_ = o_ is CqlDateTime;
+                if (ai_)
+                {
+                    ad_ = o_ as CqlDateTime;
                 }
-
-
-                CqlBoolean n_() {
-                    DataType u_ = NutritionAssessment?.Value;
-                    object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                    CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
-                    CqlBoolean x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-
-                    CqlBoolean y_() {
-                        DataType aa_ = NutritionAssessment?.Value;
-                        object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
-                        CqlValueSet ac_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
-                        CqlBoolean ad_ = context.Operators.ConceptInValueSet(ab_ as CqlConcept, ac_);
-                        return ad_;
-                    }
-
-
-                    CqlBoolean z_() {
-                        DataType ae_ = NutritionAssessment?.Value;
-                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                        CqlValueSet ag_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
-                        CqlBoolean ah_ = context.Operators.ConceptInValueSet(af_ as CqlConcept, ag_);
-                        return ah_;
-                    }
-
-                    return x_
-                        /* CQL 'or' (195:17-196:125) */ || y_()
-                        /* CQL 'or' (195:15-198:11) */ || z_();
-                }
-
-
-                CqlBoolean o_() {
-                    object ai_;
-                    DataType am_ = NutritionAssessment?.Effective;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    bool ao_ = an_ is CqlDateTime;
-                    if (ao_)
+                else
+                {
+                    if (ai_)
                     {
-                        ai_ = an_ as CqlDateTime;
+                        ad_ = o_ as CqlDateTime;
                     }
                     else
                     {
-                        if (ao_)
+                        bool aj_ = o_ is CqlInterval<CqlDateTime>;
+                        if (aj_)
                         {
-                            ai_ = an_ as CqlDateTime;
+                            ad_ = o_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ap_ = an_ is CqlInterval<CqlDateTime>;
-                            if (ap_)
-                            {
-                                ai_ = an_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                ai_ = null;
-                            }
+                            ad_ = null;
                         }
                     }
-                    CqlDateTime aj_ = QICoreCommon_4_0_000.Instance.latest(context, ai_);
-                    CqlDateTime ak_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
-                    CqlBoolean al_ = context.Operators.SameAs(aj_, ak_, "day");
-                    return al_;
                 }
-
+                CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.latest(context, ad_);
+                CqlDateTime af_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
+                CqlBoolean ag_ = context.Operators.SameAs(ae_, af_, "day");
+                CqlBoolean ah_ = ag_;
                 return l_
-                    /* CQL 'and' (193:19-194:120) */ && m_()
-                    /* CQL 'and' (193:19-198:11) */ && n_()
-                    /* CQL 'and' (193:17-200:7) */ && o_();
+                    /* CQL 'and' (193:19-194:120) */ && r_
+                    /* CQL 'and' (193:19-198:11) */ && ac_
+                    /* CQL 'and' (193:17-200:7) */ && ah_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);
@@ -952,74 +876,54 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     "corrected",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    DataType q_ = NutritionAssessment?.Effective;
-                    object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, (string)default);
-                    return t_;
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType n_ = NutritionAssessment?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
+                CqlBoolean r_ = q_;
+                DataType s_ = NutritionAssessment?.Value;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                CqlValueSet u_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, u_);
+                CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
+                CqlBoolean x_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, w_);
+                CqlBoolean y_ = x_;
+                CqlBoolean z_ = v_
+                    /* CQL 'or' (207:13-209:9) */ || y_;
+                object aa_;
+                bool af_ = o_ is CqlDateTime;
+                if (af_)
+                {
+                    aa_ = o_ as CqlDateTime;
                 }
-
-
-                CqlBoolean n_() {
-                    DataType u_ = NutritionAssessment?.Value;
-                    object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                    CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Moderately_Malnourished(context);
-                    CqlBoolean x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-
-                    CqlBoolean y_() {
-                        DataType z_ = NutritionAssessment?.Value;
-                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
-                        CqlValueSet ab_ = this.Nutrition_Assessment_Status_Finding_of_Severely_Malnourished(context);
-                        CqlBoolean ac_ = context.Operators.ConceptInValueSet(aa_ as CqlConcept, ab_);
-                        return ac_;
-                    }
-
-                    return x_
-                        /* CQL 'or' (207:13-209:9) */ || y_();
-                }
-
-
-                CqlBoolean o_() {
-                    object ad_;
-                    DataType ah_ = NutritionAssessment?.Effective;
-                    object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
-                    bool aj_ = ai_ is CqlDateTime;
-                    if (aj_)
+                else
+                {
+                    if (af_)
                     {
-                        ad_ = ai_ as CqlDateTime;
+                        aa_ = o_ as CqlDateTime;
                     }
                     else
                     {
-                        if (aj_)
+                        bool ag_ = o_ is CqlInterval<CqlDateTime>;
+                        if (ag_)
                         {
-                            ad_ = ai_ as CqlDateTime;
+                            aa_ = o_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ak_ = ai_ is CqlInterval<CqlDateTime>;
-                            if (ak_)
-                            {
-                                ad_ = ai_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                ad_ = null;
-                            }
+                            aa_ = null;
                         }
                     }
-                    CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.latest(context, ad_);
-                    CqlDateTime af_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
-                    CqlBoolean ag_ = context.Operators.SameAs(ae_, af_, "day");
-                    return ag_;
                 }
-
+                CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.latest(context, aa_);
+                CqlDateTime ac_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
+                CqlBoolean ad_ = context.Operators.SameAs(ab_, ac_, "day");
+                CqlBoolean ae_ = ad_;
                 return l_
-                    /* CQL 'and' (205:17-206:118) */ && m_()
-                    /* CQL 'and' (205:17-209:9) */ && n_()
-                    /* CQL 'and' (205:17-210:134) */ && o_();
+                    /* CQL 'and' (205:17-206:118) */ && r_
+                    /* CQL 'and' (205:17-209:9) */ && z_
+                    /* CQL 'and' (205:17-210:134) */ && ae_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);
@@ -1055,64 +959,50 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     "corrected",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    DataType q_ = NutritionAssessment?.Effective;
-                    object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, (string)default);
-                    return t_;
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                DataType n_ = NutritionAssessment?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlBoolean q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
+                CqlBoolean r_ = q_;
+                DataType s_ = NutritionAssessment?.Value;
+                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                CqlValueSet u_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
+                CqlBoolean v_ = context.Operators.ConceptInValueSet(t_ as CqlConcept, u_);
+                CqlBoolean w_ = v_;
+                object x_;
+                bool ac_ = o_ is CqlDateTime;
+                if (ac_)
+                {
+                    x_ = o_ as CqlDateTime;
                 }
-
-
-                CqlBoolean n_() {
-                    DataType u_ = NutritionAssessment?.Value;
-                    object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                    CqlValueSet w_ = this.Nutrition_Assessment_Status_Finding_of_Well_Nourished_or_Not_Malnourished_or_Mildly_Malnourished(context);
-                    CqlBoolean x_ = context.Operators.ConceptInValueSet(v_ as CqlConcept, w_);
-                    return x_;
-                }
-
-
-                CqlBoolean o_() {
-                    object y_;
-                    DataType ac_ = NutritionAssessment?.Effective;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    bool ae_ = ad_ is CqlDateTime;
-                    if (ae_)
+                else
+                {
+                    if (ac_)
                     {
-                        y_ = ad_ as CqlDateTime;
+                        x_ = o_ as CqlDateTime;
                     }
                     else
                     {
-                        if (ae_)
+                        bool ad_ = o_ is CqlInterval<CqlDateTime>;
+                        if (ad_)
                         {
-                            y_ = ad_ as CqlDateTime;
+                            x_ = o_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool af_ = ad_ is CqlInterval<CqlDateTime>;
-                            if (af_)
-                            {
-                                y_ = ad_ as CqlInterval<CqlDateTime>;
-                            }
-                            else
-                            {
-                                y_ = null;
-                            }
+                            x_ = null;
                         }
                     }
-                    CqlDateTime z_ = QICoreCommon_4_0_000.Instance.latest(context, y_);
-                    CqlDateTime aa_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
-                    CqlBoolean ab_ = context.Operators.SameAs(z_, aa_, "day");
-                    return ab_;
                 }
-
+                CqlDateTime y_ = QICoreCommon_4_0_000.Instance.latest(context, x_);
+                CqlDateTime z_ = this.Last_Nutrition_Assessment_Day_During_Encounter(context, QualifyingEncounter);
+                CqlBoolean aa_ = context.Operators.SameAs(y_, z_, "day");
+                CqlBoolean ab_ = aa_;
                 return l_
-                    /* CQL 'and' (215:19-216:120) */ && m_()
-                    /* CQL 'and' (215:19-217:156) */ && n_()
-                    /* CQL 'and' (215:17-219:7) */ && o_();
+                    /* CQL 'and' (215:19-216:120) */ && r_
+                    /* CQL 'and' (215:19-217:156) */ && w_
+                    /* CQL 'and' (215:17-219:7) */ && ab_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Observation>(e_, f_);
@@ -1129,51 +1019,27 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         CodeableConcept a_ = condition?.VerificationStatus;
         CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
-
-        CqlBoolean c_() {
-            CodeableConcept d_ = condition?.VerificationStatus;
-            CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
-            CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
-            CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
-            CqlBoolean h_ = context.Operators.Equivalent(e_, g_);
-
-            CqlBoolean i_() {
-                CodeableConcept l_ = condition?.VerificationStatus;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlCode n_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
-                CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
-                CqlBoolean p_ = context.Operators.Equivalent(m_, o_);
-                return p_;
-            }
-
-
-            CqlBoolean j_() {
-                CodeableConcept q_ = condition?.VerificationStatus;
-                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
-                CqlCode s_ = QICoreCommon_4_0_000.Instance.provisional(context);
-                CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
-                CqlBoolean u_ = context.Operators.Equivalent(r_, t_);
-                return u_;
-            }
-
-
-            CqlBoolean k_() {
-                CodeableConcept v_ = condition?.VerificationStatus;
-                CqlConcept w_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, v_);
-                CqlCode x_ = QICoreCommon_4_0_000.Instance.differential(context);
-                CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                CqlBoolean z_ = context.Operators.Equivalent(w_, y_);
-                return z_;
-            }
-
-            return h_
-                /* CQL 'or' (240:54-241:66) */ || i_()
-                /* CQL 'or' (240:54-242:66) */ || j_()
-                /* CQL 'or' (240:52-244:3) */ || k_();
-        }
-
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
+        CqlCode n_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+        CqlBoolean p_ = context.Operators.Equivalent(b_, o_);
+        CqlBoolean q_ = p_;
+        CqlBoolean r_ = e_
+            /* CQL 'or' (240:54-241:66) */ || i_
+            /* CQL 'or' (240:54-242:66) */ || m_
+            /* CQL 'or' (240:52-244:3) */ || q_;
         return (CqlBoolean)(b_ is null)
-            /* CQL 'implies' (240:3-244:3) */ || c_();
+            /* CQL 'implies' (240:3-244:3) */ || r_;
     }
 
 
@@ -1215,39 +1081,34 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
             List<CodeableConcept> d_ = QualifyingEncounter?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return p_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.Malnutrition_Diagnosis(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
+            IEnumerable<Condition> j_ = Status_1_15_000.Instance.verified(context, i_);
 
-            CqlBoolean i_() {
-                IEnumerable<Condition> k_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
-                IEnumerable<Condition> l_ = Status_1_15_000.Instance.verified(context, k_);
-
-                bool? m_(Condition @this) {
-                    CodeableConcept r_ = @this?.Code;
-                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                    return s_ is not null;
-                }
-
-
-                CqlConcept n_(Condition @this) {
-                    CodeableConcept t_ = @this?.Code;
-                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
-                    return u_;
-                }
-
-                IEnumerable<CqlConcept> o_ = context.Operators.WhereSelect<Condition, CqlConcept>(l_, m_, n_);
-                CqlValueSet p_ = this.Malnutrition_Diagnosis(context);
-                CqlBoolean q_ = context.Operators.ConceptsInValueSet(o_, p_);
-                return q_;
+            bool? k_(Condition @this) {
+                CodeableConcept q_ = @this?.Code;
+                CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
+                return r_ is not null;
             }
 
+
+            CqlConcept l_(Condition @this) {
+                CodeableConcept s_ = @this?.Code;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                return t_;
+            }
+
+            IEnumerable<CqlConcept> m_ = context.Operators.WhereSelect<Condition, CqlConcept>(j_, k_, l_);
+            CqlBoolean n_ = context.Operators.ConceptsInValueSet(m_, g_);
+            CqlBoolean o_ = n_;
             return h_
-                /* CQL 'or' (236:5-237:97) */ || i_();
+                /* CQL 'or' (236:5-237:97) */ || o_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1309,18 +1170,14 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     "in-progress",
                 ];
                 CqlBoolean l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
-
-                CqlBoolean m_() {
-                    DataType n_ = NutritionCarePlan?.Performed;
-                    object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
-                    CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_);
-                    CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    CqlBoolean r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
-                    return r_;
-                }
-
+                DataType m_ = NutritionCarePlan?.Performed;
+                object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+                CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_);
+                CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                CqlBoolean q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
+                CqlBoolean r_ = q_;
                 return l_
-                    /* CQL 'and' (249:17-250:114) */ && m_();
+                    /* CQL 'and' (249:17-250:114) */ && r_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -1475,61 +1332,35 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
     {
         IEnumerable<Encounter> a_ = this.Encounters_with_Malnutrition_Risk_Screening_or_with_Dietitian_Referral(context);
         CqlBoolean b_ = context.Operators.Contains<Encounter>(a_, QualifyingEncounter);
-
-        CqlBoolean c_() {
-            IEnumerable<Encounter> e_ = this.Encounters_with_Malnutrition_Risk_Screening_Not_At_Risk(context);
-            CqlBoolean f_ = context.Operators.Contains<Encounter>(e_, QualifyingEncounter);
-            return f_;
-        }
-
-
-        CqlBoolean d_() {
-            IEnumerable<Encounter> g_ = this.Encounters_with_Dietitian_Referral(context);
-            CqlBoolean h_ = context.Operators.Contains<Encounter>(g_, QualifyingEncounter);
-            return !h_;
-        }
-
+        IEnumerable<Encounter> c_ = this.Encounters_with_Malnutrition_Risk_Screening_Not_At_Risk(context);
+        CqlBoolean d_ = context.Operators.Contains<Encounter>(c_, QualifyingEncounter);
+        CqlBoolean e_ = d_;
+        IEnumerable<Encounter> f_ = this.Encounters_with_Dietitian_Referral(context);
+        CqlBoolean g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
+        CqlBoolean h_ = (CqlBoolean)!g_;
         if (b_
-            /* CQL 'and' (279:6-280:94) */ && c_()
-            /* CQL 'and' (279:6-281:81) */ && d_())
+            /* CQL 'and' (279:6-280:94) */ && e_
+            /* CQL 'and' (279:6-281:81) */ && h_)
         {
             return 1;
         }
         else
         {
-
-            CqlBoolean i_() {
-                IEnumerable<Encounter> m_ = this.Encounters_with_Malnutrition_Risk_Screening_At_Risk(context);
-                CqlBoolean n_ = context.Operators.Contains<Encounter>(m_, QualifyingEncounter);
-                return n_;
-            }
-
-
-            CqlBoolean j_() {
-                IEnumerable<Encounter> o_ = this.Encounters_with_Dietitian_Referral(context);
-                CqlBoolean p_ = context.Operators.Contains<Encounter>(o_, QualifyingEncounter);
-                return p_;
-            }
-
-
-            CqlBoolean k_() {
-                IEnumerable<Encounter> q_ = this.Encounter_With_Most_Recent_Nutrition_Assessment_Status_of_Not_or_Mildly_Malnourished(context);
-                CqlBoolean r_ = context.Operators.Contains<Encounter>(q_, QualifyingEncounter);
-                return r_;
-            }
-
-
-            CqlBoolean l_() {
-                IEnumerable<Encounter> s_ = this.Encounter_With_Most_Recent_Nutrition_Assessment_And_Identified_Status(context);
-                CqlBoolean t_ = context.Operators.Contains<Encounter>(s_, QualifyingEncounter);
-                return !t_;
-            }
-
+            IEnumerable<Encounter> i_ = this.Encounters_with_Malnutrition_Risk_Screening_At_Risk(context);
+            CqlBoolean j_ = context.Operators.Contains<Encounter>(i_, QualifyingEncounter);
+            CqlBoolean k_ = j_;
+            CqlBoolean l_ = g_;
+            IEnumerable<Encounter> m_ = this.Encounter_With_Most_Recent_Nutrition_Assessment_Status_of_Not_or_Mildly_Malnourished(context);
+            CqlBoolean n_ = context.Operators.Contains<Encounter>(m_, QualifyingEncounter);
+            CqlBoolean o_ = n_;
+            IEnumerable<Encounter> p_ = this.Encounter_With_Most_Recent_Nutrition_Assessment_And_Identified_Status(context);
+            CqlBoolean q_ = context.Operators.Contains<Encounter>(p_, QualifyingEncounter);
+            CqlBoolean r_ = (CqlBoolean)!q_;
             if ((((b_
-                /* CQL 'and' (282:15-283:92) */ && i_())
-                /* CQL 'or' (282:13-285:3) */ || j_())
-                /* CQL 'and' (282:13-286:123) */ && k_())
-                /* CQL 'or' (282:13-287:115) */ || l_())
+                /* CQL 'and' (282:15-283:92) */ && k_)
+                /* CQL 'or' (282:13-285:3) */ || l_)
+                /* CQL 'and' (282:13-286:123) */ && o_)
+                /* CQL 'or' (282:13-287:115) */ || r_)
             {
                 return 2;
             }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMS996FHIRAptTxforSTEMI", "2.0.000")]
 public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS996FHIRAptTxforSTEMI_2_0_000>
 {
@@ -317,51 +317,37 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             List<CodeableConcept> g_ = EDEncounter?.Type;
 
             CqlConcept h_(CodeableConcept @this) {
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return o_;
+                CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return af_;
             }
 
             IEnumerable<CqlConcept> i_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)g_, h_);
             CqlValueSet j_ = this.Emergency_Department_Evaluation_and_Management_Visit(context);
             CqlBoolean k_ = context.Operators.ConceptsInValueSet(i_, j_);
-
-            CqlBoolean l_() {
-                Period p_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.End(q_);
-                CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                CqlBoolean t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
-                return t_;
-            }
-
-
-            CqlBoolean m_() {
-                Code<Encounter.EncounterStatus> u_ = EDEncounter?.StatusElement;
-                Encounter.EncounterStatus? v_ = u_?.Value;
-                Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-                CqlBoolean x_ = context.Operators.Equal(w_, "finished");
-                return x_;
-            }
-
-
-            CqlBoolean n_() {
-                Patient y_ = this.Patient(context);
-                Date z_ = y_?.BirthDateElement;
-                string aa_ = z_?.Value;
-                CqlDate ab_ = context.Operators.ConvertStringToDate(aa_);
-                Period ac_ = EDEncounter?.Period;
-                CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                CqlDateTime ae_ = context.Operators.Start(ad_);
-                CqlDate af_ = context.Operators.DateFrom(ae_);
-                int? ag_ = context.Operators.CalculateAgeAt(ab_, af_, "year");
-                CqlBoolean ah_ = context.Operators.GreaterOrEqual(ag_, 18);
-                return ah_;
-            }
-
+            Period l_ = EDEncounter?.Period;
+            CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+            CqlDateTime n_ = context.Operators.End(m_);
+            CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+            CqlBoolean p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+            CqlBoolean q_ = p_;
+            Code<Encounter.EncounterStatus> r_ = EDEncounter?.StatusElement;
+            Encounter.EncounterStatus? s_ = r_?.Value;
+            Code<Encounter.EncounterStatus> t_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(s_);
+            CqlBoolean u_ = context.Operators.Equal(t_, "finished");
+            CqlBoolean v_ = u_;
+            Patient w_ = this.Patient(context);
+            Date x_ = w_?.BirthDateElement;
+            string y_ = x_?.Value;
+            CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+            CqlDateTime aa_ = context.Operators.Start(m_);
+            CqlDate ab_ = context.Operators.DateFrom(aa_);
+            int? ac_ = context.Operators.CalculateAgeAt(z_, ab_, "year");
+            CqlBoolean ad_ = context.Operators.GreaterOrEqual(ac_, 18);
+            CqlBoolean ae_ = ad_;
             return k_
-                /* CQL 'and' (175:11-176:68) */ && l_()
-                /* CQL 'and' (175:11-177:41) */ && m_()
-                /* CQL 'and' (175:5-178:68) */ && n_();
+                /* CQL 'and' (175:11-176:68) */ && q_
+                /* CQL 'and' (175:11-177:41) */ && v_
+                /* CQL 'and' (175:5-178:68) */ && ae_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
@@ -383,60 +369,51 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             List<CodeableConcept> d_ = EDEncounterinMP?.ReasonCode;
 
             CqlConcept e_(CodeableConcept @this) {
-                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return j_;
+                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return p_;
             }
 
             IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
             CqlValueSet g_ = this.STEMI(context);
             CqlBoolean h_ = context.Operators.ConceptsInValueSet(f_, g_);
+            IEnumerable<Condition> i_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            IEnumerable<Condition> j_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+            IEnumerable<Condition> k_ = context.Operators.Union<Condition>(i_ as IEnumerable<Condition>, j_ as IEnumerable<Condition>);
+            IEnumerable<Condition> l_ = Status_1_15_000.Instance.verified(context, k_);
 
-            CqlBoolean i_() {
-                CqlValueSet k_ = this.STEMI(context);
-                IEnumerable<Condition> l_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, k_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-                IEnumerable<Condition> m_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, k_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
-                IEnumerable<Condition> n_ = context.Operators.Union<Condition>(l_ as IEnumerable<Condition>, m_ as IEnumerable<Condition>);
-                IEnumerable<Condition> o_ = Status_1_15_000.Instance.verified(context, n_);
+            bool? m_(Condition DxSTEMI) {
+                IEnumerable<Condition> q_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, EDEncounterinMP);
 
-                bool? p_(Condition DxSTEMI) {
-                    IEnumerable<Condition> r_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, EDEncounterinMP);
-
-                    bool? s_(Condition @this) {
-                        CodeableConcept y_ = @this?.Code;
-                        CqlConcept z_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, y_);
-                        return z_ is not null;
-                    }
-
-
-                    CqlConcept t_(Condition @this) {
-                        CodeableConcept aa_ = @this?.Code;
-                        CqlConcept ab_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, aa_);
-                        return ab_;
-                    }
-
-                    IEnumerable<CqlConcept> u_ = context.Operators.WhereSelect<Condition, CqlConcept>(r_, s_, t_);
-                    CqlValueSet v_ = this.STEMI(context);
-                    CqlBoolean w_ = context.Operators.ConceptsInValueSet(u_, v_);
-
-                    CqlBoolean x_() {
-                        CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DxSTEMI);
-                        CqlDateTime ad_ = context.Operators.Start(ac_);
-                        Period ae_ = EDEncounterinMP?.Period;
-                        CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
-                        CqlBoolean ag_ = context.Operators.In<CqlDateTime>(ad_, af_, (string)default);
-                        return ag_;
-                    }
-
-                    return w_
-                        /* CQL 'or' (186:13-188:13) */ || x_();
+                bool? r_(Condition @this) {
+                    CodeableConcept ac_ = @this?.Code;
+                    CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                    return ad_ is not null;
                 }
 
-                CqlBoolean q_ = context.Operators.WhereAny<Condition>(o_, p_);
-                return q_;
+
+                CqlConcept s_(Condition @this) {
+                    CodeableConcept ae_ = @this?.Code;
+                    CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_);
+                    return af_;
+                }
+
+                IEnumerable<CqlConcept> t_ = context.Operators.WhereSelect<Condition, CqlConcept>(q_, r_, s_);
+                CqlValueSet u_ = this.STEMI(context);
+                CqlBoolean v_ = context.Operators.ConceptsInValueSet(t_, u_);
+                CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, DxSTEMI);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                Period y_ = EDEncounterinMP?.Period;
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlBoolean aa_ = context.Operators.In<CqlDateTime>(x_, z_, (string)default);
+                CqlBoolean ab_ = aa_;
+                return v_
+                    /* CQL 'or' (186:13-188:13) */ || ab_;
             }
 
+            CqlBoolean n_ = context.Operators.WhereAny<Condition>(l_, m_);
+            CqlBoolean o_ = n_;
             return h_
-                /* CQL 'or' (182:5-190:5) */ || i_();
+                /* CQL 'or' (182:5-190:5) */ || o_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -490,61 +467,33 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlCode j_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
                 CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
                 CqlBoolean l_ = context.Operators.Equivalent(i_, k_);
-
-                CqlBoolean m_() {
-                    CodeableConcept o_ = ThrombolyticAllergy?.VerificationStatus;
-                    CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-
-                    CqlBoolean q_() {
-                        CodeableConcept r_ = ThrombolyticAllergy?.VerificationStatus;
-                        CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, r_);
-                        CqlCode t_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
-                        CqlConcept u_ = context.Operators.ConvertCodeToConcept(t_);
-                        CqlBoolean v_ = context.Operators.Equivalent(s_, u_);
-
-                        CqlBoolean w_() {
-                            CodeableConcept x_ = ThrombolyticAllergy?.VerificationStatus;
-                            CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                            CqlCode z_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
-                            CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
-                            CqlBoolean ab_ = context.Operators.Equivalent(y_, aa_);
-                            return ab_;
-                        }
-
-                        return v_
-                            /* CQL 'or' (160:74-162:11) */ || w_();
-                    }
-
-                    return (CqlBoolean)(p_ is null)
-                        /* CQL 'implies' (160:13-163:9) */ || q_();
-                }
-
-
-                CqlBoolean n_() {
-                    DataType ac_ = ThrombolyticAllergy?.Onset;
-                    object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
-                    CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
-                    Period af_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                    CqlBoolean ah_ = context.Operators.Overlaps(ae_, ag_, (string)default);
-
-                    CqlBoolean ai_() {
-                        DataType aj_ = ThrombolyticAllergy?.Onset;
-                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                        Period al_ = EDwSTEMI?.Period;
-                        CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                        CqlDateTime an_ = context.Operators.End(am_);
-                        CqlBoolean ao_ = context.Operators.Before(ak_ as CqlDateTime, an_, (string)default);
-                        return ao_;
-                    }
-
-                    return ah_
-                        /* CQL 'or' (164:13-166:9) */ || ai_();
-                }
-
+                CodeableConcept m_ = ThrombolyticAllergy?.VerificationStatus;
+                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
+                CqlCode o_ = QICoreCommon_4_0_000.Instance.allergy_confirmed(context);
+                CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
+                CqlBoolean q_ = context.Operators.Equivalent(n_, p_);
+                CqlCode r_ = QICoreCommon_4_0_000.Instance.allergy_unconfirmed(context);
+                CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+                CqlBoolean t_ = context.Operators.Equivalent(n_, s_);
+                CqlBoolean u_ = t_;
+                CqlBoolean v_ = q_
+                    /* CQL 'or' (160:74-162:11) */ || u_;
+                CqlBoolean w_ = (CqlBoolean)(n_ is null)
+                    /* CQL 'implies' (160:13-163:9) */ || v_;
+                DataType x_ = ThrombolyticAllergy?.Onset;
+                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
+                Period aa_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
+                CqlBoolean ac_ = context.Operators.Overlaps(z_, ab_, (string)default);
+                CqlDateTime ad_ = context.Operators.End(ab_);
+                CqlBoolean ae_ = context.Operators.Before(y_ as CqlDateTime, ad_, (string)default);
+                CqlBoolean af_ = ae_;
+                CqlBoolean ag_ = ac_
+                    /* CQL 'or' (164:13-166:9) */ || af_;
                 return l_
-                    /* CQL 'and' (159:17-163:9) */ && m_()
-                    /* CQL 'and' (159:17-166:9) */ && n_();
+                    /* CQL 'and' (159:17-163:9) */ && w_
+                    /* CQL 'and' (159:17-166:9) */ && ag_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<AllergyIntolerance>(e_, f_);
@@ -581,17 +530,13 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                 CqlDateTime p_ = context.Operators.End(o_);
                 CqlBoolean q_ = context.Operators.Before((i_ ?? k_) ?? m_, p_, (string)default);
-
-                CqlBoolean r_() {
-                    Code<AdverseEvent.AdverseEventActuality> s_ = ThrombolyticAdverseEvent?.ActualityElement;
-                    AdverseEvent.AdverseEventActuality? t_ = s_?.Value;
-                    Code<AdverseEvent.AdverseEventActuality> u_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(t_);
-                    CqlBoolean v_ = context.Operators.Equal(u_, "actual");
-                    return v_;
-                }
-
+                Code<AdverseEvent.AdverseEventActuality> r_ = ThrombolyticAdverseEvent?.ActualityElement;
+                AdverseEvent.AdverseEventActuality? s_ = r_?.Value;
+                Code<AdverseEvent.AdverseEventActuality> t_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(s_);
+                CqlBoolean u_ = context.Operators.Equal(t_, "actual");
+                CqlBoolean v_ = u_;
                 return q_
-                    /* CQL 'and' (153:17-154:57) */ && r_();
+                    /* CQL 'and' (153:17-154:57) */ && v_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<AdverseEvent>(e_, f_);
@@ -674,17 +619,13 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Oral_Anticoagulant_Medications(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Oral_Anticoagulant_Medications(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -705,41 +646,26 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     "completed",
                 ];
                 CqlBoolean ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
-
-                CqlBoolean ad_() {
-                    Code<MedicationRequest.MedicationRequestIntent> af_ = OralAnticoagulant?.IntentElement;
-                    MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
-                    string ah_ = context.Operators.Convert<string>(ag_);
-                    CqlBoolean ai_ = context.Operators.Equal(ah_, "order");
-                    return ai_;
-                }
-
-
-                CqlBoolean ae_() {
-                    FhirDateTime aj_ = OralAnticoagulant?.AuthoredOnElement;
-                    CqlDateTime ak_ = context.Operators.Convert<CqlDateTime>(aj_);
-                    Period al_ = EDwithSTEMI?.Period;
-                    CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                    CqlDateTime an_ = context.Operators.Start(am_);
-                    CqlQuantity ao_ = context.Operators.Quantity(90m, "days");
-                    CqlDateTime ap_ = context.Operators.Subtract(an_, ao_);
-                    CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ap_, an_, true, true);
-                    CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ak_, aq_, (string)default);
-
-                    CqlBoolean as_() {
-                        Period at_ = EDwithSTEMI?.Period;
-                        CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, at_);
-                        CqlDateTime av_ = context.Operators.Start(au_);
-                        return av_ is not null;
-                    }
-
-                    return ar_
-                        /* CQL 'and' (135:13-135:97) */ && as_();
-                }
-
+                Code<MedicationRequest.MedicationRequestIntent> ad_ = OralAnticoagulant?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ae_ = ad_?.Value;
+                string af_ = context.Operators.Convert<string>(ae_);
+                CqlBoolean ag_ = context.Operators.Equal(af_, "order");
+                CqlBoolean ah_ = ag_;
+                FhirDateTime ai_ = OralAnticoagulant?.AuthoredOnElement;
+                CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
+                Period ak_ = EDwithSTEMI?.Period;
+                CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
+                CqlDateTime am_ = context.Operators.Start(al_);
+                CqlQuantity an_ = context.Operators.Quantity(90m, "days");
+                CqlDateTime ao_ = context.Operators.Subtract(am_, an_);
+                CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ao_, am_, true, true);
+                CqlBoolean aq_ = context.Operators.In<CqlDateTime>(aj_, ap_, (string)default);
+                CqlBoolean ar_ = (CqlBoolean)(am_ is not null);
+                CqlBoolean as_ = aq_
+                    /* CQL 'and' (135:13-135:97) */ && ar_;
                 return ac_
-                    /* CQL 'and' (133:17-134:46) */ && ad_()
-                    /* CQL 'and' (133:17-135:97) */ && ae_();
+                    /* CQL 'and' (133:17-134:46) */ && ah_
+                    /* CQL 'and' (133:17-135:97) */ && as_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationRequest>(i_, j_);
@@ -776,19 +702,11 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                 CqlDateTime p_ = context.Operators.Start(o_);
                 CqlBoolean q_ = context.Operators.SameOrBefore(m_, p_, (string)default);
-
-                CqlBoolean r_() {
-                    CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LongTermAnticoagulant);
-                    CqlDateTime t_ = context.Operators.End(s_);
-                    Period u_ = EDwithSTEMI?.Period;
-                    CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                    CqlDateTime w_ = context.Operators.Start(v_);
-                    CqlBoolean x_ = context.Operators.SameOrAfter(t_, w_, (string)default);
-                    return x_;
-                }
-
+                CqlDateTime r_ = context.Operators.End(l_);
+                CqlBoolean s_ = context.Operators.SameOrAfter(r_, p_, (string)default);
+                CqlBoolean t_ = s_;
                 return q_
-                    /* CQL 'and' (142:17-144:7) */ && r_();
+                    /* CQL 'and' (142:17-144:7) */ && t_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Condition>(i_, j_);
@@ -864,31 +782,16 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 Period am_ = EDwithSTEMI?.Period;
                 CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
                 CqlBoolean ao_ = context.Operators.In<CqlDateTime>(al_, an_, (string)default);
-
-                CqlBoolean ap_() {
-                    CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ExclusionDiagnosis);
-                    CqlDateTime ar_ = context.Operators.Start(aq_);
-                    Period as_ = EDwithSTEMI?.Period;
-                    CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
-                    CqlDateTime au_ = context.Operators.Start(at_);
-                    CqlQuantity av_ = context.Operators.Quantity(24m, "hours");
-                    CqlDateTime aw_ = context.Operators.Subtract(au_, av_);
-                    CqlInterval<CqlDateTime> ax_ = context.Operators.Interval(aw_, au_, true, false);
-                    CqlBoolean ay_ = context.Operators.In<CqlDateTime>(ar_, ax_, (string)default);
-
-                    CqlBoolean az_() {
-                        Period ba_ = EDwithSTEMI?.Period;
-                        CqlInterval<CqlDateTime> bb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ba_);
-                        CqlDateTime bc_ = context.Operators.Start(bb_);
-                        return bc_ is not null;
-                    }
-
-                    return ay_
-                        /* CQL 'and' (244:14-244:117) */ && az_();
-                }
-
+                CqlDateTime ap_ = context.Operators.Start(an_);
+                CqlQuantity aq_ = context.Operators.Quantity(24m, "hours");
+                CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
+                CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ar_, ap_, true, false);
+                CqlBoolean at_ = context.Operators.In<CqlDateTime>(al_, as_, (string)default);
+                CqlBoolean au_ = (CqlBoolean)(ap_ is not null);
+                CqlBoolean av_ = at_
+                    /* CQL 'and' (244:14-244:117) */ && au_;
                 return ao_
-                    /* CQL 'or' (243:17-245:7) */ || ap_();
+                    /* CQL 'or' (243:17-245:7) */ || av_;
             }
 
             CqlBoolean aj_ = context.Operators.WhereAny<Condition>(ah_, ai_);
@@ -916,33 +819,33 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
 
             bool? f_(Procedure MajorSurgery) {
                 object h_;
-                DataType u_ = MajorSurgery?.Performed;
-                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
-                bool w_ = v_ is CqlDateTime;
-                if (w_)
+                DataType ac_ = MajorSurgery?.Performed;
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                bool ae_ = ad_ is CqlDateTime;
+                if (ae_)
                 {
-                    h_ = v_ as CqlDateTime;
+                    h_ = ad_ as CqlDateTime;
                 }
                 else
                 {
-                    bool x_ = v_ is CqlQuantity;
-                    if (x_)
+                    bool af_ = ad_ is CqlQuantity;
+                    if (af_)
                     {
-                        h_ = v_ as CqlQuantity;
+                        h_ = ad_ as CqlQuantity;
                     }
                     else
                     {
-                        bool y_ = v_ is CqlInterval<CqlDateTime>;
-                        if (y_)
+                        bool ag_ = ad_ is CqlInterval<CqlDateTime>;
+                        if (ag_)
                         {
-                            h_ = v_ as CqlInterval<CqlDateTime>;
+                            h_ = ad_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool z_ = v_ is CqlInterval<CqlQuantity>;
-                            if (z_)
+                            bool ah_ = ad_ is CqlInterval<CqlQuantity>;
+                            if (ah_)
                             {
-                                h_ = v_ as CqlInterval<CqlQuantity>;
+                                h_ = ad_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -960,73 +863,56 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(o_, m_, true, false);
                 CqlBoolean q_ = context.Operators.In<CqlDateTime>(j_, p_, (string)default);
-
-                CqlBoolean r_() {
-                    Period aa_ = EDwithSTEMI?.Period;
-                    CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                    CqlDateTime ac_ = context.Operators.Start(ab_);
-                    return ac_ is not null;
+                CqlBoolean r_ = (CqlBoolean)(m_ is not null);
+                object s_;
+                DataType ai_ = MajorSurgery?.Performed;
+                object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                bool ak_ = aj_ is CqlDateTime;
+                if (ak_)
+                {
+                    s_ = aj_ as CqlDateTime;
                 }
-
-
-                CqlBoolean s_() {
-                    object ad_;
-                    DataType aj_ = MajorSurgery?.Performed;
-                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                    bool al_ = ak_ is CqlDateTime;
+                else
+                {
+                    bool al_ = aj_ is CqlQuantity;
                     if (al_)
                     {
-                        ad_ = ak_ as CqlDateTime;
+                        s_ = aj_ as CqlQuantity;
                     }
                     else
                     {
-                        bool am_ = ak_ is CqlQuantity;
+                        bool am_ = aj_ is CqlInterval<CqlDateTime>;
                         if (am_)
                         {
-                            ad_ = ak_ as CqlQuantity;
+                            s_ = aj_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool an_ = ak_ is CqlInterval<CqlDateTime>;
+                            bool an_ = aj_ is CqlInterval<CqlQuantity>;
                             if (an_)
                             {
-                                ad_ = ak_ as CqlInterval<CqlDateTime>;
+                                s_ = aj_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ao_ = ak_ is CqlInterval<CqlQuantity>;
-                                if (ao_)
-                                {
-                                    ad_ = ak_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    ad_ = null;
-                                }
+                                s_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
-                    CqlDateTime af_ = context.Operators.Start(ae_);
-                    Period ag_ = EDwithSTEMI?.Period;
-                    CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                    CqlBoolean ai_ = context.Operators.In<CqlDateTime>(af_, ah_, (string)default);
-                    return ai_;
                 }
-
-
-                CqlBoolean t_() {
-                    Code<EventStatus> ap_ = MajorSurgery?.StatusElement;
-                    EventStatus? aq_ = ap_?.Value;
-                    string ar_ = context.Operators.Convert<string>(aq_);
-                    CqlBoolean as_ = context.Operators.Equal(ar_, "completed");
-                    return as_;
-                }
-
+                CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
+                CqlDateTime u_ = context.Operators.Start(t_);
+                CqlBoolean v_ = context.Operators.In<CqlDateTime>(u_, l_, (string)default);
+                CqlBoolean w_ = v_;
+                Code<EventStatus> x_ = MajorSurgery?.StatusElement;
+                EventStatus? y_ = x_?.Value;
+                string z_ = context.Operators.Convert<string>(y_);
+                CqlBoolean aa_ = context.Operators.Equal(z_, "completed");
+                CqlBoolean ab_ = aa_;
                 return ((q_
-                    /* CQL 'and' (294:19-294:113) */ && r_())
-                    /* CQL 'or' (294:17-296:7) */ || s_())
-                    /* CQL 'and' (294:17-297:45) */ && t_();
+                    /* CQL 'and' (294:19-294:113) */ && r_)
+                    /* CQL 'or' (294:17-296:7) */ || w_)
+                    /* CQL 'and' (294:17-297:45) */ && ab_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -1057,33 +943,33 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
 
             bool? i_(Procedure AirwayProcedure) {
                 object k_;
-                DataType s_ = AirwayProcedure?.Performed;
-                object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
-                bool u_ = t_ is CqlDateTime;
-                if (u_)
+                DataType af_ = AirwayProcedure?.Performed;
+                object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                bool ah_ = ag_ is CqlDateTime;
+                if (ah_)
                 {
-                    k_ = t_ as CqlDateTime;
+                    k_ = ag_ as CqlDateTime;
                 }
                 else
                 {
-                    bool v_ = t_ is CqlQuantity;
-                    if (v_)
+                    bool ai_ = ag_ is CqlQuantity;
+                    if (ai_)
                     {
-                        k_ = t_ as CqlQuantity;
+                        k_ = ag_ as CqlQuantity;
                     }
                     else
                     {
-                        bool w_ = t_ is CqlInterval<CqlDateTime>;
-                        if (w_)
+                        bool aj_ = ag_ is CqlInterval<CqlDateTime>;
+                        if (aj_)
                         {
-                            k_ = t_ as CqlInterval<CqlDateTime>;
+                            k_ = ag_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool x_ = t_ is CqlInterval<CqlQuantity>;
-                            if (x_)
+                            bool ak_ = ag_ is CqlInterval<CqlQuantity>;
+                            if (ak_)
                             {
-                                k_ = t_ as CqlInterval<CqlQuantity>;
+                                k_ = ag_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1097,77 +983,60 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 Period n_ = EDwithSTEMI?.Period;
                 CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                 CqlBoolean p_ = context.Operators.In<CqlDateTime>(m_, o_, (string)default);
-
-                CqlBoolean q_() {
-                    object y_;
-                    DataType aj_ = AirwayProcedure?.Performed;
-                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                    bool al_ = ak_ is CqlDateTime;
-                    if (al_)
+                object q_;
+                DataType al_ = AirwayProcedure?.Performed;
+                object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+                bool an_ = am_ is CqlDateTime;
+                if (an_)
+                {
+                    q_ = am_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ao_ = am_ is CqlQuantity;
+                    if (ao_)
                     {
-                        y_ = ak_ as CqlDateTime;
+                        q_ = am_ as CqlQuantity;
                     }
                     else
                     {
-                        bool am_ = ak_ is CqlQuantity;
-                        if (am_)
+                        bool ap_ = am_ is CqlInterval<CqlDateTime>;
+                        if (ap_)
                         {
-                            y_ = ak_ as CqlQuantity;
+                            q_ = am_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool an_ = ak_ is CqlInterval<CqlDateTime>;
-                            if (an_)
+                            bool aq_ = am_ is CqlInterval<CqlQuantity>;
+                            if (aq_)
                             {
-                                y_ = ak_ as CqlInterval<CqlDateTime>;
+                                q_ = am_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ao_ = ak_ is CqlInterval<CqlQuantity>;
-                                if (ao_)
-                                {
-                                    y_ = ak_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    y_ = null;
-                                }
+                                q_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
-                    CqlDateTime aa_ = context.Operators.Start(z_);
-                    Period ab_ = EDwithSTEMI?.Period;
-                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
-                    CqlDateTime ad_ = context.Operators.Start(ac_);
-                    CqlQuantity ae_ = context.Operators.Quantity(24m, "hours");
-                    CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
-                    CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(af_, ad_, true, false);
-                    CqlBoolean ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, (string)default);
-
-                    CqlBoolean ai_() {
-                        Period ap_ = EDwithSTEMI?.Period;
-                        CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ap_);
-                        CqlDateTime ar_ = context.Operators.Start(aq_);
-                        return ar_ is not null;
-                    }
-
-                    return ah_
-                        /* CQL 'and' (287:14-287:120) */ && ai_();
                 }
-
-
-                CqlBoolean r_() {
-                    Code<EventStatus> as_ = AirwayProcedure?.StatusElement;
-                    EventStatus? at_ = as_?.Value;
-                    string au_ = context.Operators.Convert<string>(at_);
-                    CqlBoolean av_ = context.Operators.Equal(au_, "completed");
-                    return av_;
-                }
-
+                CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlDateTime t_ = context.Operators.Start(o_);
+                CqlQuantity u_ = context.Operators.Quantity(24m, "hours");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> w_ = context.Operators.Interval(v_, t_, true, false);
+                CqlBoolean x_ = context.Operators.In<CqlDateTime>(s_, w_, (string)default);
+                CqlBoolean y_ = (CqlBoolean)(t_ is not null);
+                CqlBoolean z_ = x_
+                    /* CQL 'and' (287:14-287:120) */ && y_;
+                Code<EventStatus> aa_ = AirwayProcedure?.StatusElement;
+                EventStatus? ab_ = aa_?.Value;
+                string ac_ = context.Operators.Convert<string>(ab_);
+                CqlBoolean ad_ = context.Operators.Equal(ac_, "completed");
+                CqlBoolean ae_ = ad_;
                 return (p_
-                    /* CQL 'or' (286:17-288:7) */ || q_())
-                    /* CQL 'and' (286:17-289:48) */ && r_();
+                    /* CQL 'or' (286:17-288:7) */ || z_)
+                    /* CQL 'and' (286:17-289:48) */ && ae_;
             }
 
             CqlBoolean j_ = context.Operators.WhereAny<Procedure>(h_, i_);
@@ -1240,33 +1109,33 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
 
             bool? f_(Procedure CranialorSpinalSurgery) {
                 object h_;
-                DataType t_ = CranialorSpinalSurgery?.Performed;
-                object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
-                bool v_ = u_ is CqlDateTime;
-                if (v_)
+                DataType x_ = CranialorSpinalSurgery?.Performed;
+                object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
+                bool z_ = y_ is CqlDateTime;
+                if (z_)
                 {
-                    h_ = u_ as CqlDateTime;
+                    h_ = y_ as CqlDateTime;
                 }
                 else
                 {
-                    bool w_ = u_ is CqlQuantity;
-                    if (w_)
+                    bool aa_ = y_ is CqlQuantity;
+                    if (aa_)
                     {
-                        h_ = u_ as CqlQuantity;
+                        h_ = y_ as CqlQuantity;
                     }
                     else
                     {
-                        bool x_ = u_ is CqlInterval<CqlDateTime>;
-                        if (x_)
+                        bool ab_ = y_ is CqlInterval<CqlDateTime>;
+                        if (ab_)
                         {
-                            h_ = u_ as CqlInterval<CqlDateTime>;
+                            h_ = y_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool y_ = u_ is CqlInterval<CqlQuantity>;
-                            if (y_)
+                            bool ac_ = y_ is CqlInterval<CqlQuantity>;
+                            if (ac_)
                             {
-                                h_ = u_ as CqlInterval<CqlQuantity>;
+                                h_ = y_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -1284,26 +1153,15 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(o_, m_, true, false);
                 CqlBoolean q_ = context.Operators.In<CqlDateTime>(j_, p_, (string)default);
-
-                CqlBoolean r_() {
-                    Period z_ = EDwithSTEMI?.Period;
-                    CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                    CqlDateTime ab_ = context.Operators.Start(aa_);
-                    return ab_ is not null;
-                }
-
-
-                CqlBoolean s_() {
-                    Code<EventStatus> ac_ = CranialorSpinalSurgery?.StatusElement;
-                    EventStatus? ad_ = ac_?.Value;
-                    string ae_ = context.Operators.Convert<string>(ad_);
-                    CqlBoolean af_ = context.Operators.Equal(ae_, "completed");
-                    return af_;
-                }
-
+                CqlBoolean r_ = (CqlBoolean)(m_ is not null);
+                Code<EventStatus> s_ = CranialorSpinalSurgery?.StatusElement;
+                EventStatus? t_ = s_?.Value;
+                string u_ = context.Operators.Convert<string>(t_);
+                CqlBoolean v_ = context.Operators.Equal(u_, "completed");
+                CqlBoolean w_ = v_;
                 return q_
-                    /* CQL 'and' (279:17-279:125) */ && r_()
-                    /* CQL 'and' (279:17-280:55) */ && s_();
+                    /* CQL 'and' (279:17-279:125) */ && r_
+                    /* CQL 'and' (279:17-280:55) */ && w_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -1379,312 +1237,234 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             IEnumerable<Encounter> f_ = Status_1_15_000.Instance.isEncounterPerformed(context, e_);
 
             bool? g_(Encounter InpatientEncounter) {
-                Encounter.HospitalizationComponent n_ = InpatientEncounter?.Hospitalization;
-                CodeableConcept o_ = n_?.DischargeDisposition;
-                CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                CqlCode q_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
-                CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
-                CqlBoolean s_ = context.Operators.Equivalent(p_, r_);
-
-                CqlBoolean t_() {
-                    Encounter.HospitalizationComponent w_ = InpatientEncounter?.Hospitalization;
-                    CodeableConcept x_ = w_?.DischargeDisposition;
-                    CqlConcept y_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, x_);
-                    CqlCode z_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
-                    CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
-                    CqlBoolean ab_ = context.Operators.Equivalent(y_, aa_);
-                    return ab_;
-                }
-
-
-                CqlBoolean u_() {
-                    Period ac_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                    CqlDateTime ae_ = context.Operators.Start(ad_);
-                    Period af_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.Start(ag_);
-                    CqlBoolean ai_ = context.Operators.SameOrBefore(ae_, ah_, (string)default);
-                    return ai_;
-                }
-
-
-                CqlBoolean v_() {
-                    Period aj_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
-                    Period al_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, al_);
-                    CqlDateTime an_ = context.Operators.Start(am_);
-                    CqlQuantity ao_ = context.Operators.Quantity(6m, "months");
-                    CqlDateTime ap_ = context.Operators.Subtract(an_, ao_);
-                    CqlDateTime aq_ = context.Operators.End(am_);
-                    CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(ap_, aq_, true, true);
-                    CqlBoolean as_ = context.Operators.Overlaps(ak_, ar_, "day");
-                    return as_;
-                }
-
-                return (s_
-                    /* CQL 'or' (205:17-207:11) */ || t_())
-                    /* CQL 'and' (205:17-208:90) */ && u_()
-                    /* CQL 'and' (205:11-209:85) */ && v_();
+                Encounter.HospitalizationComponent ao_ = InpatientEncounter?.Hospitalization;
+                CodeableConcept ap_ = ao_?.DischargeDisposition;
+                CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
+                CqlCode ar_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
+                CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+                CqlBoolean at_ = context.Operators.Equivalent(aq_, as_);
+                CqlCode au_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
+                CqlConcept av_ = context.Operators.ConvertCodeToConcept(au_);
+                CqlBoolean aw_ = context.Operators.Equivalent(aq_, av_);
+                CqlBoolean ax_ = aw_;
+                Period ay_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
+                CqlDateTime ba_ = context.Operators.Start(az_);
+                Period bb_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                CqlBoolean be_ = context.Operators.SameOrBefore(ba_, bd_, (string)default);
+                CqlBoolean bf_ = be_;
+                CqlQuantity bg_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime bh_ = context.Operators.Subtract(bd_, bg_);
+                CqlDateTime bi_ = context.Operators.End(bc_);
+                CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bh_, bi_, true, true);
+                CqlBoolean bk_ = context.Operators.Overlaps(az_, bj_, "day");
+                CqlBoolean bl_ = bk_;
+                return (at_
+                    /* CQL 'or' (205:17-207:11) */ || ax_)
+                    /* CQL 'and' (205:17-208:90) */ && bf_
+                    /* CQL 'and' (205:11-209:85) */ && bl_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Encounter>(f_, g_);
+            CqlValueSet i_ = this.Hospice_Encounter(context);
+            IEnumerable<Encounter> j_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            IEnumerable<Encounter> k_ = Status_1_15_000.Instance.isEncounterPerformed(context, j_);
 
-            CqlBoolean i_() {
-                CqlValueSet at_ = this.Hospice_Encounter(context);
-                IEnumerable<Encounter> au_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, at_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-                IEnumerable<Encounter> av_ = Status_1_15_000.Instance.isEncounterPerformed(context, au_);
-
-                bool? aw_(Encounter HospiceEncounter) {
-                    Period ay_ = HospiceEncounter?.Period;
-                    CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
-                    CqlDateTime ba_ = context.Operators.Start(az_);
-                    Period bb_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
-                    CqlDateTime bd_ = context.Operators.Start(bc_);
-                    CqlBoolean be_ = context.Operators.SameOrBefore(ba_, bd_, (string)default);
-
-                    CqlBoolean bf_() {
-                        Period bg_ = HospiceEncounter?.Period;
-                        CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
-                        Period bi_ = EDwSTEMI?.Period;
-                        CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bi_);
-                        CqlDateTime bk_ = context.Operators.Start(bj_);
-                        CqlQuantity bl_ = context.Operators.Quantity(6m, "months");
-                        CqlDateTime bm_ = context.Operators.Subtract(bk_, bl_);
-                        CqlDateTime bn_ = context.Operators.End(bj_);
-                        CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bm_, bn_, true, true);
-                        CqlBoolean bp_ = context.Operators.Overlaps(bh_, bo_, "day");
-                        return bp_;
-                    }
-
-                    return be_
-                        /* CQL 'and' (212:13-213:89) */ && bf_();
-                }
-
-                CqlBoolean ax_ = context.Operators.WhereAny<Encounter>(av_, aw_);
-                return ax_;
+            bool? l_(Encounter HospiceEncounter) {
+                Period bm_ = HospiceEncounter?.Period;
+                CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bm_);
+                CqlDateTime bo_ = context.Operators.Start(bn_);
+                Period bp_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bp_);
+                CqlDateTime br_ = context.Operators.Start(bq_);
+                CqlBoolean bs_ = context.Operators.SameOrBefore(bo_, br_, (string)default);
+                CqlQuantity bt_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime bu_ = context.Operators.Subtract(br_, bt_);
+                CqlDateTime bv_ = context.Operators.End(bq_);
+                CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(bu_, bv_, true, true);
+                CqlBoolean bx_ = context.Operators.Overlaps(bn_, bw_, "day");
+                CqlBoolean by_ = bx_;
+                return bs_
+                    /* CQL 'and' (212:13-213:89) */ && by_;
             }
 
+            CqlBoolean m_ = context.Operators.WhereAny<Encounter>(k_, l_);
+            CqlBoolean n_ = m_;
+            CqlCode o_ = this.Hospice_care__Minimum_Data_Set_(context);
+            IEnumerable<CqlCode> p_ = context.Operators.ToList<CqlCode>(o_);
+            IEnumerable<Observation> q_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, p_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+            IEnumerable<Observation> r_ = Status_1_15_000.Instance.isAssessmentPerformed(context, q_);
 
-            CqlBoolean j_() {
-                CqlCode bq_ = this.Hospice_care__Minimum_Data_Set_(context);
-                IEnumerable<CqlCode> br_ = context.Operators.ToList<CqlCode>(bq_);
-                IEnumerable<Observation> bs_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, br_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
-                IEnumerable<Observation> bt_ = Status_1_15_000.Instance.isAssessmentPerformed(context, bs_);
-
-                bool? bu_(Observation HospiceAssessment) {
-                    DataType bw_ = (HospiceAssessment as Observation)?.Value;
-                    object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bw_);
-                    CqlCode by_ = this.Yes__qualifier_value_(context);
-                    CqlConcept bz_ = context.Operators.ConvertCodeToConcept(by_);
-                    CqlBoolean ca_ = context.Operators.Equivalent(bx_ as CqlConcept, bz_);
-
-                    CqlBoolean cb_() {
-                        DataType cd_ = HospiceAssessment?.Effective;
-                        object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
-                        CqlInterval<CqlDateTime> cf_ = QICoreCommon_4_0_000.Instance.toInterval(context, ce_);
-                        CqlDateTime cg_ = context.Operators.Start(cf_);
-                        Period ch_ = EDwSTEMI?.Period;
-                        CqlInterval<CqlDateTime> ci_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ch_);
-                        CqlDateTime cj_ = context.Operators.Start(ci_);
-                        CqlBoolean ck_ = context.Operators.SameOrBefore(cg_, cj_, (string)default);
-                        return ck_;
-                    }
-
-
-                    CqlBoolean cc_() {
-                        DataType cl_ = HospiceAssessment?.Effective;
-                        object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
-                        CqlInterval<CqlDateTime> cn_ = QICoreCommon_4_0_000.Instance.toInterval(context, cm_);
-                        Period co_ = EDwSTEMI?.Period;
-                        CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
-                        CqlDateTime cq_ = context.Operators.Start(cp_);
-                        CqlQuantity cr_ = context.Operators.Quantity(6m, "months");
-                        CqlDateTime cs_ = context.Operators.Subtract(cq_, cr_);
-                        CqlDateTime ct_ = context.Operators.End(cp_);
-                        CqlInterval<CqlDateTime> cu_ = context.Operators.Interval(cs_, ct_, true, true);
-                        CqlBoolean cv_ = context.Operators.Overlaps(cn_, cu_, "day");
-                        return cv_;
-                    }
-
-                    return ca_
-                        /* CQL 'and' (216:19-217:109) */ && cb_()
-                        /* CQL 'and' (216:13-218:108) */ && cc_();
-                }
-
-                CqlBoolean bv_ = context.Operators.WhereAny<Observation>(bt_, bu_);
-                return bv_;
+            bool? s_(Observation HospiceAssessment) {
+                DataType bz_ = (HospiceAssessment as Observation)?.Value;
+                object ca_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bz_);
+                CqlCode cb_ = this.Yes__qualifier_value_(context);
+                CqlConcept cc_ = context.Operators.ConvertCodeToConcept(cb_);
+                CqlBoolean cd_ = context.Operators.Equivalent(ca_ as CqlConcept, cc_);
+                DataType ce_ = HospiceAssessment?.Effective;
+                object cf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ce_);
+                CqlInterval<CqlDateTime> cg_ = QICoreCommon_4_0_000.Instance.toInterval(context, cf_);
+                CqlDateTime ch_ = context.Operators.Start(cg_);
+                Period ci_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ci_);
+                CqlDateTime ck_ = context.Operators.Start(cj_);
+                CqlBoolean cl_ = context.Operators.SameOrBefore(ch_, ck_, (string)default);
+                CqlBoolean cm_ = cl_;
+                CqlQuantity cn_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime co_ = context.Operators.Subtract(ck_, cn_);
+                CqlDateTime cp_ = context.Operators.End(cj_);
+                CqlInterval<CqlDateTime> cq_ = context.Operators.Interval(co_, cp_, true, true);
+                CqlBoolean cr_ = context.Operators.Overlaps(cg_, cq_, "day");
+                CqlBoolean cs_ = cr_;
+                return cd_
+                    /* CQL 'and' (216:19-217:109) */ && cm_
+                    /* CQL 'and' (216:13-218:108) */ && cs_;
             }
 
+            CqlBoolean t_ = context.Operators.WhereAny<Observation>(r_, s_);
+            CqlBoolean u_ = t_;
+            CqlValueSet v_ = this.Hospice_Care_Ambulatory(context);
+            IEnumerable<ServiceRequest> w_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, v_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+            IEnumerable<ServiceRequest> x_ = Status_1_15_000.Instance.isInterventionOrder(context, w_);
 
-            CqlBoolean k_() {
-                CqlValueSet cw_ = this.Hospice_Care_Ambulatory(context);
-                IEnumerable<ServiceRequest> cx_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, cw_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
-                IEnumerable<ServiceRequest> cy_ = Status_1_15_000.Instance.isInterventionOrder(context, cx_);
-
-                bool? cz_(ServiceRequest HospiceOrder) {
-                    FhirDateTime db_ = HospiceOrder?.AuthoredOnElement;
-                    CqlDateTime dc_ = context.Operators.Convert<CqlDateTime>(db_);
-                    Period dd_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dd_);
-                    CqlDateTime df_ = context.Operators.Start(de_);
-                    CqlQuantity dg_ = context.Operators.Quantity(6m, "months");
-                    CqlDateTime dh_ = context.Operators.Subtract(df_, dg_);
-                    CqlInterval<CqlDateTime> di_ = context.Operators.Interval(dh_, df_, true, false);
-                    CqlBoolean dj_ = context.Operators.In<CqlDateTime>(dc_, di_, (string)default);
-
-                    CqlBoolean dk_() {
-                        Period dl_ = EDwSTEMI?.Period;
-                        CqlInterval<CqlDateTime> dm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dl_);
-                        CqlDateTime dn_ = context.Operators.Start(dm_);
-                        return dn_ is not null;
-                    }
-
-                    return dj_
-                        /* CQL 'and' (221:13-221:94) */ && dk_();
-                }
-
-                CqlBoolean da_ = context.Operators.WhereAny<ServiceRequest>(cy_, cz_);
-                return da_;
+            bool? y_(ServiceRequest HospiceOrder) {
+                FhirDateTime ct_ = HospiceOrder?.AuthoredOnElement;
+                CqlDateTime cu_ = context.Operators.Convert<CqlDateTime>(ct_);
+                Period cv_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cv_);
+                CqlDateTime cx_ = context.Operators.Start(cw_);
+                CqlQuantity cy_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime cz_ = context.Operators.Subtract(cx_, cy_);
+                CqlInterval<CqlDateTime> da_ = context.Operators.Interval(cz_, cx_, true, false);
+                CqlBoolean db_ = context.Operators.In<CqlDateTime>(cu_, da_, (string)default);
+                CqlBoolean dc_ = (CqlBoolean)(cx_ is not null);
+                return db_
+                    /* CQL 'and' (221:13-221:94) */ && dc_;
             }
 
+            CqlBoolean z_ = context.Operators.WhereAny<ServiceRequest>(x_, y_);
+            CqlBoolean aa_ = z_;
+            IEnumerable<Procedure> ab_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, v_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            IEnumerable<Procedure> ac_ = Status_1_15_000.Instance.isInterventionPerformed(context, ab_);
 
-            CqlBoolean l_() {
-                CqlValueSet do_ = this.Hospice_Care_Ambulatory(context);
-                IEnumerable<Procedure> dp_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, do_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-                IEnumerable<Procedure> dq_ = Status_1_15_000.Instance.isInterventionPerformed(context, dp_);
-
-                bool? dr_(Procedure HospicePerformed) {
-                    object dt_;
-                    DataType eb_ = HospicePerformed?.Performed;
-                    object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
-                    bool ed_ = ec_ is CqlDateTime;
-                    if (ed_)
+            bool? ad_(Procedure HospicePerformed) {
+                object dd_;
+                DataType ds_ = HospicePerformed?.Performed;
+                object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
+                bool du_ = dt_ is CqlDateTime;
+                if (du_)
+                {
+                    dd_ = dt_ as CqlDateTime;
+                }
+                else
+                {
+                    bool dv_ = dt_ is CqlQuantity;
+                    if (dv_)
                     {
-                        dt_ = ec_ as CqlDateTime;
+                        dd_ = dt_ as CqlQuantity;
                     }
                     else
                     {
-                        bool ee_ = ec_ is CqlQuantity;
-                        if (ee_)
+                        bool dw_ = dt_ is CqlInterval<CqlDateTime>;
+                        if (dw_)
                         {
-                            dt_ = ec_ as CqlQuantity;
+                            dd_ = dt_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool ef_ = ec_ is CqlInterval<CqlDateTime>;
-                            if (ef_)
+                            bool dx_ = dt_ is CqlInterval<CqlQuantity>;
+                            if (dx_)
                             {
-                                dt_ = ec_ as CqlInterval<CqlDateTime>;
+                                dd_ = dt_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool eg_ = ec_ is CqlInterval<CqlQuantity>;
-                                if (eg_)
-                                {
-                                    dt_ = ec_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    dt_ = null;
-                                }
+                                dd_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> du_ = QICoreCommon_4_0_000.Instance.toInterval(context, dt_);
-                    CqlDateTime dv_ = context.Operators.Start(du_);
-                    Period dw_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> dx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dw_);
-                    CqlDateTime dy_ = context.Operators.Start(dx_);
-                    CqlBoolean dz_ = context.Operators.SameOrBefore(dv_, dy_, (string)default);
-
-                    CqlBoolean ea_() {
-                        object eh_;
-                        DataType er_ = HospicePerformed?.Performed;
-                        object es_ = FHIRHelpers_4_4_000.Instance.ToValue(context, er_);
-                        bool et_ = es_ is CqlDateTime;
-                        if (et_)
+                }
+                CqlInterval<CqlDateTime> de_ = QICoreCommon_4_0_000.Instance.toInterval(context, dd_);
+                CqlDateTime df_ = context.Operators.Start(de_);
+                Period dg_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> dh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dg_);
+                CqlDateTime di_ = context.Operators.Start(dh_);
+                CqlBoolean dj_ = context.Operators.SameOrBefore(df_, di_, (string)default);
+                object dk_;
+                DataType dy_ = HospicePerformed?.Performed;
+                object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
+                bool ea_ = dz_ is CqlDateTime;
+                if (ea_)
+                {
+                    dk_ = dz_ as CqlDateTime;
+                }
+                else
+                {
+                    bool eb_ = dz_ is CqlQuantity;
+                    if (eb_)
+                    {
+                        dk_ = dz_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool ec_ = dz_ is CqlInterval<CqlDateTime>;
+                        if (ec_)
                         {
-                            eh_ = es_ as CqlDateTime;
+                            dk_ = dz_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool eu_ = es_ is CqlQuantity;
-                            if (eu_)
+                            bool ed_ = dz_ is CqlInterval<CqlQuantity>;
+                            if (ed_)
                             {
-                                eh_ = es_ as CqlQuantity;
+                                dk_ = dz_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool ev_ = es_ is CqlInterval<CqlDateTime>;
-                                if (ev_)
-                                {
-                                    eh_ = es_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool ew_ = es_ is CqlInterval<CqlQuantity>;
-                                    if (ew_)
-                                    {
-                                        eh_ = es_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        eh_ = null;
-                                    }
-                                }
+                                dk_ = null;
                             }
                         }
-                        CqlInterval<CqlDateTime> ei_ = QICoreCommon_4_0_000.Instance.toInterval(context, eh_);
-                        Period ej_ = EDwSTEMI?.Period;
-                        CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ej_);
-                        CqlDateTime el_ = context.Operators.Start(ek_);
-                        CqlQuantity em_ = context.Operators.Quantity(6m, "months");
-                        CqlDateTime en_ = context.Operators.Subtract(el_, em_);
-                        CqlDateTime eo_ = context.Operators.End(ek_);
-                        CqlInterval<CqlDateTime> ep_ = context.Operators.Interval(en_, eo_, true, true);
-                        CqlBoolean eq_ = context.Operators.Overlaps(ei_, ep_, "day");
-                        return eq_;
                     }
-
-                    return dz_
-                        /* CQL 'and' (224:13-225:107) */ && ea_();
                 }
-
-                CqlBoolean ds_ = context.Operators.WhereAny<Procedure>(dq_, dr_);
-                return ds_;
+                CqlInterval<CqlDateTime> dl_ = QICoreCommon_4_0_000.Instance.toInterval(context, dk_);
+                CqlQuantity dm_ = context.Operators.Quantity(6m, "months");
+                CqlDateTime dn_ = context.Operators.Subtract(di_, dm_);
+                CqlDateTime do_ = context.Operators.End(dh_);
+                CqlInterval<CqlDateTime> dp_ = context.Operators.Interval(dn_, do_, true, true);
+                CqlBoolean dq_ = context.Operators.Overlaps(dl_, dp_, "day");
+                CqlBoolean dr_ = dq_;
+                return dj_
+                    /* CQL 'and' (224:13-225:107) */ && dr_;
             }
 
+            CqlBoolean ae_ = context.Operators.WhereAny<Procedure>(ac_, ad_);
+            CqlBoolean af_ = ae_;
+            CqlValueSet ag_ = this.Hospice_Diagnosis(context);
+            IEnumerable<Condition> ah_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ag_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            Condition ai_(Condition X) => X as Condition;
+            IEnumerable<Condition> aj_ = context.Operators.Select<Condition, Condition>(ah_, ai_);
+            IEnumerable<Condition> ak_ = Status_1_15_000.Instance.verified(context, aj_);
 
-            CqlBoolean m_() {
-                CqlValueSet ex_ = this.Hospice_Diagnosis(context);
-                IEnumerable<Condition> ey_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ex_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
-                Condition ez_(Condition X) => X as Condition;
-                IEnumerable<Condition> fa_ = context.Operators.Select<Condition, Condition>(ey_, ez_);
-                IEnumerable<Condition> fb_ = Status_1_15_000.Instance.verified(context, fa_);
-
-                bool? fc_(Condition HospiceCareDiagnosis) {
-                    CqlInterval<CqlDateTime> fe_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis);
-                    CqlDateTime ff_ = context.Operators.End(fe_);
-                    Period fg_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> fh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fg_);
-                    CqlDateTime fi_ = context.Operators.Start(fh_);
-                    CqlBoolean fj_ = context.Operators.SameOrAfter(ff_, fi_, (string)default);
-                    return fj_;
-                }
-
-                CqlBoolean fd_ = context.Operators.WhereAny<Condition>(fb_, fc_);
-                return fd_;
+            bool? al_(Condition HospiceCareDiagnosis) {
+                CqlInterval<CqlDateTime> ee_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis);
+                CqlDateTime ef_ = context.Operators.End(ee_);
+                Period eg_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eg_);
+                CqlDateTime ei_ = context.Operators.Start(eh_);
+                CqlBoolean ej_ = context.Operators.SameOrAfter(ef_, ei_, (string)default);
+                return ej_;
             }
 
+            CqlBoolean am_ = context.Operators.WhereAny<Condition>(ak_, al_);
+            CqlBoolean an_ = am_;
             return h_
-                /* CQL 'or' (204:13-214:9) */ || i_()
-                /* CQL 'or' (204:13-219:9) */ || j_()
-                /* CQL 'or' (204:13-222:9) */ || k_()
-                /* CQL 'or' (204:13-226:9) */ || l_()
-                /* CQL 'or' (204:5-230:5) */ || m_();
+                /* CQL 'or' (204:13-214:9) */ || n_
+                /* CQL 'or' (204:13-219:9) */ || u_
+                /* CQL 'or' (204:13-222:9) */ || aa_
+                /* CQL 'or' (204:13-226:9) */ || af_
+                /* CQL 'or' (204:5-230:5) */ || an_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
@@ -1710,28 +1490,20 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 ObservationStatus? h_ = g_?.Value;
                 Code<ObservationStatus> i_ = context.Operators.Convert<Code<ObservationStatus>>(h_);
                 CqlBoolean j_ = context.Operators.Equal(i_, "final");
-
-                CqlBoolean k_() {
-                    DataType m_ = PregStatus?.Value;
-                    CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_ as CodeableConcept);
-                    CqlValueSet o_ = this.Pregnant_State(context);
-                    CqlBoolean p_ = context.Operators.ConceptInValueSet(n_, o_);
-                    return p_;
-                }
-
-
-                CqlBoolean l_() {
-                    DataType q_ = PregStatus?.Effective;
-                    CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-                    Period s_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
-                    CqlBoolean u_ = context.Operators.In<CqlDateTime>(r_, t_, (string)default);
-                    return u_;
-                }
-
+                DataType k_ = PregStatus?.Value;
+                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_ as CodeableConcept);
+                CqlValueSet m_ = this.Pregnant_State(context);
+                CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
+                CqlBoolean o_ = n_;
+                DataType p_ = PregStatus?.Effective;
+                CqlDateTime q_ = context.Operators.LateBoundProperty<CqlDateTime>(p_, "value");
+                Period r_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlBoolean t_ = context.Operators.In<CqlDateTime>(q_, s_, (string)default);
+                CqlBoolean u_ = t_;
                 return j_
-                    /* CQL 'and' (118:17-119:52) */ && k_()
-                    /* CQL 'and' (118:17-120:59) */ && l_();
+                    /* CQL 'and' (118:17-119:52) */ && o_
+                    /* CQL 'and' (118:17-120:59) */ && u_;
             }
 
             CqlBoolean f_ = context.Operators.WhereAny<Observation>(d_, e_);
@@ -1836,46 +1608,36 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, i_);
                 CqlValueSet k_ = this.Patient_Refusal(context);
                 CqlBoolean l_ = context.Operators.ConceptInValueSet(j_, k_);
+                CqlValueSet m_ = this.Procedure_Not_Indicated_Contraindicated(context);
+                CqlBoolean n_ = context.Operators.ConceptInValueSet(j_, m_);
+                CqlBoolean o_ = n_;
 
-                CqlBoolean m_() {
-                    CodeableConcept o_ = PCINotDone?.StatusReason;
-                    CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                    CqlValueSet q_ = this.Procedure_Not_Indicated_Contraindicated(context);
-                    CqlBoolean r_ = context.Operators.ConceptInValueSet(p_, q_);
-                    return r_;
+                bool? p_(Extension @this) {
+                    FhirUri z_ = @this?.UrlElement;
+                    string aa_ = FHIRHelpers_4_4_000.Instance.ToString(context, z_);
+                    CqlBoolean ab_ = context.Operators.Equal(aa_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return ab_;
                 }
 
 
-                CqlBoolean n_() {
-
-                    bool? s_(Extension @this) {
-                        FhirUri ab_ = @this?.UrlElement;
-                        string ac_ = FHIRHelpers_4_4_000.Instance.ToString(context, ab_);
-                        CqlBoolean ad_ = context.Operators.Equal(ac_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
-                        return ad_;
-                    }
-
-
-                    DataType t_(Extension @this) {
-                        DataType ae_ = @this?.Value;
-                        return ae_;
-                    }
-
-                    IEnumerable<DataType> u_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(PCINotDone is DomainResource
-                        ? (PCINotDone as DomainResource).Extension
-                        : default), s_, t_);
-                    DataType v_ = context.Operators.SingletonFrom<DataType>(u_);
-                    FhirDateTime w_ = context.Operators.Convert<FhirDateTime>(v_);
-                    CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
-                    Period y_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-                    CqlBoolean aa_ = context.Operators.In<CqlDateTime>(x_, z_, (string)default);
-                    return aa_;
+                DataType q_(Extension @this) {
+                    DataType ac_ = @this?.Value;
+                    return ac_;
                 }
 
+                IEnumerable<DataType> r_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(PCINotDone is DomainResource
+                    ? (PCINotDone as DomainResource).Extension
+                    : default), p_, q_);
+                DataType s_ = context.Operators.SingletonFrom<DataType>(r_);
+                FhirDateTime t_ = context.Operators.Convert<FhirDateTime>(s_);
+                CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
+                Period v_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, v_);
+                CqlBoolean x_ = context.Operators.In<CqlDateTime>(u_, w_, (string)default);
+                CqlBoolean y_ = x_;
                 return (l_
-                    /* CQL 'or' (257:17-259:7) */ || m_())
-                    /* CQL 'and' (257:17-260:54) */ && n_();
+                    /* CQL 'or' (257:17-259:7) */ || o_)
+                    /* CQL 'and' (257:17-260:54) */ && y_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<Procedure>(f_, g_);
@@ -1906,59 +1668,50 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 List<CodeableConcept> i_ = FibrinolyticNoMed?.StatusReason;
 
                 CqlConcept j_(CodeableConcept @this) {
-                    CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                    return p_;
+                    CqlConcept ac_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ac_;
                 }
 
                 IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
                 CqlValueSet l_ = this.Patient_Refusal(context);
                 CqlBoolean m_ = context.Operators.ConceptsInValueSet(k_, l_);
 
-                CqlBoolean n_() {
-                    List<CodeableConcept> q_ = FibrinolyticNoMed?.StatusReason;
+                CqlConcept n_(CodeableConcept @this) {
+                    CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return ad_;
+                }
 
-                    CqlConcept r_(CodeableConcept @this) {
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return v_;
-                    }
+                IEnumerable<CqlConcept> o_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, n_);
+                CqlValueSet p_ = this.Drug_Intervention_Not_Indicated_Contraindicated(context);
+                CqlBoolean q_ = context.Operators.ConceptsInValueSet(o_, p_);
+                CqlBoolean r_ = q_;
 
-                    IEnumerable<CqlConcept> s_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)q_, r_);
-                    CqlValueSet t_ = this.Drug_Intervention_Not_Indicated_Contraindicated(context);
-                    CqlBoolean u_ = context.Operators.ConceptsInValueSet(s_, t_);
-                    return u_;
+                bool? s_(Extension @this) {
+                    FhirUri ae_ = @this?.UrlElement;
+                    string af_ = FHIRHelpers_4_4_000.Instance.ToString(context, ae_);
+                    CqlBoolean ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+                    return ag_;
                 }
 
 
-                CqlBoolean o_() {
-
-                    bool? w_(Extension @this) {
-                        FhirUri af_ = @this?.UrlElement;
-                        string ag_ = FHIRHelpers_4_4_000.Instance.ToString(context, af_);
-                        CqlBoolean ah_ = context.Operators.Equal(ag_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
-                        return ah_;
-                    }
-
-
-                    DataType x_(Extension @this) {
-                        DataType ai_ = @this?.Value;
-                        return ai_;
-                    }
-
-                    IEnumerable<DataType> y_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(FibrinolyticNoMed is DomainResource
-                        ? (FibrinolyticNoMed as DomainResource).Extension
-                        : default), w_, x_);
-                    DataType z_ = context.Operators.SingletonFrom<DataType>(y_);
-                    FhirDateTime aa_ = context.Operators.Convert<FhirDateTime>(z_);
-                    CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-                    Period ac_ = EDwSTEMI?.Period;
-                    CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                    CqlBoolean ae_ = context.Operators.In<CqlDateTime>(ab_, ad_, (string)default);
-                    return ae_;
+                DataType t_(Extension @this) {
+                    DataType ah_ = @this?.Value;
+                    return ah_;
                 }
 
+                IEnumerable<DataType> u_ = context.Operators.WhereSelect<Extension, DataType>((IEnumerable<Extension>)(FibrinolyticNoMed is DomainResource
+                    ? (FibrinolyticNoMed as DomainResource).Extension
+                    : default), s_, t_);
+                DataType v_ = context.Operators.SingletonFrom<DataType>(u_);
+                FhirDateTime w_ = context.Operators.Convert<FhirDateTime>(v_);
+                CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+                Period y_ = EDwSTEMI?.Period;
+                CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
+                CqlBoolean aa_ = context.Operators.In<CqlDateTime>(x_, z_, (string)default);
+                CqlBoolean ab_ = aa_;
                 return (m_
-                    /* CQL 'or' (265:17-267:7) */ || n_())
-                    /* CQL 'and' (265:17-268:61) */ && o_();
+                    /* CQL 'or' (265:17-267:7) */ || r_)
+                    /* CQL 'and' (265:17-268:61) */ && ab_;
             }
 
             CqlBoolean h_ = context.Operators.WhereAny<MedicationAdministration>(f_, g_);
@@ -2006,34 +1759,22 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             bool? l_(CqlConcept LocationType) {
                 CqlValueSet p_ = this.Emergency_Department_Visit(context);
                 CqlBoolean q_ = context.Operators.ConceptInValueSet(LocationType, p_);
-
-                CqlBoolean r_() {
-                    CqlCode u_ = this.Emergency_room(context);
-                    CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                    CqlBoolean w_ = context.Operators.Equivalent(LocationType, v_);
-                    return w_;
-                }
-
-
-                CqlBoolean s_() {
-                    CqlCode x_ = this.Emergency_trauma_unit(context);
-                    CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                    CqlBoolean z_ = context.Operators.Equivalent(LocationType, y_);
-                    return z_;
-                }
-
-
-                CqlBoolean t_() {
-                    Period aa_ = EDLocation?.Period;
-                    CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                    CqlDateTime ac_ = context.Operators.Start(ab_);
-                    return ac_ is not null;
-                }
-
+                CqlCode r_ = this.Emergency_room(context);
+                CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+                CqlBoolean t_ = context.Operators.Equivalent(LocationType, s_);
+                CqlBoolean u_ = t_;
+                CqlCode v_ = this.Emergency_trauma_unit(context);
+                CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
+                CqlBoolean x_ = context.Operators.Equivalent(LocationType, w_);
+                CqlBoolean y_ = x_;
+                Period z_ = EDLocation?.Period;
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
                 return (q_
-                    /* CQL 'or' (320:17-321:48) */ || r_()
-                    /* CQL 'or' (320:16-323:11) */ || s_())
-                    /* CQL 'and' (320:11-324:54) */ && t_();
+                    /* CQL 'or' (320:17-321:48) */ || u_
+                    /* CQL 'or' (320:16-323:11) */ || y_)
+                    /* CQL 'and' (320:11-324:54) */ && ac_;
             }
 
             IEnumerable<CqlConcept> m_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_, l_);
@@ -2079,17 +1820,13 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     IEnumerable<string> q_ = context.Operators.Split((string)p_, "/");
                     string r_ = context.Operators.Last<string>(q_);
                     CqlBoolean s_ = context.Operators.Equal(o_, r_);
-
-                    CqlBoolean t_() {
-                        CodeableConcept u_ = M?.Code;
-                        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, u_);
-                        CqlValueSet w_ = this.Fibrinolytic_Therapy(context);
-                        CqlBoolean x_ = context.Operators.ConceptInValueSet(v_, w_);
-                        return x_;
-                    }
-
+                    CodeableConcept t_ = M?.Code;
+                    CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                    CqlValueSet v_ = this.Fibrinolytic_Therapy(context);
+                    CqlBoolean w_ = context.Operators.ConceptInValueSet(u_, v_);
+                    CqlBoolean x_ = w_;
                     return s_
-                        /* CQL 'and' */ && t_();
+                        /* CQL 'and' */ && x_;
                 }
 
                 CqlBoolean n_ = context.Operators.WhereAny<Medication>(l_, m_);
@@ -2106,23 +1843,19 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 MedicationAdministration.MedicationAdministrationStatusCodes? z_ = y_?.Value;
                 string aa_ = context.Operators.Convert<string>(z_);
                 CqlBoolean ab_ = context.Operators.Equal(aa_, "completed");
-
-                CqlBoolean ac_() {
-                    DataType ad_ = Fibrinolytic?.Effective;
-                    object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                    CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_);
-                    CqlDateTime ag_ = context.Operators.Start(af_);
-                    CqlDateTime ah_ = this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI);
-                    CqlQuantity ai_ = context.Operators.Quantity(30m, "minutes");
-                    CqlDateTime aj_ = context.Operators.Add(ah_, ai_);
-                    CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ah_, aj_, false, true);
-                    CqlBoolean al_ = context.Operators.In<CqlDateTime>(ag_, ak_, (string)default);
-                    return al_
-                        /* CQL 'and' (274:13-274:141) */ && ((this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI)) is not null);
-                }
-
+                DataType ac_ = Fibrinolytic?.Effective;
+                object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
+                CqlDateTime af_ = context.Operators.Start(ae_);
+                CqlDateTime ag_ = this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI);
+                CqlQuantity ah_ = context.Operators.Quantity(30m, "minutes");
+                CqlDateTime ai_ = context.Operators.Add(ag_, ah_);
+                CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ag_, ai_, false, true);
+                CqlBoolean ak_ = context.Operators.In<CqlDateTime>(af_, aj_, (string)default);
+                CqlBoolean al_ = ak_
+                    /* CQL 'and' (274:13-274:141) */ && ((this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI)) is not null);
                 return ab_
-                    /* CQL 'and' (273:17-274:141) */ && ac_();
+                    /* CQL 'and' (273:17-274:141) */ && al_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<MedicationAdministration>(i_, j_);
@@ -2150,33 +1883,33 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
 
             bool? f_(Procedure PCI) {
                 object h_;
-                DataType q_ = PCI?.Performed;
-                object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
-                bool s_ = r_ is CqlDateTime;
-                if (s_)
+                DataType u_ = PCI?.Performed;
+                object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
+                bool w_ = v_ is CqlDateTime;
+                if (w_)
                 {
-                    h_ = r_ as CqlDateTime;
+                    h_ = v_ as CqlDateTime;
                 }
                 else
                 {
-                    bool t_ = r_ is CqlQuantity;
-                    if (t_)
+                    bool x_ = v_ is CqlQuantity;
+                    if (x_)
                     {
-                        h_ = r_ as CqlQuantity;
+                        h_ = v_ as CqlQuantity;
                     }
                     else
                     {
-                        bool u_ = r_ is CqlInterval<CqlDateTime>;
-                        if (u_)
+                        bool y_ = v_ is CqlInterval<CqlDateTime>;
+                        if (y_)
                         {
-                            h_ = r_ as CqlInterval<CqlDateTime>;
+                            h_ = v_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool v_ = r_ is CqlInterval<CqlQuantity>;
-                            if (v_)
+                            bool z_ = v_ is CqlInterval<CqlQuantity>;
+                            if (z_)
                             {
-                                h_ = r_ as CqlInterval<CqlQuantity>;
+                                h_ = v_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
@@ -2192,18 +1925,14 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlDateTime m_ = context.Operators.Add(k_, l_);
                 CqlInterval<CqlDateTime> n_ = context.Operators.Interval(k_, m_, false, true);
                 CqlBoolean o_ = context.Operators.In<CqlDateTime>(j_, n_, (string)default);
-
-                CqlBoolean p_() {
-                    Code<EventStatus> w_ = PCI?.StatusElement;
-                    EventStatus? x_ = w_?.Value;
-                    string y_ = context.Operators.Convert<string>(x_);
-                    CqlBoolean z_ = context.Operators.Equal(y_, "completed");
-                    return z_;
-                }
-
+                Code<EventStatus> p_ = PCI?.StatusElement;
+                EventStatus? q_ = p_?.Value;
+                string r_ = context.Operators.Convert<string>(q_);
+                CqlBoolean s_ = context.Operators.Equal(r_, "completed");
+                CqlBoolean t_ = s_;
                 return o_
                     /* CQL 'and' (302:17-302:130) */ && ((this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI)) is not null)
-                    /* CQL 'and' (302:17-303:36) */ && p_();
+                    /* CQL 'and' (302:17-303:36) */ && t_;
             }
 
             CqlBoolean g_ = context.Operators.WhereAny<Procedure>(e_, f_);
@@ -2234,34 +1963,22 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             bool? l_(CqlConcept LocationType) {
                 CqlValueSet p_ = this.Emergency_Department_Visit(context);
                 CqlBoolean q_ = context.Operators.ConceptInValueSet(LocationType, p_);
-
-                CqlBoolean r_() {
-                    CqlCode u_ = this.Emergency_room(context);
-                    CqlConcept v_ = context.Operators.ConvertCodeToConcept(u_);
-                    CqlBoolean w_ = context.Operators.Equivalent(LocationType, v_);
-                    return w_;
-                }
-
-
-                CqlBoolean s_() {
-                    CqlCode x_ = this.Emergency_trauma_unit(context);
-                    CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
-                    CqlBoolean z_ = context.Operators.Equivalent(LocationType, y_);
-                    return z_;
-                }
-
-
-                CqlBoolean t_() {
-                    Period aa_ = EDLocation?.Period;
-                    CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                    CqlDateTime ac_ = context.Operators.End(ab_);
-                    return ac_ is not null;
-                }
-
+                CqlCode r_ = this.Emergency_room(context);
+                CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+                CqlBoolean t_ = context.Operators.Equivalent(LocationType, s_);
+                CqlBoolean u_ = t_;
+                CqlCode v_ = this.Emergency_trauma_unit(context);
+                CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
+                CqlBoolean x_ = context.Operators.Equivalent(LocationType, w_);
+                CqlBoolean y_ = x_;
+                Period z_ = EDLocation?.Period;
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
+                CqlDateTime ab_ = context.Operators.End(aa_);
+                CqlBoolean ac_ = (CqlBoolean)(ab_ is not null);
                 return (q_
-                    /* CQL 'or' (333:17-334:48) */ || r_()
-                    /* CQL 'or' (333:16-336:11) */ || s_())
-                    /* CQL 'and' (333:11-338:48) */ && t_();
+                    /* CQL 'or' (333:17-334:48) */ || u_
+                    /* CQL 'or' (333:16-336:11) */ || y_)
+                    /* CQL 'and' (333:11-338:48) */ && ac_;
             }
 
             IEnumerable<CqlConcept> m_ = context.Operators.SelectWhere<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_, l_);
@@ -2302,19 +2019,15 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
             CqlDateTime g_ = context.Operators.Add(e_, f_);
             CqlInterval<CqlDateTime> h_ = context.Operators.Interval(e_, g_, false, true);
             CqlBoolean i_ = context.Operators.In<CqlDateTime>(d_, h_, (string)default);
-
-            CqlBoolean j_() {
-                Encounter.HospitalizationComponent k_ = EDwithSTEMI?.Hospitalization;
-                CodeableConcept l_ = k_?.DischargeDisposition;
-                CqlConcept m_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, l_);
-                CqlValueSet n_ = this.Discharge_To_Acute_Care_Facility(context);
-                CqlBoolean o_ = context.Operators.ConceptInValueSet(m_, n_);
-                return o_;
-            }
-
+            Encounter.HospitalizationComponent j_ = EDwithSTEMI?.Hospitalization;
+            CodeableConcept k_ = j_?.DischargeDisposition;
+            CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
+            CqlValueSet m_ = this.Discharge_To_Acute_Care_Facility(context);
+            CqlBoolean n_ = context.Operators.ConceptInValueSet(l_, m_);
+            CqlBoolean o_ = n_;
             return i_
                 /* CQL 'and' (170:11-170:141) */ && ((this.currentemergencyDepartmentArrivalTime(context, EDwithSTEMI)) is not null)
-                /* CQL 'and' (170:5-171:96) */ && j_();
+                /* CQL 'and' (170:5-171:96) */ && o_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMSFHIR529HybridHospitalWideReadmission", "0.5.001")]
 public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary, ISingleton<CMSFHIR529HybridHospitalWideReadmission_0_5_001>
 {
@@ -148,44 +148,30 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, InpatientEncounter);
                 int? m_ = CQMCommon_4_1_000.Instance.lengthInDays(context, l_);
                 CqlBoolean n_ = context.Operators.Less(m_, 365);
-
-                CqlBoolean o_() {
-                    Code<Encounter.EncounterStatus> r_ = InpatientEncounter?.StatusElement;
-                    Encounter.EncounterStatus? s_ = r_?.Value;
-                    Code<Encounter.EncounterStatus> t_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(s_);
-                    CqlBoolean u_ = context.Operators.Equal(t_, "finished");
-                    return u_;
-                }
-
-
-                CqlBoolean p_() {
-                    Patient v_ = this.Patient(context);
-                    Date w_ = v_?.BirthDateElement;
-                    string x_ = w_?.Value;
-                    CqlDate y_ = context.Operators.ConvertStringToDate(x_);
-                    Period z_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                    CqlDateTime ab_ = context.Operators.Start(aa_);
-                    CqlDate ac_ = context.Operators.DateFrom(ab_);
-                    int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
-                    CqlBoolean ae_ = context.Operators.GreaterOrEqual(ad_, 65);
-                    return ae_;
-                }
-
-
-                CqlBoolean q_() {
-                    Period af_ = InpatientEncounter?.Period;
-                    CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.End(ag_);
-                    CqlInterval<CqlDateTime> ai_ = this.Measurement_Period(context);
-                    CqlBoolean aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, "day");
-                    return aj_;
-                }
-
+                Code<Encounter.EncounterStatus> o_ = InpatientEncounter?.StatusElement;
+                Encounter.EncounterStatus? p_ = o_?.Value;
+                Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
+                CqlBoolean r_ = context.Operators.Equal(q_, "finished");
+                CqlBoolean s_ = r_;
+                Patient t_ = this.Patient(context);
+                Date u_ = t_?.BirthDateElement;
+                string v_ = u_?.Value;
+                CqlDate w_ = context.Operators.ConvertStringToDate(v_);
+                Period x_ = InpatientEncounter?.Period;
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                CqlDate aa_ = context.Operators.DateFrom(z_);
+                int? ab_ = context.Operators.CalculateAgeAt(w_, aa_, "year");
+                CqlBoolean ac_ = context.Operators.GreaterOrEqual(ab_, 65);
+                CqlBoolean ad_ = ac_;
+                CqlDateTime ae_ = context.Operators.End(y_);
+                CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
+                CqlBoolean ag_ = context.Operators.In<CqlDateTime>(ae_, af_, "day");
+                CqlBoolean ah_ = ag_;
                 return n_
-                    /* CQL 'and' (40:17-41:50) */ && o_()
-                    /* CQL 'and' (40:17-42:76) */ && p_()
-                    /* CQL 'and' (40:17-43:77) */ && q_();
+                    /* CQL 'and' (40:17-41:50) */ && s_
+                    /* CQL 'and' (40:17-42:76) */ && ad_
+                    /* CQL 'and' (40:17-43:77) */ && ah_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Coverage>(i_, j_);
@@ -231,30 +217,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ad_ = Temperature?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType ai_ = Temperature?.Value;
-                    CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                    return aj_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = Temperature?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = Temperature?.Value;
+                CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (48:15-49:71) */ && ab_()
-                    /* CQL 'and' (48:9-50:43) */ && ac_();
+                    /* CQL 'and' (48:15-49:71) */ && ag_
+                    /* CQL 'and' (48:9-50:43) */ && aj_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -277,30 +255,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
                 CqlInterval<CqlDateTime> aq_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
-
-                CqlBoolean as_() {
-                    Code<ObservationStatus> au_ = Temperature?.StatusElement;
-                    ObservationStatus? av_ = au_?.Value;
-                    string aw_ = context.Operators.Convert<string>(av_);
-                    string[] ax_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                    return ay_;
-                }
-
-
-                CqlBoolean at_() {
-                    DataType az_ = Temperature?.Value;
-                    CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
-                    return ba_ is not null;
-                }
-
+                Code<ObservationStatus> as_ = Temperature?.StatusElement;
+                ObservationStatus? at_ = as_?.Value;
+                string au_ = context.Operators.Convert<string>(at_);
+                string[] av_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+                CqlBoolean ax_ = aw_;
+                DataType ay_ = Temperature?.Value;
+                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_ as Quantity);
+                CqlBoolean ba_ = (CqlBoolean)(az_ is not null);
                 return ar_
-                    /* CQL 'and' (48:15-49:71) */ && as_()
-                    /* CQL 'and' (48:9-50:43) */ && at_();
+                    /* CQL 'and' (48:15-49:71) */ && ax_
+                    /* CQL 'and' (48:9-50:43) */ && ba_;
             }
 
             IEnumerable<Observation> o_ = context.Operators.Where<Observation>(f_, n_);
@@ -347,30 +317,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ad_ = HeartRate?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType ai_ = HeartRate?.Value;
-                    CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                    return aj_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = HeartRate?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = HeartRate?.Value;
+                CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (62:15-63:69) */ && ab_()
-                    /* CQL 'and' (62:9-64:41) */ && ac_();
+                    /* CQL 'and' (62:15-63:69) */ && ag_
+                    /* CQL 'and' (62:9-64:41) */ && aj_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -393,30 +355,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
                 CqlInterval<CqlDateTime> aq_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
-
-                CqlBoolean as_() {
-                    Code<ObservationStatus> au_ = HeartRate?.StatusElement;
-                    ObservationStatus? av_ = au_?.Value;
-                    string aw_ = context.Operators.Convert<string>(av_);
-                    string[] ax_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                    return ay_;
-                }
-
-
-                CqlBoolean at_() {
-                    DataType az_ = HeartRate?.Value;
-                    CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
-                    return ba_ is not null;
-                }
-
+                Code<ObservationStatus> as_ = HeartRate?.StatusElement;
+                ObservationStatus? at_ = as_?.Value;
+                string au_ = context.Operators.Convert<string>(at_);
+                string[] av_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+                CqlBoolean ax_ = aw_;
+                DataType ay_ = HeartRate?.Value;
+                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_ as Quantity);
+                CqlBoolean ba_ = (CqlBoolean)(az_ is not null);
                 return ar_
-                    /* CQL 'and' (62:15-63:69) */ && as_()
-                    /* CQL 'and' (62:9-64:41) */ && at_();
+                    /* CQL 'and' (62:15-63:69) */ && ax_
+                    /* CQL 'and' (62:9-64:41) */ && ba_;
             }
 
             IEnumerable<Observation> o_ = context.Operators.Where<Observation>(f_, n_);
@@ -464,30 +418,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, y_);
                 CqlInterval<CqlDateTime> aa_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ab_ = context.Operators.In<CqlDateTime>(z_, aa_, (string)default);
-
-                CqlBoolean ac_() {
-                    Code<ObservationStatus> ae_ = O2Saturation?.StatusElement;
-                    ObservationStatus? af_ = ae_?.Value;
-                    string ag_ = context.Operators.Convert<string>(af_);
-                    string[] ah_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                    return ai_;
-                }
-
-
-                CqlBoolean ad_() {
-                    DataType aj_ = O2Saturation?.Value;
-                    CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
-                    return ak_ is not null;
-                }
-
+                Code<ObservationStatus> ac_ = O2Saturation?.StatusElement;
+                ObservationStatus? ad_ = ac_?.Value;
+                string ae_ = context.Operators.Convert<string>(ad_);
+                string[] af_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+                CqlBoolean ah_ = ag_;
+                DataType ai_ = O2Saturation?.Value;
+                CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
+                CqlBoolean ak_ = (CqlBoolean)(aj_ is not null);
                 return ab_
-                    /* CQL 'and' (76:15-77:72) */ && ac_()
-                    /* CQL 'and' (76:9-78:44) */ && ad_();
+                    /* CQL 'and' (76:15-77:72) */ && ah_
+                    /* CQL 'and' (76:9-78:44) */ && ak_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -510,30 +456,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime aq_ = QICoreCommon_4_0_000.Instance.earliest(context, ap_);
                 CqlInterval<CqlDateTime> ar_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean as_ = context.Operators.In<CqlDateTime>(aq_, ar_, (string)default);
-
-                CqlBoolean at_() {
-                    Code<ObservationStatus> av_ = O2Saturation?.StatusElement;
-                    ObservationStatus? aw_ = av_?.Value;
-                    string ax_ = context.Operators.Convert<string>(aw_);
-                    string[] ay_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
-                    return az_;
-                }
-
-
-                CqlBoolean au_() {
-                    DataType ba_ = O2Saturation?.Value;
-                    CqlQuantity bb_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ba_ as Quantity);
-                    return bb_ is not null;
-                }
-
+                Code<ObservationStatus> at_ = O2Saturation?.StatusElement;
+                ObservationStatus? au_ = at_?.Value;
+                string av_ = context.Operators.Convert<string>(au_);
+                string[] aw_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ax_ = context.Operators.In<string>(av_, (IEnumerable<string>)aw_);
+                CqlBoolean ay_ = ax_;
+                DataType az_ = O2Saturation?.Value;
+                CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
+                CqlBoolean bb_ = (CqlBoolean)(ba_ is not null);
                 return as_
-                    /* CQL 'and' (76:15-77:72) */ && at_()
-                    /* CQL 'and' (76:9-78:44) */ && au_();
+                    /* CQL 'and' (76:15-77:72) */ && ay_
+                    /* CQL 'and' (76:9-78:44) */ && bb_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -580,30 +518,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ad_ = Respirations?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType ai_ = Respirations?.Value;
-                    CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                    return aj_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = Respirations?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = Respirations?.Value;
+                CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (90:15-91:72) */ && ab_()
-                    /* CQL 'and' (90:9-92:44) */ && ac_();
+                    /* CQL 'and' (90:15-91:72) */ && ag_
+                    /* CQL 'and' (90:9-92:44) */ && aj_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -626,30 +556,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
                 CqlInterval<CqlDateTime> aq_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
-
-                CqlBoolean as_() {
-                    Code<ObservationStatus> au_ = Respirations?.StatusElement;
-                    ObservationStatus? av_ = au_?.Value;
-                    string aw_ = context.Operators.Convert<string>(av_);
-                    string[] ax_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                    return ay_;
-                }
-
-
-                CqlBoolean at_() {
-                    DataType az_ = Respirations?.Value;
-                    CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
-                    return ba_ is not null;
-                }
-
+                Code<ObservationStatus> as_ = Respirations?.StatusElement;
+                ObservationStatus? at_ = as_?.Value;
+                string au_ = context.Operators.Convert<string>(at_);
+                string[] av_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+                CqlBoolean ax_ = aw_;
+                DataType ay_ = Respirations?.Value;
+                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_ as Quantity);
+                CqlBoolean ba_ = (CqlBoolean)(az_ is not null);
                 return ar_
-                    /* CQL 'and' (90:15-91:72) */ && as_()
-                    /* CQL 'and' (90:9-92:44) */ && at_();
+                    /* CQL 'and' (90:15-91:72) */ && ax_
+                    /* CQL 'and' (90:9-92:44) */ && ba_;
             }
 
             IEnumerable<Observation> o_ = context.Operators.Where<Observation>(f_, n_);
@@ -696,44 +618,36 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_);
                 CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
+                Code<ObservationStatus> ae_ = BP?.StatusElement;
+                ObservationStatus? af_ = ae_?.Value;
+                string ag_ = context.Operators.Convert<string>(af_);
+                string[] ah_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
+                CqlBoolean aj_ = ai_;
+                List<Observation.ComponentComponent> ak_ = BP?.Component;
 
-                CqlBoolean ae_() {
-                    Code<ObservationStatus> ag_ = BP?.StatusElement;
-                    ObservationStatus? ah_ = ag_?.Value;
-                    string ai_ = context.Operators.Convert<string>(ah_);
-                    string[] aj_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-                    return ak_;
+                bool? al_(Observation.ComponentComponent @this) {
+                    DataType ap_ = @this?.Value;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    return aq_ is not null;
                 }
 
 
-                CqlBoolean af_() {
-                    List<Observation.ComponentComponent> al_ = BP?.Component;
-
-                    bool? am_(Observation.ComponentComponent @this) {
-                        DataType ap_ = @this?.Value;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return aq_ is not null;
-                    }
-
-
-                    object an_(Observation.ComponentComponent @this) {
-                        DataType ar_ = @this?.Value;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return as_;
-                    }
-
-                    IEnumerable<object> ao_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)al_, am_, an_);
-                    return ao_ is not null;
+                object am_(Observation.ComponentComponent @this) {
+                    DataType ar_ = @this?.Value;
+                    object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                    return as_;
                 }
 
+                IEnumerable<object> an_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)ak_, al_, am_);
+                CqlBoolean ao_ = (CqlBoolean)(an_ is not null);
                 return ad_
-                    /* CQL 'and' (104:15-105:62) */ && ae_()
-                    /* CQL 'and' (104:9-106:44) */ && af_();
+                    /* CQL 'and' (104:15-105:62) */ && aj_
+                    /* CQL 'and' (104:9-106:44) */ && ao_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -774,44 +688,36 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime bf_ = QICoreCommon_4_0_000.Instance.earliest(context, be_);
                 CqlInterval<CqlDateTime> bg_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean bh_ = context.Operators.In<CqlDateTime>(bf_, bg_, (string)default);
+                Code<ObservationStatus> bi_ = BP?.StatusElement;
+                ObservationStatus? bj_ = bi_?.Value;
+                string bk_ = context.Operators.Convert<string>(bj_);
+                string[] bl_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
+                CqlBoolean bn_ = bm_;
+                List<Observation.ComponentComponent> bo_ = BP?.Component;
 
-                CqlBoolean bi_() {
-                    Code<ObservationStatus> bk_ = BP?.StatusElement;
-                    ObservationStatus? bl_ = bk_?.Value;
-                    string bm_ = context.Operators.Convert<string>(bl_);
-                    string[] bn_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bo_ = context.Operators.In<string>(bm_, (IEnumerable<string>)bn_);
-                    return bo_;
+                bool? bp_(Observation.ComponentComponent @this) {
+                    DataType bt_ = @this?.Value;
+                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                    return bu_ is not null;
                 }
 
 
-                CqlBoolean bj_() {
-                    List<Observation.ComponentComponent> bp_ = BP?.Component;
-
-                    bool? bq_(Observation.ComponentComponent @this) {
-                        DataType bt_ = @this?.Value;
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        return bu_ is not null;
-                    }
-
-
-                    object br_(Observation.ComponentComponent @this) {
-                        DataType bv_ = @this?.Value;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        return bw_;
-                    }
-
-                    IEnumerable<object> bs_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)bp_, bq_, br_);
-                    return bs_ is not null;
+                object bq_(Observation.ComponentComponent @this) {
+                    DataType bv_ = @this?.Value;
+                    object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                    return bw_;
                 }
 
+                IEnumerable<object> br_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)bo_, bp_, bq_);
+                CqlBoolean bs_ = (CqlBoolean)(br_ is not null);
                 return bh_
-                    /* CQL 'and' (104:15-105:62) */ && bi_()
-                    /* CQL 'and' (104:9-106:44) */ && bj_();
+                    /* CQL 'and' (104:15-105:62) */ && bn_
+                    /* CQL 'and' (104:9-106:44) */ && bs_;
             }
 
             IEnumerable<Observation> r_ = context.Operators.Where<Observation>(f_, q_);
@@ -855,25 +761,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? h_(Observation bicarbonatelab) {
                 object x_;
-                DataType ad_ = bicarbonatelab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = bicarbonatelab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -884,30 +790,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = bicarbonatelab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = bicarbonatelab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = bicarbonatelab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = bicarbonatelab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (120:15-121:74) */ && ab_()
-                    /* CQL 'and' (120:9-122:46) */ && ac_();
+                    /* CQL 'and' (120:15-121:74) */ && ag_
+                    /* CQL 'and' (120:9-122:46) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -927,25 +825,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? o_(Observation bicarbonatelab) {
                 object as_;
-                DataType ay_ = bicarbonatelab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = bicarbonatelab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -956,30 +854,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = bicarbonatelab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = bicarbonatelab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = bicarbonatelab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = bicarbonatelab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (120:15-121:74) */ && aw_()
-                    /* CQL 'and' (120:9-122:46) */ && ax_();
+                    /* CQL 'and' (120:15-121:74) */ && bb_
+                    /* CQL 'and' (120:9-122:46) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1024,25 +914,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? h_(Observation CreatinineLab) {
                 object x_;
-                DataType ad_ = CreatinineLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = CreatinineLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1053,30 +943,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = CreatinineLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = CreatinineLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = CreatinineLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = CreatinineLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (134:15-135:73) */ && ab_()
-                    /* CQL 'and' (134:9-136:45) */ && ac_();
+                    /* CQL 'and' (134:15-135:73) */ && ag_
+                    /* CQL 'and' (134:9-136:45) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1096,25 +978,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? o_(Observation CreatinineLab) {
                 object as_;
-                DataType ay_ = CreatinineLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = CreatinineLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1125,30 +1007,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = CreatinineLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = CreatinineLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = CreatinineLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = CreatinineLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (134:15-135:73) */ && aw_()
-                    /* CQL 'and' (134:9-136:45) */ && ax_();
+                    /* CQL 'and' (134:15-135:73) */ && bb_
+                    /* CQL 'and' (134:9-136:45) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1193,25 +1067,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? h_(Observation GlucoseLab) {
                 object x_;
-                DataType ad_ = GlucoseLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = GlucoseLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1222,30 +1096,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = GlucoseLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = GlucoseLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = GlucoseLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = GlucoseLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (148:15-149:70) */ && ab_()
-                    /* CQL 'and' (148:9-150:42) */ && ac_();
+                    /* CQL 'and' (148:15-149:70) */ && ag_
+                    /* CQL 'and' (148:9-150:42) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1265,25 +1131,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? o_(Observation GlucoseLab) {
                 object as_;
-                DataType ay_ = GlucoseLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = GlucoseLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1294,30 +1160,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = GlucoseLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = GlucoseLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = GlucoseLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = GlucoseLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (148:15-149:70) */ && aw_()
-                    /* CQL 'and' (148:9-150:42) */ && ax_();
+                    /* CQL 'and' (148:15-149:70) */ && bb_
+                    /* CQL 'and' (148:9-150:42) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1362,25 +1220,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? h_(Observation HematocritLab) {
                 object x_;
-                DataType ad_ = HematocritLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = HematocritLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1391,30 +1249,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = HematocritLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = HematocritLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = HematocritLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = HematocritLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (162:15-163:73) */ && ab_()
-                    /* CQL 'and' (162:9-164:45) */ && ac_();
+                    /* CQL 'and' (162:15-163:73) */ && ag_
+                    /* CQL 'and' (162:9-164:45) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1434,25 +1284,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? o_(Observation HematocritLab) {
                 object as_;
-                DataType ay_ = HematocritLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = HematocritLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1463,30 +1313,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = HematocritLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = HematocritLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = HematocritLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = HematocritLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (162:15-163:73) */ && aw_()
-                    /* CQL 'and' (162:9-164:45) */ && ax_();
+                    /* CQL 'and' (162:15-163:73) */ && bb_
+                    /* CQL 'and' (162:9-164:45) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1531,25 +1373,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? h_(Observation PotassiumLab) {
                 object x_;
-                DataType ad_ = PotassiumLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = PotassiumLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1560,30 +1402,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = PotassiumLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = PotassiumLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = PotassiumLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = PotassiumLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (176:15-177:72) */ && ab_()
-                    /* CQL 'and' (176:9-178:44) */ && ac_();
+                    /* CQL 'and' (176:15-177:72) */ && ag_
+                    /* CQL 'and' (176:9-178:44) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1603,25 +1437,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? o_(Observation PotassiumLab) {
                 object as_;
-                DataType ay_ = PotassiumLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = PotassiumLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1632,30 +1466,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = PotassiumLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = PotassiumLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = PotassiumLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = PotassiumLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (176:15-177:72) */ && aw_()
-                    /* CQL 'and' (176:9-178:44) */ && ax_();
+                    /* CQL 'and' (176:15-177:72) */ && bb_
+                    /* CQL 'and' (176:9-178:44) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1700,25 +1526,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? h_(Observation SodiumLab) {
                 object x_;
-                DataType ad_ = SodiumLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = SodiumLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1729,30 +1555,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = SodiumLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = SodiumLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = SodiumLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = SodiumLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (190:15-191:69) */ && ab_()
-                    /* CQL 'and' (190:9-192:41) */ && ac_();
+                    /* CQL 'and' (190:15-191:69) */ && ag_
+                    /* CQL 'and' (190:9-192:41) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1772,25 +1590,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? o_(Observation SodiumLab) {
                 object as_;
-                DataType ay_ = SodiumLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = SodiumLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1801,30 +1619,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = SodiumLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = SodiumLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = SodiumLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = SodiumLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (190:15-191:69) */ && aw_()
-                    /* CQL 'and' (190:9-192:41) */ && ax_();
+                    /* CQL 'and' (190:15-191:69) */ && bb_
+                    /* CQL 'and' (190:9-192:41) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1869,25 +1679,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? h_(Observation WhiteBloodCellLab) {
                 object x_;
-                DataType ad_ = WhiteBloodCellLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = WhiteBloodCellLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1898,30 +1708,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = WhiteBloodCellLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = WhiteBloodCellLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = WhiteBloodCellLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = WhiteBloodCellLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (204:15-205:77) */ && ab_()
-                    /* CQL 'and' (204:9-206:49) */ && ac_();
+                    /* CQL 'and' (204:15-205:77) */ && ag_
+                    /* CQL 'and' (204:9-206:49) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1941,25 +1743,25 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
             bool? o_(Observation WhiteBloodCellLab) {
                 object as_;
-                DataType ay_ = WhiteBloodCellLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = WhiteBloodCellLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1970,30 +1772,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = WhiteBloodCellLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = WhiteBloodCellLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = WhiteBloodCellLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = WhiteBloodCellLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (204:15-205:77) */ && aw_()
-                    /* CQL 'and' (204:9-206:49) */ && ax_();
+                    /* CQL 'and' (204:15-205:77) */ && bb_
+                    /* CQL 'and' (204:9-206:49) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -2041,30 +1835,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ad_ = WeightExam?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType ai_ = WeightExam?.Value;
-                    CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                    return aj_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = WeightExam?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = WeightExam?.Value;
+                CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (218:15-219:70) */ && ab_()
-                    /* CQL 'and' (218:9-220:42) */ && ac_();
+                    /* CQL 'and' (218:15-219:70) */ && ag_
+                    /* CQL 'and' (218:9-220:42) */ && aj_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -2087,30 +1873,22 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                 CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
                 CqlInterval<CqlDateTime> aq_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
-
-                CqlBoolean as_() {
-                    Code<ObservationStatus> au_ = WeightExam?.StatusElement;
-                    ObservationStatus? av_ = au_?.Value;
-                    string aw_ = context.Operators.Convert<string>(av_);
-                    string[] ax_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                    return ay_;
-                }
-
-
-                CqlBoolean at_() {
-                    DataType az_ = WeightExam?.Value;
-                    CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
-                    return ba_ is not null;
-                }
-
+                Code<ObservationStatus> as_ = WeightExam?.StatusElement;
+                ObservationStatus? at_ = as_?.Value;
+                string au_ = context.Operators.Convert<string>(at_);
+                string[] av_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+                CqlBoolean ax_ = aw_;
+                DataType ay_ = WeightExam?.Value;
+                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_ as Quantity);
+                CqlBoolean ba_ = (CqlBoolean)(az_ is not null);
                 return ar_
-                    /* CQL 'and' (218:15-219:70) */ && as_()
-                    /* CQL 'and' (218:9-220:42) */ && at_();
+                    /* CQL 'and' (218:15-219:70) */ && ax_
+                    /* CQL 'and' (218:9-220:42) */ && ba_;
             }
 
             IEnumerable<Observation> o_ = context.Operators.Where<Observation>(f_, n_);
@@ -2154,264 +1932,215 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
             IEnumerable<ServiceRequest> h_ = context.Operators.Union<ServiceRequest>(e_, g_);
 
             bool? i_(ServiceRequest OxygenTherapyOrder) {
-                FhirDateTime o_ = OxygenTherapyOrder?.AuthoredOnElement;
-                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
-                Encounter q_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                Period r_ = q_?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlBoolean t_ = context.Operators.In<CqlDateTime>(p_, s_, (string)default);
-
-                CqlBoolean u_() {
-                    FhirDateTime x_ = OxygenTherapyOrder?.AuthoredOnElement;
-                    CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(x_);
-                    Encounter z_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                    Period aa_ = z_?.Period;
-                    CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                    CqlDateTime ac_ = context.Operators.Start(ab_);
-                    CqlQuantity ad_ = context.Operators.Quantity(60m, "minutes");
-                    CqlDateTime ae_ = context.Operators.Subtract(ac_, ad_);
-                    CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ae_, ac_, true, true);
-                    CqlBoolean ag_ = context.Operators.In<CqlDateTime>(y_, af_, (string)default);
-
-                    CqlBoolean ah_() {
-                        Encounter ai_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                        Period aj_ = ai_?.Period;
-                        CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
-                        CqlDateTime al_ = context.Operators.Start(ak_);
-                        return al_ is not null;
-                    }
-
-                    return ag_
-                        /* CQL 'and' (234:16-234:123) */ && ah_();
-                }
-
-
-                CqlBoolean v_() {
-                    Code<RequestStatus> am_ = OxygenTherapyOrder?.StatusElement;
-                    RequestStatus? an_ = am_?.Value;
-                    Code<RequestStatus> ao_ = context.Operators.Convert<Code<RequestStatus>>(an_);
-                    string ap_ = context.Operators.Convert<string>(ao_);
-                    string[] aq_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
-                    return ar_;
-                }
-
-
-                CqlBoolean w_() {
-                    Code<RequestIntent> as_ = OxygenTherapyOrder?.IntentElement;
-                    RequestIntent? at_ = as_?.Value;
-                    Code<RequestIntent> au_ = context.Operators.Convert<Code<RequestIntent>>(at_);
-                    CqlBoolean av_ = context.Operators.Equal(au_, "order");
-                    return av_;
-                }
-
-                return (t_
-                    /* CQL 'or' (233:15-235:9) */ || u_())
-                    /* CQL 'and' (233:15-236:68) */ && v_()
-                    /* CQL 'and' (233:9-237:49) */ && w_();
+                FhirDateTime u_ = OxygenTherapyOrder?.AuthoredOnElement;
+                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                Encounter w_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
+                Period x_ = w_?.Period;
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                CqlBoolean z_ = context.Operators.In<CqlDateTime>(v_, y_, (string)default);
+                CqlDateTime aa_ = context.Operators.Start(y_);
+                CqlQuantity ab_ = context.Operators.Quantity(60m, "minutes");
+                CqlDateTime ac_ = context.Operators.Subtract(aa_, ab_);
+                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(ac_, aa_, true, true);
+                CqlBoolean ae_ = context.Operators.In<CqlDateTime>(v_, ad_, (string)default);
+                CqlBoolean af_ = (CqlBoolean)(aa_ is not null);
+                CqlBoolean ag_ = ae_
+                    /* CQL 'and' (234:16-234:123) */ && af_;
+                Code<RequestStatus> ah_ = OxygenTherapyOrder?.StatusElement;
+                RequestStatus? ai_ = ah_?.Value;
+                Code<RequestStatus> aj_ = context.Operators.Convert<Code<RequestStatus>>(ai_);
+                string ak_ = context.Operators.Convert<string>(aj_);
+                string[] al_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
+                CqlBoolean an_ = am_;
+                Code<RequestIntent> ao_ = OxygenTherapyOrder?.IntentElement;
+                RequestIntent? ap_ = ao_?.Value;
+                Code<RequestIntent> aq_ = context.Operators.Convert<Code<RequestIntent>>(ap_);
+                CqlBoolean ar_ = context.Operators.Equal(aq_, "order");
+                CqlBoolean as_ = ar_;
+                return (z_
+                    /* CQL 'or' (233:15-235:9) */ || ag_)
+                    /* CQL 'and' (233:15-236:68) */ && an_
+                    /* CQL 'and' (233:9-237:49) */ && as_;
             }
 
 
             (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)? j_(ServiceRequest OxygenTherapyOrder) {
-                Id aw_ = EncounterInpatient?.IdElement;
-                string ax_ = aw_?.Value;
-                Code<RequestStatus> ay_ = OxygenTherapyOrder?.StatusElement;
-                RequestStatus? az_ = ay_?.Value;
-                Code<RequestStatus> ba_ = context.Operators.Convert<Code<RequestStatus>>(az_);
-                FhirDateTime bb_ = OxygenTherapyOrder?.AuthoredOnElement;
-                CqlDateTime bc_ = context.Operators.Convert<CqlDateTime>(bb_);
-                (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)? bd_ = (CqlTupleMetadata_BTRiFTXPQGKeiLWUSieghMWCU, ax_, ba_, bc_);
-                return bd_;
+                Id at_ = EncounterInpatient?.IdElement;
+                string au_ = at_?.Value;
+                Code<RequestStatus> av_ = OxygenTherapyOrder?.StatusElement;
+                RequestStatus? aw_ = av_?.Value;
+                Code<RequestStatus> ax_ = context.Operators.Convert<Code<RequestStatus>>(aw_);
+                FhirDateTime ay_ = OxygenTherapyOrder?.AuthoredOnElement;
+                CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
+                (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)? ba_ = (CqlTupleMetadata_BTRiFTXPQGKeiLWUSieghMWCU, au_, ax_, az_);
+                return ba_;
             }
 
             IEnumerable<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?> k_ = context.Operators.WhereSelect<ServiceRequest, (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?>(h_, i_, j_);
             IEnumerable<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?>(k_);
             CqlBoolean m_ = context.Operators.Exists<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?>(l_);
+            IEnumerable<Procedure> n_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-            CqlBoolean n_() {
-                CqlValueSet be_ = this.Non_Invasive_Oxygen_Therapy_by_Nasal_Cannula_or_Mask(context);
-                IEnumerable<Procedure> bf_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, be_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-                bool? bg_(Procedure OxygenAdminInterv) {
-                    object bl_;
-                    DataType bu_ = OxygenAdminInterv?.Performed;
-                    object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                    bool bw_ = bv_ is CqlDateTime;
-                    if (bw_)
+            bool? o_(Procedure OxygenAdminInterv) {
+                object bb_;
+                DataType bx_ = OxygenAdminInterv?.Performed;
+                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                bool bz_ = by_ is CqlDateTime;
+                if (bz_)
+                {
+                    bb_ = by_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ca_ = by_ is CqlQuantity;
+                    if (ca_)
                     {
-                        bl_ = bv_ as CqlDateTime;
+                        bb_ = by_ as CqlQuantity;
                     }
                     else
                     {
-                        bool bx_ = bv_ is CqlQuantity;
-                        if (bx_)
+                        bool cb_ = by_ is CqlInterval<CqlDateTime>;
+                        if (cb_)
                         {
-                            bl_ = bv_ as CqlQuantity;
+                            bb_ = by_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool by_ = bv_ is CqlInterval<CqlDateTime>;
-                            if (by_)
+                            bool cc_ = by_ is CqlInterval<CqlQuantity>;
+                            if (cc_)
                             {
-                                bl_ = bv_ as CqlInterval<CqlDateTime>;
+                                bb_ = by_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool bz_ = bv_ is CqlInterval<CqlQuantity>;
-                                if (bz_)
-                                {
-                                    bl_ = bv_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    bl_ = null;
-                                }
+                                bb_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_);
-                    CqlDateTime bn_ = context.Operators.Start(bm_);
-                    Encounter bo_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                    Period bp_ = bo_?.Period;
-                    CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bp_);
-                    CqlBoolean br_ = context.Operators.In<CqlDateTime>(bn_, bq_, (string)default);
-
-                    CqlBoolean bs_() {
-                        object ca_;
-                        DataType cm_ = OxygenAdminInterv?.Performed;
-                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                        bool co_ = cn_ is CqlDateTime;
-                        if (co_)
-                        {
-                            ca_ = cn_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool cp_ = cn_ is CqlQuantity;
-                            if (cp_)
-                            {
-                                ca_ = cn_ as CqlQuantity;
-                            }
-                            else
-                            {
-                                bool cq_ = cn_ is CqlInterval<CqlDateTime>;
-                                if (cq_)
-                                {
-                                    ca_ = cn_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool cr_ = cn_ is CqlInterval<CqlQuantity>;
-                                    if (cr_)
-                                    {
-                                        ca_ = cn_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        ca_ = null;
-                                    }
-                                }
-                            }
-                        }
-                        CqlInterval<CqlDateTime> cb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ca_);
-                        CqlDateTime cc_ = context.Operators.End(cb_);
-                        Encounter cd_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                        Period ce_ = cd_?.Period;
-                        CqlInterval<CqlDateTime> cf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ce_);
-                        CqlDateTime cg_ = context.Operators.Start(cf_);
-                        CqlQuantity ch_ = context.Operators.Quantity(60m, "minutes");
-                        CqlDateTime ci_ = context.Operators.Subtract(cg_, ch_);
-                        CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(ci_, cg_, true, true);
-                        CqlBoolean ck_ = context.Operators.In<CqlDateTime>(cc_, cj_, (string)default);
-
-                        CqlBoolean cl_() {
-                            Encounter cs_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                            Period ct_ = cs_?.Period;
-                            CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
-                            CqlDateTime cv_ = context.Operators.Start(cu_);
-                            return cv_ is not null;
-                        }
-
-                        return ck_
-                            /* CQL 'and' (246:18-246:138) */ && cl_();
-                    }
-
-
-                    CqlBoolean bt_() {
-                        Code<EventStatus> cw_ = OxygenAdminInterv?.StatusElement;
-                        EventStatus? cx_ = cw_?.Value;
-                        string cy_ = context.Operators.Convert<string>(cx_);
-                        CqlBoolean cz_ = context.Operators.Equal(cy_, "completed");
-                        return cz_;
-                    }
-
-                    return (br_
-                        /* CQL 'or' (245:17-247:11) */ || bs_())
-                        /* CQL 'and' (245:11-248:54) */ && bt_();
                 }
-
-
-                (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? bh_(Procedure OxygenAdminInterv) {
-                    Id da_ = EncounterInpatient?.IdElement;
-                    string db_ = da_?.Value;
-                    Encounter dc_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                    Period dd_ = dc_?.Period;
-                    CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dd_);
-                    Code<EventStatus> df_ = OxygenAdminInterv?.StatusElement;
-                    EventStatus? dg_ = df_?.Value;
-                    string dh_ = context.Operators.Convert<string>(dg_);
-                    object di_;
-                    DataType dl_ = OxygenAdminInterv?.Performed;
-                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                    bool dn_ = dm_ is CqlDateTime;
-                    if (dn_)
+                CqlInterval<CqlDateTime> bc_ = QICoreCommon_4_0_000.Instance.toInterval(context, bb_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                Encounter be_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
+                Period bf_ = be_?.Period;
+                CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
+                CqlBoolean bh_ = context.Operators.In<CqlDateTime>(bd_, bg_, (string)default);
+                object bi_;
+                DataType cd_ = OxygenAdminInterv?.Performed;
+                object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                bool cf_ = ce_ is CqlDateTime;
+                if (cf_)
+                {
+                    bi_ = ce_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cg_ = ce_ is CqlQuantity;
+                    if (cg_)
                     {
-                        di_ = dm_ as CqlDateTime;
+                        bi_ = ce_ as CqlQuantity;
                     }
                     else
                     {
-                        bool do_ = dm_ is CqlQuantity;
-                        if (do_)
+                        bool ch_ = ce_ is CqlInterval<CqlDateTime>;
+                        if (ch_)
                         {
-                            di_ = dm_ as CqlQuantity;
+                            bi_ = ce_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool dp_ = dm_ is CqlInterval<CqlDateTime>;
-                            if (dp_)
+                            bool ci_ = ce_ is CqlInterval<CqlQuantity>;
+                            if (ci_)
                             {
-                                di_ = dm_ as CqlInterval<CqlDateTime>;
+                                bi_ = ce_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool dq_ = dm_ is CqlInterval<CqlQuantity>;
-                                if (dq_)
-                                {
-                                    di_ = dm_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    di_ = null;
-                                }
+                                bi_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> dj_ = QICoreCommon_4_0_000.Instance.toInterval(context, di_);
-                    (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? dk_ = (CqlTupleMetadata_HBSiHLDibCXHQcPZYMVBgXBIH, db_, de_, dh_, dj_);
-                    return dk_;
                 }
-
-                IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> bi_ = context.Operators.WhereSelect<Procedure, (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(bf_, bg_, bh_);
-                IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> bj_ = context.Operators.Distinct<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(bi_);
-                CqlBoolean bk_ = context.Operators.Exists<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(bj_);
-                return bk_;
+                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
+                CqlDateTime bk_ = context.Operators.End(bj_);
+                CqlDateTime bl_ = context.Operators.Start(bg_);
+                CqlQuantity bm_ = context.Operators.Quantity(60m, "minutes");
+                CqlDateTime bn_ = context.Operators.Subtract(bl_, bm_);
+                CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bn_, bl_, true, true);
+                CqlBoolean bp_ = context.Operators.In<CqlDateTime>(bk_, bo_, (string)default);
+                CqlBoolean bq_ = (CqlBoolean)(bl_ is not null);
+                CqlBoolean br_ = bp_
+                    /* CQL 'and' (246:18-246:138) */ && bq_;
+                Code<EventStatus> bs_ = OxygenAdminInterv?.StatusElement;
+                EventStatus? bt_ = bs_?.Value;
+                string bu_ = context.Operators.Convert<string>(bt_);
+                CqlBoolean bv_ = context.Operators.Equal(bu_, "completed");
+                CqlBoolean bw_ = bv_;
+                return (bh_
+                    /* CQL 'or' (245:17-247:11) */ || br_)
+                    /* CQL 'and' (245:11-248:54) */ && bw_;
             }
 
+
+            (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? p_(Procedure OxygenAdminInterv) {
+                Id cj_ = EncounterInpatient?.IdElement;
+                string ck_ = cj_?.Value;
+                Encounter cl_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
+                Period cm_ = cl_?.Period;
+                CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
+                Code<EventStatus> co_ = OxygenAdminInterv?.StatusElement;
+                EventStatus? cp_ = co_?.Value;
+                string cq_ = context.Operators.Convert<string>(cp_);
+                object cr_;
+                DataType cu_ = OxygenAdminInterv?.Performed;
+                object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+                bool cw_ = cv_ is CqlDateTime;
+                if (cw_)
+                {
+                    cr_ = cv_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cx_ = cv_ is CqlQuantity;
+                    if (cx_)
+                    {
+                        cr_ = cv_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool cy_ = cv_ is CqlInterval<CqlDateTime>;
+                        if (cy_)
+                        {
+                            cr_ = cv_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool cz_ = cv_ is CqlInterval<CqlQuantity>;
+                            if (cz_)
+                            {
+                                cr_ = cv_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                cr_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> cs_ = QICoreCommon_4_0_000.Instance.toInterval(context, cr_);
+                (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? ct_ = (CqlTupleMetadata_HBSiHLDibCXHQcPZYMVBgXBIH, ck_, cn_, cq_, cs_);
+                return ct_;
+            }
+
+            IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> q_ = context.Operators.WhereSelect<Procedure, (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(n_, o_, p_);
+            IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> r_ = context.Operators.Distinct<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(q_);
+            CqlBoolean s_ = context.Operators.Exists<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(r_);
+            CqlBoolean t_ = s_;
             return m_
-                /* CQL 'or' (231:5-255:7) */ || n_();
+                /* CQL 'or' (231:5-255:7) */ || t_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CMSFHIR844HybridHospitalWideMortality", "0.5.001")]
 public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, ISingleton<CMSFHIR844HybridHospitalWideMortality_0_5_001>
 {
@@ -148,45 +148,31 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlInterval<CqlDateTime> l_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 int? m_ = CQMCommon_4_1_000.Instance.lengthInDays(context, l_);
                 CqlBoolean n_ = context.Operators.Less(m_, 365);
-
-                CqlBoolean o_() {
-                    Code<Encounter.EncounterStatus> r_ = EncounterInpatient?.StatusElement;
-                    Encounter.EncounterStatus? s_ = r_?.Value;
-                    Code<Encounter.EncounterStatus> t_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(s_);
-                    CqlBoolean u_ = context.Operators.Equal(t_, "finished");
-                    return u_;
-                }
-
-
-                CqlBoolean p_() {
-                    Patient v_ = this.Patient(context);
-                    Date w_ = v_?.BirthDateElement;
-                    string x_ = w_?.Value;
-                    CqlDate y_ = context.Operators.ConvertStringToDate(x_);
-                    Period z_ = EncounterInpatient?.Period;
-                    CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
-                    CqlDateTime ab_ = context.Operators.Start(aa_);
-                    CqlDate ac_ = context.Operators.DateFrom(ab_);
-                    int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
-                    CqlInterval<int?> ae_ = context.Operators.Interval(65, 94, true, true);
-                    CqlBoolean af_ = context.Operators.In<int?>(ad_, ae_, (string)default);
-                    return af_;
-                }
-
-
-                CqlBoolean q_() {
-                    Period ag_ = EncounterInpatient?.Period;
-                    CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-                    CqlDateTime ai_ = context.Operators.End(ah_);
-                    CqlInterval<CqlDateTime> aj_ = this.Measurement_Period(context);
-                    CqlBoolean ak_ = context.Operators.In<CqlDateTime>(ai_, aj_, "day");
-                    return ak_;
-                }
-
+                Code<Encounter.EncounterStatus> o_ = EncounterInpatient?.StatusElement;
+                Encounter.EncounterStatus? p_ = o_?.Value;
+                Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
+                CqlBoolean r_ = context.Operators.Equal(q_, "finished");
+                CqlBoolean s_ = r_;
+                Patient t_ = this.Patient(context);
+                Date u_ = t_?.BirthDateElement;
+                string v_ = u_?.Value;
+                CqlDate w_ = context.Operators.ConvertStringToDate(v_);
+                Period x_ = EncounterInpatient?.Period;
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                CqlDateTime z_ = context.Operators.Start(y_);
+                CqlDate aa_ = context.Operators.DateFrom(z_);
+                int? ab_ = context.Operators.CalculateAgeAt(w_, aa_, "year");
+                CqlInterval<int?> ac_ = context.Operators.Interval(65, 94, true, true);
+                CqlBoolean ad_ = context.Operators.In<int?>(ab_, ac_, (string)default);
+                CqlBoolean ae_ = ad_;
+                CqlDateTime af_ = context.Operators.End(y_);
+                CqlInterval<CqlDateTime> ag_ = this.Measurement_Period(context);
+                CqlBoolean ah_ = context.Operators.In<CqlDateTime>(af_, ag_, "day");
+                CqlBoolean ai_ = ah_;
                 return n_
-                    /* CQL 'and' (40:17-41:50) */ && o_()
-                    /* CQL 'and' (40:17-42:90) */ && p_()
-                    /* CQL 'and' (40:17-43:77) */ && q_();
+                    /* CQL 'and' (40:17-41:50) */ && s_
+                    /* CQL 'and' (40:17-42:90) */ && ae_
+                    /* CQL 'and' (40:17-43:77) */ && ai_;
             }
 
             CqlBoolean k_ = context.Operators.WhereAny<Coverage>(i_, j_);
@@ -232,30 +218,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ad_ = Temperature?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType ai_ = Temperature?.Value;
-                    CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                    return aj_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = Temperature?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = Temperature?.Value;
+                CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (48:15-49:71) */ && ab_()
-                    /* CQL 'and' (48:9-50:43) */ && ac_();
+                    /* CQL 'and' (48:15-49:71) */ && ag_
+                    /* CQL 'and' (48:9-50:43) */ && aj_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -278,30 +256,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
                 CqlInterval<CqlDateTime> aq_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
-
-                CqlBoolean as_() {
-                    Code<ObservationStatus> au_ = Temperature?.StatusElement;
-                    ObservationStatus? av_ = au_?.Value;
-                    string aw_ = context.Operators.Convert<string>(av_);
-                    string[] ax_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                    return ay_;
-                }
-
-
-                CqlBoolean at_() {
-                    DataType az_ = Temperature?.Value;
-                    CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
-                    return ba_ is not null;
-                }
-
+                Code<ObservationStatus> as_ = Temperature?.StatusElement;
+                ObservationStatus? at_ = as_?.Value;
+                string au_ = context.Operators.Convert<string>(at_);
+                string[] av_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+                CqlBoolean ax_ = aw_;
+                DataType ay_ = Temperature?.Value;
+                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_ as Quantity);
+                CqlBoolean ba_ = (CqlBoolean)(az_ is not null);
                 return ar_
-                    /* CQL 'and' (48:15-49:71) */ && as_()
-                    /* CQL 'and' (48:9-50:43) */ && at_();
+                    /* CQL 'and' (48:15-49:71) */ && ax_
+                    /* CQL 'and' (48:9-50:43) */ && ba_;
             }
 
             IEnumerable<Observation> o_ = context.Operators.Where<Observation>(f_, n_);
@@ -348,30 +318,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ad_ = HeartRate?.StatusElement;
-                    ObservationStatus? ae_ = ad_?.Value;
-                    string af_ = context.Operators.Convert<string>(ae_);
-                    string[] ag_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
-                    return ah_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType ai_ = HeartRate?.Value;
-                    CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
-                    return aj_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = HeartRate?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = HeartRate?.Value;
+                CqlQuantity ai_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ah_ as Quantity);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (62:15-63:69) */ && ab_()
-                    /* CQL 'and' (62:9-64:41) */ && ac_();
+                    /* CQL 'and' (62:15-63:69) */ && ag_
+                    /* CQL 'and' (62:9-64:41) */ && aj_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -394,30 +356,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_);
                 CqlInterval<CqlDateTime> aq_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
-
-                CqlBoolean as_() {
-                    Code<ObservationStatus> au_ = HeartRate?.StatusElement;
-                    ObservationStatus? av_ = au_?.Value;
-                    string aw_ = context.Operators.Convert<string>(av_);
-                    string[] ax_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
-                    return ay_;
-                }
-
-
-                CqlBoolean at_() {
-                    DataType az_ = HeartRate?.Value;
-                    CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
-                    return ba_ is not null;
-                }
-
+                Code<ObservationStatus> as_ = HeartRate?.StatusElement;
+                ObservationStatus? at_ = as_?.Value;
+                string au_ = context.Operators.Convert<string>(at_);
+                string[] av_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+                CqlBoolean ax_ = aw_;
+                DataType ay_ = HeartRate?.Value;
+                CqlQuantity az_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ay_ as Quantity);
+                CqlBoolean ba_ = (CqlBoolean)(az_ is not null);
                 return ar_
-                    /* CQL 'and' (62:15-63:69) */ && as_()
-                    /* CQL 'and' (62:9-64:41) */ && at_();
+                    /* CQL 'and' (62:15-63:69) */ && ax_
+                    /* CQL 'and' (62:9-64:41) */ && ba_;
             }
 
             IEnumerable<Observation> o_ = context.Operators.Where<Observation>(f_, n_);
@@ -465,30 +419,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, y_);
                 CqlInterval<CqlDateTime> aa_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ab_ = context.Operators.In<CqlDateTime>(z_, aa_, (string)default);
-
-                CqlBoolean ac_() {
-                    Code<ObservationStatus> ae_ = O2Saturation?.StatusElement;
-                    ObservationStatus? af_ = ae_?.Value;
-                    string ag_ = context.Operators.Convert<string>(af_);
-                    string[] ah_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
-                    return ai_;
-                }
-
-
-                CqlBoolean ad_() {
-                    DataType aj_ = O2Saturation?.Value;
-                    CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
-                    return ak_ is not null;
-                }
-
+                Code<ObservationStatus> ac_ = O2Saturation?.StatusElement;
+                ObservationStatus? ad_ = ac_?.Value;
+                string ae_ = context.Operators.Convert<string>(ad_);
+                string[] af_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
+                CqlBoolean ah_ = ag_;
+                DataType ai_ = O2Saturation?.Value;
+                CqlQuantity aj_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ai_ as Quantity);
+                CqlBoolean ak_ = (CqlBoolean)(aj_ is not null);
                 return ab_
-                    /* CQL 'and' (76:15-77:72) */ && ac_()
-                    /* CQL 'and' (76:9-78:44) */ && ad_();
+                    /* CQL 'and' (76:15-77:72) */ && ah_
+                    /* CQL 'and' (76:9-78:44) */ && ak_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -511,30 +457,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime aq_ = QICoreCommon_4_0_000.Instance.earliest(context, ap_);
                 CqlInterval<CqlDateTime> ar_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean as_ = context.Operators.In<CqlDateTime>(aq_, ar_, (string)default);
-
-                CqlBoolean at_() {
-                    Code<ObservationStatus> av_ = O2Saturation?.StatusElement;
-                    ObservationStatus? aw_ = av_?.Value;
-                    string ax_ = context.Operators.Convert<string>(aw_);
-                    string[] ay_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
-                    return az_;
-                }
-
-
-                CqlBoolean au_() {
-                    DataType ba_ = O2Saturation?.Value;
-                    CqlQuantity bb_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ba_ as Quantity);
-                    return bb_ is not null;
-                }
-
+                Code<ObservationStatus> at_ = O2Saturation?.StatusElement;
+                ObservationStatus? au_ = at_?.Value;
+                string av_ = context.Operators.Convert<string>(au_);
+                string[] aw_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ax_ = context.Operators.In<string>(av_, (IEnumerable<string>)aw_);
+                CqlBoolean ay_ = ax_;
+                DataType az_ = O2Saturation?.Value;
+                CqlQuantity ba_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, az_ as Quantity);
+                CqlBoolean bb_ = (CqlBoolean)(ba_ is not null);
                 return as_
-                    /* CQL 'and' (76:15-77:72) */ && at_()
-                    /* CQL 'and' (76:9-78:44) */ && au_();
+                    /* CQL 'and' (76:15-77:72) */ && ay_
+                    /* CQL 'and' (76:9-78:44) */ && bb_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -581,44 +519,36 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_);
                 CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
+                Code<ObservationStatus> ae_ = BP?.StatusElement;
+                ObservationStatus? af_ = ae_?.Value;
+                string ag_ = context.Operators.Convert<string>(af_);
+                string[] ah_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
+                CqlBoolean aj_ = ai_;
+                List<Observation.ComponentComponent> ak_ = BP?.Component;
 
-                CqlBoolean ae_() {
-                    Code<ObservationStatus> ag_ = BP?.StatusElement;
-                    ObservationStatus? ah_ = ag_?.Value;
-                    string ai_ = context.Operators.Convert<string>(ah_);
-                    string[] aj_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
-                    return ak_;
+                bool? al_(Observation.ComponentComponent @this) {
+                    DataType ap_ = @this?.Value;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    return aq_ is not null;
                 }
 
 
-                CqlBoolean af_() {
-                    List<Observation.ComponentComponent> al_ = BP?.Component;
-
-                    bool? am_(Observation.ComponentComponent @this) {
-                        DataType ap_ = @this?.Value;
-                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
-                        return aq_ is not null;
-                    }
-
-
-                    object an_(Observation.ComponentComponent @this) {
-                        DataType ar_ = @this?.Value;
-                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
-                        return as_;
-                    }
-
-                    IEnumerable<object> ao_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)al_, am_, an_);
-                    return ao_ is not null;
+                object am_(Observation.ComponentComponent @this) {
+                    DataType ar_ = @this?.Value;
+                    object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                    return as_;
                 }
 
+                IEnumerable<object> an_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)ak_, al_, am_);
+                CqlBoolean ao_ = (CqlBoolean)(an_ is not null);
                 return ad_
-                    /* CQL 'and' (90:15-91:62) */ && ae_()
-                    /* CQL 'and' (90:9-92:44) */ && af_();
+                    /* CQL 'and' (90:15-91:62) */ && aj_
+                    /* CQL 'and' (90:9-92:44) */ && ao_;
             }
 
             IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
@@ -659,44 +589,36 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime bf_ = QICoreCommon_4_0_000.Instance.earliest(context, be_);
                 CqlInterval<CqlDateTime> bg_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean bh_ = context.Operators.In<CqlDateTime>(bf_, bg_, (string)default);
+                Code<ObservationStatus> bi_ = BP?.StatusElement;
+                ObservationStatus? bj_ = bi_?.Value;
+                string bk_ = context.Operators.Convert<string>(bj_);
+                string[] bl_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
+                CqlBoolean bn_ = bm_;
+                List<Observation.ComponentComponent> bo_ = BP?.Component;
 
-                CqlBoolean bi_() {
-                    Code<ObservationStatus> bk_ = BP?.StatusElement;
-                    ObservationStatus? bl_ = bk_?.Value;
-                    string bm_ = context.Operators.Convert<string>(bl_);
-                    string[] bn_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bo_ = context.Operators.In<string>(bm_, (IEnumerable<string>)bn_);
-                    return bo_;
+                bool? bp_(Observation.ComponentComponent @this) {
+                    DataType bt_ = @this?.Value;
+                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+                    return bu_ is not null;
                 }
 
 
-                CqlBoolean bj_() {
-                    List<Observation.ComponentComponent> bp_ = BP?.Component;
-
-                    bool? bq_(Observation.ComponentComponent @this) {
-                        DataType bt_ = @this?.Value;
-                        object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
-                        return bu_ is not null;
-                    }
-
-
-                    object br_(Observation.ComponentComponent @this) {
-                        DataType bv_ = @this?.Value;
-                        object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
-                        return bw_;
-                    }
-
-                    IEnumerable<object> bs_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)bp_, bq_, br_);
-                    return bs_ is not null;
+                object bq_(Observation.ComponentComponent @this) {
+                    DataType bv_ = @this?.Value;
+                    object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+                    return bw_;
                 }
 
+                IEnumerable<object> br_ = context.Operators.WhereSelect<Observation.ComponentComponent, object>((IEnumerable<Observation.ComponentComponent>)bo_, bp_, bq_);
+                CqlBoolean bs_ = (CqlBoolean)(br_ is not null);
                 return bh_
-                    /* CQL 'and' (90:15-91:62) */ && bi_()
-                    /* CQL 'and' (90:9-92:44) */ && bj_();
+                    /* CQL 'and' (90:15-91:62) */ && bn_
+                    /* CQL 'and' (90:9-92:44) */ && bs_;
             }
 
             IEnumerable<Observation> r_ = context.Operators.Where<Observation>(f_, q_);
@@ -740,25 +662,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? h_(Observation BicarbonateLab) {
                 object x_;
-                DataType ad_ = BicarbonateLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = BicarbonateLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -769,30 +691,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = BicarbonateLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = BicarbonateLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = BicarbonateLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = BicarbonateLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (106:15-107:74) */ && ab_()
-                    /* CQL 'and' (106:9-108:46) */ && ac_();
+                    /* CQL 'and' (106:15-107:74) */ && ag_
+                    /* CQL 'and' (106:9-108:46) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -812,25 +726,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? o_(Observation BicarbonateLab) {
                 object as_;
-                DataType ay_ = BicarbonateLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = BicarbonateLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -841,30 +755,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = BicarbonateLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = BicarbonateLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = BicarbonateLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = BicarbonateLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (106:15-107:74) */ && aw_()
-                    /* CQL 'and' (106:9-108:46) */ && ax_();
+                    /* CQL 'and' (106:15-107:74) */ && bb_
+                    /* CQL 'and' (106:9-108:46) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -909,25 +815,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? h_(Observation CreatinineLab) {
                 object x_;
-                DataType ad_ = CreatinineLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = CreatinineLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -938,30 +844,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = CreatinineLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = CreatinineLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = CreatinineLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = CreatinineLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (120:15-121:73) */ && ab_()
-                    /* CQL 'and' (120:9-122:45) */ && ac_();
+                    /* CQL 'and' (120:15-121:73) */ && ag_
+                    /* CQL 'and' (120:9-122:45) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -981,25 +879,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? o_(Observation CreatinineLab) {
                 object as_;
-                DataType ay_ = CreatinineLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = CreatinineLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1010,30 +908,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = CreatinineLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = CreatinineLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = CreatinineLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = CreatinineLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (120:15-121:73) */ && aw_()
-                    /* CQL 'and' (120:9-122:45) */ && ax_();
+                    /* CQL 'and' (120:15-121:73) */ && bb_
+                    /* CQL 'and' (120:9-122:45) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1078,25 +968,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? h_(Observation HematocritLab) {
                 object x_;
-                DataType ad_ = HematocritLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = HematocritLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1107,30 +997,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = HematocritLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = HematocritLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = HematocritLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = HematocritLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (134:15-135:73) */ && ab_()
-                    /* CQL 'and' (134:9-136:45) */ && ac_();
+                    /* CQL 'and' (134:15-135:73) */ && ag_
+                    /* CQL 'and' (134:9-136:45) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1150,25 +1032,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? o_(Observation HematocritLab) {
                 object as_;
-                DataType ay_ = HematocritLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = HematocritLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1179,30 +1061,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = HematocritLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = HematocritLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = HematocritLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = HematocritLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (134:15-135:73) */ && aw_()
-                    /* CQL 'and' (134:9-136:45) */ && ax_();
+                    /* CQL 'and' (134:15-135:73) */ && bb_
+                    /* CQL 'and' (134:9-136:45) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1247,25 +1121,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? h_(Observation PlateletLab) {
                 object x_;
-                DataType ad_ = PlateletLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = PlateletLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1276,30 +1150,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = PlateletLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = PlateletLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = PlateletLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = PlateletLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (148:15-149:71) */ && ab_()
-                    /* CQL 'and' (148:9-150:43) */ && ac_();
+                    /* CQL 'and' (148:15-149:71) */ && ag_
+                    /* CQL 'and' (148:9-150:43) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1319,25 +1185,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? o_(Observation PlateletLab) {
                 object as_;
-                DataType ay_ = PlateletLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = PlateletLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1348,30 +1214,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = PlateletLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = PlateletLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = PlateletLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = PlateletLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (148:15-149:71) */ && aw_()
-                    /* CQL 'and' (148:9-150:43) */ && ax_();
+                    /* CQL 'and' (148:15-149:71) */ && bb_
+                    /* CQL 'and' (148:9-150:43) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1416,25 +1274,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? h_(Observation SodiumLab) {
                 object x_;
-                DataType ad_ = SodiumLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = SodiumLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1445,30 +1303,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = SodiumLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = SodiumLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = SodiumLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = SodiumLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (162:15-163:69) */ && ab_()
-                    /* CQL 'and' (162:9-164:41) */ && ac_();
+                    /* CQL 'and' (162:15-163:69) */ && ag_
+                    /* CQL 'and' (162:9-164:41) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1488,25 +1338,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? o_(Observation SodiumLab) {
                 object as_;
-                DataType ay_ = SodiumLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = SodiumLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1517,30 +1367,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = SodiumLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = SodiumLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = SodiumLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = SodiumLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (162:15-163:69) */ && aw_()
-                    /* CQL 'and' (162:9-164:41) */ && ax_();
+                    /* CQL 'and' (162:15-163:69) */ && bb_
+                    /* CQL 'and' (162:9-164:41) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1585,25 +1427,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? h_(Observation WhiteBloodCellLab) {
                 object x_;
-                DataType ad_ = WhiteBloodCellLab?.Effective;
-                object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
-                bool af_ = ae_ is CqlDateTime;
-                if (af_)
+                DataType ak_ = WhiteBloodCellLab?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                bool am_ = al_ is CqlDateTime;
+                if (am_)
                 {
-                    x_ = ae_ as CqlDateTime;
+                    x_ = al_ as CqlDateTime;
                 }
                 else
                 {
-                    if (af_)
+                    if (am_)
                     {
-                        x_ = ae_ as CqlDateTime;
+                        x_ = al_ as CqlDateTime;
                     }
                     else
                     {
-                        bool ag_ = ae_ is CqlInterval<CqlDateTime>;
-                        if (ag_)
+                        bool an_ = al_ is CqlInterval<CqlDateTime>;
+                        if (an_)
                         {
-                            x_ = ae_ as CqlInterval<CqlDateTime>;
+                            x_ = al_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1614,30 +1456,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime y_ = QICoreCommon_4_0_000.Instance.earliest(context, x_);
                 CqlInterval<CqlDateTime> z_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean aa_ = context.Operators.In<CqlDateTime>(y_, z_, (string)default);
-
-                CqlBoolean ab_() {
-                    Code<ObservationStatus> ah_ = WhiteBloodCellLab?.StatusElement;
-                    ObservationStatus? ai_ = ah_?.Value;
-                    string aj_ = context.Operators.Convert<string>(ai_);
-                    string[] ak_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
-                    return al_;
-                }
-
-
-                CqlBoolean ac_() {
-                    DataType am_ = WhiteBloodCellLab?.Value;
-                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
-                    return an_ is not null;
-                }
-
+                Code<ObservationStatus> ab_ = WhiteBloodCellLab?.StatusElement;
+                ObservationStatus? ac_ = ab_?.Value;
+                string ad_ = context.Operators.Convert<string>(ac_);
+                string[] ae_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
+                CqlBoolean ag_ = af_;
+                DataType ah_ = WhiteBloodCellLab?.Value;
+                object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                CqlBoolean aj_ = (CqlBoolean)(ai_ is not null);
                 return aa_
-                    /* CQL 'and' (176:15-177:77) */ && ab_()
-                    /* CQL 'and' (176:9-178:49) */ && ac_();
+                    /* CQL 'and' (176:15-177:77) */ && ag_
+                    /* CQL 'and' (176:9-178:49) */ && aj_;
             }
 
             IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
@@ -1657,25 +1491,25 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
             bool? o_(Observation WhiteBloodCellLab) {
                 object as_;
-                DataType ay_ = WhiteBloodCellLab?.Effective;
-                object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);
-                bool ba_ = az_ is CqlDateTime;
-                if (ba_)
+                DataType bf_ = WhiteBloodCellLab?.Effective;
+                object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                bool bh_ = bg_ is CqlDateTime;
+                if (bh_)
                 {
-                    as_ = az_ as CqlDateTime;
+                    as_ = bg_ as CqlDateTime;
                 }
                 else
                 {
-                    if (ba_)
+                    if (bh_)
                     {
-                        as_ = az_ as CqlDateTime;
+                        as_ = bg_ as CqlDateTime;
                     }
                     else
                     {
-                        bool bb_ = az_ is CqlInterval<CqlDateTime>;
-                        if (bb_)
+                        bool bi_ = bg_ is CqlInterval<CqlDateTime>;
+                        if (bi_)
                         {
-                            as_ = az_ as CqlInterval<CqlDateTime>;
+                            as_ = bg_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
@@ -1686,30 +1520,22 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                 CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_);
                 CqlInterval<CqlDateTime> au_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
                 CqlBoolean av_ = context.Operators.In<CqlDateTime>(at_, au_, (string)default);
-
-                CqlBoolean aw_() {
-                    Code<ObservationStatus> bc_ = WhiteBloodCellLab?.StatusElement;
-                    ObservationStatus? bd_ = bc_?.Value;
-                    string be_ = context.Operators.Convert<string>(bd_);
-                    string[] bf_ = [
-                        "final",
-                        "amended",
-                        "corrected",
-                    ];
-                    CqlBoolean bg_ = context.Operators.In<string>(be_, (IEnumerable<string>)bf_);
-                    return bg_;
-                }
-
-
-                CqlBoolean ax_() {
-                    DataType bh_ = WhiteBloodCellLab?.Value;
-                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
-                    return bi_ is not null;
-                }
-
+                Code<ObservationStatus> aw_ = WhiteBloodCellLab?.StatusElement;
+                ObservationStatus? ax_ = aw_?.Value;
+                string ay_ = context.Operators.Convert<string>(ax_);
+                string[] az_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                CqlBoolean ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+                CqlBoolean bb_ = ba_;
+                DataType bc_ = WhiteBloodCellLab?.Value;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+                CqlBoolean be_ = (CqlBoolean)(bd_ is not null);
                 return av_
-                    /* CQL 'and' (176:15-177:77) */ && aw_()
-                    /* CQL 'and' (176:9-178:49) */ && ax_();
+                    /* CQL 'and' (176:15-177:77) */ && bb_
+                    /* CQL 'and' (176:9-178:49) */ && be_;
             }
 
             IEnumerable<Observation> p_ = context.Operators.Where<Observation>(g_, o_);
@@ -1754,264 +1580,215 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
             IEnumerable<ServiceRequest> h_ = context.Operators.Union<ServiceRequest>(e_, g_);
 
             bool? i_(ServiceRequest OxygenTherapyOrder) {
-                FhirDateTime o_ = OxygenTherapyOrder?.AuthoredOnElement;
-                CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
-                Encounter q_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                Period r_ = q_?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlBoolean t_ = context.Operators.In<CqlDateTime>(p_, s_, (string)default);
-
-                CqlBoolean u_() {
-                    FhirDateTime x_ = OxygenTherapyOrder?.AuthoredOnElement;
-                    CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(x_);
-                    Encounter z_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                    Period aa_ = z_?.Period;
-                    CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                    CqlDateTime ac_ = context.Operators.Start(ab_);
-                    CqlQuantity ad_ = context.Operators.Quantity(60m, "minutes");
-                    CqlDateTime ae_ = context.Operators.Subtract(ac_, ad_);
-                    CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ae_, ac_, true, true);
-                    CqlBoolean ag_ = context.Operators.In<CqlDateTime>(y_, af_, (string)default);
-
-                    CqlBoolean ah_() {
-                        Encounter ai_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                        Period aj_ = ai_?.Period;
-                        CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aj_);
-                        CqlDateTime al_ = context.Operators.Start(ak_);
-                        return al_ is not null;
-                    }
-
-                    return ag_
-                        /* CQL 'and' (192:16-192:123) */ && ah_();
-                }
-
-
-                CqlBoolean v_() {
-                    Code<RequestStatus> am_ = OxygenTherapyOrder?.StatusElement;
-                    RequestStatus? an_ = am_?.Value;
-                    Code<RequestStatus> ao_ = context.Operators.Convert<Code<RequestStatus>>(an_);
-                    string ap_ = context.Operators.Convert<string>(ao_);
-                    string[] aq_ = [
-                        "active",
-                        "completed",
-                    ];
-                    CqlBoolean ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
-                    return ar_;
-                }
-
-
-                CqlBoolean w_() {
-                    Code<RequestIntent> as_ = OxygenTherapyOrder?.IntentElement;
-                    RequestIntent? at_ = as_?.Value;
-                    Code<RequestIntent> au_ = context.Operators.Convert<Code<RequestIntent>>(at_);
-                    CqlBoolean av_ = context.Operators.Equal(au_, "order");
-                    return av_;
-                }
-
-                return (t_
-                    /* CQL 'or' (191:15-193:9) */ || u_())
-                    /* CQL 'and' (191:15-194:68) */ && v_()
-                    /* CQL 'and' (191:9-195:49) */ && w_();
+                FhirDateTime u_ = OxygenTherapyOrder?.AuthoredOnElement;
+                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                Encounter w_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
+                Period x_ = w_?.Period;
+                CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+                CqlBoolean z_ = context.Operators.In<CqlDateTime>(v_, y_, (string)default);
+                CqlDateTime aa_ = context.Operators.Start(y_);
+                CqlQuantity ab_ = context.Operators.Quantity(60m, "minutes");
+                CqlDateTime ac_ = context.Operators.Subtract(aa_, ab_);
+                CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(ac_, aa_, true, true);
+                CqlBoolean ae_ = context.Operators.In<CqlDateTime>(v_, ad_, (string)default);
+                CqlBoolean af_ = (CqlBoolean)(aa_ is not null);
+                CqlBoolean ag_ = ae_
+                    /* CQL 'and' (192:16-192:123) */ && af_;
+                Code<RequestStatus> ah_ = OxygenTherapyOrder?.StatusElement;
+                RequestStatus? ai_ = ah_?.Value;
+                Code<RequestStatus> aj_ = context.Operators.Convert<Code<RequestStatus>>(ai_);
+                string ak_ = context.Operators.Convert<string>(aj_);
+                string[] al_ = [
+                    "active",
+                    "completed",
+                ];
+                CqlBoolean am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
+                CqlBoolean an_ = am_;
+                Code<RequestIntent> ao_ = OxygenTherapyOrder?.IntentElement;
+                RequestIntent? ap_ = ao_?.Value;
+                Code<RequestIntent> aq_ = context.Operators.Convert<Code<RequestIntent>>(ap_);
+                CqlBoolean ar_ = context.Operators.Equal(aq_, "order");
+                CqlBoolean as_ = ar_;
+                return (z_
+                    /* CQL 'or' (191:15-193:9) */ || ag_)
+                    /* CQL 'and' (191:15-194:68) */ && an_
+                    /* CQL 'and' (191:9-195:49) */ && as_;
             }
 
 
             (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)? j_(ServiceRequest OxygenTherapyOrder) {
-                Id aw_ = EncounterInpatient?.IdElement;
-                string ax_ = aw_?.Value;
-                Code<RequestStatus> ay_ = OxygenTherapyOrder?.StatusElement;
-                RequestStatus? az_ = ay_?.Value;
-                Code<RequestStatus> ba_ = context.Operators.Convert<Code<RequestStatus>>(az_);
-                FhirDateTime bb_ = OxygenTherapyOrder?.AuthoredOnElement;
-                CqlDateTime bc_ = context.Operators.Convert<CqlDateTime>(bb_);
-                (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)? bd_ = (CqlTupleMetadata_BTRiFTXPQGKeiLWUSieghMWCU, ax_, ba_, bc_);
-                return bd_;
+                Id at_ = EncounterInpatient?.IdElement;
+                string au_ = at_?.Value;
+                Code<RequestStatus> av_ = OxygenTherapyOrder?.StatusElement;
+                RequestStatus? aw_ = av_?.Value;
+                Code<RequestStatus> ax_ = context.Operators.Convert<Code<RequestStatus>>(aw_);
+                FhirDateTime ay_ = OxygenTherapyOrder?.AuthoredOnElement;
+                CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
+                (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)? ba_ = (CqlTupleMetadata_BTRiFTXPQGKeiLWUSieghMWCU, au_, ax_, az_);
+                return ba_;
             }
 
             IEnumerable<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?> k_ = context.Operators.WhereSelect<ServiceRequest, (CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?>(h_, i_, j_);
             IEnumerable<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?>(k_);
             CqlBoolean m_ = context.Operators.Exists<(CqlTupleMetadata, string EncounterId, Code<RequestStatus> OrderStatus, CqlDateTime OrderTiming)?>(l_);
+            IEnumerable<Procedure> n_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
 
-            CqlBoolean n_() {
-                CqlValueSet be_ = this.Non_Invasive_Oxygen_Therapy_by_Nasal_Cannula_or_Mask(context);
-                IEnumerable<Procedure> bf_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, be_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
-
-                bool? bg_(Procedure OxygenAdminInterv) {
-                    object bl_;
-                    DataType bu_ = OxygenAdminInterv?.Performed;
-                    object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
-                    bool bw_ = bv_ is CqlDateTime;
-                    if (bw_)
+            bool? o_(Procedure OxygenAdminInterv) {
+                object bb_;
+                DataType bx_ = OxygenAdminInterv?.Performed;
+                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                bool bz_ = by_ is CqlDateTime;
+                if (bz_)
+                {
+                    bb_ = by_ as CqlDateTime;
+                }
+                else
+                {
+                    bool ca_ = by_ is CqlQuantity;
+                    if (ca_)
                     {
-                        bl_ = bv_ as CqlDateTime;
+                        bb_ = by_ as CqlQuantity;
                     }
                     else
                     {
-                        bool bx_ = bv_ is CqlQuantity;
-                        if (bx_)
+                        bool cb_ = by_ is CqlInterval<CqlDateTime>;
+                        if (cb_)
                         {
-                            bl_ = bv_ as CqlQuantity;
+                            bb_ = by_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool by_ = bv_ is CqlInterval<CqlDateTime>;
-                            if (by_)
+                            bool cc_ = by_ is CqlInterval<CqlQuantity>;
+                            if (cc_)
                             {
-                                bl_ = bv_ as CqlInterval<CqlDateTime>;
+                                bb_ = by_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool bz_ = bv_ is CqlInterval<CqlQuantity>;
-                                if (bz_)
-                                {
-                                    bl_ = bv_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    bl_ = null;
-                                }
+                                bb_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_);
-                    CqlDateTime bn_ = context.Operators.Start(bm_);
-                    Encounter bo_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                    Period bp_ = bo_?.Period;
-                    CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bp_);
-                    CqlBoolean br_ = context.Operators.In<CqlDateTime>(bn_, bq_, (string)default);
-
-                    CqlBoolean bs_() {
-                        object ca_;
-                        DataType cm_ = OxygenAdminInterv?.Performed;
-                        object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
-                        bool co_ = cn_ is CqlDateTime;
-                        if (co_)
-                        {
-                            ca_ = cn_ as CqlDateTime;
-                        }
-                        else
-                        {
-                            bool cp_ = cn_ is CqlQuantity;
-                            if (cp_)
-                            {
-                                ca_ = cn_ as CqlQuantity;
-                            }
-                            else
-                            {
-                                bool cq_ = cn_ is CqlInterval<CqlDateTime>;
-                                if (cq_)
-                                {
-                                    ca_ = cn_ as CqlInterval<CqlDateTime>;
-                                }
-                                else
-                                {
-                                    bool cr_ = cn_ is CqlInterval<CqlQuantity>;
-                                    if (cr_)
-                                    {
-                                        ca_ = cn_ as CqlInterval<CqlQuantity>;
-                                    }
-                                    else
-                                    {
-                                        ca_ = null;
-                                    }
-                                }
-                            }
-                        }
-                        CqlInterval<CqlDateTime> cb_ = QICoreCommon_4_0_000.Instance.toInterval(context, ca_);
-                        CqlDateTime cc_ = context.Operators.End(cb_);
-                        Encounter cd_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                        Period ce_ = cd_?.Period;
-                        CqlInterval<CqlDateTime> cf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ce_);
-                        CqlDateTime cg_ = context.Operators.Start(cf_);
-                        CqlQuantity ch_ = context.Operators.Quantity(60m, "minutes");
-                        CqlDateTime ci_ = context.Operators.Subtract(cg_, ch_);
-                        CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(ci_, cg_, true, true);
-                        CqlBoolean ck_ = context.Operators.In<CqlDateTime>(cc_, cj_, (string)default);
-
-                        CqlBoolean cl_() {
-                            Encounter cs_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                            Period ct_ = cs_?.Period;
-                            CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
-                            CqlDateTime cv_ = context.Operators.Start(cu_);
-                            return cv_ is not null;
-                        }
-
-                        return ck_
-                            /* CQL 'and' (204:18-204:138) */ && cl_();
-                    }
-
-
-                    CqlBoolean bt_() {
-                        Code<EventStatus> cw_ = OxygenAdminInterv?.StatusElement;
-                        EventStatus? cx_ = cw_?.Value;
-                        string cy_ = context.Operators.Convert<string>(cx_);
-                        CqlBoolean cz_ = context.Operators.Equal(cy_, "completed");
-                        return cz_;
-                    }
-
-                    return (br_
-                        /* CQL 'or' (203:17-205:11) */ || bs_())
-                        /* CQL 'and' (203:11-206:54) */ && bt_();
                 }
-
-
-                (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? bh_(Procedure OxygenAdminInterv) {
-                    Id da_ = EncounterInpatient?.IdElement;
-                    string db_ = da_?.Value;
-                    Encounter dc_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
-                    Period dd_ = dc_?.Period;
-                    CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dd_);
-                    Code<EventStatus> df_ = OxygenAdminInterv?.StatusElement;
-                    EventStatus? dg_ = df_?.Value;
-                    string dh_ = context.Operators.Convert<string>(dg_);
-                    object di_;
-                    DataType dl_ = OxygenAdminInterv?.Performed;
-                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
-                    bool dn_ = dm_ is CqlDateTime;
-                    if (dn_)
+                CqlInterval<CqlDateTime> bc_ = QICoreCommon_4_0_000.Instance.toInterval(context, bb_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                Encounter be_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
+                Period bf_ = be_?.Period;
+                CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
+                CqlBoolean bh_ = context.Operators.In<CqlDateTime>(bd_, bg_, (string)default);
+                object bi_;
+                DataType cd_ = OxygenAdminInterv?.Performed;
+                object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                bool cf_ = ce_ is CqlDateTime;
+                if (cf_)
+                {
+                    bi_ = ce_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cg_ = ce_ is CqlQuantity;
+                    if (cg_)
                     {
-                        di_ = dm_ as CqlDateTime;
+                        bi_ = ce_ as CqlQuantity;
                     }
                     else
                     {
-                        bool do_ = dm_ is CqlQuantity;
-                        if (do_)
+                        bool ch_ = ce_ is CqlInterval<CqlDateTime>;
+                        if (ch_)
                         {
-                            di_ = dm_ as CqlQuantity;
+                            bi_ = ce_ as CqlInterval<CqlDateTime>;
                         }
                         else
                         {
-                            bool dp_ = dm_ is CqlInterval<CqlDateTime>;
-                            if (dp_)
+                            bool ci_ = ce_ is CqlInterval<CqlQuantity>;
+                            if (ci_)
                             {
-                                di_ = dm_ as CqlInterval<CqlDateTime>;
+                                bi_ = ce_ as CqlInterval<CqlQuantity>;
                             }
                             else
                             {
-                                bool dq_ = dm_ is CqlInterval<CqlQuantity>;
-                                if (dq_)
-                                {
-                                    di_ = dm_ as CqlInterval<CqlQuantity>;
-                                }
-                                else
-                                {
-                                    di_ = null;
-                                }
+                                bi_ = null;
                             }
                         }
                     }
-                    CqlInterval<CqlDateTime> dj_ = QICoreCommon_4_0_000.Instance.toInterval(context, di_);
-                    (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? dk_ = (CqlTupleMetadata_HBSiHLDibCXHQcPZYMVBgXBIH, db_, de_, dh_, dj_);
-                    return dk_;
                 }
-
-                IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> bi_ = context.Operators.WhereSelect<Procedure, (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(bf_, bg_, bh_);
-                IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> bj_ = context.Operators.Distinct<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(bi_);
-                CqlBoolean bk_ = context.Operators.Exists<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(bj_);
-                return bk_;
+                CqlInterval<CqlDateTime> bj_ = QICoreCommon_4_0_000.Instance.toInterval(context, bi_);
+                CqlDateTime bk_ = context.Operators.End(bj_);
+                CqlDateTime bl_ = context.Operators.Start(bg_);
+                CqlQuantity bm_ = context.Operators.Quantity(60m, "minutes");
+                CqlDateTime bn_ = context.Operators.Subtract(bl_, bm_);
+                CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bn_, bl_, true, true);
+                CqlBoolean bp_ = context.Operators.In<CqlDateTime>(bk_, bo_, (string)default);
+                CqlBoolean bq_ = (CqlBoolean)(bl_ is not null);
+                CqlBoolean br_ = bp_
+                    /* CQL 'and' (204:18-204:138) */ && bq_;
+                Code<EventStatus> bs_ = OxygenAdminInterv?.StatusElement;
+                EventStatus? bt_ = bs_?.Value;
+                string bu_ = context.Operators.Convert<string>(bt_);
+                CqlBoolean bv_ = context.Operators.Equal(bu_, "completed");
+                CqlBoolean bw_ = bv_;
+                return (bh_
+                    /* CQL 'or' (203:17-205:11) */ || br_)
+                    /* CQL 'and' (203:11-206:54) */ && bw_;
             }
 
+
+            (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? p_(Procedure OxygenAdminInterv) {
+                Id cj_ = EncounterInpatient?.IdElement;
+                string ck_ = cj_?.Value;
+                Encounter cl_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
+                Period cm_ = cl_?.Period;
+                CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
+                Code<EventStatus> co_ = OxygenAdminInterv?.StatusElement;
+                EventStatus? cp_ = co_?.Value;
+                string cq_ = context.Operators.Convert<string>(cp_);
+                object cr_;
+                DataType cu_ = OxygenAdminInterv?.Performed;
+                object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+                bool cw_ = cv_ is CqlDateTime;
+                if (cw_)
+                {
+                    cr_ = cv_ as CqlDateTime;
+                }
+                else
+                {
+                    bool cx_ = cv_ is CqlQuantity;
+                    if (cx_)
+                    {
+                        cr_ = cv_ as CqlQuantity;
+                    }
+                    else
+                    {
+                        bool cy_ = cv_ is CqlInterval<CqlDateTime>;
+                        if (cy_)
+                        {
+                            cr_ = cv_ as CqlInterval<CqlDateTime>;
+                        }
+                        else
+                        {
+                            bool cz_ = cv_ is CqlInterval<CqlQuantity>;
+                            if (cz_)
+                            {
+                                cr_ = cv_ as CqlInterval<CqlQuantity>;
+                            }
+                            else
+                            {
+                                cr_ = null;
+                            }
+                        }
+                    }
+                }
+                CqlInterval<CqlDateTime> cs_ = QICoreCommon_4_0_000.Instance.toInterval(context, cr_);
+                (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)? ct_ = (CqlTupleMetadata_HBSiHLDibCXHQcPZYMVBgXBIH, ck_, cn_, cq_, cs_);
+                return ct_;
+            }
+
+            IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> q_ = context.Operators.WhereSelect<Procedure, (CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(n_, o_, p_);
+            IEnumerable<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?> r_ = context.Operators.Distinct<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(q_);
+            CqlBoolean s_ = context.Operators.Exists<(CqlTupleMetadata, string EncounterId, CqlInterval<CqlDateTime> EDEncounterTiming, string PerformedStatus, CqlInterval<CqlDateTime> PerformedTiming)?>(r_);
+            CqlBoolean t_ = s_;
             return m_
-                /* CQL 'or' (189:5-213:7) */ || n_();
+                /* CQL 'or' (189:5-213:7) */ || t_;
         }
 
         IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/CQMCommon-4.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/CQMCommon-4.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("CQMCommon", "4.1.000")]
 public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
 {
@@ -216,18 +216,14 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             Encounter.EncounterStatus? f_ = e_?.Value;
             Code<Encounter.EncounterStatus> g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
             CqlBoolean h_ = context.Operators.Equal(g_, "finished");
-
-            CqlBoolean i_() {
-                Period j_ = EncounterInpatient?.Period;
-                CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
-                CqlDateTime l_ = context.Operators.End(k_);
-                CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                CqlBoolean n_ = context.Operators.In<CqlDateTime>(l_, m_, "day");
-                return n_;
-            }
-
+            Period i_ = EncounterInpatient?.Period;
+            CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+            CqlDateTime k_ = context.Operators.End(j_);
+            CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
+            CqlBoolean m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+            CqlBoolean n_ = m_;
             return h_
-                /* CQL 'and' (46:5-47:75) */ && i_();
+                /* CQL 'and' (46:5-47:75) */ && n_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
@@ -285,41 +281,30 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             Encounter.EncounterStatus? i_ = h_?.Value;
             Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
             CqlBoolean k_ = context.Operators.Equal(j_, "finished");
-
-            CqlBoolean l_() {
-                Period m_ = EDVisit?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime o_ = context.Operators.End(n_);
-                Period p_ = TheEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(1m, "hour");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(t_, r_, true, true);
-                CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, (string)default);
-
-                CqlBoolean w_() {
-                    Period x_ = TheEncounter?.Period;
-                    CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
-                    CqlDateTime z_ = context.Operators.Start(y_);
-                    return z_ is not null;
-                }
-
-                return v_
-                    /* CQL 'and' (80:13-80:88) */ && w_();
-            }
-
+            Period l_ = EDVisit?.Period;
+            CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+            CqlDateTime n_ = context.Operators.End(m_);
+            Period o_ = TheEncounter?.Period;
+            CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlQuantity r_ = context.Operators.Quantity(1m, "hour");
+            CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+            CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, q_, true, true);
+            CqlBoolean u_ = context.Operators.In<CqlDateTime>(n_, t_, (string)default);
+            CqlBoolean v_ = (CqlBoolean)(q_ is not null);
+            CqlBoolean w_ = u_
+                /* CQL 'and' (80:13-80:88) */ && v_;
             return k_
-                /* CQL 'and' (79:7-80:88) */ && l_();
+                /* CQL 'and' (79:7-80:88) */ && w_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
         object e_(Encounter @this) {
-            Period aa_ = @this?.Period;
-            CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-            CqlDateTime ac_ = context.Operators.End(ab_);
-            return ac_;
+            Period x_ = @this?.Period;
+            CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+            CqlDateTime z_ = context.Operators.End(y_);
+            return z_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
@@ -340,41 +325,30 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             Encounter.EncounterStatus? i_ = h_?.Value;
             Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
             CqlBoolean k_ = context.Operators.Equal(j_, "finished");
-
-            CqlBoolean l_() {
-                Period m_ = EDVisit?.Period;
-                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                CqlDateTime o_ = context.Operators.End(n_);
-                Period p_ = TheEncounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                CqlDateTime r_ = context.Operators.Start(q_);
-                CqlQuantity s_ = context.Operators.Quantity(1m, "hour");
-                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(t_, r_, true, true);
-                CqlBoolean v_ = context.Operators.In<CqlDateTime>(o_, u_, (string)default);
-
-                CqlBoolean w_() {
-                    Period x_ = TheEncounter?.Period;
-                    CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
-                    CqlDateTime z_ = context.Operators.Start(y_);
-                    return z_ is not null;
-                }
-
-                return v_
-                    /* CQL 'and' (91:13-91:88) */ && w_();
-            }
-
+            Period l_ = EDVisit?.Period;
+            CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+            CqlDateTime n_ = context.Operators.End(m_);
+            Period o_ = TheEncounter?.Period;
+            CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlQuantity r_ = context.Operators.Quantity(1m, "hour");
+            CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+            CqlInterval<CqlDateTime> t_ = context.Operators.Interval(s_, q_, true, true);
+            CqlBoolean u_ = context.Operators.In<CqlDateTime>(n_, t_, (string)default);
+            CqlBoolean v_ = (CqlBoolean)(q_ is not null);
+            CqlBoolean w_ = u_
+                /* CQL 'and' (91:13-91:88) */ && v_;
             return k_
-                /* CQL 'and' (90:7-91:88) */ && l_();
+                /* CQL 'and' (90:7-91:88) */ && w_;
         }
 
         IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
         object e_(Encounter @this) {
-            Period aa_ = @this?.Period;
-            CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-            CqlDateTime ac_ = context.Operators.End(ab_);
-            return ac_;
+            Period x_ = @this?.Period;
+            CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, x_);
+            CqlDateTime z_ = context.Operators.End(y_);
+            return z_;
         }
 
         IEnumerable<Encounter> f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
@@ -779,193 +753,147 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 IEnumerable<Encounter> ar_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? as_(Encounter LastED) {
-                    Code<Encounter.EncounterStatus> ci_ = LastED?.StatusElement;
-                    Encounter.EncounterStatus? cj_ = ci_?.Value;
-                    Code<Encounter.EncounterStatus> ck_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cj_);
-                    CqlBoolean cl_ = context.Operators.Equal(ck_, "finished");
+                    Code<Encounter.EncounterStatus> cy_ = LastED?.StatusElement;
+                    Encounter.EncounterStatus? cz_ = cy_?.Value;
+                    Code<Encounter.EncounterStatus> da_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cz_);
+                    CqlBoolean db_ = context.Operators.Equal(da_, "finished");
+                    Period dc_ = LastED?.Period;
+                    CqlInterval<CqlDateTime> dd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dc_);
+                    CqlDateTime de_ = context.Operators.End(dd_);
+                    CqlValueSet df_ = this.Observation_Services(context);
+                    IEnumerable<Encounter> dg_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, df_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                    CqlBoolean cm_() {
-                        Period cn_ = LastED?.Period;
-                        CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cn_);
-                        CqlDateTime cp_ = context.Operators.End(co_);
-                        CqlValueSet cq_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> cr_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, cq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? cs_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> dq_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? dr_ = dq_?.Value;
-                            Code<Encounter.EncounterStatus> ds_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dr_);
-                            CqlBoolean dt_ = context.Operators.Equal(ds_, "finished");
-
-                            CqlBoolean du_() {
-                                Period dv_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
-                                CqlDateTime dx_ = context.Operators.End(dw_);
-                                Period dy_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
-                                CqlDateTime ea_ = context.Operators.Start(dz_);
-                                CqlQuantity eb_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime ec_ = context.Operators.Subtract(ea_, eb_);
-                                CqlInterval<CqlDateTime> ed_ = context.Operators.Interval(ec_, ea_, true, true);
-                                CqlBoolean ee_ = context.Operators.In<CqlDateTime>(dx_, ed_, (string)default);
-
-                                CqlBoolean ef_() {
-                                    Period eg_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eg_);
-                                    CqlDateTime ei_ = context.Operators.Start(eh_);
-                                    return ei_ is not null;
-                                }
-
-                                return ee_
-                                    /* CQL 'and' (241:15-241:83) */ && ef_();
-                            }
-
-                            return dt_
-                                /* CQL 'and' (240:6-241:83) */ && du_();
-                        }
-
-                        IEnumerable<Encounter> ct_ = context.Operators.Where<Encounter>(cr_, cs_);
-
-                        object cu_(Encounter @this) {
-                            Period ej_ = @this?.Period;
-                            CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ej_);
-                            CqlDateTime el_ = context.Operators.End(ek_);
-                            return el_;
-                        }
-
-                        IEnumerable<Encounter> cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter cw_ = context.Operators.Last<Encounter>(cv_);
-                        Period cx_ = cw_?.Period;
-                        CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cx_);
-                        CqlDateTime cz_ = context.Operators.Start(cy_);
-                        Period da_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, da_);
-                        CqlDateTime dc_ = context.Operators.Start(db_);
-                        CqlQuantity dd_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime de_ = context.Operators.Subtract(cz_ ?? dc_, dd_);
-
-                        bool? df_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> em_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? en_ = em_?.Value;
-                            Code<Encounter.EncounterStatus> eo_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(en_);
-                            CqlBoolean ep_ = context.Operators.Equal(eo_, "finished");
-
-                            CqlBoolean eq_() {
-                                Period er_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> es_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, er_);
-                                CqlDateTime et_ = context.Operators.End(es_);
-                                Period eu_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eu_);
-                                CqlDateTime ew_ = context.Operators.Start(ev_);
-                                CqlQuantity ex_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime ey_ = context.Operators.Subtract(ew_, ex_);
-                                CqlInterval<CqlDateTime> ez_ = context.Operators.Interval(ey_, ew_, true, true);
-                                CqlBoolean fa_ = context.Operators.In<CqlDateTime>(et_, ez_, (string)default);
-
-                                CqlBoolean fb_() {
-                                    Period fc_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fc_);
-                                    CqlDateTime fe_ = context.Operators.Start(fd_);
-                                    return fe_ is not null;
-                                }
-
-                                return fa_
-                                    /* CQL 'and' (241:15-241:83) */ && fb_();
-                            }
-
-                            return ep_
-                                /* CQL 'and' (240:6-241:83) */ && eq_();
-                        }
-
-                        IEnumerable<Encounter> dg_ = context.Operators.Where<Encounter>(cr_, df_);
-
-                        object dh_(Encounter @this) {
-                            Period ff_ = @this?.Period;
-                            CqlInterval<CqlDateTime> fg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ff_);
-                            CqlDateTime fh_ = context.Operators.End(fg_);
-                            return fh_;
-                        }
-
-                        IEnumerable<Encounter> di_ = context.Operators.SortBy<Encounter>(dg_, dh_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter dj_ = context.Operators.Last<Encounter>(di_);
-                        Period dk_ = dj_?.Period;
-                        CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dk_);
-                        CqlDateTime dm_ = context.Operators.Start(dl_);
-                        CqlInterval<CqlDateTime> dn_ = context.Operators.Interval(de_, dm_ ?? dc_, true, true);
-                        CqlBoolean do_ = context.Operators.In<CqlDateTime>(cp_, dn_, (string)default);
-
-                        CqlBoolean dp_() {
-                            CqlValueSet fi_ = this.Observation_Services(context);
-                            IEnumerable<Encounter> fj_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, fi_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                            bool? fk_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> fv_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? fw_ = fv_?.Value;
-                                Code<Encounter.EncounterStatus> fx_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fw_);
-                                CqlBoolean fy_ = context.Operators.Equal(fx_, "finished");
-
-                                CqlBoolean fz_() {
-                                    Period ga_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ga_);
-                                    CqlDateTime gc_ = context.Operators.End(gb_);
-                                    Period gd_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> ge_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gd_);
-                                    CqlDateTime gf_ = context.Operators.Start(ge_);
-                                    CqlQuantity gg_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime gh_ = context.Operators.Subtract(gf_, gg_);
-                                    CqlInterval<CqlDateTime> gi_ = context.Operators.Interval(gh_, gf_, true, true);
-                                    CqlBoolean gj_ = context.Operators.In<CqlDateTime>(gc_, gi_, (string)default);
-
-                                    CqlBoolean gk_() {
-                                        Period gl_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> gm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gl_);
-                                        CqlDateTime gn_ = context.Operators.Start(gm_);
-                                        return gn_ is not null;
-                                    }
-
-                                    return gj_
-                                        /* CQL 'and' (241:15-241:83) */ && gk_();
-                                }
-
-                                return fy_
-                                    /* CQL 'and' (240:6-241:83) */ && fz_();
-                            }
-
-                            IEnumerable<Encounter> fl_ = context.Operators.Where<Encounter>(fj_, fk_);
-
-                            object fm_(Encounter @this) {
-                                Period go_ = @this?.Period;
-                                CqlInterval<CqlDateTime> gp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, go_);
-                                CqlDateTime gq_ = context.Operators.End(gp_);
-                                return gq_;
-                            }
-
-                            IEnumerable<Encounter> fn_ = context.Operators.SortBy<Encounter>(fl_, fm_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter fo_ = context.Operators.Last<Encounter>(fn_);
-                            Period fp_ = fo_?.Period;
-                            CqlInterval<CqlDateTime> fq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fp_);
-                            CqlDateTime fr_ = context.Operators.Start(fq_);
-                            Period fs_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> ft_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fs_);
-                            CqlDateTime fu_ = context.Operators.Start(ft_);
-                            return (fr_ ?? fu_) is not null;
-                        }
-
-                        return do_
-                            /* CQL 'and' (247:15-247:71) */ && dp_();
+                    bool? dh_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> eo_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? ep_ = eo_?.Value;
+                        Code<Encounter.EncounterStatus> eq_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ep_);
+                        CqlBoolean er_ = context.Operators.Equal(eq_, "finished");
+                        Period es_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, es_);
+                        CqlDateTime eu_ = context.Operators.End(et_);
+                        Period ev_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
+                        CqlDateTime ex_ = context.Operators.Start(ew_);
+                        CqlQuantity ey_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime ez_ = context.Operators.Subtract(ex_, ey_);
+                        CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ez_, ex_, true, true);
+                        CqlBoolean fb_ = context.Operators.In<CqlDateTime>(eu_, fa_, (string)default);
+                        CqlBoolean fc_ = (CqlBoolean)(ex_ is not null);
+                        CqlBoolean fd_ = fb_
+                            /* CQL 'and' (241:15-241:83) */ && fc_;
+                        return er_
+                            /* CQL 'and' (240:6-241:83) */ && fd_;
                     }
 
-                    return cl_
-                        /* CQL 'and' (246:6-247:71) */ && cm_();
+                    IEnumerable<Encounter> di_ = context.Operators.Where<Encounter>(dg_, dh_);
+
+                    object dj_(Encounter @this) {
+                        Period fe_ = @this?.Period;
+                        CqlInterval<CqlDateTime> ff_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fe_);
+                        CqlDateTime fg_ = context.Operators.End(ff_);
+                        return fg_;
+                    }
+
+                    IEnumerable<Encounter> dk_ = context.Operators.SortBy<Encounter>(di_, dj_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter dl_ = context.Operators.Last<Encounter>(dk_);
+                    Period dm_ = dl_?.Period;
+                    CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dm_);
+                    CqlDateTime do_ = context.Operators.Start(dn_);
+                    Period dp_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> dq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dp_);
+                    CqlDateTime dr_ = context.Operators.Start(dq_);
+                    CqlQuantity ds_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime dt_ = context.Operators.Subtract(do_ ?? dr_, ds_);
+
+                    bool? du_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> fh_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? fi_ = fh_?.Value;
+                        Code<Encounter.EncounterStatus> fj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fi_);
+                        CqlBoolean fk_ = context.Operators.Equal(fj_, "finished");
+                        Period fl_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> fm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fl_);
+                        CqlDateTime fn_ = context.Operators.End(fm_);
+                        Period fo_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> fp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fo_);
+                        CqlDateTime fq_ = context.Operators.Start(fp_);
+                        CqlQuantity fr_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime fs_ = context.Operators.Subtract(fq_, fr_);
+                        CqlInterval<CqlDateTime> ft_ = context.Operators.Interval(fs_, fq_, true, true);
+                        CqlBoolean fu_ = context.Operators.In<CqlDateTime>(fn_, ft_, (string)default);
+                        CqlBoolean fv_ = (CqlBoolean)(fq_ is not null);
+                        CqlBoolean fw_ = fu_
+                            /* CQL 'and' (241:15-241:83) */ && fv_;
+                        return fk_
+                            /* CQL 'and' (240:6-241:83) */ && fw_;
+                    }
+
+                    IEnumerable<Encounter> dv_ = context.Operators.Where<Encounter>(dg_, du_);
+
+                    object dw_(Encounter @this) {
+                        Period fx_ = @this?.Period;
+                        CqlInterval<CqlDateTime> fy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fx_);
+                        CqlDateTime fz_ = context.Operators.End(fy_);
+                        return fz_;
+                    }
+
+                    IEnumerable<Encounter> dx_ = context.Operators.SortBy<Encounter>(dv_, dw_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter dy_ = context.Operators.Last<Encounter>(dx_);
+                    Period dz_ = dy_?.Period;
+                    CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dz_);
+                    CqlDateTime eb_ = context.Operators.Start(ea_);
+                    CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dt_, eb_ ?? dr_, true, true);
+                    CqlBoolean ed_ = context.Operators.In<CqlDateTime>(de_, ec_, (string)default);
+
+                    bool? ee_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> ga_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? gb_ = ga_?.Value;
+                        Code<Encounter.EncounterStatus> gc_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gb_);
+                        CqlBoolean gd_ = context.Operators.Equal(gc_, "finished");
+                        Period ge_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> gf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ge_);
+                        CqlDateTime gg_ = context.Operators.End(gf_);
+                        Period gh_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gh_);
+                        CqlDateTime gj_ = context.Operators.Start(gi_);
+                        CqlQuantity gk_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime gl_ = context.Operators.Subtract(gj_, gk_);
+                        CqlInterval<CqlDateTime> gm_ = context.Operators.Interval(gl_, gj_, true, true);
+                        CqlBoolean gn_ = context.Operators.In<CqlDateTime>(gg_, gm_, (string)default);
+                        CqlBoolean go_ = (CqlBoolean)(gj_ is not null);
+                        CqlBoolean gp_ = gn_
+                            /* CQL 'and' (241:15-241:83) */ && go_;
+                        return gd_
+                            /* CQL 'and' (240:6-241:83) */ && gp_;
+                    }
+
+                    IEnumerable<Encounter> ef_ = context.Operators.Where<Encounter>(dg_, ee_);
+
+                    object eg_(Encounter @this) {
+                        Period gq_ = @this?.Period;
+                        CqlInterval<CqlDateTime> gr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gq_);
+                        CqlDateTime gs_ = context.Operators.End(gr_);
+                        return gs_;
+                    }
+
+                    IEnumerable<Encounter> eh_ = context.Operators.SortBy<Encounter>(ef_, eg_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ei_ = context.Operators.Last<Encounter>(eh_);
+                    Period ej_ = ei_?.Period;
+                    CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ej_);
+                    CqlDateTime el_ = context.Operators.Start(ek_);
+                    CqlBoolean em_ = (CqlBoolean)((el_ ?? dr_) is not null);
+                    CqlBoolean en_ = ed_
+                        /* CQL 'and' (247:15-247:71) */ && em_;
+                    return db_
+                        /* CQL 'and' (246:6-247:71) */ && en_;
                 }
 
                 IEnumerable<Encounter> at_ = context.Operators.Where<Encounter>(ar_, as_);
 
                 object au_(Encounter @this) {
-                    Period gr_ = @this?.Period;
-                    CqlInterval<CqlDateTime> gs_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gr_);
-                    CqlDateTime gt_ = context.Operators.End(gs_);
-                    return gt_;
+                    Period gt_ = @this?.Period;
+                    CqlInterval<CqlDateTime> gu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gt_);
+                    CqlDateTime gv_ = context.Operators.End(gu_);
+                    return gv_;
                 }
 
                 IEnumerable<Encounter> av_ = context.Operators.SortBy<Encounter>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
@@ -977,45 +905,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 IEnumerable<Encounter> bb_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ba_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? bc_(Encounter LastObs) {
-                    Code<Encounter.EncounterStatus> gu_ = LastObs?.StatusElement;
-                    Encounter.EncounterStatus? gv_ = gu_?.Value;
-                    Code<Encounter.EncounterStatus> gw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gv_);
-                    CqlBoolean gx_ = context.Operators.Equal(gw_, "finished");
-
-                    CqlBoolean gy_() {
-                        Period gz_ = LastObs?.Period;
-                        CqlInterval<CqlDateTime> ha_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gz_);
-                        CqlDateTime hb_ = context.Operators.End(ha_);
-                        Period hc_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hc_);
-                        CqlDateTime he_ = context.Operators.Start(hd_);
-                        CqlQuantity hf_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime hg_ = context.Operators.Subtract(he_, hf_);
-                        CqlInterval<CqlDateTime> hh_ = context.Operators.Interval(hg_, he_, true, true);
-                        CqlBoolean hi_ = context.Operators.In<CqlDateTime>(hb_, hh_, (string)default);
-
-                        CqlBoolean hj_() {
-                            Period hk_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> hl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hk_);
-                            CqlDateTime hm_ = context.Operators.Start(hl_);
-                            return hm_ is not null;
-                        }
-
-                        return hi_
-                            /* CQL 'and' (241:15-241:83) */ && hj_();
-                    }
-
-                    return gx_
-                        /* CQL 'and' (240:6-241:83) */ && gy_();
+                    Code<Encounter.EncounterStatus> gw_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? gx_ = gw_?.Value;
+                    Code<Encounter.EncounterStatus> gy_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gx_);
+                    CqlBoolean gz_ = context.Operators.Equal(gy_, "finished");
+                    Period ha_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> hb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ha_);
+                    CqlDateTime hc_ = context.Operators.End(hb_);
+                    Period hd_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> he_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hd_);
+                    CqlDateTime hf_ = context.Operators.Start(he_);
+                    CqlQuantity hg_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime hh_ = context.Operators.Subtract(hf_, hg_);
+                    CqlInterval<CqlDateTime> hi_ = context.Operators.Interval(hh_, hf_, true, true);
+                    CqlBoolean hj_ = context.Operators.In<CqlDateTime>(hc_, hi_, (string)default);
+                    CqlBoolean hk_ = (CqlBoolean)(hf_ is not null);
+                    CqlBoolean hl_ = hj_
+                        /* CQL 'and' (241:15-241:83) */ && hk_;
+                    return gz_
+                        /* CQL 'and' (240:6-241:83) */ && hl_;
                 }
 
                 IEnumerable<Encounter> bd_ = context.Operators.Where<Encounter>(bb_, bc_);
 
                 object be_(Encounter @this) {
-                    Period hn_ = @this?.Period;
-                    CqlInterval<CqlDateTime> ho_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hn_);
-                    CqlDateTime hp_ = context.Operators.End(ho_);
-                    return hp_;
+                    Period hm_ = @this?.Period;
+                    CqlInterval<CqlDateTime> hn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hm_);
+                    CqlDateTime ho_ = context.Operators.End(hn_);
+                    return ho_;
                 }
 
                 IEnumerable<Encounter> bf_ = context.Operators.SortBy<Encounter>(bd_, be_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1030,193 +947,147 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlDateTime bo_ = context.Operators.Subtract(az_ ?? bj_ ?? bm_, bn_);
 
                 bool? bp_(Encounter LastED) {
-                    Code<Encounter.EncounterStatus> hq_ = LastED?.StatusElement;
-                    Encounter.EncounterStatus? hr_ = hq_?.Value;
-                    Code<Encounter.EncounterStatus> hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
-                    CqlBoolean ht_ = context.Operators.Equal(hs_, "finished");
+                    Code<Encounter.EncounterStatus> hp_ = LastED?.StatusElement;
+                    Encounter.EncounterStatus? hq_ = hp_?.Value;
+                    Code<Encounter.EncounterStatus> hr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hq_);
+                    CqlBoolean hs_ = context.Operators.Equal(hr_, "finished");
+                    Period ht_ = LastED?.Period;
+                    CqlInterval<CqlDateTime> hu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ht_);
+                    CqlDateTime hv_ = context.Operators.End(hu_);
+                    CqlValueSet hw_ = this.Observation_Services(context);
+                    IEnumerable<Encounter> hx_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, hw_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                    CqlBoolean hu_() {
-                        Period hv_ = LastED?.Period;
-                        CqlInterval<CqlDateTime> hw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hv_);
-                        CqlDateTime hx_ = context.Operators.End(hw_);
-                        CqlValueSet hy_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> hz_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, hy_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? ia_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> iy_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? iz_ = iy_?.Value;
-                            Code<Encounter.EncounterStatus> ja_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iz_);
-                            CqlBoolean jb_ = context.Operators.Equal(ja_, "finished");
-
-                            CqlBoolean jc_() {
-                                Period jd_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> je_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jd_);
-                                CqlDateTime jf_ = context.Operators.End(je_);
-                                Period jg_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> jh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jg_);
-                                CqlDateTime ji_ = context.Operators.Start(jh_);
-                                CqlQuantity jj_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime jk_ = context.Operators.Subtract(ji_, jj_);
-                                CqlInterval<CqlDateTime> jl_ = context.Operators.Interval(jk_, ji_, true, true);
-                                CqlBoolean jm_ = context.Operators.In<CqlDateTime>(jf_, jl_, (string)default);
-
-                                CqlBoolean jn_() {
-                                    Period jo_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> jp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jo_);
-                                    CqlDateTime jq_ = context.Operators.Start(jp_);
-                                    return jq_ is not null;
-                                }
-
-                                return jm_
-                                    /* CQL 'and' (241:15-241:83) */ && jn_();
-                            }
-
-                            return jb_
-                                /* CQL 'and' (240:6-241:83) */ && jc_();
-                        }
-
-                        IEnumerable<Encounter> ib_ = context.Operators.Where<Encounter>(hz_, ia_);
-
-                        object ic_(Encounter @this) {
-                            Period jr_ = @this?.Period;
-                            CqlInterval<CqlDateTime> js_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jr_);
-                            CqlDateTime jt_ = context.Operators.End(js_);
-                            return jt_;
-                        }
-
-                        IEnumerable<Encounter> id_ = context.Operators.SortBy<Encounter>(ib_, ic_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter ie_ = context.Operators.Last<Encounter>(id_);
-                        Period if_ = ie_?.Period;
-                        CqlInterval<CqlDateTime> ig_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, if_);
-                        CqlDateTime ih_ = context.Operators.Start(ig_);
-                        Period ii_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> ij_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
-                        CqlDateTime ik_ = context.Operators.Start(ij_);
-                        CqlQuantity il_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime im_ = context.Operators.Subtract(ih_ ?? ik_, il_);
-
-                        bool? in_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> ju_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? jv_ = ju_?.Value;
-                            Code<Encounter.EncounterStatus> jw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(jv_);
-                            CqlBoolean jx_ = context.Operators.Equal(jw_, "finished");
-
-                            CqlBoolean jy_() {
-                                Period jz_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> ka_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jz_);
-                                CqlDateTime kb_ = context.Operators.End(ka_);
-                                Period kc_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> kd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kc_);
-                                CqlDateTime ke_ = context.Operators.Start(kd_);
-                                CqlQuantity kf_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime kg_ = context.Operators.Subtract(ke_, kf_);
-                                CqlInterval<CqlDateTime> kh_ = context.Operators.Interval(kg_, ke_, true, true);
-                                CqlBoolean ki_ = context.Operators.In<CqlDateTime>(kb_, kh_, (string)default);
-
-                                CqlBoolean kj_() {
-                                    Period kk_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> kl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kk_);
-                                    CqlDateTime km_ = context.Operators.Start(kl_);
-                                    return km_ is not null;
-                                }
-
-                                return ki_
-                                    /* CQL 'and' (241:15-241:83) */ && kj_();
-                            }
-
-                            return jx_
-                                /* CQL 'and' (240:6-241:83) */ && jy_();
-                        }
-
-                        IEnumerable<Encounter> io_ = context.Operators.Where<Encounter>(hz_, in_);
-
-                        object ip_(Encounter @this) {
-                            Period kn_ = @this?.Period;
-                            CqlInterval<CqlDateTime> ko_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kn_);
-                            CqlDateTime kp_ = context.Operators.End(ko_);
-                            return kp_;
-                        }
-
-                        IEnumerable<Encounter> iq_ = context.Operators.SortBy<Encounter>(io_, ip_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter ir_ = context.Operators.Last<Encounter>(iq_);
-                        Period is_ = ir_?.Period;
-                        CqlInterval<CqlDateTime> it_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, is_);
-                        CqlDateTime iu_ = context.Operators.Start(it_);
-                        CqlInterval<CqlDateTime> iv_ = context.Operators.Interval(im_, iu_ ?? ik_, true, true);
-                        CqlBoolean iw_ = context.Operators.In<CqlDateTime>(hx_, iv_, (string)default);
-
-                        CqlBoolean ix_() {
-                            CqlValueSet kq_ = this.Observation_Services(context);
-                            IEnumerable<Encounter> kr_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, kq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                            bool? ks_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> ld_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? le_ = ld_?.Value;
-                                Code<Encounter.EncounterStatus> lf_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(le_);
-                                CqlBoolean lg_ = context.Operators.Equal(lf_, "finished");
-
-                                CqlBoolean lh_() {
-                                    Period li_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> lj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, li_);
-                                    CqlDateTime lk_ = context.Operators.End(lj_);
-                                    Period ll_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> lm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ll_);
-                                    CqlDateTime ln_ = context.Operators.Start(lm_);
-                                    CqlQuantity lo_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime lp_ = context.Operators.Subtract(ln_, lo_);
-                                    CqlInterval<CqlDateTime> lq_ = context.Operators.Interval(lp_, ln_, true, true);
-                                    CqlBoolean lr_ = context.Operators.In<CqlDateTime>(lk_, lq_, (string)default);
-
-                                    CqlBoolean ls_() {
-                                        Period lt_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> lu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lt_);
-                                        CqlDateTime lv_ = context.Operators.Start(lu_);
-                                        return lv_ is not null;
-                                    }
-
-                                    return lr_
-                                        /* CQL 'and' (241:15-241:83) */ && ls_();
-                                }
-
-                                return lg_
-                                    /* CQL 'and' (240:6-241:83) */ && lh_();
-                            }
-
-                            IEnumerable<Encounter> kt_ = context.Operators.Where<Encounter>(kr_, ks_);
-
-                            object ku_(Encounter @this) {
-                                Period lw_ = @this?.Period;
-                                CqlInterval<CqlDateTime> lx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lw_);
-                                CqlDateTime ly_ = context.Operators.End(lx_);
-                                return ly_;
-                            }
-
-                            IEnumerable<Encounter> kv_ = context.Operators.SortBy<Encounter>(kt_, ku_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter kw_ = context.Operators.Last<Encounter>(kv_);
-                            Period kx_ = kw_?.Period;
-                            CqlInterval<CqlDateTime> ky_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kx_);
-                            CqlDateTime kz_ = context.Operators.Start(ky_);
-                            Period la_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> lb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, la_);
-                            CqlDateTime lc_ = context.Operators.Start(lb_);
-                            return (kz_ ?? lc_) is not null;
-                        }
-
-                        return iw_
-                            /* CQL 'and' (247:15-247:71) */ && ix_();
+                    bool? hy_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> jf_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? jg_ = jf_?.Value;
+                        Code<Encounter.EncounterStatus> jh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(jg_);
+                        CqlBoolean ji_ = context.Operators.Equal(jh_, "finished");
+                        Period jj_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> jk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jj_);
+                        CqlDateTime jl_ = context.Operators.End(jk_);
+                        Period jm_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> jn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jm_);
+                        CqlDateTime jo_ = context.Operators.Start(jn_);
+                        CqlQuantity jp_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime jq_ = context.Operators.Subtract(jo_, jp_);
+                        CqlInterval<CqlDateTime> jr_ = context.Operators.Interval(jq_, jo_, true, true);
+                        CqlBoolean js_ = context.Operators.In<CqlDateTime>(jl_, jr_, (string)default);
+                        CqlBoolean jt_ = (CqlBoolean)(jo_ is not null);
+                        CqlBoolean ju_ = js_
+                            /* CQL 'and' (241:15-241:83) */ && jt_;
+                        return ji_
+                            /* CQL 'and' (240:6-241:83) */ && ju_;
                     }
 
-                    return ht_
-                        /* CQL 'and' (246:6-247:71) */ && hu_();
+                    IEnumerable<Encounter> hz_ = context.Operators.Where<Encounter>(hx_, hy_);
+
+                    object ia_(Encounter @this) {
+                        Period jv_ = @this?.Period;
+                        CqlInterval<CqlDateTime> jw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jv_);
+                        CqlDateTime jx_ = context.Operators.End(jw_);
+                        return jx_;
+                    }
+
+                    IEnumerable<Encounter> ib_ = context.Operators.SortBy<Encounter>(hz_, ia_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ic_ = context.Operators.Last<Encounter>(ib_);
+                    Period id_ = ic_?.Period;
+                    CqlInterval<CqlDateTime> ie_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, id_);
+                    CqlDateTime if_ = context.Operators.Start(ie_);
+                    Period ig_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> ih_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ig_);
+                    CqlDateTime ii_ = context.Operators.Start(ih_);
+                    CqlQuantity ij_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ik_ = context.Operators.Subtract(if_ ?? ii_, ij_);
+
+                    bool? il_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> jy_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? jz_ = jy_?.Value;
+                        Code<Encounter.EncounterStatus> ka_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(jz_);
+                        CqlBoolean kb_ = context.Operators.Equal(ka_, "finished");
+                        Period kc_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> kd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kc_);
+                        CqlDateTime ke_ = context.Operators.End(kd_);
+                        Period kf_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> kg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kf_);
+                        CqlDateTime kh_ = context.Operators.Start(kg_);
+                        CqlQuantity ki_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime kj_ = context.Operators.Subtract(kh_, ki_);
+                        CqlInterval<CqlDateTime> kk_ = context.Operators.Interval(kj_, kh_, true, true);
+                        CqlBoolean kl_ = context.Operators.In<CqlDateTime>(ke_, kk_, (string)default);
+                        CqlBoolean km_ = (CqlBoolean)(kh_ is not null);
+                        CqlBoolean kn_ = kl_
+                            /* CQL 'and' (241:15-241:83) */ && km_;
+                        return kb_
+                            /* CQL 'and' (240:6-241:83) */ && kn_;
+                    }
+
+                    IEnumerable<Encounter> im_ = context.Operators.Where<Encounter>(hx_, il_);
+
+                    object in_(Encounter @this) {
+                        Period ko_ = @this?.Period;
+                        CqlInterval<CqlDateTime> kp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ko_);
+                        CqlDateTime kq_ = context.Operators.End(kp_);
+                        return kq_;
+                    }
+
+                    IEnumerable<Encounter> io_ = context.Operators.SortBy<Encounter>(im_, in_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ip_ = context.Operators.Last<Encounter>(io_);
+                    Period iq_ = ip_?.Period;
+                    CqlInterval<CqlDateTime> ir_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, iq_);
+                    CqlDateTime is_ = context.Operators.Start(ir_);
+                    CqlInterval<CqlDateTime> it_ = context.Operators.Interval(ik_, is_ ?? ii_, true, true);
+                    CqlBoolean iu_ = context.Operators.In<CqlDateTime>(hv_, it_, (string)default);
+
+                    bool? iv_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> kr_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? ks_ = kr_?.Value;
+                        Code<Encounter.EncounterStatus> kt_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ks_);
+                        CqlBoolean ku_ = context.Operators.Equal(kt_, "finished");
+                        Period kv_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> kw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kv_);
+                        CqlDateTime kx_ = context.Operators.End(kw_);
+                        Period ky_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> kz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ky_);
+                        CqlDateTime la_ = context.Operators.Start(kz_);
+                        CqlQuantity lb_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime lc_ = context.Operators.Subtract(la_, lb_);
+                        CqlInterval<CqlDateTime> ld_ = context.Operators.Interval(lc_, la_, true, true);
+                        CqlBoolean le_ = context.Operators.In<CqlDateTime>(kx_, ld_, (string)default);
+                        CqlBoolean lf_ = (CqlBoolean)(la_ is not null);
+                        CqlBoolean lg_ = le_
+                            /* CQL 'and' (241:15-241:83) */ && lf_;
+                        return ku_
+                            /* CQL 'and' (240:6-241:83) */ && lg_;
+                    }
+
+                    IEnumerable<Encounter> iw_ = context.Operators.Where<Encounter>(hx_, iv_);
+
+                    object ix_(Encounter @this) {
+                        Period lh_ = @this?.Period;
+                        CqlInterval<CqlDateTime> li_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lh_);
+                        CqlDateTime lj_ = context.Operators.End(li_);
+                        return lj_;
+                    }
+
+                    IEnumerable<Encounter> iy_ = context.Operators.SortBy<Encounter>(iw_, ix_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter iz_ = context.Operators.Last<Encounter>(iy_);
+                    Period ja_ = iz_?.Period;
+                    CqlInterval<CqlDateTime> jb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ja_);
+                    CqlDateTime jc_ = context.Operators.Start(jb_);
+                    CqlBoolean jd_ = (CqlBoolean)((jc_ ?? ii_) is not null);
+                    CqlBoolean je_ = iu_
+                        /* CQL 'and' (247:15-247:71) */ && jd_;
+                    return hs_
+                        /* CQL 'and' (246:6-247:71) */ && je_;
                 }
 
                 IEnumerable<Encounter> bq_ = context.Operators.Where<Encounter>(ar_, bp_);
 
                 object br_(Encounter @this) {
-                    Period lz_ = @this?.Period;
-                    CqlInterval<CqlDateTime> ma_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lz_);
-                    CqlDateTime mb_ = context.Operators.End(ma_);
-                    return mb_;
+                    Period lk_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ll_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lk_);
+                    CqlDateTime lm_ = context.Operators.End(ll_);
+                    return lm_;
                 }
 
                 IEnumerable<Encounter> bs_ = context.Operators.SortBy<Encounter>(bq_, br_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1226,45 +1097,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlDateTime bw_ = context.Operators.Start(bv_);
 
                 bool? bx_(Encounter LastObs) {
-                    Code<Encounter.EncounterStatus> mc_ = LastObs?.StatusElement;
-                    Encounter.EncounterStatus? md_ = mc_?.Value;
-                    Code<Encounter.EncounterStatus> me_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(md_);
-                    CqlBoolean mf_ = context.Operators.Equal(me_, "finished");
-
-                    CqlBoolean mg_() {
-                        Period mh_ = LastObs?.Period;
-                        CqlInterval<CqlDateTime> mi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mh_);
-                        CqlDateTime mj_ = context.Operators.End(mi_);
-                        Period mk_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> ml_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mk_);
-                        CqlDateTime mm_ = context.Operators.Start(ml_);
-                        CqlQuantity mn_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime mo_ = context.Operators.Subtract(mm_, mn_);
-                        CqlInterval<CqlDateTime> mp_ = context.Operators.Interval(mo_, mm_, true, true);
-                        CqlBoolean mq_ = context.Operators.In<CqlDateTime>(mj_, mp_, (string)default);
-
-                        CqlBoolean mr_() {
-                            Period ms_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> mt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ms_);
-                            CqlDateTime mu_ = context.Operators.Start(mt_);
-                            return mu_ is not null;
-                        }
-
-                        return mq_
-                            /* CQL 'and' (241:15-241:83) */ && mr_();
-                    }
-
-                    return mf_
-                        /* CQL 'and' (240:6-241:83) */ && mg_();
+                    Code<Encounter.EncounterStatus> ln_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? lo_ = ln_?.Value;
+                    Code<Encounter.EncounterStatus> lp_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lo_);
+                    CqlBoolean lq_ = context.Operators.Equal(lp_, "finished");
+                    Period lr_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> ls_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lr_);
+                    CqlDateTime lt_ = context.Operators.End(ls_);
+                    Period lu_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> lv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lu_);
+                    CqlDateTime lw_ = context.Operators.Start(lv_);
+                    CqlQuantity lx_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ly_ = context.Operators.Subtract(lw_, lx_);
+                    CqlInterval<CqlDateTime> lz_ = context.Operators.Interval(ly_, lw_, true, true);
+                    CqlBoolean ma_ = context.Operators.In<CqlDateTime>(lt_, lz_, (string)default);
+                    CqlBoolean mb_ = (CqlBoolean)(lw_ is not null);
+                    CqlBoolean mc_ = ma_
+                        /* CQL 'and' (241:15-241:83) */ && mb_;
+                    return lq_
+                        /* CQL 'and' (240:6-241:83) */ && mc_;
                 }
 
                 IEnumerable<Encounter> by_ = context.Operators.Where<Encounter>(bb_, bx_);
 
                 object bz_(Encounter @this) {
-                    Period mv_ = @this?.Period;
-                    CqlInterval<CqlDateTime> mw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mv_);
-                    CqlDateTime mx_ = context.Operators.End(mw_);
-                    return mx_;
+                    Period md_ = @this?.Period;
+                    CqlInterval<CqlDateTime> me_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, md_);
+                    CqlDateTime mf_ = context.Operators.End(me_);
+                    return mf_;
                 }
 
                 IEnumerable<Encounter> ca_ = context.Operators.SortBy<Encounter>(by_, bz_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1275,272 +1135,204 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> cf_ = context.Operators.Interval(bo_, bw_ ?? ce_ ?? bm_, true, true);
                 CqlBoolean cg_ = context.Operators.In<CqlDateTime>(ap_, cf_, (string)default);
 
-                CqlBoolean ch_() {
-                    CqlValueSet my_ = this.Emergency_Department_Visit(context);
-                    IEnumerable<Encounter> mz_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, my_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+                bool? ch_(Encounter LastED) {
+                    Code<Encounter.EncounterStatus> mg_ = LastED?.StatusElement;
+                    Encounter.EncounterStatus? mh_ = mg_?.Value;
+                    Code<Encounter.EncounterStatus> mi_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mh_);
+                    CqlBoolean mj_ = context.Operators.Equal(mi_, "finished");
+                    Period mk_ = LastED?.Period;
+                    CqlInterval<CqlDateTime> ml_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mk_);
+                    CqlDateTime mm_ = context.Operators.End(ml_);
+                    CqlValueSet mn_ = this.Observation_Services(context);
+                    IEnumerable<Encounter> mo_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, mn_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                    bool? na_(Encounter LastED) {
-                        Code<Encounter.EncounterStatus> nv_ = LastED?.StatusElement;
-                        Encounter.EncounterStatus? nw_ = nv_?.Value;
-                        Code<Encounter.EncounterStatus> nx_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nw_);
-                        CqlBoolean ny_ = context.Operators.Equal(nx_, "finished");
-
-                        CqlBoolean nz_() {
-                            Period oa_ = LastED?.Period;
-                            CqlInterval<CqlDateTime> ob_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oa_);
-                            CqlDateTime oc_ = context.Operators.End(ob_);
-                            CqlValueSet od_ = this.Observation_Services(context);
-                            IEnumerable<Encounter> oe_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, od_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                            bool? of_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> pd_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? pe_ = pd_?.Value;
-                                Code<Encounter.EncounterStatus> pf_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(pe_);
-                                CqlBoolean pg_ = context.Operators.Equal(pf_, "finished");
-
-                                CqlBoolean ph_() {
-                                    Period pi_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> pj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pi_);
-                                    CqlDateTime pk_ = context.Operators.End(pj_);
-                                    Period pl_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> pm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pl_);
-                                    CqlDateTime pn_ = context.Operators.Start(pm_);
-                                    CqlQuantity po_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime pp_ = context.Operators.Subtract(pn_, po_);
-                                    CqlInterval<CqlDateTime> pq_ = context.Operators.Interval(pp_, pn_, true, true);
-                                    CqlBoolean pr_ = context.Operators.In<CqlDateTime>(pk_, pq_, (string)default);
-
-                                    CqlBoolean ps_() {
-                                        Period pt_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> pu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pt_);
-                                        CqlDateTime pv_ = context.Operators.Start(pu_);
-                                        return pv_ is not null;
-                                    }
-
-                                    return pr_
-                                        /* CQL 'and' (241:15-241:83) */ && ps_();
-                                }
-
-                                return pg_
-                                    /* CQL 'and' (240:6-241:83) */ && ph_();
-                            }
-
-                            IEnumerable<Encounter> og_ = context.Operators.Where<Encounter>(oe_, of_);
-
-                            object oh_(Encounter @this) {
-                                Period pw_ = @this?.Period;
-                                CqlInterval<CqlDateTime> px_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pw_);
-                                CqlDateTime py_ = context.Operators.End(px_);
-                                return py_;
-                            }
-
-                            IEnumerable<Encounter> oi_ = context.Operators.SortBy<Encounter>(og_, oh_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter oj_ = context.Operators.Last<Encounter>(oi_);
-                            Period ok_ = oj_?.Period;
-                            CqlInterval<CqlDateTime> ol_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ok_);
-                            CqlDateTime om_ = context.Operators.Start(ol_);
-                            Period on_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> oo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, on_);
-                            CqlDateTime op_ = context.Operators.Start(oo_);
-                            CqlQuantity oq_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime or_ = context.Operators.Subtract(om_ ?? op_, oq_);
-
-                            bool? os_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> pz_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? qa_ = pz_?.Value;
-                                Code<Encounter.EncounterStatus> qb_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(qa_);
-                                CqlBoolean qc_ = context.Operators.Equal(qb_, "finished");
-
-                                CqlBoolean qd_() {
-                                    Period qe_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> qf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qe_);
-                                    CqlDateTime qg_ = context.Operators.End(qf_);
-                                    Period qh_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> qi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qh_);
-                                    CqlDateTime qj_ = context.Operators.Start(qi_);
-                                    CqlQuantity qk_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime ql_ = context.Operators.Subtract(qj_, qk_);
-                                    CqlInterval<CqlDateTime> qm_ = context.Operators.Interval(ql_, qj_, true, true);
-                                    CqlBoolean qn_ = context.Operators.In<CqlDateTime>(qg_, qm_, (string)default);
-
-                                    CqlBoolean qo_() {
-                                        Period qp_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> qq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qp_);
-                                        CqlDateTime qr_ = context.Operators.Start(qq_);
-                                        return qr_ is not null;
-                                    }
-
-                                    return qn_
-                                        /* CQL 'and' (241:15-241:83) */ && qo_();
-                                }
-
-                                return qc_
-                                    /* CQL 'and' (240:6-241:83) */ && qd_();
-                            }
-
-                            IEnumerable<Encounter> ot_ = context.Operators.Where<Encounter>(oe_, os_);
-
-                            object ou_(Encounter @this) {
-                                Period qs_ = @this?.Period;
-                                CqlInterval<CqlDateTime> qt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qs_);
-                                CqlDateTime qu_ = context.Operators.End(qt_);
-                                return qu_;
-                            }
-
-                            IEnumerable<Encounter> ov_ = context.Operators.SortBy<Encounter>(ot_, ou_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter ow_ = context.Operators.Last<Encounter>(ov_);
-                            Period ox_ = ow_?.Period;
-                            CqlInterval<CqlDateTime> oy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ox_);
-                            CqlDateTime oz_ = context.Operators.Start(oy_);
-                            CqlInterval<CqlDateTime> pa_ = context.Operators.Interval(or_, oz_ ?? op_, true, true);
-                            CqlBoolean pb_ = context.Operators.In<CqlDateTime>(oc_, pa_, (string)default);
-
-                            CqlBoolean pc_() {
-                                CqlValueSet qv_ = this.Observation_Services(context);
-                                IEnumerable<Encounter> qw_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, qv_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                                bool? qx_(Encounter LastObs) {
-                                    Code<Encounter.EncounterStatus> ri_ = LastObs?.StatusElement;
-                                    Encounter.EncounterStatus? rj_ = ri_?.Value;
-                                    Code<Encounter.EncounterStatus> rk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rj_);
-                                    CqlBoolean rl_ = context.Operators.Equal(rk_, "finished");
-
-                                    CqlBoolean rm_() {
-                                        Period rn_ = LastObs?.Period;
-                                        CqlInterval<CqlDateTime> ro_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rn_);
-                                        CqlDateTime rp_ = context.Operators.End(ro_);
-                                        Period rq_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> rr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rq_);
-                                        CqlDateTime rs_ = context.Operators.Start(rr_);
-                                        CqlQuantity rt_ = context.Operators.Quantity(1m, "hour");
-                                        CqlDateTime ru_ = context.Operators.Subtract(rs_, rt_);
-                                        CqlInterval<CqlDateTime> rv_ = context.Operators.Interval(ru_, rs_, true, true);
-                                        CqlBoolean rw_ = context.Operators.In<CqlDateTime>(rp_, rv_, (string)default);
-
-                                        CqlBoolean rx_() {
-                                            Period ry_ = Visit?.Period;
-                                            CqlInterval<CqlDateTime> rz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ry_);
-                                            CqlDateTime sa_ = context.Operators.Start(rz_);
-                                            return sa_ is not null;
-                                        }
-
-                                        return rw_
-                                            /* CQL 'and' (241:15-241:83) */ && rx_();
-                                    }
-
-                                    return rl_
-                                        /* CQL 'and' (240:6-241:83) */ && rm_();
-                                }
-
-                                IEnumerable<Encounter> qy_ = context.Operators.Where<Encounter>(qw_, qx_);
-
-                                object qz_(Encounter @this) {
-                                    Period sb_ = @this?.Period;
-                                    CqlInterval<CqlDateTime> sc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sb_);
-                                    CqlDateTime sd_ = context.Operators.End(sc_);
-                                    return sd_;
-                                }
-
-                                IEnumerable<Encounter> ra_ = context.Operators.SortBy<Encounter>(qy_, qz_, System.ComponentModel.ListSortDirection.Ascending);
-                                Encounter rb_ = context.Operators.Last<Encounter>(ra_);
-                                Period rc_ = rb_?.Period;
-                                CqlInterval<CqlDateTime> rd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rc_);
-                                CqlDateTime re_ = context.Operators.Start(rd_);
-                                Period rf_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> rg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rf_);
-                                CqlDateTime rh_ = context.Operators.Start(rg_);
-                                return (re_ ?? rh_) is not null;
-                            }
-
-                            return pb_
-                                /* CQL 'and' (247:15-247:71) */ && pc_();
-                        }
-
-                        return ny_
-                            /* CQL 'and' (246:6-247:71) */ && nz_();
+                    bool? mp_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> nw_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? nx_ = nw_?.Value;
+                        Code<Encounter.EncounterStatus> ny_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nx_);
+                        CqlBoolean nz_ = context.Operators.Equal(ny_, "finished");
+                        Period oa_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> ob_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oa_);
+                        CqlDateTime oc_ = context.Operators.End(ob_);
+                        Period od_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> oe_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, od_);
+                        CqlDateTime of_ = context.Operators.Start(oe_);
+                        CqlQuantity og_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime oh_ = context.Operators.Subtract(of_, og_);
+                        CqlInterval<CqlDateTime> oi_ = context.Operators.Interval(oh_, of_, true, true);
+                        CqlBoolean oj_ = context.Operators.In<CqlDateTime>(oc_, oi_, (string)default);
+                        CqlBoolean ok_ = (CqlBoolean)(of_ is not null);
+                        CqlBoolean ol_ = oj_
+                            /* CQL 'and' (241:15-241:83) */ && ok_;
+                        return nz_
+                            /* CQL 'and' (240:6-241:83) */ && ol_;
                     }
 
-                    IEnumerable<Encounter> nb_ = context.Operators.Where<Encounter>(mz_, na_);
+                    IEnumerable<Encounter> mq_ = context.Operators.Where<Encounter>(mo_, mp_);
 
-                    object nc_(Encounter @this) {
-                        Period se_ = @this?.Period;
-                        CqlInterval<CqlDateTime> sf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, se_);
-                        CqlDateTime sg_ = context.Operators.End(sf_);
-                        return sg_;
+                    object mr_(Encounter @this) {
+                        Period om_ = @this?.Period;
+                        CqlInterval<CqlDateTime> on_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, om_);
+                        CqlDateTime oo_ = context.Operators.End(on_);
+                        return oo_;
                     }
 
-                    IEnumerable<Encounter> nd_ = context.Operators.SortBy<Encounter>(nb_, nc_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter ne_ = context.Operators.Last<Encounter>(nd_);
-                    Period nf_ = ne_?.Period;
-                    CqlInterval<CqlDateTime> ng_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nf_);
-                    CqlDateTime nh_ = context.Operators.Start(ng_);
-                    CqlValueSet ni_ = this.Observation_Services(context);
-                    IEnumerable<Encounter> nj_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ni_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+                    IEnumerable<Encounter> ms_ = context.Operators.SortBy<Encounter>(mq_, mr_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter mt_ = context.Operators.Last<Encounter>(ms_);
+                    Period mu_ = mt_?.Period;
+                    CqlInterval<CqlDateTime> mv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mu_);
+                    CqlDateTime mw_ = context.Operators.Start(mv_);
+                    Period mx_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> my_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mx_);
+                    CqlDateTime mz_ = context.Operators.Start(my_);
+                    CqlQuantity na_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime nb_ = context.Operators.Subtract(mw_ ?? mz_, na_);
 
-                    bool? nk_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> sh_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? si_ = sh_?.Value;
-                        Code<Encounter.EncounterStatus> sj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(si_);
-                        CqlBoolean sk_ = context.Operators.Equal(sj_, "finished");
-
-                        CqlBoolean sl_() {
-                            Period sm_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> sn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sm_);
-                            CqlDateTime so_ = context.Operators.End(sn_);
-                            Period sp_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sp_);
-                            CqlDateTime sr_ = context.Operators.Start(sq_);
-                            CqlQuantity ss_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime st_ = context.Operators.Subtract(sr_, ss_);
-                            CqlInterval<CqlDateTime> su_ = context.Operators.Interval(st_, sr_, true, true);
-                            CqlBoolean sv_ = context.Operators.In<CqlDateTime>(so_, su_, (string)default);
-
-                            CqlBoolean sw_() {
-                                Period sx_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> sy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sx_);
-                                CqlDateTime sz_ = context.Operators.Start(sy_);
-                                return sz_ is not null;
-                            }
-
-                            return sv_
-                                /* CQL 'and' (241:15-241:83) */ && sw_();
-                        }
-
-                        return sk_
-                            /* CQL 'and' (240:6-241:83) */ && sl_();
+                    bool? nc_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> op_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? oq_ = op_?.Value;
+                        Code<Encounter.EncounterStatus> or_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oq_);
+                        CqlBoolean os_ = context.Operators.Equal(or_, "finished");
+                        Period ot_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> ou_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ot_);
+                        CqlDateTime ov_ = context.Operators.End(ou_);
+                        Period ow_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> ox_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ow_);
+                        CqlDateTime oy_ = context.Operators.Start(ox_);
+                        CqlQuantity oz_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime pa_ = context.Operators.Subtract(oy_, oz_);
+                        CqlInterval<CqlDateTime> pb_ = context.Operators.Interval(pa_, oy_, true, true);
+                        CqlBoolean pc_ = context.Operators.In<CqlDateTime>(ov_, pb_, (string)default);
+                        CqlBoolean pd_ = (CqlBoolean)(oy_ is not null);
+                        CqlBoolean pe_ = pc_
+                            /* CQL 'and' (241:15-241:83) */ && pd_;
+                        return os_
+                            /* CQL 'and' (240:6-241:83) */ && pe_;
                     }
 
-                    IEnumerable<Encounter> nl_ = context.Operators.Where<Encounter>(nj_, nk_);
+                    IEnumerable<Encounter> nd_ = context.Operators.Where<Encounter>(mo_, nc_);
 
-                    object nm_(Encounter @this) {
-                        Period ta_ = @this?.Period;
-                        CqlInterval<CqlDateTime> tb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ta_);
-                        CqlDateTime tc_ = context.Operators.End(tb_);
-                        return tc_;
+                    object ne_(Encounter @this) {
+                        Period pf_ = @this?.Period;
+                        CqlInterval<CqlDateTime> pg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pf_);
+                        CqlDateTime ph_ = context.Operators.End(pg_);
+                        return ph_;
                     }
 
-                    IEnumerable<Encounter> nn_ = context.Operators.SortBy<Encounter>(nl_, nm_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter no_ = context.Operators.Last<Encounter>(nn_);
-                    Period np_ = no_?.Period;
-                    CqlInterval<CqlDateTime> nq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, np_);
-                    CqlDateTime nr_ = context.Operators.Start(nq_);
-                    Period ns_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> nt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ns_);
-                    CqlDateTime nu_ = context.Operators.Start(nt_);
-                    return (nh_ ?? nr_ ?? nu_) is not null;
+                    IEnumerable<Encounter> nf_ = context.Operators.SortBy<Encounter>(nd_, ne_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ng_ = context.Operators.Last<Encounter>(nf_);
+                    Period nh_ = ng_?.Period;
+                    CqlInterval<CqlDateTime> ni_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nh_);
+                    CqlDateTime nj_ = context.Operators.Start(ni_);
+                    CqlInterval<CqlDateTime> nk_ = context.Operators.Interval(nb_, nj_ ?? mz_, true, true);
+                    CqlBoolean nl_ = context.Operators.In<CqlDateTime>(mm_, nk_, (string)default);
+
+                    bool? nm_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> pi_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? pj_ = pi_?.Value;
+                        Code<Encounter.EncounterStatus> pk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(pj_);
+                        CqlBoolean pl_ = context.Operators.Equal(pk_, "finished");
+                        Period pm_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> pn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pm_);
+                        CqlDateTime po_ = context.Operators.End(pn_);
+                        Period pp_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> pq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pp_);
+                        CqlDateTime pr_ = context.Operators.Start(pq_);
+                        CqlQuantity ps_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime pt_ = context.Operators.Subtract(pr_, ps_);
+                        CqlInterval<CqlDateTime> pu_ = context.Operators.Interval(pt_, pr_, true, true);
+                        CqlBoolean pv_ = context.Operators.In<CqlDateTime>(po_, pu_, (string)default);
+                        CqlBoolean pw_ = (CqlBoolean)(pr_ is not null);
+                        CqlBoolean px_ = pv_
+                            /* CQL 'and' (241:15-241:83) */ && pw_;
+                        return pl_
+                            /* CQL 'and' (240:6-241:83) */ && px_;
+                    }
+
+                    IEnumerable<Encounter> nn_ = context.Operators.Where<Encounter>(mo_, nm_);
+
+                    object no_(Encounter @this) {
+                        Period py_ = @this?.Period;
+                        CqlInterval<CqlDateTime> pz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, py_);
+                        CqlDateTime qa_ = context.Operators.End(pz_);
+                        return qa_;
+                    }
+
+                    IEnumerable<Encounter> np_ = context.Operators.SortBy<Encounter>(nn_, no_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter nq_ = context.Operators.Last<Encounter>(np_);
+                    Period nr_ = nq_?.Period;
+                    CqlInterval<CqlDateTime> ns_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nr_);
+                    CqlDateTime nt_ = context.Operators.Start(ns_);
+                    CqlBoolean nu_ = (CqlBoolean)((nt_ ?? mz_) is not null);
+                    CqlBoolean nv_ = nl_
+                        /* CQL 'and' (247:15-247:71) */ && nu_;
+                    return mj_
+                        /* CQL 'and' (246:6-247:71) */ && nv_;
                 }
 
+                IEnumerable<Encounter> ci_ = context.Operators.Where<Encounter>(ar_, ch_);
+
+                object cj_(Encounter @this) {
+                    Period qb_ = @this?.Period;
+                    CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qb_);
+                    CqlDateTime qd_ = context.Operators.End(qc_);
+                    return qd_;
+                }
+
+                IEnumerable<Encounter> ck_ = context.Operators.SortBy<Encounter>(ci_, cj_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter cl_ = context.Operators.Last<Encounter>(ck_);
+                Period cm_ = cl_?.Period;
+                CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
+                CqlDateTime co_ = context.Operators.Start(cn_);
+
+                bool? cp_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> qe_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? qf_ = qe_?.Value;
+                    Code<Encounter.EncounterStatus> qg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(qf_);
+                    CqlBoolean qh_ = context.Operators.Equal(qg_, "finished");
+                    Period qi_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> qj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qi_);
+                    CqlDateTime qk_ = context.Operators.End(qj_);
+                    Period ql_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> qm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ql_);
+                    CqlDateTime qn_ = context.Operators.Start(qm_);
+                    CqlQuantity qo_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime qp_ = context.Operators.Subtract(qn_, qo_);
+                    CqlInterval<CqlDateTime> qq_ = context.Operators.Interval(qp_, qn_, true, true);
+                    CqlBoolean qr_ = context.Operators.In<CqlDateTime>(qk_, qq_, (string)default);
+                    CqlBoolean qs_ = (CqlBoolean)(qn_ is not null);
+                    CqlBoolean qt_ = qr_
+                        /* CQL 'and' (241:15-241:83) */ && qs_;
+                    return qh_
+                        /* CQL 'and' (240:6-241:83) */ && qt_;
+                }
+
+                IEnumerable<Encounter> cq_ = context.Operators.Where<Encounter>(bb_, cp_);
+
+                object cr_(Encounter @this) {
+                    Period qu_ = @this?.Period;
+                    CqlInterval<CqlDateTime> qv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qu_);
+                    CqlDateTime qw_ = context.Operators.End(qv_);
+                    return qw_;
+                }
+
+                IEnumerable<Encounter> cs_ = context.Operators.SortBy<Encounter>(cq_, cr_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter ct_ = context.Operators.Last<Encounter>(cs_);
+                Period cu_ = ct_?.Period;
+                CqlInterval<CqlDateTime> cv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cu_);
+                CqlDateTime cw_ = context.Operators.Start(cv_);
+                CqlBoolean cx_ = (CqlBoolean)((co_ ?? cw_ ?? bm_) is not null);
                 return cg_
-                    /* CQL 'and' (252:6-252:81) */ && ch_();
+                    /* CQL 'and' (252:6-252:81) */ && cx_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 
             object i_(Encounter @this) {
-                Period td_ = @this?.Period;
-                CqlInterval<CqlDateTime> te_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, td_);
-                CqlDateTime tf_ = context.Operators.End(te_);
-                return tf_;
+                Period qx_ = @this?.Period;
+                CqlInterval<CqlDateTime> qy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qx_);
+                CqlDateTime qz_ = context.Operators.End(qy_);
+                return qz_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1552,193 +1344,147 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             IEnumerable<Encounter> p_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? q_(Encounter LastED) {
-                Code<Encounter.EncounterStatus> tg_ = LastED?.StatusElement;
-                Encounter.EncounterStatus? th_ = tg_?.Value;
-                Code<Encounter.EncounterStatus> ti_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(th_);
-                CqlBoolean tj_ = context.Operators.Equal(ti_, "finished");
+                Code<Encounter.EncounterStatus> ra_ = LastED?.StatusElement;
+                Encounter.EncounterStatus? rb_ = ra_?.Value;
+                Code<Encounter.EncounterStatus> rc_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rb_);
+                CqlBoolean rd_ = context.Operators.Equal(rc_, "finished");
+                Period re_ = LastED?.Period;
+                CqlInterval<CqlDateTime> rf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, re_);
+                CqlDateTime rg_ = context.Operators.End(rf_);
+                CqlValueSet rh_ = this.Observation_Services(context);
+                IEnumerable<Encounter> ri_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, rh_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                CqlBoolean tk_() {
-                    Period tl_ = LastED?.Period;
-                    CqlInterval<CqlDateTime> tm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tl_);
-                    CqlDateTime tn_ = context.Operators.End(tm_);
-                    CqlValueSet to_ = this.Observation_Services(context);
-                    IEnumerable<Encounter> tp_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, to_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                    bool? tq_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> uo_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? up_ = uo_?.Value;
-                        Code<Encounter.EncounterStatus> uq_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(up_);
-                        CqlBoolean ur_ = context.Operators.Equal(uq_, "finished");
-
-                        CqlBoolean us_() {
-                            Period ut_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> uu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ut_);
-                            CqlDateTime uv_ = context.Operators.End(uu_);
-                            Period uw_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> ux_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, uw_);
-                            CqlDateTime uy_ = context.Operators.Start(ux_);
-                            CqlQuantity uz_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime va_ = context.Operators.Subtract(uy_, uz_);
-                            CqlInterval<CqlDateTime> vb_ = context.Operators.Interval(va_, uy_, true, true);
-                            CqlBoolean vc_ = context.Operators.In<CqlDateTime>(uv_, vb_, (string)default);
-
-                            CqlBoolean vd_() {
-                                Period ve_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> vf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ve_);
-                                CqlDateTime vg_ = context.Operators.Start(vf_);
-                                return vg_ is not null;
-                            }
-
-                            return vc_
-                                /* CQL 'and' (241:15-241:83) */ && vd_();
-                        }
-
-                        return ur_
-                            /* CQL 'and' (240:6-241:83) */ && us_();
-                    }
-
-                    IEnumerable<Encounter> tr_ = context.Operators.Where<Encounter>(tp_, tq_);
-
-                    object ts_(Encounter @this) {
-                        Period vh_ = @this?.Period;
-                        CqlInterval<CqlDateTime> vi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vh_);
-                        CqlDateTime vj_ = context.Operators.End(vi_);
-                        return vj_;
-                    }
-
-                    IEnumerable<Encounter> tt_ = context.Operators.SortBy<Encounter>(tr_, ts_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter tu_ = context.Operators.Last<Encounter>(tt_);
-                    Period tv_ = tu_?.Period;
-                    CqlInterval<CqlDateTime> tw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tv_);
-                    CqlDateTime tx_ = context.Operators.Start(tw_);
-                    Period ty_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> tz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ty_);
-                    CqlDateTime ua_ = context.Operators.Start(tz_);
-                    CqlQuantity ub_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime uc_ = context.Operators.Subtract(tx_ ?? ua_, ub_);
-
-                    bool? ud_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> vk_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? vl_ = vk_?.Value;
-                        Code<Encounter.EncounterStatus> vm_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vl_);
-                        CqlBoolean vn_ = context.Operators.Equal(vm_, "finished");
-
-                        CqlBoolean vo_() {
-                            Period vp_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> vq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vp_);
-                            CqlDateTime vr_ = context.Operators.End(vq_);
-                            Period vs_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vs_);
-                            CqlDateTime vu_ = context.Operators.Start(vt_);
-                            CqlQuantity vv_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime vw_ = context.Operators.Subtract(vu_, vv_);
-                            CqlInterval<CqlDateTime> vx_ = context.Operators.Interval(vw_, vu_, true, true);
-                            CqlBoolean vy_ = context.Operators.In<CqlDateTime>(vr_, vx_, (string)default);
-
-                            CqlBoolean vz_() {
-                                Period wa_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> wb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wa_);
-                                CqlDateTime wc_ = context.Operators.Start(wb_);
-                                return wc_ is not null;
-                            }
-
-                            return vy_
-                                /* CQL 'and' (241:15-241:83) */ && vz_();
-                        }
-
-                        return vn_
-                            /* CQL 'and' (240:6-241:83) */ && vo_();
-                    }
-
-                    IEnumerable<Encounter> ue_ = context.Operators.Where<Encounter>(tp_, ud_);
-
-                    object uf_(Encounter @this) {
-                        Period wd_ = @this?.Period;
-                        CqlInterval<CqlDateTime> we_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wd_);
-                        CqlDateTime wf_ = context.Operators.End(we_);
-                        return wf_;
-                    }
-
-                    IEnumerable<Encounter> ug_ = context.Operators.SortBy<Encounter>(ue_, uf_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter uh_ = context.Operators.Last<Encounter>(ug_);
-                    Period ui_ = uh_?.Period;
-                    CqlInterval<CqlDateTime> uj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ui_);
-                    CqlDateTime uk_ = context.Operators.Start(uj_);
-                    CqlInterval<CqlDateTime> ul_ = context.Operators.Interval(uc_, uk_ ?? ua_, true, true);
-                    CqlBoolean um_ = context.Operators.In<CqlDateTime>(tn_, ul_, (string)default);
-
-                    CqlBoolean un_() {
-                        CqlValueSet wg_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> wh_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, wg_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? wi_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> wt_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? wu_ = wt_?.Value;
-                            Code<Encounter.EncounterStatus> wv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wu_);
-                            CqlBoolean ww_ = context.Operators.Equal(wv_, "finished");
-
-                            CqlBoolean wx_() {
-                                Period wy_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> wz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wy_);
-                                CqlDateTime xa_ = context.Operators.End(wz_);
-                                Period xb_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> xc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xb_);
-                                CqlDateTime xd_ = context.Operators.Start(xc_);
-                                CqlQuantity xe_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime xf_ = context.Operators.Subtract(xd_, xe_);
-                                CqlInterval<CqlDateTime> xg_ = context.Operators.Interval(xf_, xd_, true, true);
-                                CqlBoolean xh_ = context.Operators.In<CqlDateTime>(xa_, xg_, (string)default);
-
-                                CqlBoolean xi_() {
-                                    Period xj_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> xk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xj_);
-                                    CqlDateTime xl_ = context.Operators.Start(xk_);
-                                    return xl_ is not null;
-                                }
-
-                                return xh_
-                                    /* CQL 'and' (241:15-241:83) */ && xi_();
-                            }
-
-                            return ww_
-                                /* CQL 'and' (240:6-241:83) */ && wx_();
-                        }
-
-                        IEnumerable<Encounter> wj_ = context.Operators.Where<Encounter>(wh_, wi_);
-
-                        object wk_(Encounter @this) {
-                            Period xm_ = @this?.Period;
-                            CqlInterval<CqlDateTime> xn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xm_);
-                            CqlDateTime xo_ = context.Operators.End(xn_);
-                            return xo_;
-                        }
-
-                        IEnumerable<Encounter> wl_ = context.Operators.SortBy<Encounter>(wj_, wk_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter wm_ = context.Operators.Last<Encounter>(wl_);
-                        Period wn_ = wm_?.Period;
-                        CqlInterval<CqlDateTime> wo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wn_);
-                        CqlDateTime wp_ = context.Operators.Start(wo_);
-                        Period wq_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> wr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wq_);
-                        CqlDateTime ws_ = context.Operators.Start(wr_);
-                        return (wp_ ?? ws_) is not null;
-                    }
-
-                    return um_
-                        /* CQL 'and' (247:15-247:71) */ && un_();
+                bool? rj_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> sq_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? sr_ = sq_?.Value;
+                    Code<Encounter.EncounterStatus> ss_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sr_);
+                    CqlBoolean st_ = context.Operators.Equal(ss_, "finished");
+                    Period su_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> sv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, su_);
+                    CqlDateTime sw_ = context.Operators.End(sv_);
+                    Period sx_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> sy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sx_);
+                    CqlDateTime sz_ = context.Operators.Start(sy_);
+                    CqlQuantity ta_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime tb_ = context.Operators.Subtract(sz_, ta_);
+                    CqlInterval<CqlDateTime> tc_ = context.Operators.Interval(tb_, sz_, true, true);
+                    CqlBoolean td_ = context.Operators.In<CqlDateTime>(sw_, tc_, (string)default);
+                    CqlBoolean te_ = (CqlBoolean)(sz_ is not null);
+                    CqlBoolean tf_ = td_
+                        /* CQL 'and' (241:15-241:83) */ && te_;
+                    return st_
+                        /* CQL 'and' (240:6-241:83) */ && tf_;
                 }
 
-                return tj_
-                    /* CQL 'and' (246:6-247:71) */ && tk_();
+                IEnumerable<Encounter> rk_ = context.Operators.Where<Encounter>(ri_, rj_);
+
+                object rl_(Encounter @this) {
+                    Period tg_ = @this?.Period;
+                    CqlInterval<CqlDateTime> th_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tg_);
+                    CqlDateTime ti_ = context.Operators.End(th_);
+                    return ti_;
+                }
+
+                IEnumerable<Encounter> rm_ = context.Operators.SortBy<Encounter>(rk_, rl_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter rn_ = context.Operators.Last<Encounter>(rm_);
+                Period ro_ = rn_?.Period;
+                CqlInterval<CqlDateTime> rp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ro_);
+                CqlDateTime rq_ = context.Operators.Start(rp_);
+                Period rr_ = Visit?.Period;
+                CqlInterval<CqlDateTime> rs_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rr_);
+                CqlDateTime rt_ = context.Operators.Start(rs_);
+                CqlQuantity ru_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime rv_ = context.Operators.Subtract(rq_ ?? rt_, ru_);
+
+                bool? rw_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> tj_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? tk_ = tj_?.Value;
+                    Code<Encounter.EncounterStatus> tl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tk_);
+                    CqlBoolean tm_ = context.Operators.Equal(tl_, "finished");
+                    Period tn_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> to_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tn_);
+                    CqlDateTime tp_ = context.Operators.End(to_);
+                    Period tq_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> tr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tq_);
+                    CqlDateTime ts_ = context.Operators.Start(tr_);
+                    CqlQuantity tt_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime tu_ = context.Operators.Subtract(ts_, tt_);
+                    CqlInterval<CqlDateTime> tv_ = context.Operators.Interval(tu_, ts_, true, true);
+                    CqlBoolean tw_ = context.Operators.In<CqlDateTime>(tp_, tv_, (string)default);
+                    CqlBoolean tx_ = (CqlBoolean)(ts_ is not null);
+                    CqlBoolean ty_ = tw_
+                        /* CQL 'and' (241:15-241:83) */ && tx_;
+                    return tm_
+                        /* CQL 'and' (240:6-241:83) */ && ty_;
+                }
+
+                IEnumerable<Encounter> rx_ = context.Operators.Where<Encounter>(ri_, rw_);
+
+                object ry_(Encounter @this) {
+                    Period tz_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ua_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tz_);
+                    CqlDateTime ub_ = context.Operators.End(ua_);
+                    return ub_;
+                }
+
+                IEnumerable<Encounter> rz_ = context.Operators.SortBy<Encounter>(rx_, ry_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter sa_ = context.Operators.Last<Encounter>(rz_);
+                Period sb_ = sa_?.Period;
+                CqlInterval<CqlDateTime> sc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sb_);
+                CqlDateTime sd_ = context.Operators.Start(sc_);
+                CqlInterval<CqlDateTime> se_ = context.Operators.Interval(rv_, sd_ ?? rt_, true, true);
+                CqlBoolean sf_ = context.Operators.In<CqlDateTime>(rg_, se_, (string)default);
+
+                bool? sg_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> uc_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? ud_ = uc_?.Value;
+                    Code<Encounter.EncounterStatus> ue_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ud_);
+                    CqlBoolean uf_ = context.Operators.Equal(ue_, "finished");
+                    Period ug_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> uh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ug_);
+                    CqlDateTime ui_ = context.Operators.End(uh_);
+                    Period uj_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> uk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, uj_);
+                    CqlDateTime ul_ = context.Operators.Start(uk_);
+                    CqlQuantity um_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime un_ = context.Operators.Subtract(ul_, um_);
+                    CqlInterval<CqlDateTime> uo_ = context.Operators.Interval(un_, ul_, true, true);
+                    CqlBoolean up_ = context.Operators.In<CqlDateTime>(ui_, uo_, (string)default);
+                    CqlBoolean uq_ = (CqlBoolean)(ul_ is not null);
+                    CqlBoolean ur_ = up_
+                        /* CQL 'and' (241:15-241:83) */ && uq_;
+                    return uf_
+                        /* CQL 'and' (240:6-241:83) */ && ur_;
+                }
+
+                IEnumerable<Encounter> sh_ = context.Operators.Where<Encounter>(ri_, sg_);
+
+                object si_(Encounter @this) {
+                    Period us_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ut_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, us_);
+                    CqlDateTime uu_ = context.Operators.End(ut_);
+                    return uu_;
+                }
+
+                IEnumerable<Encounter> sj_ = context.Operators.SortBy<Encounter>(sh_, si_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter sk_ = context.Operators.Last<Encounter>(sj_);
+                Period sl_ = sk_?.Period;
+                CqlInterval<CqlDateTime> sm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sl_);
+                CqlDateTime sn_ = context.Operators.Start(sm_);
+                CqlBoolean so_ = (CqlBoolean)((sn_ ?? rt_) is not null);
+                CqlBoolean sp_ = sf_
+                    /* CQL 'and' (247:15-247:71) */ && so_;
+                return rd_
+                    /* CQL 'and' (246:6-247:71) */ && sp_;
             }
 
             IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 
             object s_(Encounter @this) {
-                Period xp_ = @this?.Period;
-                CqlInterval<CqlDateTime> xq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xp_);
-                CqlDateTime xr_ = context.Operators.End(xq_);
-                return xr_;
+                Period uv_ = @this?.Period;
+                CqlInterval<CqlDateTime> uw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, uv_);
+                CqlDateTime ux_ = context.Operators.End(uw_);
+                return ux_;
             }
 
             IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1750,45 +1496,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             IEnumerable<Encounter> z_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? aa_(Encounter LastObs) {
-                Code<Encounter.EncounterStatus> xs_ = LastObs?.StatusElement;
-                Encounter.EncounterStatus? xt_ = xs_?.Value;
-                Code<Encounter.EncounterStatus> xu_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(xt_);
-                CqlBoolean xv_ = context.Operators.Equal(xu_, "finished");
-
-                CqlBoolean xw_() {
-                    Period xx_ = LastObs?.Period;
-                    CqlInterval<CqlDateTime> xy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xx_);
-                    CqlDateTime xz_ = context.Operators.End(xy_);
-                    Period ya_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> yb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ya_);
-                    CqlDateTime yc_ = context.Operators.Start(yb_);
-                    CqlQuantity yd_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime ye_ = context.Operators.Subtract(yc_, yd_);
-                    CqlInterval<CqlDateTime> yf_ = context.Operators.Interval(ye_, yc_, true, true);
-                    CqlBoolean yg_ = context.Operators.In<CqlDateTime>(xz_, yf_, (string)default);
-
-                    CqlBoolean yh_() {
-                        Period yi_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> yj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yi_);
-                        CqlDateTime yk_ = context.Operators.Start(yj_);
-                        return yk_ is not null;
-                    }
-
-                    return yg_
-                        /* CQL 'and' (241:15-241:83) */ && yh_();
-                }
-
-                return xv_
-                    /* CQL 'and' (240:6-241:83) */ && xw_();
+                Code<Encounter.EncounterStatus> uy_ = LastObs?.StatusElement;
+                Encounter.EncounterStatus? uz_ = uy_?.Value;
+                Code<Encounter.EncounterStatus> va_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(uz_);
+                CqlBoolean vb_ = context.Operators.Equal(va_, "finished");
+                Period vc_ = LastObs?.Period;
+                CqlInterval<CqlDateTime> vd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vc_);
+                CqlDateTime ve_ = context.Operators.End(vd_);
+                Period vf_ = Visit?.Period;
+                CqlInterval<CqlDateTime> vg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vf_);
+                CqlDateTime vh_ = context.Operators.Start(vg_);
+                CqlQuantity vi_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime vj_ = context.Operators.Subtract(vh_, vi_);
+                CqlInterval<CqlDateTime> vk_ = context.Operators.Interval(vj_, vh_, true, true);
+                CqlBoolean vl_ = context.Operators.In<CqlDateTime>(ve_, vk_, (string)default);
+                CqlBoolean vm_ = (CqlBoolean)(vh_ is not null);
+                CqlBoolean vn_ = vl_
+                    /* CQL 'and' (241:15-241:83) */ && vm_;
+                return vb_
+                    /* CQL 'and' (240:6-241:83) */ && vn_;
             }
 
             IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
 
             object ac_(Encounter @this) {
-                Period yl_ = @this?.Period;
-                CqlInterval<CqlDateTime> ym_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yl_);
-                CqlDateTime yn_ = context.Operators.End(ym_);
-                return yn_;
+                Period vo_ = @this?.Period;
+                CqlInterval<CqlDateTime> vp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vo_);
+                CqlDateTime vq_ = context.Operators.End(vp_);
+                return vq_;
             }
 
             IEnumerable<Encounter> ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
@@ -1830,193 +1565,147 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 IEnumerable<Encounter> ar_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? as_(Encounter LastED) {
-                    Code<Encounter.EncounterStatus> ci_ = LastED?.StatusElement;
-                    Encounter.EncounterStatus? cj_ = ci_?.Value;
-                    Code<Encounter.EncounterStatus> ck_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cj_);
-                    CqlBoolean cl_ = context.Operators.Equal(ck_, "finished");
+                    Code<Encounter.EncounterStatus> cy_ = LastED?.StatusElement;
+                    Encounter.EncounterStatus? cz_ = cy_?.Value;
+                    Code<Encounter.EncounterStatus> da_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cz_);
+                    CqlBoolean db_ = context.Operators.Equal(da_, "finished");
+                    Period dc_ = LastED?.Period;
+                    CqlInterval<CqlDateTime> dd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dc_);
+                    CqlDateTime de_ = context.Operators.End(dd_);
+                    CqlValueSet df_ = this.Observation_Services(context);
+                    IEnumerable<Encounter> dg_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, df_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                    CqlBoolean cm_() {
-                        Period cn_ = LastED?.Period;
-                        CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cn_);
-                        CqlDateTime cp_ = context.Operators.End(co_);
-                        CqlValueSet cq_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> cr_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, cq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? cs_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> dq_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? dr_ = dq_?.Value;
-                            Code<Encounter.EncounterStatus> ds_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dr_);
-                            CqlBoolean dt_ = context.Operators.Equal(ds_, "finished");
-
-                            CqlBoolean du_() {
-                                Period dv_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
-                                CqlDateTime dx_ = context.Operators.End(dw_);
-                                Period dy_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
-                                CqlDateTime ea_ = context.Operators.Start(dz_);
-                                CqlQuantity eb_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime ec_ = context.Operators.Subtract(ea_, eb_);
-                                CqlInterval<CqlDateTime> ed_ = context.Operators.Interval(ec_, ea_, true, true);
-                                CqlBoolean ee_ = context.Operators.In<CqlDateTime>(dx_, ed_, (string)default);
-
-                                CqlBoolean ef_() {
-                                    Period eg_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eg_);
-                                    CqlDateTime ei_ = context.Operators.Start(eh_);
-                                    return ei_ is not null;
-                                }
-
-                                return ee_
-                                    /* CQL 'and' (264:15-264:83) */ && ef_();
-                            }
-
-                            return dt_
-                                /* CQL 'and' (263:6-264:83) */ && du_();
-                        }
-
-                        IEnumerable<Encounter> ct_ = context.Operators.Where<Encounter>(cr_, cs_);
-
-                        object cu_(Encounter @this) {
-                            Period ej_ = @this?.Period;
-                            CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ej_);
-                            CqlDateTime el_ = context.Operators.End(ek_);
-                            return el_;
-                        }
-
-                        IEnumerable<Encounter> cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter cw_ = context.Operators.Last<Encounter>(cv_);
-                        Period cx_ = cw_?.Period;
-                        CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cx_);
-                        CqlDateTime cz_ = context.Operators.Start(cy_);
-                        Period da_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, da_);
-                        CqlDateTime dc_ = context.Operators.Start(db_);
-                        CqlQuantity dd_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime de_ = context.Operators.Subtract(cz_ ?? dc_, dd_);
-
-                        bool? df_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> em_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? en_ = em_?.Value;
-                            Code<Encounter.EncounterStatus> eo_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(en_);
-                            CqlBoolean ep_ = context.Operators.Equal(eo_, "finished");
-
-                            CqlBoolean eq_() {
-                                Period er_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> es_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, er_);
-                                CqlDateTime et_ = context.Operators.End(es_);
-                                Period eu_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eu_);
-                                CqlDateTime ew_ = context.Operators.Start(ev_);
-                                CqlQuantity ex_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime ey_ = context.Operators.Subtract(ew_, ex_);
-                                CqlInterval<CqlDateTime> ez_ = context.Operators.Interval(ey_, ew_, true, true);
-                                CqlBoolean fa_ = context.Operators.In<CqlDateTime>(et_, ez_, (string)default);
-
-                                CqlBoolean fb_() {
-                                    Period fc_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fc_);
-                                    CqlDateTime fe_ = context.Operators.Start(fd_);
-                                    return fe_ is not null;
-                                }
-
-                                return fa_
-                                    /* CQL 'and' (264:15-264:83) */ && fb_();
-                            }
-
-                            return ep_
-                                /* CQL 'and' (263:6-264:83) */ && eq_();
-                        }
-
-                        IEnumerable<Encounter> dg_ = context.Operators.Where<Encounter>(cr_, df_);
-
-                        object dh_(Encounter @this) {
-                            Period ff_ = @this?.Period;
-                            CqlInterval<CqlDateTime> fg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ff_);
-                            CqlDateTime fh_ = context.Operators.End(fg_);
-                            return fh_;
-                        }
-
-                        IEnumerable<Encounter> di_ = context.Operators.SortBy<Encounter>(dg_, dh_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter dj_ = context.Operators.Last<Encounter>(di_);
-                        Period dk_ = dj_?.Period;
-                        CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dk_);
-                        CqlDateTime dm_ = context.Operators.Start(dl_);
-                        CqlInterval<CqlDateTime> dn_ = context.Operators.Interval(de_, dm_ ?? dc_, true, true);
-                        CqlBoolean do_ = context.Operators.In<CqlDateTime>(cp_, dn_, (string)default);
-
-                        CqlBoolean dp_() {
-                            CqlValueSet fi_ = this.Observation_Services(context);
-                            IEnumerable<Encounter> fj_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, fi_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                            bool? fk_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> fv_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? fw_ = fv_?.Value;
-                                Code<Encounter.EncounterStatus> fx_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fw_);
-                                CqlBoolean fy_ = context.Operators.Equal(fx_, "finished");
-
-                                CqlBoolean fz_() {
-                                    Period ga_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ga_);
-                                    CqlDateTime gc_ = context.Operators.End(gb_);
-                                    Period gd_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> ge_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gd_);
-                                    CqlDateTime gf_ = context.Operators.Start(ge_);
-                                    CqlQuantity gg_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime gh_ = context.Operators.Subtract(gf_, gg_);
-                                    CqlInterval<CqlDateTime> gi_ = context.Operators.Interval(gh_, gf_, true, true);
-                                    CqlBoolean gj_ = context.Operators.In<CqlDateTime>(gc_, gi_, (string)default);
-
-                                    CqlBoolean gk_() {
-                                        Period gl_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> gm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gl_);
-                                        CqlDateTime gn_ = context.Operators.Start(gm_);
-                                        return gn_ is not null;
-                                    }
-
-                                    return gj_
-                                        /* CQL 'and' (264:15-264:83) */ && gk_();
-                                }
-
-                                return fy_
-                                    /* CQL 'and' (263:6-264:83) */ && fz_();
-                            }
-
-                            IEnumerable<Encounter> fl_ = context.Operators.Where<Encounter>(fj_, fk_);
-
-                            object fm_(Encounter @this) {
-                                Period go_ = @this?.Period;
-                                CqlInterval<CqlDateTime> gp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, go_);
-                                CqlDateTime gq_ = context.Operators.End(gp_);
-                                return gq_;
-                            }
-
-                            IEnumerable<Encounter> fn_ = context.Operators.SortBy<Encounter>(fl_, fm_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter fo_ = context.Operators.Last<Encounter>(fn_);
-                            Period fp_ = fo_?.Period;
-                            CqlInterval<CqlDateTime> fq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fp_);
-                            CqlDateTime fr_ = context.Operators.Start(fq_);
-                            Period fs_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> ft_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fs_);
-                            CqlDateTime fu_ = context.Operators.Start(ft_);
-                            return (fr_ ?? fu_) is not null;
-                        }
-
-                        return do_
-                            /* CQL 'and' (270:15-270:71) */ && dp_();
+                    bool? dh_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> eo_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? ep_ = eo_?.Value;
+                        Code<Encounter.EncounterStatus> eq_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ep_);
+                        CqlBoolean er_ = context.Operators.Equal(eq_, "finished");
+                        Period es_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, es_);
+                        CqlDateTime eu_ = context.Operators.End(et_);
+                        Period ev_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ev_);
+                        CqlDateTime ex_ = context.Operators.Start(ew_);
+                        CqlQuantity ey_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime ez_ = context.Operators.Subtract(ex_, ey_);
+                        CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ez_, ex_, true, true);
+                        CqlBoolean fb_ = context.Operators.In<CqlDateTime>(eu_, fa_, (string)default);
+                        CqlBoolean fc_ = (CqlBoolean)(ex_ is not null);
+                        CqlBoolean fd_ = fb_
+                            /* CQL 'and' (264:15-264:83) */ && fc_;
+                        return er_
+                            /* CQL 'and' (263:6-264:83) */ && fd_;
                     }
 
-                    return cl_
-                        /* CQL 'and' (269:6-270:71) */ && cm_();
+                    IEnumerable<Encounter> di_ = context.Operators.Where<Encounter>(dg_, dh_);
+
+                    object dj_(Encounter @this) {
+                        Period fe_ = @this?.Period;
+                        CqlInterval<CqlDateTime> ff_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fe_);
+                        CqlDateTime fg_ = context.Operators.End(ff_);
+                        return fg_;
+                    }
+
+                    IEnumerable<Encounter> dk_ = context.Operators.SortBy<Encounter>(di_, dj_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter dl_ = context.Operators.Last<Encounter>(dk_);
+                    Period dm_ = dl_?.Period;
+                    CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dm_);
+                    CqlDateTime do_ = context.Operators.Start(dn_);
+                    Period dp_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> dq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dp_);
+                    CqlDateTime dr_ = context.Operators.Start(dq_);
+                    CqlQuantity ds_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime dt_ = context.Operators.Subtract(do_ ?? dr_, ds_);
+
+                    bool? du_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> fh_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? fi_ = fh_?.Value;
+                        Code<Encounter.EncounterStatus> fj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fi_);
+                        CqlBoolean fk_ = context.Operators.Equal(fj_, "finished");
+                        Period fl_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> fm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fl_);
+                        CqlDateTime fn_ = context.Operators.End(fm_);
+                        Period fo_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> fp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fo_);
+                        CqlDateTime fq_ = context.Operators.Start(fp_);
+                        CqlQuantity fr_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime fs_ = context.Operators.Subtract(fq_, fr_);
+                        CqlInterval<CqlDateTime> ft_ = context.Operators.Interval(fs_, fq_, true, true);
+                        CqlBoolean fu_ = context.Operators.In<CqlDateTime>(fn_, ft_, (string)default);
+                        CqlBoolean fv_ = (CqlBoolean)(fq_ is not null);
+                        CqlBoolean fw_ = fu_
+                            /* CQL 'and' (264:15-264:83) */ && fv_;
+                        return fk_
+                            /* CQL 'and' (263:6-264:83) */ && fw_;
+                    }
+
+                    IEnumerable<Encounter> dv_ = context.Operators.Where<Encounter>(dg_, du_);
+
+                    object dw_(Encounter @this) {
+                        Period fx_ = @this?.Period;
+                        CqlInterval<CqlDateTime> fy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fx_);
+                        CqlDateTime fz_ = context.Operators.End(fy_);
+                        return fz_;
+                    }
+
+                    IEnumerable<Encounter> dx_ = context.Operators.SortBy<Encounter>(dv_, dw_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter dy_ = context.Operators.Last<Encounter>(dx_);
+                    Period dz_ = dy_?.Period;
+                    CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dz_);
+                    CqlDateTime eb_ = context.Operators.Start(ea_);
+                    CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dt_, eb_ ?? dr_, true, true);
+                    CqlBoolean ed_ = context.Operators.In<CqlDateTime>(de_, ec_, (string)default);
+
+                    bool? ee_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> ga_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? gb_ = ga_?.Value;
+                        Code<Encounter.EncounterStatus> gc_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gb_);
+                        CqlBoolean gd_ = context.Operators.Equal(gc_, "finished");
+                        Period ge_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> gf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ge_);
+                        CqlDateTime gg_ = context.Operators.End(gf_);
+                        Period gh_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gh_);
+                        CqlDateTime gj_ = context.Operators.Start(gi_);
+                        CqlQuantity gk_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime gl_ = context.Operators.Subtract(gj_, gk_);
+                        CqlInterval<CqlDateTime> gm_ = context.Operators.Interval(gl_, gj_, true, true);
+                        CqlBoolean gn_ = context.Operators.In<CqlDateTime>(gg_, gm_, (string)default);
+                        CqlBoolean go_ = (CqlBoolean)(gj_ is not null);
+                        CqlBoolean gp_ = gn_
+                            /* CQL 'and' (264:15-264:83) */ && go_;
+                        return gd_
+                            /* CQL 'and' (263:6-264:83) */ && gp_;
+                    }
+
+                    IEnumerable<Encounter> ef_ = context.Operators.Where<Encounter>(dg_, ee_);
+
+                    object eg_(Encounter @this) {
+                        Period gq_ = @this?.Period;
+                        CqlInterval<CqlDateTime> gr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gq_);
+                        CqlDateTime gs_ = context.Operators.End(gr_);
+                        return gs_;
+                    }
+
+                    IEnumerable<Encounter> eh_ = context.Operators.SortBy<Encounter>(ef_, eg_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ei_ = context.Operators.Last<Encounter>(eh_);
+                    Period ej_ = ei_?.Period;
+                    CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ej_);
+                    CqlDateTime el_ = context.Operators.Start(ek_);
+                    CqlBoolean em_ = (CqlBoolean)((el_ ?? dr_) is not null);
+                    CqlBoolean en_ = ed_
+                        /* CQL 'and' (270:15-270:71) */ && em_;
+                    return db_
+                        /* CQL 'and' (269:6-270:71) */ && en_;
                 }
 
                 IEnumerable<Encounter> at_ = context.Operators.Where<Encounter>(ar_, as_);
 
                 object au_(Encounter @this) {
-                    Period gr_ = @this?.Period;
-                    CqlInterval<CqlDateTime> gs_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gr_);
-                    CqlDateTime gt_ = context.Operators.End(gs_);
-                    return gt_;
+                    Period gt_ = @this?.Period;
+                    CqlInterval<CqlDateTime> gu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gt_);
+                    CqlDateTime gv_ = context.Operators.End(gu_);
+                    return gv_;
                 }
 
                 IEnumerable<Encounter> av_ = context.Operators.SortBy<Encounter>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
@@ -2028,45 +1717,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 IEnumerable<Encounter> bb_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ba_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? bc_(Encounter LastObs) {
-                    Code<Encounter.EncounterStatus> gu_ = LastObs?.StatusElement;
-                    Encounter.EncounterStatus? gv_ = gu_?.Value;
-                    Code<Encounter.EncounterStatus> gw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gv_);
-                    CqlBoolean gx_ = context.Operators.Equal(gw_, "finished");
-
-                    CqlBoolean gy_() {
-                        Period gz_ = LastObs?.Period;
-                        CqlInterval<CqlDateTime> ha_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gz_);
-                        CqlDateTime hb_ = context.Operators.End(ha_);
-                        Period hc_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hc_);
-                        CqlDateTime he_ = context.Operators.Start(hd_);
-                        CqlQuantity hf_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime hg_ = context.Operators.Subtract(he_, hf_);
-                        CqlInterval<CqlDateTime> hh_ = context.Operators.Interval(hg_, he_, true, true);
-                        CqlBoolean hi_ = context.Operators.In<CqlDateTime>(hb_, hh_, (string)default);
-
-                        CqlBoolean hj_() {
-                            Period hk_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> hl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hk_);
-                            CqlDateTime hm_ = context.Operators.Start(hl_);
-                            return hm_ is not null;
-                        }
-
-                        return hi_
-                            /* CQL 'and' (264:15-264:83) */ && hj_();
-                    }
-
-                    return gx_
-                        /* CQL 'and' (263:6-264:83) */ && gy_();
+                    Code<Encounter.EncounterStatus> gw_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? gx_ = gw_?.Value;
+                    Code<Encounter.EncounterStatus> gy_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gx_);
+                    CqlBoolean gz_ = context.Operators.Equal(gy_, "finished");
+                    Period ha_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> hb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ha_);
+                    CqlDateTime hc_ = context.Operators.End(hb_);
+                    Period hd_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> he_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hd_);
+                    CqlDateTime hf_ = context.Operators.Start(he_);
+                    CqlQuantity hg_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime hh_ = context.Operators.Subtract(hf_, hg_);
+                    CqlInterval<CqlDateTime> hi_ = context.Operators.Interval(hh_, hf_, true, true);
+                    CqlBoolean hj_ = context.Operators.In<CqlDateTime>(hc_, hi_, (string)default);
+                    CqlBoolean hk_ = (CqlBoolean)(hf_ is not null);
+                    CqlBoolean hl_ = hj_
+                        /* CQL 'and' (264:15-264:83) */ && hk_;
+                    return gz_
+                        /* CQL 'and' (263:6-264:83) */ && hl_;
                 }
 
                 IEnumerable<Encounter> bd_ = context.Operators.Where<Encounter>(bb_, bc_);
 
                 object be_(Encounter @this) {
-                    Period hn_ = @this?.Period;
-                    CqlInterval<CqlDateTime> ho_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hn_);
-                    CqlDateTime hp_ = context.Operators.End(ho_);
-                    return hp_;
+                    Period hm_ = @this?.Period;
+                    CqlInterval<CqlDateTime> hn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hm_);
+                    CqlDateTime ho_ = context.Operators.End(hn_);
+                    return ho_;
                 }
 
                 IEnumerable<Encounter> bf_ = context.Operators.SortBy<Encounter>(bd_, be_, System.ComponentModel.ListSortDirection.Ascending);
@@ -2081,193 +1759,147 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlDateTime bo_ = context.Operators.Subtract(az_ ?? bj_ ?? bm_, bn_);
 
                 bool? bp_(Encounter LastED) {
-                    Code<Encounter.EncounterStatus> hq_ = LastED?.StatusElement;
-                    Encounter.EncounterStatus? hr_ = hq_?.Value;
-                    Code<Encounter.EncounterStatus> hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
-                    CqlBoolean ht_ = context.Operators.Equal(hs_, "finished");
+                    Code<Encounter.EncounterStatus> hp_ = LastED?.StatusElement;
+                    Encounter.EncounterStatus? hq_ = hp_?.Value;
+                    Code<Encounter.EncounterStatus> hr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hq_);
+                    CqlBoolean hs_ = context.Operators.Equal(hr_, "finished");
+                    Period ht_ = LastED?.Period;
+                    CqlInterval<CqlDateTime> hu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ht_);
+                    CqlDateTime hv_ = context.Operators.End(hu_);
+                    CqlValueSet hw_ = this.Observation_Services(context);
+                    IEnumerable<Encounter> hx_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, hw_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                    CqlBoolean hu_() {
-                        Period hv_ = LastED?.Period;
-                        CqlInterval<CqlDateTime> hw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hv_);
-                        CqlDateTime hx_ = context.Operators.End(hw_);
-                        CqlValueSet hy_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> hz_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, hy_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? ia_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> iy_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? iz_ = iy_?.Value;
-                            Code<Encounter.EncounterStatus> ja_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iz_);
-                            CqlBoolean jb_ = context.Operators.Equal(ja_, "finished");
-
-                            CqlBoolean jc_() {
-                                Period jd_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> je_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jd_);
-                                CqlDateTime jf_ = context.Operators.End(je_);
-                                Period jg_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> jh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jg_);
-                                CqlDateTime ji_ = context.Operators.Start(jh_);
-                                CqlQuantity jj_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime jk_ = context.Operators.Subtract(ji_, jj_);
-                                CqlInterval<CqlDateTime> jl_ = context.Operators.Interval(jk_, ji_, true, true);
-                                CqlBoolean jm_ = context.Operators.In<CqlDateTime>(jf_, jl_, (string)default);
-
-                                CqlBoolean jn_() {
-                                    Period jo_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> jp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jo_);
-                                    CqlDateTime jq_ = context.Operators.Start(jp_);
-                                    return jq_ is not null;
-                                }
-
-                                return jm_
-                                    /* CQL 'and' (264:15-264:83) */ && jn_();
-                            }
-
-                            return jb_
-                                /* CQL 'and' (263:6-264:83) */ && jc_();
-                        }
-
-                        IEnumerable<Encounter> ib_ = context.Operators.Where<Encounter>(hz_, ia_);
-
-                        object ic_(Encounter @this) {
-                            Period jr_ = @this?.Period;
-                            CqlInterval<CqlDateTime> js_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jr_);
-                            CqlDateTime jt_ = context.Operators.End(js_);
-                            return jt_;
-                        }
-
-                        IEnumerable<Encounter> id_ = context.Operators.SortBy<Encounter>(ib_, ic_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter ie_ = context.Operators.Last<Encounter>(id_);
-                        Period if_ = ie_?.Period;
-                        CqlInterval<CqlDateTime> ig_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, if_);
-                        CqlDateTime ih_ = context.Operators.Start(ig_);
-                        Period ii_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> ij_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ii_);
-                        CqlDateTime ik_ = context.Operators.Start(ij_);
-                        CqlQuantity il_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime im_ = context.Operators.Subtract(ih_ ?? ik_, il_);
-
-                        bool? in_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> ju_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? jv_ = ju_?.Value;
-                            Code<Encounter.EncounterStatus> jw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(jv_);
-                            CqlBoolean jx_ = context.Operators.Equal(jw_, "finished");
-
-                            CqlBoolean jy_() {
-                                Period jz_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> ka_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jz_);
-                                CqlDateTime kb_ = context.Operators.End(ka_);
-                                Period kc_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> kd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kc_);
-                                CqlDateTime ke_ = context.Operators.Start(kd_);
-                                CqlQuantity kf_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime kg_ = context.Operators.Subtract(ke_, kf_);
-                                CqlInterval<CqlDateTime> kh_ = context.Operators.Interval(kg_, ke_, true, true);
-                                CqlBoolean ki_ = context.Operators.In<CqlDateTime>(kb_, kh_, (string)default);
-
-                                CqlBoolean kj_() {
-                                    Period kk_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> kl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kk_);
-                                    CqlDateTime km_ = context.Operators.Start(kl_);
-                                    return km_ is not null;
-                                }
-
-                                return ki_
-                                    /* CQL 'and' (264:15-264:83) */ && kj_();
-                            }
-
-                            return jx_
-                                /* CQL 'and' (263:6-264:83) */ && jy_();
-                        }
-
-                        IEnumerable<Encounter> io_ = context.Operators.Where<Encounter>(hz_, in_);
-
-                        object ip_(Encounter @this) {
-                            Period kn_ = @this?.Period;
-                            CqlInterval<CqlDateTime> ko_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kn_);
-                            CqlDateTime kp_ = context.Operators.End(ko_);
-                            return kp_;
-                        }
-
-                        IEnumerable<Encounter> iq_ = context.Operators.SortBy<Encounter>(io_, ip_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter ir_ = context.Operators.Last<Encounter>(iq_);
-                        Period is_ = ir_?.Period;
-                        CqlInterval<CqlDateTime> it_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, is_);
-                        CqlDateTime iu_ = context.Operators.Start(it_);
-                        CqlInterval<CqlDateTime> iv_ = context.Operators.Interval(im_, iu_ ?? ik_, true, true);
-                        CqlBoolean iw_ = context.Operators.In<CqlDateTime>(hx_, iv_, (string)default);
-
-                        CqlBoolean ix_() {
-                            CqlValueSet kq_ = this.Observation_Services(context);
-                            IEnumerable<Encounter> kr_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, kq_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                            bool? ks_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> ld_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? le_ = ld_?.Value;
-                                Code<Encounter.EncounterStatus> lf_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(le_);
-                                CqlBoolean lg_ = context.Operators.Equal(lf_, "finished");
-
-                                CqlBoolean lh_() {
-                                    Period li_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> lj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, li_);
-                                    CqlDateTime lk_ = context.Operators.End(lj_);
-                                    Period ll_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> lm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ll_);
-                                    CqlDateTime ln_ = context.Operators.Start(lm_);
-                                    CqlQuantity lo_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime lp_ = context.Operators.Subtract(ln_, lo_);
-                                    CqlInterval<CqlDateTime> lq_ = context.Operators.Interval(lp_, ln_, true, true);
-                                    CqlBoolean lr_ = context.Operators.In<CqlDateTime>(lk_, lq_, (string)default);
-
-                                    CqlBoolean ls_() {
-                                        Period lt_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> lu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lt_);
-                                        CqlDateTime lv_ = context.Operators.Start(lu_);
-                                        return lv_ is not null;
-                                    }
-
-                                    return lr_
-                                        /* CQL 'and' (264:15-264:83) */ && ls_();
-                                }
-
-                                return lg_
-                                    /* CQL 'and' (263:6-264:83) */ && lh_();
-                            }
-
-                            IEnumerable<Encounter> kt_ = context.Operators.Where<Encounter>(kr_, ks_);
-
-                            object ku_(Encounter @this) {
-                                Period lw_ = @this?.Period;
-                                CqlInterval<CqlDateTime> lx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lw_);
-                                CqlDateTime ly_ = context.Operators.End(lx_);
-                                return ly_;
-                            }
-
-                            IEnumerable<Encounter> kv_ = context.Operators.SortBy<Encounter>(kt_, ku_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter kw_ = context.Operators.Last<Encounter>(kv_);
-                            Period kx_ = kw_?.Period;
-                            CqlInterval<CqlDateTime> ky_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kx_);
-                            CqlDateTime kz_ = context.Operators.Start(ky_);
-                            Period la_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> lb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, la_);
-                            CqlDateTime lc_ = context.Operators.Start(lb_);
-                            return (kz_ ?? lc_) is not null;
-                        }
-
-                        return iw_
-                            /* CQL 'and' (270:15-270:71) */ && ix_();
+                    bool? hy_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> jf_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? jg_ = jf_?.Value;
+                        Code<Encounter.EncounterStatus> jh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(jg_);
+                        CqlBoolean ji_ = context.Operators.Equal(jh_, "finished");
+                        Period jj_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> jk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jj_);
+                        CqlDateTime jl_ = context.Operators.End(jk_);
+                        Period jm_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> jn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jm_);
+                        CqlDateTime jo_ = context.Operators.Start(jn_);
+                        CqlQuantity jp_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime jq_ = context.Operators.Subtract(jo_, jp_);
+                        CqlInterval<CqlDateTime> jr_ = context.Operators.Interval(jq_, jo_, true, true);
+                        CqlBoolean js_ = context.Operators.In<CqlDateTime>(jl_, jr_, (string)default);
+                        CqlBoolean jt_ = (CqlBoolean)(jo_ is not null);
+                        CqlBoolean ju_ = js_
+                            /* CQL 'and' (264:15-264:83) */ && jt_;
+                        return ji_
+                            /* CQL 'and' (263:6-264:83) */ && ju_;
                     }
 
-                    return ht_
-                        /* CQL 'and' (269:6-270:71) */ && hu_();
+                    IEnumerable<Encounter> hz_ = context.Operators.Where<Encounter>(hx_, hy_);
+
+                    object ia_(Encounter @this) {
+                        Period jv_ = @this?.Period;
+                        CqlInterval<CqlDateTime> jw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jv_);
+                        CqlDateTime jx_ = context.Operators.End(jw_);
+                        return jx_;
+                    }
+
+                    IEnumerable<Encounter> ib_ = context.Operators.SortBy<Encounter>(hz_, ia_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ic_ = context.Operators.Last<Encounter>(ib_);
+                    Period id_ = ic_?.Period;
+                    CqlInterval<CqlDateTime> ie_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, id_);
+                    CqlDateTime if_ = context.Operators.Start(ie_);
+                    Period ig_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> ih_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ig_);
+                    CqlDateTime ii_ = context.Operators.Start(ih_);
+                    CqlQuantity ij_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ik_ = context.Operators.Subtract(if_ ?? ii_, ij_);
+
+                    bool? il_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> jy_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? jz_ = jy_?.Value;
+                        Code<Encounter.EncounterStatus> ka_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(jz_);
+                        CqlBoolean kb_ = context.Operators.Equal(ka_, "finished");
+                        Period kc_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> kd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kc_);
+                        CqlDateTime ke_ = context.Operators.End(kd_);
+                        Period kf_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> kg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kf_);
+                        CqlDateTime kh_ = context.Operators.Start(kg_);
+                        CqlQuantity ki_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime kj_ = context.Operators.Subtract(kh_, ki_);
+                        CqlInterval<CqlDateTime> kk_ = context.Operators.Interval(kj_, kh_, true, true);
+                        CqlBoolean kl_ = context.Operators.In<CqlDateTime>(ke_, kk_, (string)default);
+                        CqlBoolean km_ = (CqlBoolean)(kh_ is not null);
+                        CqlBoolean kn_ = kl_
+                            /* CQL 'and' (264:15-264:83) */ && km_;
+                        return kb_
+                            /* CQL 'and' (263:6-264:83) */ && kn_;
+                    }
+
+                    IEnumerable<Encounter> im_ = context.Operators.Where<Encounter>(hx_, il_);
+
+                    object in_(Encounter @this) {
+                        Period ko_ = @this?.Period;
+                        CqlInterval<CqlDateTime> kp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ko_);
+                        CqlDateTime kq_ = context.Operators.End(kp_);
+                        return kq_;
+                    }
+
+                    IEnumerable<Encounter> io_ = context.Operators.SortBy<Encounter>(im_, in_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ip_ = context.Operators.Last<Encounter>(io_);
+                    Period iq_ = ip_?.Period;
+                    CqlInterval<CqlDateTime> ir_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, iq_);
+                    CqlDateTime is_ = context.Operators.Start(ir_);
+                    CqlInterval<CqlDateTime> it_ = context.Operators.Interval(ik_, is_ ?? ii_, true, true);
+                    CqlBoolean iu_ = context.Operators.In<CqlDateTime>(hv_, it_, (string)default);
+
+                    bool? iv_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> kr_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? ks_ = kr_?.Value;
+                        Code<Encounter.EncounterStatus> kt_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ks_);
+                        CqlBoolean ku_ = context.Operators.Equal(kt_, "finished");
+                        Period kv_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> kw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kv_);
+                        CqlDateTime kx_ = context.Operators.End(kw_);
+                        Period ky_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> kz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ky_);
+                        CqlDateTime la_ = context.Operators.Start(kz_);
+                        CqlQuantity lb_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime lc_ = context.Operators.Subtract(la_, lb_);
+                        CqlInterval<CqlDateTime> ld_ = context.Operators.Interval(lc_, la_, true, true);
+                        CqlBoolean le_ = context.Operators.In<CqlDateTime>(kx_, ld_, (string)default);
+                        CqlBoolean lf_ = (CqlBoolean)(la_ is not null);
+                        CqlBoolean lg_ = le_
+                            /* CQL 'and' (264:15-264:83) */ && lf_;
+                        return ku_
+                            /* CQL 'and' (263:6-264:83) */ && lg_;
+                    }
+
+                    IEnumerable<Encounter> iw_ = context.Operators.Where<Encounter>(hx_, iv_);
+
+                    object ix_(Encounter @this) {
+                        Period lh_ = @this?.Period;
+                        CqlInterval<CqlDateTime> li_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lh_);
+                        CqlDateTime lj_ = context.Operators.End(li_);
+                        return lj_;
+                    }
+
+                    IEnumerable<Encounter> iy_ = context.Operators.SortBy<Encounter>(iw_, ix_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter iz_ = context.Operators.Last<Encounter>(iy_);
+                    Period ja_ = iz_?.Period;
+                    CqlInterval<CqlDateTime> jb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ja_);
+                    CqlDateTime jc_ = context.Operators.Start(jb_);
+                    CqlBoolean jd_ = (CqlBoolean)((jc_ ?? ii_) is not null);
+                    CqlBoolean je_ = iu_
+                        /* CQL 'and' (270:15-270:71) */ && jd_;
+                    return hs_
+                        /* CQL 'and' (269:6-270:71) */ && je_;
                 }
 
                 IEnumerable<Encounter> bq_ = context.Operators.Where<Encounter>(ar_, bp_);
 
                 object br_(Encounter @this) {
-                    Period lz_ = @this?.Period;
-                    CqlInterval<CqlDateTime> ma_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lz_);
-                    CqlDateTime mb_ = context.Operators.End(ma_);
-                    return mb_;
+                    Period lk_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ll_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lk_);
+                    CqlDateTime lm_ = context.Operators.End(ll_);
+                    return lm_;
                 }
 
                 IEnumerable<Encounter> bs_ = context.Operators.SortBy<Encounter>(bq_, br_, System.ComponentModel.ListSortDirection.Ascending);
@@ -2277,45 +1909,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlDateTime bw_ = context.Operators.Start(bv_);
 
                 bool? bx_(Encounter LastObs) {
-                    Code<Encounter.EncounterStatus> mc_ = LastObs?.StatusElement;
-                    Encounter.EncounterStatus? md_ = mc_?.Value;
-                    Code<Encounter.EncounterStatus> me_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(md_);
-                    CqlBoolean mf_ = context.Operators.Equal(me_, "finished");
-
-                    CqlBoolean mg_() {
-                        Period mh_ = LastObs?.Period;
-                        CqlInterval<CqlDateTime> mi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mh_);
-                        CqlDateTime mj_ = context.Operators.End(mi_);
-                        Period mk_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> ml_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mk_);
-                        CqlDateTime mm_ = context.Operators.Start(ml_);
-                        CqlQuantity mn_ = context.Operators.Quantity(1m, "hour");
-                        CqlDateTime mo_ = context.Operators.Subtract(mm_, mn_);
-                        CqlInterval<CqlDateTime> mp_ = context.Operators.Interval(mo_, mm_, true, true);
-                        CqlBoolean mq_ = context.Operators.In<CqlDateTime>(mj_, mp_, (string)default);
-
-                        CqlBoolean mr_() {
-                            Period ms_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> mt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ms_);
-                            CqlDateTime mu_ = context.Operators.Start(mt_);
-                            return mu_ is not null;
-                        }
-
-                        return mq_
-                            /* CQL 'and' (264:15-264:83) */ && mr_();
-                    }
-
-                    return mf_
-                        /* CQL 'and' (263:6-264:83) */ && mg_();
+                    Code<Encounter.EncounterStatus> ln_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? lo_ = ln_?.Value;
+                    Code<Encounter.EncounterStatus> lp_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lo_);
+                    CqlBoolean lq_ = context.Operators.Equal(lp_, "finished");
+                    Period lr_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> ls_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lr_);
+                    CqlDateTime lt_ = context.Operators.End(ls_);
+                    Period lu_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> lv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, lu_);
+                    CqlDateTime lw_ = context.Operators.Start(lv_);
+                    CqlQuantity lx_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ly_ = context.Operators.Subtract(lw_, lx_);
+                    CqlInterval<CqlDateTime> lz_ = context.Operators.Interval(ly_, lw_, true, true);
+                    CqlBoolean ma_ = context.Operators.In<CqlDateTime>(lt_, lz_, (string)default);
+                    CqlBoolean mb_ = (CqlBoolean)(lw_ is not null);
+                    CqlBoolean mc_ = ma_
+                        /* CQL 'and' (264:15-264:83) */ && mb_;
+                    return lq_
+                        /* CQL 'and' (263:6-264:83) */ && mc_;
                 }
 
                 IEnumerable<Encounter> by_ = context.Operators.Where<Encounter>(bb_, bx_);
 
                 object bz_(Encounter @this) {
-                    Period mv_ = @this?.Period;
-                    CqlInterval<CqlDateTime> mw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mv_);
-                    CqlDateTime mx_ = context.Operators.End(mw_);
-                    return mx_;
+                    Period md_ = @this?.Period;
+                    CqlInterval<CqlDateTime> me_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, md_);
+                    CqlDateTime mf_ = context.Operators.End(me_);
+                    return mf_;
                 }
 
                 IEnumerable<Encounter> ca_ = context.Operators.SortBy<Encounter>(by_, bz_, System.ComponentModel.ListSortDirection.Ascending);
@@ -2326,272 +1947,204 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> cf_ = context.Operators.Interval(bo_, bw_ ?? ce_ ?? bm_, true, true);
                 CqlBoolean cg_ = context.Operators.In<CqlDateTime>(ap_, cf_, (string)default);
 
-                CqlBoolean ch_() {
-                    CqlValueSet my_ = this.Emergency_Department_Visit(context);
-                    IEnumerable<Encounter> mz_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, my_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+                bool? ch_(Encounter LastED) {
+                    Code<Encounter.EncounterStatus> mg_ = LastED?.StatusElement;
+                    Encounter.EncounterStatus? mh_ = mg_?.Value;
+                    Code<Encounter.EncounterStatus> mi_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mh_);
+                    CqlBoolean mj_ = context.Operators.Equal(mi_, "finished");
+                    Period mk_ = LastED?.Period;
+                    CqlInterval<CqlDateTime> ml_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mk_);
+                    CqlDateTime mm_ = context.Operators.End(ml_);
+                    CqlValueSet mn_ = this.Observation_Services(context);
+                    IEnumerable<Encounter> mo_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, mn_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                    bool? na_(Encounter LastED) {
-                        Code<Encounter.EncounterStatus> nv_ = LastED?.StatusElement;
-                        Encounter.EncounterStatus? nw_ = nv_?.Value;
-                        Code<Encounter.EncounterStatus> nx_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nw_);
-                        CqlBoolean ny_ = context.Operators.Equal(nx_, "finished");
-
-                        CqlBoolean nz_() {
-                            Period oa_ = LastED?.Period;
-                            CqlInterval<CqlDateTime> ob_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oa_);
-                            CqlDateTime oc_ = context.Operators.End(ob_);
-                            CqlValueSet od_ = this.Observation_Services(context);
-                            IEnumerable<Encounter> oe_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, od_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                            bool? of_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> pd_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? pe_ = pd_?.Value;
-                                Code<Encounter.EncounterStatus> pf_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(pe_);
-                                CqlBoolean pg_ = context.Operators.Equal(pf_, "finished");
-
-                                CqlBoolean ph_() {
-                                    Period pi_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> pj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pi_);
-                                    CqlDateTime pk_ = context.Operators.End(pj_);
-                                    Period pl_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> pm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pl_);
-                                    CqlDateTime pn_ = context.Operators.Start(pm_);
-                                    CqlQuantity po_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime pp_ = context.Operators.Subtract(pn_, po_);
-                                    CqlInterval<CqlDateTime> pq_ = context.Operators.Interval(pp_, pn_, true, true);
-                                    CqlBoolean pr_ = context.Operators.In<CqlDateTime>(pk_, pq_, (string)default);
-
-                                    CqlBoolean ps_() {
-                                        Period pt_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> pu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pt_);
-                                        CqlDateTime pv_ = context.Operators.Start(pu_);
-                                        return pv_ is not null;
-                                    }
-
-                                    return pr_
-                                        /* CQL 'and' (264:15-264:83) */ && ps_();
-                                }
-
-                                return pg_
-                                    /* CQL 'and' (263:6-264:83) */ && ph_();
-                            }
-
-                            IEnumerable<Encounter> og_ = context.Operators.Where<Encounter>(oe_, of_);
-
-                            object oh_(Encounter @this) {
-                                Period pw_ = @this?.Period;
-                                CqlInterval<CqlDateTime> px_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pw_);
-                                CqlDateTime py_ = context.Operators.End(px_);
-                                return py_;
-                            }
-
-                            IEnumerable<Encounter> oi_ = context.Operators.SortBy<Encounter>(og_, oh_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter oj_ = context.Operators.Last<Encounter>(oi_);
-                            Period ok_ = oj_?.Period;
-                            CqlInterval<CqlDateTime> ol_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ok_);
-                            CqlDateTime om_ = context.Operators.Start(ol_);
-                            Period on_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> oo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, on_);
-                            CqlDateTime op_ = context.Operators.Start(oo_);
-                            CqlQuantity oq_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime or_ = context.Operators.Subtract(om_ ?? op_, oq_);
-
-                            bool? os_(Encounter LastObs) {
-                                Code<Encounter.EncounterStatus> pz_ = LastObs?.StatusElement;
-                                Encounter.EncounterStatus? qa_ = pz_?.Value;
-                                Code<Encounter.EncounterStatus> qb_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(qa_);
-                                CqlBoolean qc_ = context.Operators.Equal(qb_, "finished");
-
-                                CqlBoolean qd_() {
-                                    Period qe_ = LastObs?.Period;
-                                    CqlInterval<CqlDateTime> qf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qe_);
-                                    CqlDateTime qg_ = context.Operators.End(qf_);
-                                    Period qh_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> qi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qh_);
-                                    CqlDateTime qj_ = context.Operators.Start(qi_);
-                                    CqlQuantity qk_ = context.Operators.Quantity(1m, "hour");
-                                    CqlDateTime ql_ = context.Operators.Subtract(qj_, qk_);
-                                    CqlInterval<CqlDateTime> qm_ = context.Operators.Interval(ql_, qj_, true, true);
-                                    CqlBoolean qn_ = context.Operators.In<CqlDateTime>(qg_, qm_, (string)default);
-
-                                    CqlBoolean qo_() {
-                                        Period qp_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> qq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qp_);
-                                        CqlDateTime qr_ = context.Operators.Start(qq_);
-                                        return qr_ is not null;
-                                    }
-
-                                    return qn_
-                                        /* CQL 'and' (264:15-264:83) */ && qo_();
-                                }
-
-                                return qc_
-                                    /* CQL 'and' (263:6-264:83) */ && qd_();
-                            }
-
-                            IEnumerable<Encounter> ot_ = context.Operators.Where<Encounter>(oe_, os_);
-
-                            object ou_(Encounter @this) {
-                                Period qs_ = @this?.Period;
-                                CqlInterval<CqlDateTime> qt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qs_);
-                                CqlDateTime qu_ = context.Operators.End(qt_);
-                                return qu_;
-                            }
-
-                            IEnumerable<Encounter> ov_ = context.Operators.SortBy<Encounter>(ot_, ou_, System.ComponentModel.ListSortDirection.Ascending);
-                            Encounter ow_ = context.Operators.Last<Encounter>(ov_);
-                            Period ox_ = ow_?.Period;
-                            CqlInterval<CqlDateTime> oy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ox_);
-                            CqlDateTime oz_ = context.Operators.Start(oy_);
-                            CqlInterval<CqlDateTime> pa_ = context.Operators.Interval(or_, oz_ ?? op_, true, true);
-                            CqlBoolean pb_ = context.Operators.In<CqlDateTime>(oc_, pa_, (string)default);
-
-                            CqlBoolean pc_() {
-                                CqlValueSet qv_ = this.Observation_Services(context);
-                                IEnumerable<Encounter> qw_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, qv_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                                bool? qx_(Encounter LastObs) {
-                                    Code<Encounter.EncounterStatus> ri_ = LastObs?.StatusElement;
-                                    Encounter.EncounterStatus? rj_ = ri_?.Value;
-                                    Code<Encounter.EncounterStatus> rk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rj_);
-                                    CqlBoolean rl_ = context.Operators.Equal(rk_, "finished");
-
-                                    CqlBoolean rm_() {
-                                        Period rn_ = LastObs?.Period;
-                                        CqlInterval<CqlDateTime> ro_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rn_);
-                                        CqlDateTime rp_ = context.Operators.End(ro_);
-                                        Period rq_ = Visit?.Period;
-                                        CqlInterval<CqlDateTime> rr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rq_);
-                                        CqlDateTime rs_ = context.Operators.Start(rr_);
-                                        CqlQuantity rt_ = context.Operators.Quantity(1m, "hour");
-                                        CqlDateTime ru_ = context.Operators.Subtract(rs_, rt_);
-                                        CqlInterval<CqlDateTime> rv_ = context.Operators.Interval(ru_, rs_, true, true);
-                                        CqlBoolean rw_ = context.Operators.In<CqlDateTime>(rp_, rv_, (string)default);
-
-                                        CqlBoolean rx_() {
-                                            Period ry_ = Visit?.Period;
-                                            CqlInterval<CqlDateTime> rz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ry_);
-                                            CqlDateTime sa_ = context.Operators.Start(rz_);
-                                            return sa_ is not null;
-                                        }
-
-                                        return rw_
-                                            /* CQL 'and' (264:15-264:83) */ && rx_();
-                                    }
-
-                                    return rl_
-                                        /* CQL 'and' (263:6-264:83) */ && rm_();
-                                }
-
-                                IEnumerable<Encounter> qy_ = context.Operators.Where<Encounter>(qw_, qx_);
-
-                                object qz_(Encounter @this) {
-                                    Period sb_ = @this?.Period;
-                                    CqlInterval<CqlDateTime> sc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sb_);
-                                    CqlDateTime sd_ = context.Operators.End(sc_);
-                                    return sd_;
-                                }
-
-                                IEnumerable<Encounter> ra_ = context.Operators.SortBy<Encounter>(qy_, qz_, System.ComponentModel.ListSortDirection.Ascending);
-                                Encounter rb_ = context.Operators.Last<Encounter>(ra_);
-                                Period rc_ = rb_?.Period;
-                                CqlInterval<CqlDateTime> rd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rc_);
-                                CqlDateTime re_ = context.Operators.Start(rd_);
-                                Period rf_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> rg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rf_);
-                                CqlDateTime rh_ = context.Operators.Start(rg_);
-                                return (re_ ?? rh_) is not null;
-                            }
-
-                            return pb_
-                                /* CQL 'and' (270:15-270:71) */ && pc_();
-                        }
-
-                        return ny_
-                            /* CQL 'and' (269:6-270:71) */ && nz_();
+                    bool? mp_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> nw_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? nx_ = nw_?.Value;
+                        Code<Encounter.EncounterStatus> ny_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nx_);
+                        CqlBoolean nz_ = context.Operators.Equal(ny_, "finished");
+                        Period oa_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> ob_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oa_);
+                        CqlDateTime oc_ = context.Operators.End(ob_);
+                        Period od_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> oe_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, od_);
+                        CqlDateTime of_ = context.Operators.Start(oe_);
+                        CqlQuantity og_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime oh_ = context.Operators.Subtract(of_, og_);
+                        CqlInterval<CqlDateTime> oi_ = context.Operators.Interval(oh_, of_, true, true);
+                        CqlBoolean oj_ = context.Operators.In<CqlDateTime>(oc_, oi_, (string)default);
+                        CqlBoolean ok_ = (CqlBoolean)(of_ is not null);
+                        CqlBoolean ol_ = oj_
+                            /* CQL 'and' (264:15-264:83) */ && ok_;
+                        return nz_
+                            /* CQL 'and' (263:6-264:83) */ && ol_;
                     }
 
-                    IEnumerable<Encounter> nb_ = context.Operators.Where<Encounter>(mz_, na_);
+                    IEnumerable<Encounter> mq_ = context.Operators.Where<Encounter>(mo_, mp_);
 
-                    object nc_(Encounter @this) {
-                        Period se_ = @this?.Period;
-                        CqlInterval<CqlDateTime> sf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, se_);
-                        CqlDateTime sg_ = context.Operators.End(sf_);
-                        return sg_;
+                    object mr_(Encounter @this) {
+                        Period om_ = @this?.Period;
+                        CqlInterval<CqlDateTime> on_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, om_);
+                        CqlDateTime oo_ = context.Operators.End(on_);
+                        return oo_;
                     }
 
-                    IEnumerable<Encounter> nd_ = context.Operators.SortBy<Encounter>(nb_, nc_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter ne_ = context.Operators.Last<Encounter>(nd_);
-                    Period nf_ = ne_?.Period;
-                    CqlInterval<CqlDateTime> ng_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nf_);
-                    CqlDateTime nh_ = context.Operators.Start(ng_);
-                    CqlValueSet ni_ = this.Observation_Services(context);
-                    IEnumerable<Encounter> nj_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ni_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+                    IEnumerable<Encounter> ms_ = context.Operators.SortBy<Encounter>(mq_, mr_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter mt_ = context.Operators.Last<Encounter>(ms_);
+                    Period mu_ = mt_?.Period;
+                    CqlInterval<CqlDateTime> mv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mu_);
+                    CqlDateTime mw_ = context.Operators.Start(mv_);
+                    Period mx_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> my_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mx_);
+                    CqlDateTime mz_ = context.Operators.Start(my_);
+                    CqlQuantity na_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime nb_ = context.Operators.Subtract(mw_ ?? mz_, na_);
 
-                    bool? nk_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> sh_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? si_ = sh_?.Value;
-                        Code<Encounter.EncounterStatus> sj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(si_);
-                        CqlBoolean sk_ = context.Operators.Equal(sj_, "finished");
-
-                        CqlBoolean sl_() {
-                            Period sm_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> sn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sm_);
-                            CqlDateTime so_ = context.Operators.End(sn_);
-                            Period sp_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sp_);
-                            CqlDateTime sr_ = context.Operators.Start(sq_);
-                            CqlQuantity ss_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime st_ = context.Operators.Subtract(sr_, ss_);
-                            CqlInterval<CqlDateTime> su_ = context.Operators.Interval(st_, sr_, true, true);
-                            CqlBoolean sv_ = context.Operators.In<CqlDateTime>(so_, su_, (string)default);
-
-                            CqlBoolean sw_() {
-                                Period sx_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> sy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sx_);
-                                CqlDateTime sz_ = context.Operators.Start(sy_);
-                                return sz_ is not null;
-                            }
-
-                            return sv_
-                                /* CQL 'and' (264:15-264:83) */ && sw_();
-                        }
-
-                        return sk_
-                            /* CQL 'and' (263:6-264:83) */ && sl_();
+                    bool? nc_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> op_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? oq_ = op_?.Value;
+                        Code<Encounter.EncounterStatus> or_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oq_);
+                        CqlBoolean os_ = context.Operators.Equal(or_, "finished");
+                        Period ot_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> ou_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ot_);
+                        CqlDateTime ov_ = context.Operators.End(ou_);
+                        Period ow_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> ox_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ow_);
+                        CqlDateTime oy_ = context.Operators.Start(ox_);
+                        CqlQuantity oz_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime pa_ = context.Operators.Subtract(oy_, oz_);
+                        CqlInterval<CqlDateTime> pb_ = context.Operators.Interval(pa_, oy_, true, true);
+                        CqlBoolean pc_ = context.Operators.In<CqlDateTime>(ov_, pb_, (string)default);
+                        CqlBoolean pd_ = (CqlBoolean)(oy_ is not null);
+                        CqlBoolean pe_ = pc_
+                            /* CQL 'and' (264:15-264:83) */ && pd_;
+                        return os_
+                            /* CQL 'and' (263:6-264:83) */ && pe_;
                     }
 
-                    IEnumerable<Encounter> nl_ = context.Operators.Where<Encounter>(nj_, nk_);
+                    IEnumerable<Encounter> nd_ = context.Operators.Where<Encounter>(mo_, nc_);
 
-                    object nm_(Encounter @this) {
-                        Period ta_ = @this?.Period;
-                        CqlInterval<CqlDateTime> tb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ta_);
-                        CqlDateTime tc_ = context.Operators.End(tb_);
-                        return tc_;
+                    object ne_(Encounter @this) {
+                        Period pf_ = @this?.Period;
+                        CqlInterval<CqlDateTime> pg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pf_);
+                        CqlDateTime ph_ = context.Operators.End(pg_);
+                        return ph_;
                     }
 
-                    IEnumerable<Encounter> nn_ = context.Operators.SortBy<Encounter>(nl_, nm_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter no_ = context.Operators.Last<Encounter>(nn_);
-                    Period np_ = no_?.Period;
-                    CqlInterval<CqlDateTime> nq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, np_);
-                    CqlDateTime nr_ = context.Operators.Start(nq_);
-                    Period ns_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> nt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ns_);
-                    CqlDateTime nu_ = context.Operators.Start(nt_);
-                    return (nh_ ?? nr_ ?? nu_) is not null;
+                    IEnumerable<Encounter> nf_ = context.Operators.SortBy<Encounter>(nd_, ne_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter ng_ = context.Operators.Last<Encounter>(nf_);
+                    Period nh_ = ng_?.Period;
+                    CqlInterval<CqlDateTime> ni_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nh_);
+                    CqlDateTime nj_ = context.Operators.Start(ni_);
+                    CqlInterval<CqlDateTime> nk_ = context.Operators.Interval(nb_, nj_ ?? mz_, true, true);
+                    CqlBoolean nl_ = context.Operators.In<CqlDateTime>(mm_, nk_, (string)default);
+
+                    bool? nm_(Encounter LastObs) {
+                        Code<Encounter.EncounterStatus> pi_ = LastObs?.StatusElement;
+                        Encounter.EncounterStatus? pj_ = pi_?.Value;
+                        Code<Encounter.EncounterStatus> pk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(pj_);
+                        CqlBoolean pl_ = context.Operators.Equal(pk_, "finished");
+                        Period pm_ = LastObs?.Period;
+                        CqlInterval<CqlDateTime> pn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pm_);
+                        CqlDateTime po_ = context.Operators.End(pn_);
+                        Period pp_ = Visit?.Period;
+                        CqlInterval<CqlDateTime> pq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pp_);
+                        CqlDateTime pr_ = context.Operators.Start(pq_);
+                        CqlQuantity ps_ = context.Operators.Quantity(1m, "hour");
+                        CqlDateTime pt_ = context.Operators.Subtract(pr_, ps_);
+                        CqlInterval<CqlDateTime> pu_ = context.Operators.Interval(pt_, pr_, true, true);
+                        CqlBoolean pv_ = context.Operators.In<CqlDateTime>(po_, pu_, (string)default);
+                        CqlBoolean pw_ = (CqlBoolean)(pr_ is not null);
+                        CqlBoolean px_ = pv_
+                            /* CQL 'and' (264:15-264:83) */ && pw_;
+                        return pl_
+                            /* CQL 'and' (263:6-264:83) */ && px_;
+                    }
+
+                    IEnumerable<Encounter> nn_ = context.Operators.Where<Encounter>(mo_, nm_);
+
+                    object no_(Encounter @this) {
+                        Period py_ = @this?.Period;
+                        CqlInterval<CqlDateTime> pz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, py_);
+                        CqlDateTime qa_ = context.Operators.End(pz_);
+                        return qa_;
+                    }
+
+                    IEnumerable<Encounter> np_ = context.Operators.SortBy<Encounter>(nn_, no_, System.ComponentModel.ListSortDirection.Ascending);
+                    Encounter nq_ = context.Operators.Last<Encounter>(np_);
+                    Period nr_ = nq_?.Period;
+                    CqlInterval<CqlDateTime> ns_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nr_);
+                    CqlDateTime nt_ = context.Operators.Start(ns_);
+                    CqlBoolean nu_ = (CqlBoolean)((nt_ ?? mz_) is not null);
+                    CqlBoolean nv_ = nl_
+                        /* CQL 'and' (270:15-270:71) */ && nu_;
+                    return mj_
+                        /* CQL 'and' (269:6-270:71) */ && nv_;
                 }
 
+                IEnumerable<Encounter> ci_ = context.Operators.Where<Encounter>(ar_, ch_);
+
+                object cj_(Encounter @this) {
+                    Period qb_ = @this?.Period;
+                    CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qb_);
+                    CqlDateTime qd_ = context.Operators.End(qc_);
+                    return qd_;
+                }
+
+                IEnumerable<Encounter> ck_ = context.Operators.SortBy<Encounter>(ci_, cj_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter cl_ = context.Operators.Last<Encounter>(ck_);
+                Period cm_ = cl_?.Period;
+                CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
+                CqlDateTime co_ = context.Operators.Start(cn_);
+
+                bool? cp_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> qe_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? qf_ = qe_?.Value;
+                    Code<Encounter.EncounterStatus> qg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(qf_);
+                    CqlBoolean qh_ = context.Operators.Equal(qg_, "finished");
+                    Period qi_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> qj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qi_);
+                    CqlDateTime qk_ = context.Operators.End(qj_);
+                    Period ql_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> qm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ql_);
+                    CqlDateTime qn_ = context.Operators.Start(qm_);
+                    CqlQuantity qo_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime qp_ = context.Operators.Subtract(qn_, qo_);
+                    CqlInterval<CqlDateTime> qq_ = context.Operators.Interval(qp_, qn_, true, true);
+                    CqlBoolean qr_ = context.Operators.In<CqlDateTime>(qk_, qq_, (string)default);
+                    CqlBoolean qs_ = (CqlBoolean)(qn_ is not null);
+                    CqlBoolean qt_ = qr_
+                        /* CQL 'and' (264:15-264:83) */ && qs_;
+                    return qh_
+                        /* CQL 'and' (263:6-264:83) */ && qt_;
+                }
+
+                IEnumerable<Encounter> cq_ = context.Operators.Where<Encounter>(bb_, cp_);
+
+                object cr_(Encounter @this) {
+                    Period qu_ = @this?.Period;
+                    CqlInterval<CqlDateTime> qv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qu_);
+                    CqlDateTime qw_ = context.Operators.End(qv_);
+                    return qw_;
+                }
+
+                IEnumerable<Encounter> cs_ = context.Operators.SortBy<Encounter>(cq_, cr_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter ct_ = context.Operators.Last<Encounter>(cs_);
+                Period cu_ = ct_?.Period;
+                CqlInterval<CqlDateTime> cv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cu_);
+                CqlDateTime cw_ = context.Operators.Start(cv_);
+                CqlBoolean cx_ = (CqlBoolean)((co_ ?? cw_ ?? bm_) is not null);
                 return cg_
-                    /* CQL 'and' (275:6-275:81) */ && ch_();
+                    /* CQL 'and' (275:6-275:81) */ && cx_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 
             object i_(Encounter @this) {
-                Period td_ = @this?.Period;
-                CqlInterval<CqlDateTime> te_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, td_);
-                CqlDateTime tf_ = context.Operators.End(te_);
-                return tf_;
+                Period qx_ = @this?.Period;
+                CqlInterval<CqlDateTime> qy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qx_);
+                CqlDateTime qz_ = context.Operators.End(qy_);
+                return qz_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -2603,193 +2156,147 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             IEnumerable<Encounter> p_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? q_(Encounter LastED) {
-                Code<Encounter.EncounterStatus> tg_ = LastED?.StatusElement;
-                Encounter.EncounterStatus? th_ = tg_?.Value;
-                Code<Encounter.EncounterStatus> ti_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(th_);
-                CqlBoolean tj_ = context.Operators.Equal(ti_, "finished");
+                Code<Encounter.EncounterStatus> ra_ = LastED?.StatusElement;
+                Encounter.EncounterStatus? rb_ = ra_?.Value;
+                Code<Encounter.EncounterStatus> rc_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rb_);
+                CqlBoolean rd_ = context.Operators.Equal(rc_, "finished");
+                Period re_ = LastED?.Period;
+                CqlInterval<CqlDateTime> rf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, re_);
+                CqlDateTime rg_ = context.Operators.End(rf_);
+                CqlValueSet rh_ = this.Observation_Services(context);
+                IEnumerable<Encounter> ri_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, rh_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                CqlBoolean tk_() {
-                    Period tl_ = LastED?.Period;
-                    CqlInterval<CqlDateTime> tm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tl_);
-                    CqlDateTime tn_ = context.Operators.End(tm_);
-                    CqlValueSet to_ = this.Observation_Services(context);
-                    IEnumerable<Encounter> tp_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, to_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                    bool? tq_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> uo_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? up_ = uo_?.Value;
-                        Code<Encounter.EncounterStatus> uq_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(up_);
-                        CqlBoolean ur_ = context.Operators.Equal(uq_, "finished");
-
-                        CqlBoolean us_() {
-                            Period ut_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> uu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ut_);
-                            CqlDateTime uv_ = context.Operators.End(uu_);
-                            Period uw_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> ux_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, uw_);
-                            CqlDateTime uy_ = context.Operators.Start(ux_);
-                            CqlQuantity uz_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime va_ = context.Operators.Subtract(uy_, uz_);
-                            CqlInterval<CqlDateTime> vb_ = context.Operators.Interval(va_, uy_, true, true);
-                            CqlBoolean vc_ = context.Operators.In<CqlDateTime>(uv_, vb_, (string)default);
-
-                            CqlBoolean vd_() {
-                                Period ve_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> vf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ve_);
-                                CqlDateTime vg_ = context.Operators.Start(vf_);
-                                return vg_ is not null;
-                            }
-
-                            return vc_
-                                /* CQL 'and' (264:15-264:83) */ && vd_();
-                        }
-
-                        return ur_
-                            /* CQL 'and' (263:6-264:83) */ && us_();
-                    }
-
-                    IEnumerable<Encounter> tr_ = context.Operators.Where<Encounter>(tp_, tq_);
-
-                    object ts_(Encounter @this) {
-                        Period vh_ = @this?.Period;
-                        CqlInterval<CqlDateTime> vi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vh_);
-                        CqlDateTime vj_ = context.Operators.End(vi_);
-                        return vj_;
-                    }
-
-                    IEnumerable<Encounter> tt_ = context.Operators.SortBy<Encounter>(tr_, ts_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter tu_ = context.Operators.Last<Encounter>(tt_);
-                    Period tv_ = tu_?.Period;
-                    CqlInterval<CqlDateTime> tw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tv_);
-                    CqlDateTime tx_ = context.Operators.Start(tw_);
-                    Period ty_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> tz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ty_);
-                    CqlDateTime ua_ = context.Operators.Start(tz_);
-                    CqlQuantity ub_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime uc_ = context.Operators.Subtract(tx_ ?? ua_, ub_);
-
-                    bool? ud_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> vk_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? vl_ = vk_?.Value;
-                        Code<Encounter.EncounterStatus> vm_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vl_);
-                        CqlBoolean vn_ = context.Operators.Equal(vm_, "finished");
-
-                        CqlBoolean vo_() {
-                            Period vp_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> vq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vp_);
-                            CqlDateTime vr_ = context.Operators.End(vq_);
-                            Period vs_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vs_);
-                            CqlDateTime vu_ = context.Operators.Start(vt_);
-                            CqlQuantity vv_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime vw_ = context.Operators.Subtract(vu_, vv_);
-                            CqlInterval<CqlDateTime> vx_ = context.Operators.Interval(vw_, vu_, true, true);
-                            CqlBoolean vy_ = context.Operators.In<CqlDateTime>(vr_, vx_, (string)default);
-
-                            CqlBoolean vz_() {
-                                Period wa_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> wb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wa_);
-                                CqlDateTime wc_ = context.Operators.Start(wb_);
-                                return wc_ is not null;
-                            }
-
-                            return vy_
-                                /* CQL 'and' (264:15-264:83) */ && vz_();
-                        }
-
-                        return vn_
-                            /* CQL 'and' (263:6-264:83) */ && vo_();
-                    }
-
-                    IEnumerable<Encounter> ue_ = context.Operators.Where<Encounter>(tp_, ud_);
-
-                    object uf_(Encounter @this) {
-                        Period wd_ = @this?.Period;
-                        CqlInterval<CqlDateTime> we_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wd_);
-                        CqlDateTime wf_ = context.Operators.End(we_);
-                        return wf_;
-                    }
-
-                    IEnumerable<Encounter> ug_ = context.Operators.SortBy<Encounter>(ue_, uf_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter uh_ = context.Operators.Last<Encounter>(ug_);
-                    Period ui_ = uh_?.Period;
-                    CqlInterval<CqlDateTime> uj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ui_);
-                    CqlDateTime uk_ = context.Operators.Start(uj_);
-                    CqlInterval<CqlDateTime> ul_ = context.Operators.Interval(uc_, uk_ ?? ua_, true, true);
-                    CqlBoolean um_ = context.Operators.In<CqlDateTime>(tn_, ul_, (string)default);
-
-                    CqlBoolean un_() {
-                        CqlValueSet wg_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> wh_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, wg_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? wi_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> wt_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? wu_ = wt_?.Value;
-                            Code<Encounter.EncounterStatus> wv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wu_);
-                            CqlBoolean ww_ = context.Operators.Equal(wv_, "finished");
-
-                            CqlBoolean wx_() {
-                                Period wy_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> wz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wy_);
-                                CqlDateTime xa_ = context.Operators.End(wz_);
-                                Period xb_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> xc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xb_);
-                                CqlDateTime xd_ = context.Operators.Start(xc_);
-                                CqlQuantity xe_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime xf_ = context.Operators.Subtract(xd_, xe_);
-                                CqlInterval<CqlDateTime> xg_ = context.Operators.Interval(xf_, xd_, true, true);
-                                CqlBoolean xh_ = context.Operators.In<CqlDateTime>(xa_, xg_, (string)default);
-
-                                CqlBoolean xi_() {
-                                    Period xj_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> xk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xj_);
-                                    CqlDateTime xl_ = context.Operators.Start(xk_);
-                                    return xl_ is not null;
-                                }
-
-                                return xh_
-                                    /* CQL 'and' (264:15-264:83) */ && xi_();
-                            }
-
-                            return ww_
-                                /* CQL 'and' (263:6-264:83) */ && wx_();
-                        }
-
-                        IEnumerable<Encounter> wj_ = context.Operators.Where<Encounter>(wh_, wi_);
-
-                        object wk_(Encounter @this) {
-                            Period xm_ = @this?.Period;
-                            CqlInterval<CqlDateTime> xn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xm_);
-                            CqlDateTime xo_ = context.Operators.End(xn_);
-                            return xo_;
-                        }
-
-                        IEnumerable<Encounter> wl_ = context.Operators.SortBy<Encounter>(wj_, wk_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter wm_ = context.Operators.Last<Encounter>(wl_);
-                        Period wn_ = wm_?.Period;
-                        CqlInterval<CqlDateTime> wo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wn_);
-                        CqlDateTime wp_ = context.Operators.Start(wo_);
-                        Period wq_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> wr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, wq_);
-                        CqlDateTime ws_ = context.Operators.Start(wr_);
-                        return (wp_ ?? ws_) is not null;
-                    }
-
-                    return um_
-                        /* CQL 'and' (270:15-270:71) */ && un_();
+                bool? rj_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> sq_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? sr_ = sq_?.Value;
+                    Code<Encounter.EncounterStatus> ss_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sr_);
+                    CqlBoolean st_ = context.Operators.Equal(ss_, "finished");
+                    Period su_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> sv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, su_);
+                    CqlDateTime sw_ = context.Operators.End(sv_);
+                    Period sx_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> sy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sx_);
+                    CqlDateTime sz_ = context.Operators.Start(sy_);
+                    CqlQuantity ta_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime tb_ = context.Operators.Subtract(sz_, ta_);
+                    CqlInterval<CqlDateTime> tc_ = context.Operators.Interval(tb_, sz_, true, true);
+                    CqlBoolean td_ = context.Operators.In<CqlDateTime>(sw_, tc_, (string)default);
+                    CqlBoolean te_ = (CqlBoolean)(sz_ is not null);
+                    CqlBoolean tf_ = td_
+                        /* CQL 'and' (264:15-264:83) */ && te_;
+                    return st_
+                        /* CQL 'and' (263:6-264:83) */ && tf_;
                 }
 
-                return tj_
-                    /* CQL 'and' (269:6-270:71) */ && tk_();
+                IEnumerable<Encounter> rk_ = context.Operators.Where<Encounter>(ri_, rj_);
+
+                object rl_(Encounter @this) {
+                    Period tg_ = @this?.Period;
+                    CqlInterval<CqlDateTime> th_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tg_);
+                    CqlDateTime ti_ = context.Operators.End(th_);
+                    return ti_;
+                }
+
+                IEnumerable<Encounter> rm_ = context.Operators.SortBy<Encounter>(rk_, rl_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter rn_ = context.Operators.Last<Encounter>(rm_);
+                Period ro_ = rn_?.Period;
+                CqlInterval<CqlDateTime> rp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ro_);
+                CqlDateTime rq_ = context.Operators.Start(rp_);
+                Period rr_ = Visit?.Period;
+                CqlInterval<CqlDateTime> rs_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, rr_);
+                CqlDateTime rt_ = context.Operators.Start(rs_);
+                CqlQuantity ru_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime rv_ = context.Operators.Subtract(rq_ ?? rt_, ru_);
+
+                bool? rw_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> tj_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? tk_ = tj_?.Value;
+                    Code<Encounter.EncounterStatus> tl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tk_);
+                    CqlBoolean tm_ = context.Operators.Equal(tl_, "finished");
+                    Period tn_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> to_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tn_);
+                    CqlDateTime tp_ = context.Operators.End(to_);
+                    Period tq_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> tr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tq_);
+                    CqlDateTime ts_ = context.Operators.Start(tr_);
+                    CqlQuantity tt_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime tu_ = context.Operators.Subtract(ts_, tt_);
+                    CqlInterval<CqlDateTime> tv_ = context.Operators.Interval(tu_, ts_, true, true);
+                    CqlBoolean tw_ = context.Operators.In<CqlDateTime>(tp_, tv_, (string)default);
+                    CqlBoolean tx_ = (CqlBoolean)(ts_ is not null);
+                    CqlBoolean ty_ = tw_
+                        /* CQL 'and' (264:15-264:83) */ && tx_;
+                    return tm_
+                        /* CQL 'and' (263:6-264:83) */ && ty_;
+                }
+
+                IEnumerable<Encounter> rx_ = context.Operators.Where<Encounter>(ri_, rw_);
+
+                object ry_(Encounter @this) {
+                    Period tz_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ua_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tz_);
+                    CqlDateTime ub_ = context.Operators.End(ua_);
+                    return ub_;
+                }
+
+                IEnumerable<Encounter> rz_ = context.Operators.SortBy<Encounter>(rx_, ry_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter sa_ = context.Operators.Last<Encounter>(rz_);
+                Period sb_ = sa_?.Period;
+                CqlInterval<CqlDateTime> sc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sb_);
+                CqlDateTime sd_ = context.Operators.Start(sc_);
+                CqlInterval<CqlDateTime> se_ = context.Operators.Interval(rv_, sd_ ?? rt_, true, true);
+                CqlBoolean sf_ = context.Operators.In<CqlDateTime>(rg_, se_, (string)default);
+
+                bool? sg_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> uc_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? ud_ = uc_?.Value;
+                    Code<Encounter.EncounterStatus> ue_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ud_);
+                    CqlBoolean uf_ = context.Operators.Equal(ue_, "finished");
+                    Period ug_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> uh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ug_);
+                    CqlDateTime ui_ = context.Operators.End(uh_);
+                    Period uj_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> uk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, uj_);
+                    CqlDateTime ul_ = context.Operators.Start(uk_);
+                    CqlQuantity um_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime un_ = context.Operators.Subtract(ul_, um_);
+                    CqlInterval<CqlDateTime> uo_ = context.Operators.Interval(un_, ul_, true, true);
+                    CqlBoolean up_ = context.Operators.In<CqlDateTime>(ui_, uo_, (string)default);
+                    CqlBoolean uq_ = (CqlBoolean)(ul_ is not null);
+                    CqlBoolean ur_ = up_
+                        /* CQL 'and' (264:15-264:83) */ && uq_;
+                    return uf_
+                        /* CQL 'and' (263:6-264:83) */ && ur_;
+                }
+
+                IEnumerable<Encounter> sh_ = context.Operators.Where<Encounter>(ri_, sg_);
+
+                object si_(Encounter @this) {
+                    Period us_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ut_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, us_);
+                    CqlDateTime uu_ = context.Operators.End(ut_);
+                    return uu_;
+                }
+
+                IEnumerable<Encounter> sj_ = context.Operators.SortBy<Encounter>(sh_, si_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter sk_ = context.Operators.Last<Encounter>(sj_);
+                Period sl_ = sk_?.Period;
+                CqlInterval<CqlDateTime> sm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sl_);
+                CqlDateTime sn_ = context.Operators.Start(sm_);
+                CqlBoolean so_ = (CqlBoolean)((sn_ ?? rt_) is not null);
+                CqlBoolean sp_ = sf_
+                    /* CQL 'and' (270:15-270:71) */ && so_;
+                return rd_
+                    /* CQL 'and' (269:6-270:71) */ && sp_;
             }
 
             IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 
             object s_(Encounter @this) {
-                Period xp_ = @this?.Period;
-                CqlInterval<CqlDateTime> xq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xp_);
-                CqlDateTime xr_ = context.Operators.End(xq_);
-                return xr_;
+                Period uv_ = @this?.Period;
+                CqlInterval<CqlDateTime> uw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, uv_);
+                CqlDateTime ux_ = context.Operators.End(uw_);
+                return ux_;
             }
 
             IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
@@ -2801,45 +2308,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             IEnumerable<Encounter> z_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, y_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? aa_(Encounter LastObs) {
-                Code<Encounter.EncounterStatus> xs_ = LastObs?.StatusElement;
-                Encounter.EncounterStatus? xt_ = xs_?.Value;
-                Code<Encounter.EncounterStatus> xu_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(xt_);
-                CqlBoolean xv_ = context.Operators.Equal(xu_, "finished");
-
-                CqlBoolean xw_() {
-                    Period xx_ = LastObs?.Period;
-                    CqlInterval<CqlDateTime> xy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, xx_);
-                    CqlDateTime xz_ = context.Operators.End(xy_);
-                    Period ya_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> yb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ya_);
-                    CqlDateTime yc_ = context.Operators.Start(yb_);
-                    CqlQuantity yd_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime ye_ = context.Operators.Subtract(yc_, yd_);
-                    CqlInterval<CqlDateTime> yf_ = context.Operators.Interval(ye_, yc_, true, true);
-                    CqlBoolean yg_ = context.Operators.In<CqlDateTime>(xz_, yf_, (string)default);
-
-                    CqlBoolean yh_() {
-                        Period yi_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> yj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yi_);
-                        CqlDateTime yk_ = context.Operators.Start(yj_);
-                        return yk_ is not null;
-                    }
-
-                    return yg_
-                        /* CQL 'and' (264:15-264:83) */ && yh_();
-                }
-
-                return xv_
-                    /* CQL 'and' (263:6-264:83) */ && xw_();
+                Code<Encounter.EncounterStatus> uy_ = LastObs?.StatusElement;
+                Encounter.EncounterStatus? uz_ = uy_?.Value;
+                Code<Encounter.EncounterStatus> va_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(uz_);
+                CqlBoolean vb_ = context.Operators.Equal(va_, "finished");
+                Period vc_ = LastObs?.Period;
+                CqlInterval<CqlDateTime> vd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vc_);
+                CqlDateTime ve_ = context.Operators.End(vd_);
+                Period vf_ = Visit?.Period;
+                CqlInterval<CqlDateTime> vg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vf_);
+                CqlDateTime vh_ = context.Operators.Start(vg_);
+                CqlQuantity vi_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime vj_ = context.Operators.Subtract(vh_, vi_);
+                CqlInterval<CqlDateTime> vk_ = context.Operators.Interval(vj_, vh_, true, true);
+                CqlBoolean vl_ = context.Operators.In<CqlDateTime>(ve_, vk_, (string)default);
+                CqlBoolean vm_ = (CqlBoolean)(vh_ is not null);
+                CqlBoolean vn_ = vl_
+                    /* CQL 'and' (264:15-264:83) */ && vm_;
+                return vb_
+                    /* CQL 'and' (263:6-264:83) */ && vn_;
             }
 
             IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
 
             object ac_(Encounter @this) {
-                Period yl_ = @this?.Period;
-                CqlInterval<CqlDateTime> ym_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yl_);
-                CqlDateTime yn_ = context.Operators.End(ym_);
-                return yn_;
+                Period vo_ = @this?.Period;
+                CqlInterval<CqlDateTime> vp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vo_);
+                CqlDateTime vq_ = context.Operators.End(vp_);
+                return vq_;
             }
 
             IEnumerable<Encounter> ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
@@ -2879,189 +2375,143 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 Encounter.EncounterStatus? ae_ = ad_?.Value;
                 Code<Encounter.EncounterStatus> af_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ae_);
                 CqlBoolean ag_ = context.Operators.Equal(af_, "finished");
+                Period ah_ = LastED?.Period;
+                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
+                CqlDateTime aj_ = context.Operators.End(ai_);
+                CqlValueSet ak_ = this.Observation_Services(context);
+                IEnumerable<Encounter> al_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ak_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                CqlBoolean ah_() {
-                    Period ai_ = LastED?.Period;
-                    CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
-                    CqlDateTime ak_ = context.Operators.End(aj_);
-                    CqlValueSet al_ = this.Observation_Services(context);
-                    IEnumerable<Encounter> am_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, al_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                    bool? an_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> bl_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? bm_ = bl_?.Value;
-                        Code<Encounter.EncounterStatus> bn_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bm_);
-                        CqlBoolean bo_ = context.Operators.Equal(bn_, "finished");
-
-                        CqlBoolean bp_() {
-                            Period bq_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bq_);
-                            CqlDateTime bs_ = context.Operators.End(br_);
-                            Period bt_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bt_);
-                            CqlDateTime bv_ = context.Operators.Start(bu_);
-                            CqlQuantity bw_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime bx_ = context.Operators.Subtract(bv_, bw_);
-                            CqlInterval<CqlDateTime> by_ = context.Operators.Interval(bx_, bv_, true, true);
-                            CqlBoolean bz_ = context.Operators.In<CqlDateTime>(bs_, by_, (string)default);
-
-                            CqlBoolean ca_() {
-                                Period cb_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cb_);
-                                CqlDateTime cd_ = context.Operators.Start(cc_);
-                                return cd_ is not null;
-                            }
-
-                            return bz_
-                                /* CQL 'and' (288:17-288:85) */ && ca_();
-                        }
-
-                        return bo_
-                            /* CQL 'and' (287:7-288:85) */ && bp_();
-                    }
-
-                    IEnumerable<Encounter> ao_ = context.Operators.Where<Encounter>(am_, an_);
-
-                    object ap_(Encounter @this) {
-                        Period ce_ = @this?.Period;
-                        CqlInterval<CqlDateTime> cf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ce_);
-                        CqlDateTime cg_ = context.Operators.End(cf_);
-                        return cg_;
-                    }
-
-                    IEnumerable<Encounter> aq_ = context.Operators.SortBy<Encounter>(ao_, ap_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter ar_ = context.Operators.Last<Encounter>(aq_);
-                    Period as_ = ar_?.Period;
-                    CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
-                    CqlDateTime au_ = context.Operators.Start(at_);
-                    Period av_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
-                    CqlDateTime ax_ = context.Operators.Start(aw_);
-                    CqlQuantity ay_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime az_ = context.Operators.Subtract(au_ ?? ax_, ay_);
-
-                    bool? ba_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> ch_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? ci_ = ch_?.Value;
-                        Code<Encounter.EncounterStatus> cj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ci_);
-                        CqlBoolean ck_ = context.Operators.Equal(cj_, "finished");
-
-                        CqlBoolean cl_() {
-                            Period cm_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
-                            CqlDateTime co_ = context.Operators.End(cn_);
-                            Period cp_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
-                            CqlDateTime cr_ = context.Operators.Start(cq_);
-                            CqlQuantity cs_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime ct_ = context.Operators.Subtract(cr_, cs_);
-                            CqlInterval<CqlDateTime> cu_ = context.Operators.Interval(ct_, cr_, true, true);
-                            CqlBoolean cv_ = context.Operators.In<CqlDateTime>(co_, cu_, (string)default);
-
-                            CqlBoolean cw_() {
-                                Period cx_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cx_);
-                                CqlDateTime cz_ = context.Operators.Start(cy_);
-                                return cz_ is not null;
-                            }
-
-                            return cv_
-                                /* CQL 'and' (288:17-288:85) */ && cw_();
-                        }
-
-                        return ck_
-                            /* CQL 'and' (287:7-288:85) */ && cl_();
-                    }
-
-                    IEnumerable<Encounter> bb_ = context.Operators.Where<Encounter>(am_, ba_);
-
-                    object bc_(Encounter @this) {
-                        Period da_ = @this?.Period;
-                        CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, da_);
-                        CqlDateTime dc_ = context.Operators.End(db_);
-                        return dc_;
-                    }
-
-                    IEnumerable<Encounter> bd_ = context.Operators.SortBy<Encounter>(bb_, bc_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter be_ = context.Operators.Last<Encounter>(bd_);
-                    Period bf_ = be_?.Period;
-                    CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-                    CqlDateTime bh_ = context.Operators.Start(bg_);
-                    CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(az_, bh_ ?? ax_, true, true);
-                    CqlBoolean bj_ = context.Operators.In<CqlDateTime>(ak_, bi_, (string)default);
-
-                    CqlBoolean bk_() {
-                        CqlValueSet dd_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> de_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, dd_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? df_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> dq_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? dr_ = dq_?.Value;
-                            Code<Encounter.EncounterStatus> ds_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dr_);
-                            CqlBoolean dt_ = context.Operators.Equal(ds_, "finished");
-
-                            CqlBoolean du_() {
-                                Period dv_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
-                                CqlDateTime dx_ = context.Operators.End(dw_);
-                                Period dy_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
-                                CqlDateTime ea_ = context.Operators.Start(dz_);
-                                CqlQuantity eb_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime ec_ = context.Operators.Subtract(ea_, eb_);
-                                CqlInterval<CqlDateTime> ed_ = context.Operators.Interval(ec_, ea_, true, true);
-                                CqlBoolean ee_ = context.Operators.In<CqlDateTime>(dx_, ed_, (string)default);
-
-                                CqlBoolean ef_() {
-                                    Period eg_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eg_);
-                                    CqlDateTime ei_ = context.Operators.Start(eh_);
-                                    return ei_ is not null;
-                                }
-
-                                return ee_
-                                    /* CQL 'and' (288:17-288:85) */ && ef_();
-                            }
-
-                            return dt_
-                                /* CQL 'and' (287:7-288:85) */ && du_();
-                        }
-
-                        IEnumerable<Encounter> dg_ = context.Operators.Where<Encounter>(de_, df_);
-
-                        object dh_(Encounter @this) {
-                            Period ej_ = @this?.Period;
-                            CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ej_);
-                            CqlDateTime el_ = context.Operators.End(ek_);
-                            return el_;
-                        }
-
-                        IEnumerable<Encounter> di_ = context.Operators.SortBy<Encounter>(dg_, dh_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter dj_ = context.Operators.Last<Encounter>(di_);
-                        Period dk_ = dj_?.Period;
-                        CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dk_);
-                        CqlDateTime dm_ = context.Operators.Start(dl_);
-                        Period dn_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> do_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dn_);
-                        CqlDateTime dp_ = context.Operators.Start(do_);
-                        return (dm_ ?? dp_) is not null;
-                    }
-
-                    return bj_
-                        /* CQL 'and' (294:17-294:73) */ && bk_();
+                bool? am_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> bt_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? bu_ = bt_?.Value;
+                    Code<Encounter.EncounterStatus> bv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bu_);
+                    CqlBoolean bw_ = context.Operators.Equal(bv_, "finished");
+                    Period bx_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> by_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bx_);
+                    CqlDateTime bz_ = context.Operators.End(by_);
+                    Period ca_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ca_);
+                    CqlDateTime cc_ = context.Operators.Start(cb_);
+                    CqlQuantity cd_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ce_ = context.Operators.Subtract(cc_, cd_);
+                    CqlInterval<CqlDateTime> cf_ = context.Operators.Interval(ce_, cc_, true, true);
+                    CqlBoolean cg_ = context.Operators.In<CqlDateTime>(bz_, cf_, (string)default);
+                    CqlBoolean ch_ = (CqlBoolean)(cc_ is not null);
+                    CqlBoolean ci_ = cg_
+                        /* CQL 'and' (288:17-288:85) */ && ch_;
+                    return bw_
+                        /* CQL 'and' (287:7-288:85) */ && ci_;
                 }
 
+                IEnumerable<Encounter> an_ = context.Operators.Where<Encounter>(al_, am_);
+
+                object ao_(Encounter @this) {
+                    Period cj_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cj_);
+                    CqlDateTime cl_ = context.Operators.End(ck_);
+                    return cl_;
+                }
+
+                IEnumerable<Encounter> ap_ = context.Operators.SortBy<Encounter>(an_, ao_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter aq_ = context.Operators.Last<Encounter>(ap_);
+                Period ar_ = aq_?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                Period au_ = Visit?.Period;
+                CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
+                CqlDateTime aw_ = context.Operators.Start(av_);
+                CqlQuantity ax_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime ay_ = context.Operators.Subtract(at_ ?? aw_, ax_);
+
+                bool? az_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> cm_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? cn_ = cm_?.Value;
+                    Code<Encounter.EncounterStatus> co_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cn_);
+                    CqlBoolean cp_ = context.Operators.Equal(co_, "finished");
+                    Period cq_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> cr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
+                    CqlDateTime cs_ = context.Operators.End(cr_);
+                    Period ct_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
+                    CqlDateTime cv_ = context.Operators.Start(cu_);
+                    CqlQuantity cw_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime cx_ = context.Operators.Subtract(cv_, cw_);
+                    CqlInterval<CqlDateTime> cy_ = context.Operators.Interval(cx_, cv_, true, true);
+                    CqlBoolean cz_ = context.Operators.In<CqlDateTime>(cs_, cy_, (string)default);
+                    CqlBoolean da_ = (CqlBoolean)(cv_ is not null);
+                    CqlBoolean db_ = cz_
+                        /* CQL 'and' (288:17-288:85) */ && da_;
+                    return cp_
+                        /* CQL 'and' (287:7-288:85) */ && db_;
+                }
+
+                IEnumerable<Encounter> ba_ = context.Operators.Where<Encounter>(al_, az_);
+
+                object bb_(Encounter @this) {
+                    Period dc_ = @this?.Period;
+                    CqlInterval<CqlDateTime> dd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dc_);
+                    CqlDateTime de_ = context.Operators.End(dd_);
+                    return de_;
+                }
+
+                IEnumerable<Encounter> bc_ = context.Operators.SortBy<Encounter>(ba_, bb_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter bd_ = context.Operators.Last<Encounter>(bc_);
+                Period be_ = bd_?.Period;
+                CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, be_);
+                CqlDateTime bg_ = context.Operators.Start(bf_);
+                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(ay_, bg_ ?? aw_, true, true);
+                CqlBoolean bi_ = context.Operators.In<CqlDateTime>(aj_, bh_, (string)default);
+
+                bool? bj_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> df_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? dg_ = df_?.Value;
+                    Code<Encounter.EncounterStatus> dh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dg_);
+                    CqlBoolean di_ = context.Operators.Equal(dh_, "finished");
+                    Period dj_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dj_);
+                    CqlDateTime dl_ = context.Operators.End(dk_);
+                    Period dm_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dm_);
+                    CqlDateTime do_ = context.Operators.Start(dn_);
+                    CqlQuantity dp_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime dq_ = context.Operators.Subtract(do_, dp_);
+                    CqlInterval<CqlDateTime> dr_ = context.Operators.Interval(dq_, do_, true, true);
+                    CqlBoolean ds_ = context.Operators.In<CqlDateTime>(dl_, dr_, (string)default);
+                    CqlBoolean dt_ = (CqlBoolean)(do_ is not null);
+                    CqlBoolean du_ = ds_
+                        /* CQL 'and' (288:17-288:85) */ && dt_;
+                    return di_
+                        /* CQL 'and' (287:7-288:85) */ && du_;
+                }
+
+                IEnumerable<Encounter> bk_ = context.Operators.Where<Encounter>(al_, bj_);
+
+                object bl_(Encounter @this) {
+                    Period dv_ = @this?.Period;
+                    CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
+                    CqlDateTime dx_ = context.Operators.End(dw_);
+                    return dx_;
+                }
+
+                IEnumerable<Encounter> bm_ = context.Operators.SortBy<Encounter>(bk_, bl_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter bn_ = context.Operators.Last<Encounter>(bm_);
+                Period bo_ = bn_?.Period;
+                CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
+                CqlDateTime bq_ = context.Operators.Start(bp_);
+                CqlBoolean br_ = (CqlBoolean)((bq_ ?? aw_) is not null);
+                CqlBoolean bs_ = bi_
+                    /* CQL 'and' (294:17-294:73) */ && br_;
                 return ag_
-                    /* CQL 'and' (293:7-294:73) */ && ah_();
+                    /* CQL 'and' (293:7-294:73) */ && bs_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 
             object i_(Encounter @this) {
-                Period em_ = @this?.Period;
-                CqlInterval<CqlDateTime> en_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, em_);
-                CqlDateTime eo_ = context.Operators.End(en_);
-                return eo_;
+                Period dy_ = @this?.Period;
+                CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
+                CqlDateTime ea_ = context.Operators.End(dz_);
+                return ea_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -3073,45 +2523,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             IEnumerable<Encounter> p_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? q_(Encounter LastObs) {
-                Code<Encounter.EncounterStatus> ep_ = LastObs?.StatusElement;
-                Encounter.EncounterStatus? eq_ = ep_?.Value;
-                Code<Encounter.EncounterStatus> er_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eq_);
-                CqlBoolean es_ = context.Operators.Equal(er_, "finished");
-
-                CqlBoolean et_() {
-                    Period eu_ = LastObs?.Period;
-                    CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eu_);
-                    CqlDateTime ew_ = context.Operators.End(ev_);
-                    Period ex_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ex_);
-                    CqlDateTime ez_ = context.Operators.Start(ey_);
-                    CqlQuantity fa_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime fb_ = context.Operators.Subtract(ez_, fa_);
-                    CqlInterval<CqlDateTime> fc_ = context.Operators.Interval(fb_, ez_, true, true);
-                    CqlBoolean fd_ = context.Operators.In<CqlDateTime>(ew_, fc_, (string)default);
-
-                    CqlBoolean fe_() {
-                        Period ff_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> fg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ff_);
-                        CqlDateTime fh_ = context.Operators.Start(fg_);
-                        return fh_ is not null;
-                    }
-
-                    return fd_
-                        /* CQL 'and' (288:17-288:85) */ && fe_();
-                }
-
-                return es_
-                    /* CQL 'and' (287:7-288:85) */ && et_();
+                Code<Encounter.EncounterStatus> eb_ = LastObs?.StatusElement;
+                Encounter.EncounterStatus? ec_ = eb_?.Value;
+                Code<Encounter.EncounterStatus> ed_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ec_);
+                CqlBoolean ee_ = context.Operators.Equal(ed_, "finished");
+                Period ef_ = LastObs?.Period;
+                CqlInterval<CqlDateTime> eg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ef_);
+                CqlDateTime eh_ = context.Operators.End(eg_);
+                Period ei_ = Visit?.Period;
+                CqlInterval<CqlDateTime> ej_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ei_);
+                CqlDateTime ek_ = context.Operators.Start(ej_);
+                CqlQuantity el_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime em_ = context.Operators.Subtract(ek_, el_);
+                CqlInterval<CqlDateTime> en_ = context.Operators.Interval(em_, ek_, true, true);
+                CqlBoolean eo_ = context.Operators.In<CqlDateTime>(eh_, en_, (string)default);
+                CqlBoolean ep_ = (CqlBoolean)(ek_ is not null);
+                CqlBoolean eq_ = eo_
+                    /* CQL 'and' (288:17-288:85) */ && ep_;
+                return ee_
+                    /* CQL 'and' (287:7-288:85) */ && eq_;
             }
 
             IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 
             object s_(Encounter @this) {
-                Period fi_ = @this?.Period;
-                CqlInterval<CqlDateTime> fj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fi_);
-                CqlDateTime fk_ = context.Operators.End(fj_);
-                return fk_;
+                Period er_ = @this?.Period;
+                CqlInterval<CqlDateTime> es_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, er_);
+                CqlDateTime et_ = context.Operators.End(es_);
+                return et_;
             }
 
             IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
@@ -3150,189 +2589,143 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 Encounter.EncounterStatus? ae_ = ad_?.Value;
                 Code<Encounter.EncounterStatus> af_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ae_);
                 CqlBoolean ag_ = context.Operators.Equal(af_, "finished");
+                Period ah_ = LastED?.Period;
+                CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
+                CqlDateTime aj_ = context.Operators.End(ai_);
+                CqlValueSet ak_ = this.Observation_Services(context);
+                IEnumerable<Encounter> al_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, ak_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
-                CqlBoolean ah_() {
-                    Period ai_ = LastED?.Period;
-                    CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
-                    CqlDateTime ak_ = context.Operators.End(aj_);
-                    CqlValueSet al_ = this.Observation_Services(context);
-                    IEnumerable<Encounter> am_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, al_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                    bool? an_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> bl_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? bm_ = bl_?.Value;
-                        Code<Encounter.EncounterStatus> bn_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bm_);
-                        CqlBoolean bo_ = context.Operators.Equal(bn_, "finished");
-
-                        CqlBoolean bp_() {
-                            Period bq_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bq_);
-                            CqlDateTime bs_ = context.Operators.End(br_);
-                            Period bt_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bt_);
-                            CqlDateTime bv_ = context.Operators.Start(bu_);
-                            CqlQuantity bw_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime bx_ = context.Operators.Subtract(bv_, bw_);
-                            CqlInterval<CqlDateTime> by_ = context.Operators.Interval(bx_, bv_, true, true);
-                            CqlBoolean bz_ = context.Operators.In<CqlDateTime>(bs_, by_, (string)default);
-
-                            CqlBoolean ca_() {
-                                Period cb_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cb_);
-                                CqlDateTime cd_ = context.Operators.Start(cc_);
-                                return cd_ is not null;
-                            }
-
-                            return bz_
-                                /* CQL 'and' (306:17-306:85) */ && ca_();
-                        }
-
-                        return bo_
-                            /* CQL 'and' (305:7-306:85) */ && bp_();
-                    }
-
-                    IEnumerable<Encounter> ao_ = context.Operators.Where<Encounter>(am_, an_);
-
-                    object ap_(Encounter @this) {
-                        Period ce_ = @this?.Period;
-                        CqlInterval<CqlDateTime> cf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ce_);
-                        CqlDateTime cg_ = context.Operators.End(cf_);
-                        return cg_;
-                    }
-
-                    IEnumerable<Encounter> aq_ = context.Operators.SortBy<Encounter>(ao_, ap_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter ar_ = context.Operators.Last<Encounter>(aq_);
-                    Period as_ = ar_?.Period;
-                    CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
-                    CqlDateTime au_ = context.Operators.Start(at_);
-                    Period av_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, av_);
-                    CqlDateTime ax_ = context.Operators.Start(aw_);
-                    CqlQuantity ay_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime az_ = context.Operators.Subtract(au_ ?? ax_, ay_);
-
-                    bool? ba_(Encounter LastObs) {
-                        Code<Encounter.EncounterStatus> ch_ = LastObs?.StatusElement;
-                        Encounter.EncounterStatus? ci_ = ch_?.Value;
-                        Code<Encounter.EncounterStatus> cj_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ci_);
-                        CqlBoolean ck_ = context.Operators.Equal(cj_, "finished");
-
-                        CqlBoolean cl_() {
-                            Period cm_ = LastObs?.Period;
-                            CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cm_);
-                            CqlDateTime co_ = context.Operators.End(cn_);
-                            Period cp_ = Visit?.Period;
-                            CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
-                            CqlDateTime cr_ = context.Operators.Start(cq_);
-                            CqlQuantity cs_ = context.Operators.Quantity(1m, "hour");
-                            CqlDateTime ct_ = context.Operators.Subtract(cr_, cs_);
-                            CqlInterval<CqlDateTime> cu_ = context.Operators.Interval(ct_, cr_, true, true);
-                            CqlBoolean cv_ = context.Operators.In<CqlDateTime>(co_, cu_, (string)default);
-
-                            CqlBoolean cw_() {
-                                Period cx_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cx_);
-                                CqlDateTime cz_ = context.Operators.Start(cy_);
-                                return cz_ is not null;
-                            }
-
-                            return cv_
-                                /* CQL 'and' (306:17-306:85) */ && cw_();
-                        }
-
-                        return ck_
-                            /* CQL 'and' (305:7-306:85) */ && cl_();
-                    }
-
-                    IEnumerable<Encounter> bb_ = context.Operators.Where<Encounter>(am_, ba_);
-
-                    object bc_(Encounter @this) {
-                        Period da_ = @this?.Period;
-                        CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, da_);
-                        CqlDateTime dc_ = context.Operators.End(db_);
-                        return dc_;
-                    }
-
-                    IEnumerable<Encounter> bd_ = context.Operators.SortBy<Encounter>(bb_, bc_, System.ComponentModel.ListSortDirection.Ascending);
-                    Encounter be_ = context.Operators.Last<Encounter>(bd_);
-                    Period bf_ = be_?.Period;
-                    CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bf_);
-                    CqlDateTime bh_ = context.Operators.Start(bg_);
-                    CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(az_, bh_ ?? ax_, true, true);
-                    CqlBoolean bj_ = context.Operators.In<CqlDateTime>(ak_, bi_, (string)default);
-
-                    CqlBoolean bk_() {
-                        CqlValueSet dd_ = this.Observation_Services(context);
-                        IEnumerable<Encounter> de_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, dd_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
-
-                        bool? df_(Encounter LastObs) {
-                            Code<Encounter.EncounterStatus> dq_ = LastObs?.StatusElement;
-                            Encounter.EncounterStatus? dr_ = dq_?.Value;
-                            Code<Encounter.EncounterStatus> ds_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dr_);
-                            CqlBoolean dt_ = context.Operators.Equal(ds_, "finished");
-
-                            CqlBoolean du_() {
-                                Period dv_ = LastObs?.Period;
-                                CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
-                                CqlDateTime dx_ = context.Operators.End(dw_);
-                                Period dy_ = Visit?.Period;
-                                CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
-                                CqlDateTime ea_ = context.Operators.Start(dz_);
-                                CqlQuantity eb_ = context.Operators.Quantity(1m, "hour");
-                                CqlDateTime ec_ = context.Operators.Subtract(ea_, eb_);
-                                CqlInterval<CqlDateTime> ed_ = context.Operators.Interval(ec_, ea_, true, true);
-                                CqlBoolean ee_ = context.Operators.In<CqlDateTime>(dx_, ed_, (string)default);
-
-                                CqlBoolean ef_() {
-                                    Period eg_ = Visit?.Period;
-                                    CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eg_);
-                                    CqlDateTime ei_ = context.Operators.Start(eh_);
-                                    return ei_ is not null;
-                                }
-
-                                return ee_
-                                    /* CQL 'and' (306:17-306:85) */ && ef_();
-                            }
-
-                            return dt_
-                                /* CQL 'and' (305:7-306:85) */ && du_();
-                        }
-
-                        IEnumerable<Encounter> dg_ = context.Operators.Where<Encounter>(de_, df_);
-
-                        object dh_(Encounter @this) {
-                            Period ej_ = @this?.Period;
-                            CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ej_);
-                            CqlDateTime el_ = context.Operators.End(ek_);
-                            return el_;
-                        }
-
-                        IEnumerable<Encounter> di_ = context.Operators.SortBy<Encounter>(dg_, dh_, System.ComponentModel.ListSortDirection.Ascending);
-                        Encounter dj_ = context.Operators.Last<Encounter>(di_);
-                        Period dk_ = dj_?.Period;
-                        CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dk_);
-                        CqlDateTime dm_ = context.Operators.Start(dl_);
-                        Period dn_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> do_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dn_);
-                        CqlDateTime dp_ = context.Operators.Start(do_);
-                        return (dm_ ?? dp_) is not null;
-                    }
-
-                    return bj_
-                        /* CQL 'and' (312:17-312:73) */ && bk_();
+                bool? am_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> bt_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? bu_ = bt_?.Value;
+                    Code<Encounter.EncounterStatus> bv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bu_);
+                    CqlBoolean bw_ = context.Operators.Equal(bv_, "finished");
+                    Period bx_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> by_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bx_);
+                    CqlDateTime bz_ = context.Operators.End(by_);
+                    Period ca_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ca_);
+                    CqlDateTime cc_ = context.Operators.Start(cb_);
+                    CqlQuantity cd_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime ce_ = context.Operators.Subtract(cc_, cd_);
+                    CqlInterval<CqlDateTime> cf_ = context.Operators.Interval(ce_, cc_, true, true);
+                    CqlBoolean cg_ = context.Operators.In<CqlDateTime>(bz_, cf_, (string)default);
+                    CqlBoolean ch_ = (CqlBoolean)(cc_ is not null);
+                    CqlBoolean ci_ = cg_
+                        /* CQL 'and' (306:17-306:85) */ && ch_;
+                    return bw_
+                        /* CQL 'and' (305:7-306:85) */ && ci_;
                 }
 
+                IEnumerable<Encounter> an_ = context.Operators.Where<Encounter>(al_, am_);
+
+                object ao_(Encounter @this) {
+                    Period cj_ = @this?.Period;
+                    CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cj_);
+                    CqlDateTime cl_ = context.Operators.End(ck_);
+                    return cl_;
+                }
+
+                IEnumerable<Encounter> ap_ = context.Operators.SortBy<Encounter>(an_, ao_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter aq_ = context.Operators.Last<Encounter>(ap_);
+                Period ar_ = aq_?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                Period au_ = Visit?.Period;
+                CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
+                CqlDateTime aw_ = context.Operators.Start(av_);
+                CqlQuantity ax_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime ay_ = context.Operators.Subtract(at_ ?? aw_, ax_);
+
+                bool? az_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> cm_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? cn_ = cm_?.Value;
+                    Code<Encounter.EncounterStatus> co_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cn_);
+                    CqlBoolean cp_ = context.Operators.Equal(co_, "finished");
+                    Period cq_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> cr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cq_);
+                    CqlDateTime cs_ = context.Operators.End(cr_);
+                    Period ct_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
+                    CqlDateTime cv_ = context.Operators.Start(cu_);
+                    CqlQuantity cw_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime cx_ = context.Operators.Subtract(cv_, cw_);
+                    CqlInterval<CqlDateTime> cy_ = context.Operators.Interval(cx_, cv_, true, true);
+                    CqlBoolean cz_ = context.Operators.In<CqlDateTime>(cs_, cy_, (string)default);
+                    CqlBoolean da_ = (CqlBoolean)(cv_ is not null);
+                    CqlBoolean db_ = cz_
+                        /* CQL 'and' (306:17-306:85) */ && da_;
+                    return cp_
+                        /* CQL 'and' (305:7-306:85) */ && db_;
+                }
+
+                IEnumerable<Encounter> ba_ = context.Operators.Where<Encounter>(al_, az_);
+
+                object bb_(Encounter @this) {
+                    Period dc_ = @this?.Period;
+                    CqlInterval<CqlDateTime> dd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dc_);
+                    CqlDateTime de_ = context.Operators.End(dd_);
+                    return de_;
+                }
+
+                IEnumerable<Encounter> bc_ = context.Operators.SortBy<Encounter>(ba_, bb_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter bd_ = context.Operators.Last<Encounter>(bc_);
+                Period be_ = bd_?.Period;
+                CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, be_);
+                CqlDateTime bg_ = context.Operators.Start(bf_);
+                CqlInterval<CqlDateTime> bh_ = context.Operators.Interval(ay_, bg_ ?? aw_, true, true);
+                CqlBoolean bi_ = context.Operators.In<CqlDateTime>(aj_, bh_, (string)default);
+
+                bool? bj_(Encounter LastObs) {
+                    Code<Encounter.EncounterStatus> df_ = LastObs?.StatusElement;
+                    Encounter.EncounterStatus? dg_ = df_?.Value;
+                    Code<Encounter.EncounterStatus> dh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dg_);
+                    CqlBoolean di_ = context.Operators.Equal(dh_, "finished");
+                    Period dj_ = LastObs?.Period;
+                    CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dj_);
+                    CqlDateTime dl_ = context.Operators.End(dk_);
+                    Period dm_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dm_);
+                    CqlDateTime do_ = context.Operators.Start(dn_);
+                    CqlQuantity dp_ = context.Operators.Quantity(1m, "hour");
+                    CqlDateTime dq_ = context.Operators.Subtract(do_, dp_);
+                    CqlInterval<CqlDateTime> dr_ = context.Operators.Interval(dq_, do_, true, true);
+                    CqlBoolean ds_ = context.Operators.In<CqlDateTime>(dl_, dr_, (string)default);
+                    CqlBoolean dt_ = (CqlBoolean)(do_ is not null);
+                    CqlBoolean du_ = ds_
+                        /* CQL 'and' (306:17-306:85) */ && dt_;
+                    return di_
+                        /* CQL 'and' (305:7-306:85) */ && du_;
+                }
+
+                IEnumerable<Encounter> bk_ = context.Operators.Where<Encounter>(al_, bj_);
+
+                object bl_(Encounter @this) {
+                    Period dv_ = @this?.Period;
+                    CqlInterval<CqlDateTime> dw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dv_);
+                    CqlDateTime dx_ = context.Operators.End(dw_);
+                    return dx_;
+                }
+
+                IEnumerable<Encounter> bm_ = context.Operators.SortBy<Encounter>(bk_, bl_, System.ComponentModel.ListSortDirection.Ascending);
+                Encounter bn_ = context.Operators.Last<Encounter>(bm_);
+                Period bo_ = bn_?.Period;
+                CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
+                CqlDateTime bq_ = context.Operators.Start(bp_);
+                CqlBoolean br_ = (CqlBoolean)((bq_ ?? aw_) is not null);
+                CqlBoolean bs_ = bi_
+                    /* CQL 'and' (312:17-312:73) */ && br_;
                 return ag_
-                    /* CQL 'and' (311:7-312:73) */ && ah_();
+                    /* CQL 'and' (311:7-312:73) */ && bs_;
             }
 
             IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 
             object i_(Encounter @this) {
-                Period em_ = @this?.Period;
-                CqlInterval<CqlDateTime> en_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, em_);
-                CqlDateTime eo_ = context.Operators.End(en_);
-                return eo_;
+                Period dy_ = @this?.Period;
+                CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dy_);
+                CqlDateTime ea_ = context.Operators.End(dz_);
+                return ea_;
             }
 
             IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
@@ -3344,45 +2737,34 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             IEnumerable<Encounter> p_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, o_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
             bool? q_(Encounter LastObs) {
-                Code<Encounter.EncounterStatus> ep_ = LastObs?.StatusElement;
-                Encounter.EncounterStatus? eq_ = ep_?.Value;
-                Code<Encounter.EncounterStatus> er_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eq_);
-                CqlBoolean es_ = context.Operators.Equal(er_, "finished");
-
-                CqlBoolean et_() {
-                    Period eu_ = LastObs?.Period;
-                    CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eu_);
-                    CqlDateTime ew_ = context.Operators.End(ev_);
-                    Period ex_ = Visit?.Period;
-                    CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ex_);
-                    CqlDateTime ez_ = context.Operators.Start(ey_);
-                    CqlQuantity fa_ = context.Operators.Quantity(1m, "hour");
-                    CqlDateTime fb_ = context.Operators.Subtract(ez_, fa_);
-                    CqlInterval<CqlDateTime> fc_ = context.Operators.Interval(fb_, ez_, true, true);
-                    CqlBoolean fd_ = context.Operators.In<CqlDateTime>(ew_, fc_, (string)default);
-
-                    CqlBoolean fe_() {
-                        Period ff_ = Visit?.Period;
-                        CqlInterval<CqlDateTime> fg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ff_);
-                        CqlDateTime fh_ = context.Operators.Start(fg_);
-                        return fh_ is not null;
-                    }
-
-                    return fd_
-                        /* CQL 'and' (306:17-306:85) */ && fe_();
-                }
-
-                return es_
-                    /* CQL 'and' (305:7-306:85) */ && et_();
+                Code<Encounter.EncounterStatus> eb_ = LastObs?.StatusElement;
+                Encounter.EncounterStatus? ec_ = eb_?.Value;
+                Code<Encounter.EncounterStatus> ed_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ec_);
+                CqlBoolean ee_ = context.Operators.Equal(ed_, "finished");
+                Period ef_ = LastObs?.Period;
+                CqlInterval<CqlDateTime> eg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ef_);
+                CqlDateTime eh_ = context.Operators.End(eg_);
+                Period ei_ = Visit?.Period;
+                CqlInterval<CqlDateTime> ej_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ei_);
+                CqlDateTime ek_ = context.Operators.Start(ej_);
+                CqlQuantity el_ = context.Operators.Quantity(1m, "hour");
+                CqlDateTime em_ = context.Operators.Subtract(ek_, el_);
+                CqlInterval<CqlDateTime> en_ = context.Operators.Interval(em_, ek_, true, true);
+                CqlBoolean eo_ = context.Operators.In<CqlDateTime>(eh_, en_, (string)default);
+                CqlBoolean ep_ = (CqlBoolean)(ek_ is not null);
+                CqlBoolean eq_ = eo_
+                    /* CQL 'and' (306:17-306:85) */ && ep_;
+                return ee_
+                    /* CQL 'and' (305:7-306:85) */ && eq_;
             }
 
             IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 
             object s_(Encounter @this) {
-                Period fi_ = @this?.Period;
-                CqlInterval<CqlDateTime> fj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fi_);
-                CqlDateTime fk_ = context.Operators.End(fj_);
-                return fk_;
+                Period er_ = @this?.Period;
+                CqlInterval<CqlDateTime> es_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, er_);
+                CqlDateTime et_ = context.Operators.End(es_);
+                return et_;
             }
 
             IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
@@ -3438,25 +2820,21 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             List<CodeableConcept> i_ = h_?.Type;
 
             CqlConcept j_(CodeableConcept @this) {
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return o_;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return t_;
             }
 
             IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
             CqlValueSet l_ = this.Intensive_Care_Unit(context);
             CqlBoolean m_ = context.Operators.ConceptsInValueSet(k_, l_);
-
-            CqlBoolean n_() {
-                Period p_ = Encounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                Period r_ = HospitalLocation?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, (string)default);
-                return t_;
-            }
-
+            Period n_ = Encounter?.Period;
+            CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+            Period p_ = HospitalLocation?.Period;
+            CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+            CqlBoolean r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
+            CqlBoolean s_ = r_;
             return m_
-                /* CQL 'and' (336:6-337:57) */ && n_();
+                /* CQL 'and' (336:6-337:57) */ && s_;
         }
 
         IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
@@ -3486,25 +2864,21 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             List<CodeableConcept> i_ = h_?.Type;
 
             CqlConcept j_(CodeableConcept @this) {
-                CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                return o_;
+                CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                return t_;
             }
 
             IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
             CqlValueSet l_ = this.Intensive_Care_Unit(context);
             CqlBoolean m_ = context.Operators.ConceptsInValueSet(k_, l_);
-
-            CqlBoolean n_() {
-                Period p_ = Encounter?.Period;
-                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                Period r_ = HospitalLocation?.Period;
-                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                CqlBoolean t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, (string)default);
-                return t_;
-            }
-
+            Period n_ = Encounter?.Period;
+            CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+            Period p_ = HospitalLocation?.Period;
+            CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+            CqlBoolean r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
+            CqlBoolean s_ = r_;
             return m_
-                /* CQL 'and' (346:6-347:57) */ && n_();
+                /* CQL 'and' (346:6-347:57) */ && s_;
         }
 
         IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
@@ -3634,18 +3008,14 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             PositiveInt g_ = D?.RankElement;
             int? h_ = g_?.Value;
             CqlBoolean i_ = context.Operators.Equal(h_, 1);
-
-            CqlBoolean j_() {
-                CodeableConcept k_ = D?.Use;
-                CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
-                CqlCode m_ = this.Billing(context);
-                CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
-                CqlBoolean o_ = context.Operators.Equivalent(l_, n_);
-                return o_;
-            }
-
+            CodeableConcept j_ = D?.Use;
+            CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, j_);
+            CqlCode l_ = this.Billing(context);
+            CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
+            CqlBoolean n_ = context.Operators.Equivalent(k_, m_);
+            CqlBoolean o_ = n_;
             return i_
-                /* CQL 'and' (386:25-386:62) */ && j_();
+                /* CQL 'and' (386:25-386:62) */ && o_;
         }
 
 
@@ -3718,32 +3088,24 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 FinancialResourceStatusCodes? o_ = n_?.Value;
                 Code<FinancialResourceStatusCodes> p_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(o_);
                 CqlBoolean q_ = context.Operators.Equal(p_, "active");
+                Code<ClaimUseCode> r_ = C?.UseElement;
+                ClaimUseCode? s_ = r_?.Value;
+                Code<ClaimUseCode> t_ = context.Operators.Convert<Code<ClaimUseCode>>(s_);
+                CqlBoolean u_ = context.Operators.Equal(t_, "claim");
+                CqlBoolean v_ = u_;
+                List<Claim.ItemComponent> w_ = C?.Item;
 
-                CqlBoolean r_() {
-                    Code<ClaimUseCode> t_ = C?.UseElement;
-                    ClaimUseCode? u_ = t_?.Value;
-                    Code<ClaimUseCode> v_ = context.Operators.Convert<Code<ClaimUseCode>>(u_);
-                    CqlBoolean w_ = context.Operators.Equal(v_, "claim");
-                    return w_;
+                bool? x_(Claim.ItemComponent I) {
+                    List<ResourceReference> aa_ = I?.Encounter;
+                    CqlBoolean ab_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)aa_, E);
+                    return ab_;
                 }
 
-
-                CqlBoolean s_() {
-                    List<Claim.ItemComponent> x_ = C?.Item;
-
-                    bool? y_(Claim.ItemComponent I) {
-                        List<ResourceReference> aa_ = I?.Encounter;
-                        CqlBoolean ab_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)aa_, E);
-                        return ab_;
-                    }
-
-                    CqlBoolean z_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)x_, y_);
-                    return z_;
-                }
-
+                CqlBoolean y_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)w_, x_);
+                CqlBoolean z_ = y_;
                 return q_
-                    /* CQL 'and' (406:31-406:69) */ && r_()
-                    /* CQL 'and' (406:25-406:123) */ && s_();
+                    /* CQL 'and' (406:31-406:69) */ && v_
+                    /* CQL 'and' (406:25-406:123) */ && z_;
             }
 
             IEnumerable<Claim> g_ = context.Operators.Where<Claim>(e_, f_);
@@ -3772,32 +3134,24 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     FinancialResourceStatusCodes? av_ = au_?.Value;
                     Code<FinancialResourceStatusCodes> aw_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(av_);
                     CqlBoolean ax_ = context.Operators.Equal(aw_, "active");
+                    Code<ClaimUseCode> ay_ = C?.UseElement;
+                    ClaimUseCode? az_ = ay_?.Value;
+                    Code<ClaimUseCode> ba_ = context.Operators.Convert<Code<ClaimUseCode>>(az_);
+                    CqlBoolean bb_ = context.Operators.Equal(ba_, "claim");
+                    CqlBoolean bc_ = bb_;
+                    List<Claim.ItemComponent> bd_ = C?.Item;
 
-                    CqlBoolean ay_() {
-                        Code<ClaimUseCode> ba_ = C?.UseElement;
-                        ClaimUseCode? bb_ = ba_?.Value;
-                        Code<ClaimUseCode> bc_ = context.Operators.Convert<Code<ClaimUseCode>>(bb_);
-                        CqlBoolean bd_ = context.Operators.Equal(bc_, "claim");
-                        return bd_;
+                    bool? be_(Claim.ItemComponent I) {
+                        List<ResourceReference> bh_ = I?.Encounter;
+                        CqlBoolean bi_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bh_, E);
+                        return bi_;
                     }
 
-
-                    CqlBoolean az_() {
-                        List<Claim.ItemComponent> be_ = C?.Item;
-
-                        bool? bf_(Claim.ItemComponent I) {
-                            List<ResourceReference> bh_ = I?.Encounter;
-                            CqlBoolean bi_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bh_, E);
-                            return bi_;
-                        }
-
-                        CqlBoolean bg_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)be_, bf_);
-                        return bg_;
-                    }
-
+                    CqlBoolean bf_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)bd_, be_);
+                    CqlBoolean bg_ = bf_;
                     return ax_
-                        /* CQL 'and' (406:31-406:69) */ && ay_()
-                        /* CQL 'and' (406:25-406:123) */ && az_();
+                        /* CQL 'and' (406:31-406:69) */ && bc_
+                        /* CQL 'and' (406:25-406:123) */ && bg_;
                 }
 
                 IEnumerable<Claim> ai_ = context.Operators.Where<Claim>(ag_, ah_);
@@ -3879,19 +3233,13 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             DataType f_ = PD?.Diagnosis;
             object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
             CqlBoolean h_ = context.Operators.ConceptInValueSet(g_ as CqlConcept, valueSet);
-
-            CqlBoolean i_() {
-                DataType j_ = PD?.Diagnosis;
-                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
-                Condition l_ = this.getCondition(context, k_ as ResourceReference);
-                CodeableConcept m_ = l_?.Code;
-                CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-                CqlBoolean o_ = context.Operators.ConceptInValueSet(n_, valueSet);
-                return o_;
-            }
-
+            Condition i_ = this.getCondition(context, g_ as ResourceReference);
+            CodeableConcept j_ = i_?.Code;
+            CqlConcept k_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, j_);
+            CqlBoolean l_ = context.Operators.ConceptInValueSet(k_, valueSet);
+            CqlBoolean m_ = l_;
             return h_
-                /* CQL 'or' (417:13-418:54) */ || i_();
+                /* CQL 'or' (417:13-418:54) */ || m_;
         }
 
         IEnumerable<bool?> d_ = context.Operators.SelectDistinct<Claim.DiagnosisComponent, bool?>((IEnumerable<Claim.DiagnosisComponent>)b_, c_);
@@ -3911,28 +3259,18 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             CodeableConcept d_ = CD?.OnAdmission;
             CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, d_);
             CqlBoolean f_ = context.Operators.ConceptInValueSet(e_, poaValueSet);
-
-            CqlBoolean g_() {
-                DataType h_ = CD?.Diagnosis;
-                object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
-                CqlBoolean j_ = context.Operators.ConceptInValueSet(i_ as CqlConcept, diagnosisValueSet);
-
-                CqlBoolean k_() {
-                    DataType l_ = CD?.Diagnosis;
-                    object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
-                    Condition n_ = this.getCondition(context, m_ as ResourceReference);
-                    CodeableConcept o_ = n_?.Code;
-                    CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, o_);
-                    CqlBoolean q_ = context.Operators.ConceptInValueSet(p_, diagnosisValueSet);
-                    return q_;
-                }
-
-                return j_
-                    /* CQL 'or' (428:14-431:10) */ || k_();
-            }
-
+            DataType g_ = CD?.Diagnosis;
+            object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+            CqlBoolean i_ = context.Operators.ConceptInValueSet(h_ as CqlConcept, diagnosisValueSet);
+            Condition j_ = this.getCondition(context, h_ as ResourceReference);
+            CodeableConcept k_ = j_?.Code;
+            CqlConcept l_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, k_);
+            CqlBoolean m_ = context.Operators.ConceptInValueSet(l_, diagnosisValueSet);
+            CqlBoolean n_ = m_;
+            CqlBoolean o_ = i_
+                /* CQL 'or' (428:14-431:10) */ || n_;
             return f_
-                /* CQL 'and' (427:8-431:10) */ && g_();
+                /* CQL 'and' (427:8-431:10) */ && o_;
         }
 
         CqlBoolean c_ = context.Operators.WhereAny<Claim.DiagnosisComponent>(a_, b_);
@@ -4036,32 +3374,24 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 FinancialResourceStatusCodes? p_ = o_?.Value;
                 Code<FinancialResourceStatusCodes> q_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(p_);
                 CqlBoolean r_ = context.Operators.Equal(q_, "active");
+                Code<ClaimUseCode> s_ = C?.UseElement;
+                ClaimUseCode? t_ = s_?.Value;
+                Code<ClaimUseCode> u_ = context.Operators.Convert<Code<ClaimUseCode>>(t_);
+                CqlBoolean v_ = context.Operators.Equal(u_, "claim");
+                CqlBoolean w_ = v_;
+                List<Claim.ItemComponent> x_ = C?.Item;
 
-                CqlBoolean s_() {
-                    Code<ClaimUseCode> u_ = C?.UseElement;
-                    ClaimUseCode? v_ = u_?.Value;
-                    Code<ClaimUseCode> w_ = context.Operators.Convert<Code<ClaimUseCode>>(v_);
-                    CqlBoolean x_ = context.Operators.Equal(w_, "claim");
-                    return x_;
+                bool? y_(Claim.ItemComponent I) {
+                    List<ResourceReference> ab_ = I?.Encounter;
+                    CqlBoolean ac_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)ab_, E);
+                    return ac_;
                 }
 
-
-                CqlBoolean t_() {
-                    List<Claim.ItemComponent> y_ = C?.Item;
-
-                    bool? z_(Claim.ItemComponent I) {
-                        List<ResourceReference> ab_ = I?.Encounter;
-                        CqlBoolean ac_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)ab_, E);
-                        return ac_;
-                    }
-
-                    CqlBoolean aa_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)y_, z_);
-                    return aa_;
-                }
-
+                CqlBoolean z_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)x_, y_);
+                CqlBoolean aa_ = z_;
                 return r_
-                    /* CQL 'and' (476:32-476:70) */ && s_()
-                    /* CQL 'and' (476:26-476:124) */ && t_();
+                    /* CQL 'and' (476:32-476:70) */ && w_
+                    /* CQL 'and' (476:26-476:124) */ && aa_;
             }
 
             IEnumerable<Claim> g_ = context.Operators.Where<Claim>(e_, f_);
@@ -4086,107 +3416,95 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 IEnumerable<Claim> ah_ = context.Operators.Retrieve<Claim>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim"));
 
                 bool? ai_(Claim C) {
-                    Code<FinancialResourceStatusCodes> aw_ = C?.StatusElement;
-                    FinancialResourceStatusCodes? ax_ = aw_?.Value;
-                    Code<FinancialResourceStatusCodes> ay_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(ax_);
-                    CqlBoolean az_ = context.Operators.Equal(ay_, "active");
+                    Code<FinancialResourceStatusCodes> bb_ = C?.StatusElement;
+                    FinancialResourceStatusCodes? bc_ = bb_?.Value;
+                    Code<FinancialResourceStatusCodes> bd_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(bc_);
+                    CqlBoolean be_ = context.Operators.Equal(bd_, "active");
+                    Code<ClaimUseCode> bf_ = C?.UseElement;
+                    ClaimUseCode? bg_ = bf_?.Value;
+                    Code<ClaimUseCode> bh_ = context.Operators.Convert<Code<ClaimUseCode>>(bg_);
+                    CqlBoolean bi_ = context.Operators.Equal(bh_, "claim");
+                    CqlBoolean bj_ = bi_;
+                    List<Claim.ItemComponent> bk_ = C?.Item;
 
-                    CqlBoolean ba_() {
-                        Code<ClaimUseCode> bc_ = C?.UseElement;
-                        ClaimUseCode? bd_ = bc_?.Value;
-                        Code<ClaimUseCode> be_ = context.Operators.Convert<Code<ClaimUseCode>>(bd_);
-                        CqlBoolean bf_ = context.Operators.Equal(be_, "claim");
-                        return bf_;
+                    bool? bl_(Claim.ItemComponent I) {
+                        List<ResourceReference> bo_ = I?.Encounter;
+                        CqlBoolean bp_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bo_, E);
+                        return bp_;
                     }
 
-
-                    CqlBoolean bb_() {
-                        List<Claim.ItemComponent> bg_ = C?.Item;
-
-                        bool? bh_(Claim.ItemComponent I) {
-                            List<ResourceReference> bj_ = I?.Encounter;
-                            CqlBoolean bk_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bj_, E);
-                            return bk_;
-                        }
-
-                        CqlBoolean bi_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)bg_, bh_);
-                        return bi_;
-                    }
-
-                    return az_
-                        /* CQL 'and' (476:32-476:70) */ && ba_()
-                        /* CQL 'and' (476:26-476:124) */ && bb_();
+                    CqlBoolean bm_ = context.Operators.WhereAny<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)bk_, bl_);
+                    CqlBoolean bn_ = bm_;
+                    return be_
+                        /* CQL 'and' (476:32-476:70) */ && bj_
+                        /* CQL 'and' (476:26-476:124) */ && bn_;
                 }
 
                 IEnumerable<Claim> aj_ = context.Operators.Where<Claim>(ah_, ai_);
 
                 bool? ak_(Claim @this) {
-                    List<Claim.ItemComponent> bl_ = @this?.Item;
-                    return bl_ is not null;
+                    List<Claim.ItemComponent> bq_ = @this?.Item;
+                    return bq_ is not null;
                 }
 
 
                 List<Claim.ItemComponent> al_(Claim @this) {
-                    List<Claim.ItemComponent> bm_ = @this?.Item;
-                    return bm_;
+                    List<Claim.ItemComponent> br_ = @this?.Item;
+                    return br_;
                 }
 
                 IEnumerable<List<Claim.ItemComponent>> am_ = context.Operators.WhereSelect<Claim, List<Claim.ItemComponent>>(aj_, ak_, al_);
                 IEnumerable<Claim.ItemComponent> an_ = context.Operators.Flatten<Claim.ItemComponent>((IEnumerable<IEnumerable<Claim.ItemComponent>>)am_);
 
                 bool? ao_(Claim.ItemComponent I) {
-                    List<ResourceReference> bn_ = I?.Encounter;
-                    CqlBoolean bo_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bn_, E);
-                    return bo_;
+                    List<ResourceReference> bs_ = I?.Encounter;
+                    CqlBoolean bt_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)bs_, E);
+                    return bt_;
                 }
 
                 IEnumerable<Claim.ItemComponent> ap_ = context.Operators.Where<Claim.ItemComponent>(an_, ao_);
 
                 bool? aq_(Claim.ItemComponent @this) {
-                    List<PositiveInt> bp_ = @this?.ProcedureSequenceElement;
+                    List<PositiveInt> bu_ = @this?.ProcedureSequenceElement;
 
-                    int? bq_(PositiveInt @this) {
-                        int? bs_ = @this?.Value;
-                        return bs_;
+                    int? bv_(PositiveInt @this) {
+                        int? bx_ = @this?.Value;
+                        return bx_;
                     }
 
-                    IEnumerable<int?> br_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)bp_, bq_);
-                    return br_ is not null;
+                    IEnumerable<int?> bw_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)bu_, bv_);
+                    return bw_ is not null;
                 }
 
 
                 IEnumerable<int?> ar_(Claim.ItemComponent @this) {
-                    List<PositiveInt> bt_ = @this?.ProcedureSequenceElement;
+                    List<PositiveInt> by_ = @this?.ProcedureSequenceElement;
 
-                    int? bu_(PositiveInt @this) {
-                        int? bw_ = @this?.Value;
-                        return bw_;
+                    int? bz_(PositiveInt @this) {
+                        int? cb_ = @this?.Value;
+                        return cb_;
                     }
 
-                    IEnumerable<int?> bv_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)bt_, bu_);
-                    return bv_;
+                    IEnumerable<int?> ca_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)by_, bz_);
+                    return ca_;
                 }
 
                 IEnumerable<IEnumerable<int?>> as_ = context.Operators.WhereSelect<Claim.ItemComponent, IEnumerable<int?>>(ap_, aq_, ar_);
                 IEnumerable<int?> at_ = context.Operators.Flatten<int?>(as_);
                 CqlBoolean au_ = context.Operators.In<int?>(ag_, at_);
+                List<CodeableConcept> av_ = P?.Type;
 
-                CqlBoolean av_() {
-                    List<CodeableConcept> bx_ = P?.Type;
-
-                    CqlConcept by_(CodeableConcept @this) {
-                        CqlConcept cc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
-                        return cc_;
-                    }
-
-                    IEnumerable<CqlConcept> bz_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bx_, by_);
-                    CqlCode ca_ = this.Primary_procedure(context);
-                    CqlBoolean cb_ = QICoreCommon_4_0_000.Instance.includesCode(context, bz_, ca_);
-                    return cb_;
+                CqlConcept aw_(CodeableConcept @this) {
+                    CqlConcept cc_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return cc_;
                 }
 
+                IEnumerable<CqlConcept> ax_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)av_, aw_);
+                CqlCode ay_ = this.Primary_procedure(context);
+                CqlBoolean az_ = QICoreCommon_4_0_000.Instance.includesCode(context, ax_, ay_);
+                CqlBoolean ba_ = az_;
                 return au_
-                    /* CQL 'and' (478:59-478:150) */ && av_();
+                    /* CQL 'and' (478:59-478:150) */ && ba_;
             }
 
             IEnumerable<Claim.ProcedureComponent> m_ = context.Operators.Where<Claim.ProcedureComponent>(k_, l_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/FHIRHelpers-4.4.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/FHIRHelpers-4.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.7.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("FHIRHelpers", "4.4.000")]
 public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_000>
 {
@@ -195,50 +195,38 @@ public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_
         else
         {
             FhirUri b_ = quantity?.SystemElement;
-
-            CqlBoolean c_() {
-                FhirUri e_ = quantity?.SystemElement;
-                string f_ = e_?.Value;
-                CqlBoolean g_ = context.Operators.Equal(f_, "http://unitsofmeasure.org");
-                return g_;
-            }
-
-
-            CqlBoolean d_() {
-                FhirUri h_ = quantity?.SystemElement;
-                string i_ = h_?.Value;
-                CqlBoolean j_ = context.Operators.Equal(i_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
-                return j_;
-            }
-
+            string c_ = b_?.Value;
+            CqlBoolean d_ = context.Operators.Equal(c_, "http://unitsofmeasure.org");
+            CqlBoolean e_ = d_;
+            CqlBoolean f_ = context.Operators.Equal(c_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
+            CqlBoolean g_ = f_;
             if ((CqlBoolean)(b_ is null)
-                /* CQL 'or' (54:14-54:91) */ || c_()
-                /* CQL 'or' (54:14-55:92) */ || d_())
+                /* CQL 'or' (54:14-54:91) */ || e_
+                /* CQL 'or' (54:14-55:92) */ || g_)
             {
-                FhirDecimal k_ = quantity?.ValueElement;
-                decimal? l_ = k_?.Value;
-                Code m_ = quantity?.CodeElement;
-                string n_ = m_?.Value;
-                FhirString o_ = quantity?.UnitElement;
-                string p_ = o_?.Value;
-                string q_ = this.ToCalendarUnit(context, (n_ ?? p_) ?? "1");
-                return new CqlQuantity(l_, q_);
+                FhirDecimal h_ = quantity?.ValueElement;
+                decimal? i_ = h_?.Value;
+                Code j_ = quantity?.CodeElement;
+                string k_ = j_?.Value;
+                FhirString l_ = quantity?.UnitElement;
+                string m_ = l_?.Value;
+                string n_ = this.ToCalendarUnit(context, (k_ ?? m_) ?? "1");
+                return new CqlQuantity(i_, n_);
             }
             else
             {
-                FhirString r_ = quantity?.UnitElement;
-                string s_ = r_?.Value;
-                string t_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", s_ ?? "");
-                string u_ = context.Operators.Concatenate(t_ ?? "", " (");
-                string v_ = b_?.Value;
-                string w_ = context.Operators.Concatenate(u_ ?? "", v_ ?? "");
-                string x_ = context.Operators.Concatenate(w_ ?? "", "|");
-                Code y_ = quantity?.CodeElement;
-                string z_ = y_?.Value;
-                string aa_ = context.Operators.Concatenate(x_ ?? "", z_ ?? "");
-                string ab_ = context.Operators.Concatenate(aa_ ?? "", ")");
-                object ac_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ab_);
-                return ac_ as CqlQuantity;
+                FhirString o_ = quantity?.UnitElement;
+                string p_ = o_?.Value;
+                string q_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", p_ ?? "");
+                string r_ = context.Operators.Concatenate(q_ ?? "", " (");
+                string s_ = context.Operators.Concatenate(r_ ?? "", c_ ?? "");
+                string t_ = context.Operators.Concatenate(s_ ?? "", "|");
+                Code u_ = quantity?.CodeElement;
+                string v_ = u_?.Value;
+                string w_ = context.Operators.Concatenate(t_ ?? "", v_ ?? "");
+                string x_ = context.Operators.Concatenate(w_ ?? "", ")");
+                object y_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", x_);
+                return y_ as CqlQuantity;
             }
         }
     }
@@ -261,50 +249,38 @@ public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_
         else
         {
             FhirUri a_ = quantity?.SystemElement;
-
-            CqlBoolean b_() {
-                FhirUri d_ = quantity?.SystemElement;
-                string e_ = d_?.Value;
-                CqlBoolean f_ = context.Operators.Equal(e_, "http://unitsofmeasure.org");
-                return f_;
-            }
-
-
-            CqlBoolean c_() {
-                FhirUri g_ = quantity?.SystemElement;
-                string h_ = g_?.Value;
-                CqlBoolean i_ = context.Operators.Equal(h_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
-                return i_;
-            }
-
+            string b_ = a_?.Value;
+            CqlBoolean c_ = context.Operators.Equal(b_, "http://unitsofmeasure.org");
+            CqlBoolean d_ = c_;
+            CqlBoolean e_ = context.Operators.Equal(b_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
+            CqlBoolean f_ = e_;
             if ((CqlBoolean)(a_ is null)
-                /* CQL 'or' (74:14-74:91) */ || b_()
-                /* CQL 'or' (74:14-75:92) */ || c_())
+                /* CQL 'or' (74:14-74:91) */ || d_
+                /* CQL 'or' (74:14-75:92) */ || f_)
             {
-                FhirDecimal j_ = quantity?.ValueElement;
-                decimal? k_ = j_?.Value;
-                Code l_ = quantity?.CodeElement;
-                string m_ = l_?.Value;
-                FhirString n_ = quantity?.UnitElement;
-                string o_ = n_?.Value;
-                string p_ = this.ToCalendarUnit(context, (m_ ?? o_) ?? "1");
-                return new CqlQuantity(k_, p_);
+                FhirDecimal g_ = quantity?.ValueElement;
+                decimal? h_ = g_?.Value;
+                Code i_ = quantity?.CodeElement;
+                string j_ = i_?.Value;
+                FhirString k_ = quantity?.UnitElement;
+                string l_ = k_?.Value;
+                string m_ = this.ToCalendarUnit(context, (j_ ?? l_) ?? "1");
+                return new CqlQuantity(h_, m_);
             }
             else
             {
-                FhirString q_ = quantity?.UnitElement;
-                string r_ = q_?.Value;
-                string s_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", r_ ?? "");
-                string t_ = context.Operators.Concatenate(s_ ?? "", " (");
-                string u_ = a_?.Value;
-                string v_ = context.Operators.Concatenate(t_ ?? "", u_ ?? "");
-                string w_ = context.Operators.Concatenate(v_ ?? "", "|");
-                Code x_ = quantity?.CodeElement;
-                string y_ = x_?.Value;
-                string z_ = context.Operators.Concatenate(w_ ?? "", y_ ?? "");
-                string aa_ = context.Operators.Concatenate(z_ ?? "", ")");
-                object ab_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", aa_);
-                return ab_ as CqlQuantity;
+                FhirString n_ = quantity?.UnitElement;
+                string o_ = n_?.Value;
+                string p_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", o_ ?? "");
+                string q_ = context.Operators.Concatenate(p_ ?? "", " (");
+                string r_ = context.Operators.Concatenate(q_ ?? "", b_ ?? "");
+                string s_ = context.Operators.Concatenate(r_ ?? "", "|");
+                Code t_ = quantity?.CodeElement;
+                string u_ = t_?.Value;
+                string v_ = context.Operators.Concatenate(s_ ?? "", u_ ?? "");
+                string w_ = context.Operators.Concatenate(v_ ?? "", ")");
+                object x_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", w_);
+                return x_ as CqlQuantity;
             }
         }
     }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/QICoreCommon-4.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/QICoreCommon-4.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.6.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.3.8.0")]
 [CqlLibrary("QICoreCommon", "4.0.000")]
 public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_0_000>
 {
@@ -419,29 +419,17 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlCode c_ = this.active(context);
         CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
         CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
-
-        CqlBoolean f_() {
-            CodeableConcept h_ = condition?.ClinicalStatus;
-            CqlConcept i_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, h_);
-            CqlCode j_ = this.recurrence(context);
-            CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
-            CqlBoolean l_ = context.Operators.Equivalent(i_, k_);
-            return l_;
-        }
-
-
-        CqlBoolean g_() {
-            CodeableConcept m_ = condition?.ClinicalStatus;
-            CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-            CqlCode o_ = this.relapse(context);
-            CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
-            CqlBoolean q_ = context.Operators.Equivalent(n_, p_);
-            return q_;
-        }
-
+        CqlCode f_ = this.recurrence(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = this.relapse(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
         return e_
-            /* CQL 'or' (112:3-113:46) */ || f_()
-            /* CQL 'or' (112:3-114:43) */ || g_();
+            /* CQL 'or' (112:3-113:46) */ || i_
+            /* CQL 'or' (112:3-114:43) */ || m_;
     }
 
 
@@ -1137,71 +1125,59 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlCode c_ = this.active(context);
         CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
         CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
-
-        CqlBoolean f_() {
-            CodeableConcept h_ = condition?.ClinicalStatus;
-            CqlConcept i_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, h_);
-            CqlCode j_ = this.recurrence(context);
-            CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
-            CqlBoolean l_ = context.Operators.Equivalent(i_, k_);
-            return l_;
-        }
-
-
-        CqlBoolean g_() {
-            CodeableConcept m_ = condition?.ClinicalStatus;
-            CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-            CqlCode o_ = this.relapse(context);
-            CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
-            CqlBoolean q_ = context.Operators.Equivalent(n_, p_);
-            return q_;
-        }
-
+        CqlCode f_ = this.recurrence(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = this.relapse(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
         if (e_
-            /* CQL 'or' (435:4-436:44) */ || f_()
-            /* CQL 'or' (435:4-437:41) */ || g_())
+            /* CQL 'or' (435:4-436:44) */ || i_
+            /* CQL 'or' (435:4-437:41) */ || m_)
         {
-            DataType r_ = condition?.Onset;
-            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-            CqlInterval<CqlDateTime> t_ = this.ToInterval(context, s_);
-            CqlDateTime u_ = context.Operators.Start(t_);
-            CqlInterval<CqlDateTime> v_ = this.ToAbatementInterval(context, condition);
-            CqlDateTime w_ = context.Operators.End(v_);
-            CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
-            return x_;
+            DataType n_ = condition?.Onset;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = this.ToInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlInterval<CqlDateTime> r_ = this.ToAbatementInterval(context, condition);
+            CqlDateTime s_ = context.Operators.End(r_);
+            CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
+            return t_;
         }
         else
         {
-            CqlInterval<CqlDateTime> y_ = this.ToAbatementInterval(context, condition);
-            CqlDateTime z_ = context.Operators.End(y_);
-            CqlDateTime[] aa_ = [
-                z_,
+            CqlInterval<CqlDateTime> u_ = this.ToAbatementInterval(context, condition);
+            CqlDateTime v_ = context.Operators.End(u_);
+            CqlDateTime[] w_ = [
+                v_,
             ];
 
-            CqlInterval<CqlDateTime> ab_(CqlDateTime abatementDate) {
+            CqlInterval<CqlDateTime> x_(CqlDateTime abatementDate) {
                 if (abatementDate is null)
                 {
-                    DataType ae_ = condition?.Onset;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    CqlInterval<CqlDateTime> ag_ = this.ToInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.Start(ag_);
-                    CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ah_, abatementDate, true, false);
-                    return ai_;
+                    DataType aa_ = condition?.Onset;
+                    object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                    CqlInterval<CqlDateTime> ac_ = this.ToInterval(context, ab_);
+                    CqlDateTime ad_ = context.Operators.Start(ac_);
+                    CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ad_, abatementDate, true, false);
+                    return ae_;
                 }
                 else
                 {
-                    DataType aj_ = condition?.Onset;
-                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                    CqlInterval<CqlDateTime> al_ = this.ToInterval(context, ak_);
-                    CqlDateTime am_ = context.Operators.Start(al_);
-                    CqlInterval<CqlDateTime> an_ = context.Operators.Interval(am_, abatementDate, true, true);
-                    return an_;
+                    DataType af_ = condition?.Onset;
+                    object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                    CqlInterval<CqlDateTime> ah_ = this.ToInterval(context, ag_);
+                    CqlDateTime ai_ = context.Operators.Start(ah_);
+                    CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ai_, abatementDate, true, true);
+                    return aj_;
                 }
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.SelectDistinct<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)aa_, ab_);
-            CqlInterval<CqlDateTime> ad_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ac_);
-            return ad_;
+            IEnumerable<CqlInterval<CqlDateTime>> y_ = context.Operators.SelectDistinct<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)w_, x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(y_);
+            return z_;
         }
     }
 
@@ -1216,71 +1192,59 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlCode c_ = this.active(context);
         CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
         CqlBoolean e_ = context.Operators.Equivalent(b_, d_);
-
-        CqlBoolean f_() {
-            CodeableConcept h_ = condition?.ClinicalStatus;
-            CqlConcept i_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, h_);
-            CqlCode j_ = this.recurrence(context);
-            CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
-            CqlBoolean l_ = context.Operators.Equivalent(i_, k_);
-            return l_;
-        }
-
-
-        CqlBoolean g_() {
-            CodeableConcept m_ = condition?.ClinicalStatus;
-            CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
-            CqlCode o_ = this.relapse(context);
-            CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
-            CqlBoolean q_ = context.Operators.Equivalent(n_, p_);
-            return q_;
-        }
-
+        CqlCode f_ = this.recurrence(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        CqlBoolean h_ = context.Operators.Equivalent(b_, g_);
+        CqlBoolean i_ = h_;
+        CqlCode j_ = this.relapse(context);
+        CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+        CqlBoolean l_ = context.Operators.Equivalent(b_, k_);
+        CqlBoolean m_ = l_;
         if (e_
-            /* CQL 'or' (453:4-454:44) */ || f_()
-            /* CQL 'or' (453:4-455:41) */ || g_())
+            /* CQL 'or' (453:4-454:44) */ || i_
+            /* CQL 'or' (453:4-455:41) */ || m_)
         {
-            DataType r_ = condition?.Onset;
-            object s_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
-            CqlInterval<CqlDateTime> t_ = this.toInterval(context, s_);
-            CqlDateTime u_ = context.Operators.Start(t_);
-            CqlInterval<CqlDateTime> v_ = this.abatementInterval(context, condition);
-            CqlDateTime w_ = context.Operators.End(v_);
-            CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
-            return x_;
+            DataType n_ = condition?.Onset;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = this.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlInterval<CqlDateTime> r_ = this.abatementInterval(context, condition);
+            CqlDateTime s_ = context.Operators.End(r_);
+            CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
+            return t_;
         }
         else
         {
-            CqlInterval<CqlDateTime> y_ = this.abatementInterval(context, condition);
-            CqlDateTime z_ = context.Operators.End(y_);
-            CqlDateTime[] aa_ = [
-                z_,
+            CqlInterval<CqlDateTime> u_ = this.abatementInterval(context, condition);
+            CqlDateTime v_ = context.Operators.End(u_);
+            CqlDateTime[] w_ = [
+                v_,
             ];
 
-            CqlInterval<CqlDateTime> ab_(CqlDateTime abatementDate) {
+            CqlInterval<CqlDateTime> x_(CqlDateTime abatementDate) {
                 if (abatementDate is null)
                 {
-                    DataType ae_ = condition?.Onset;
-                    object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
-                    CqlInterval<CqlDateTime> ag_ = this.toInterval(context, af_);
-                    CqlDateTime ah_ = context.Operators.Start(ag_);
-                    CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ah_, abatementDate, true, false);
-                    return ai_;
+                    DataType aa_ = condition?.Onset;
+                    object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                    CqlInterval<CqlDateTime> ac_ = this.toInterval(context, ab_);
+                    CqlDateTime ad_ = context.Operators.Start(ac_);
+                    CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ad_, abatementDate, true, false);
+                    return ae_;
                 }
                 else
                 {
-                    DataType aj_ = condition?.Onset;
-                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
-                    CqlInterval<CqlDateTime> al_ = this.toInterval(context, ak_);
-                    CqlDateTime am_ = context.Operators.Start(al_);
-                    CqlInterval<CqlDateTime> an_ = context.Operators.Interval(am_, abatementDate, true, true);
-                    return an_;
+                    DataType af_ = condition?.Onset;
+                    object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                    CqlInterval<CqlDateTime> ah_ = this.toInterval(context, ag_);
+                    CqlDateTime ai_ = context.Operators.Start(ah_);
+                    CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ai_, abatementDate, true, true);
+                    return aj_;
                 }
             }
 
-            IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.SelectDistinct<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)aa_, ab_);
-            CqlInterval<CqlDateTime> ad_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ac_);
-            return ad_;
+            IEnumerable<CqlInterval<CqlDateTime>> y_ = context.Operators.SelectDistinct<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)w_, x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(y_);
+            return z_;
         }
     }
 
@@ -1393,16 +1357,11 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
     public bool? HasStart(CqlContext context, CqlInterval<CqlDateTime> period)
     {
         CqlDateTime a_ = context.Operators.Start(period);
-
-        CqlBoolean b_() {
-            CqlDateTime c_ = context.Operators.Start(period);
-            CqlDateTime d_ = context.Operators.MinValue<CqlDateTime>();
-            CqlBoolean e_ = context.Operators.Equal(c_, d_);
-            return e_;
-        }
-
+        CqlDateTime b_ = context.Operators.MinValue<CqlDateTime>();
+        CqlBoolean c_ = context.Operators.Equal(a_, b_);
+        CqlBoolean d_ = c_;
         return !((bool?)((CqlBoolean)(a_ is null)
-            /* CQL 'or' (528:7-530:3) */ || b_()));
+            /* CQL 'or' (528:7-530:3) */ || d_));
     }
 
 
@@ -1411,16 +1370,11 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
     public bool? hasStart(CqlContext context, CqlInterval<CqlDateTime> period)
     {
         CqlDateTime a_ = context.Operators.Start(period);
-
-        CqlBoolean b_() {
-            CqlDateTime c_ = context.Operators.Start(period);
-            CqlDateTime d_ = context.Operators.MinValue<CqlDateTime>();
-            CqlBoolean e_ = context.Operators.Equal(c_, d_);
-            return e_;
-        }
-
+        CqlDateTime b_ = context.Operators.MinValue<CqlDateTime>();
+        CqlBoolean c_ = context.Operators.Equal(a_, b_);
+        CqlBoolean d_ = c_;
         return !((bool?)((CqlBoolean)(a_ is null)
-            /* CQL 'or' (537:7-539:3) */ || b_()));
+            /* CQL 'or' (537:7-539:3) */ || d_));
     }
 
 
@@ -1430,16 +1384,11 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
     public bool? HasEnd(CqlContext context, CqlInterval<CqlDateTime> period)
     {
         CqlDateTime a_ = context.Operators.End(period);
-
-        CqlBoolean b_() {
-            CqlDateTime c_ = context.Operators.End(period);
-            CqlDateTime d_ = context.Operators.MaxValue<CqlDateTime>();
-            CqlBoolean e_ = context.Operators.Equal(c_, d_);
-            return e_;
-        }
-
+        CqlDateTime b_ = context.Operators.MaxValue<CqlDateTime>();
+        CqlBoolean c_ = context.Operators.Equal(a_, b_);
+        CqlBoolean d_ = c_;
         return !((bool?)((CqlBoolean)(a_ is null)
-            /* CQL 'or' (547:7-550:3) */ || b_()));
+            /* CQL 'or' (547:7-550:3) */ || d_));
     }
 
 
@@ -1448,16 +1397,11 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
     public bool? hasEnd(CqlContext context, CqlInterval<CqlDateTime> period)
     {
         CqlDateTime a_ = context.Operators.End(period);
-
-        CqlBoolean b_() {
-            CqlDateTime c_ = context.Operators.End(period);
-            CqlDateTime d_ = context.Operators.MaxValue<CqlDateTime>();
-            CqlBoolean e_ = context.Operators.Equal(c_, d_);
-            return e_;
-        }
-
+        CqlDateTime b_ = context.Operators.MaxValue<CqlDateTime>();
+        CqlBoolean c_ = context.Operators.Equal(a_, b_);
+        CqlBoolean d_ = c_;
         return !((bool?)((CqlBoolean)(a_ is null)
-            /* CQL 'or' (557:7-560:3) */ || b_()));
+            /* CQL 'or' (557:7-560:3) */ || d_));
     }
 
 


### PR DESCRIPTION
**Draft, for review of the approach rather than for merge** — the integration suite has not been run against this output yet, and three of the four corpora are not regenerated, so CI will fail on the golden tests. See "Outstanding" below.

This is a sub-PR of #1565. It answers @ewoutkramer's review question there — *"if there are more retrieve sites, the overall performance might be slower"* — with measurements, and then changes the PR in response to them.

---

## Primary Work

### The measurement that prompted this

`IDataSource` has exactly one member, so a counting decorator was injected by reflection into `CqlOperators.DataSource` after `FhirCqlContext.ForBundle` had bound everything. Case sets verified identical by ID; counts deterministic (a 3-iteration run returns exactly 3× the 1-iteration count); a provenance probe confirmed the generator stamp on every run.

Two traps worth recording, because both silently produce wrong comparisons: `CQL_CMS_TEST_RUNNER_CmsMeasuresDllFile` is only validated and never loads anything, and the runner loads a **pre-compiled assembly embedded in each vendored FHIR `Library` resource** — so the comparison variable is the checkout, not the DLL.

**Runtime `Retrieve` invocations, 231 test cases:**

| measure | cases | develop | #1565 |
|---|---|---|---|
| CMS22FHIRPCSBPScreeningFollowUp | 40 | 1,675 | 2,144 (+28.0%) |
| CMS0334FHIRPCCesareanBirth | 136 | 6,652 | 9,412 (+41.5%) |
| CMS156FHIRHighRiskMedsElderly | 55 | 5,815 | 5,795 (−0.3%) |
| **total** | **231** | **14,142** | **17,351 (+22.7%)** |

**Wall clock** (CMS0334, 136 cases × 3 iterations, two interleaved passes, median ms/iter): branch 1.460 / 1.506, develop 1.505 / 1.476. The sides swap rank between passes — no measurable difference either way. Since #1477/#1480 `BundleDataSource.Retrieve` returns a materialized result, so a retrieve is a cheap filtered enumeration over an in-memory bundle. Against a real data source the +22.7% would matter; this harness cannot show it.

### Root cause

Attribution by calling frame located it exactly. In `PCMaternal.lastTimeOfDelivery`, develop computes a call once and uses it twice; #1565 splits that define body into sibling operand functions and each re-emits the call, taking its call sites from 3 to 4. That function performs 2 retrieves per call, so **that single duplicate accounted for +2,802 retrieves** — essentially all of CMS0334's regression.

The cause is **not** `&&` and **not** `CqlBoolean`. It is that hoisting an operand into a local function gives it its own scope and therefore its own dedup table, so subexpressions the enclosing scope already holds get emitted again inside it. Corpus-wide, 145 of 453 sibling groups (32%) share a subexpression, giving **371 removable duplicate evaluations** — of which 75 are calls into other CQL functions, each dragging a whole body along.

### The change

One method in the emitter. A short-circuit operand that cannot print inline is now **evaluated eagerly into the enclosing scope**, and the operator position becomes a reference to the resulting local. One scope, one dedup table.

| | develop | #1565 | this PR |
|---|---|---|---|
| retrieve invocations (231 cases) | 14,142 | 17,351 (+22.7%) | **15,182 (+7.4%)** |
| CMS22 | 1,675 | 2,144 | **1,675** — exact parity |
| CMS0334 | 6,652 | 9,412 | **7,732** |
| CMS156 | 5,815 | 5,795 | **5,775** — better than develop |
| duplicated `hospitalization…` call sites | 3 | 4 | **3** — parity |
| zero-arg operand functions | 0 | ~1,900 | **0** |
| generated lines | 111,742 | ~118,900 | **106,537** |

**68% of the retrieve regression removed.** The corpus is now ~5,200 lines *shorter* than develop, where #1565 added ~7,100.

Nothing else about #1565 changes: `and`/`or`/`not`/`xor`/`implies`/`IsTrue`/`IsFalse` still lower to C# operators rather than `ICqlOperators` calls (−3,835 call sites), the `ToValue` dedup fix stands (−2,844), `CqlBoolean` stays, and the **565 short-circuit operands that print inline keep their skip** — those never leave the scope, so they cost nothing.

### The trade, stated plainly

Operands too large to inline **no longer skip**. On the one call site we could attribute, both operands were reached in ~98% of evaluations, so the skip was worth very little while the duplication it bought was expensive. The CQL specification only *permits* short-circuiting for `and`/`or` — it mandates nothing, and calls it out explicitly only for `implies` — so this is conformant. `GeneratorToolVersion` 5.3.7.0 → 5.3.8.0 (patch, inside the invoker's `[5.1.0.0, 5.4.0.0)` window).

---

## Auxiliary Work

None. The commit is the emitter change, the version bump, and the regenerated `dqm-content-qicore-2025` corpus.

---

## Also tried, and rejected

Recorded so they are not retried:

- **Inherit dedup into operand bodies / pass shared values as parameters** — reaches only duplicates of locals the enclosing scope still holds (~15–23% of the regression). Implemented and measured at 16,617 retrieves.
- **`static` local functions with parameters** — needs an *exact* read set, since one miss is CS8421. Tracking references during linearization both misses and over-reports; deriving them from the printed text fixes that (115 errors → 16) but cannot tell a variable read from an identifier in tuple **type syntax**, and the heuristic for that broke genuine reads (1051 errors). There is no single point where a local's name becomes text — atoms carry pre-rendered strings and a `let` rebinds a name to another atom's code — so this needs `Atom` to carry the locals it reads. A code comment records this.
- **`LazyInitializer` for a shared value** — throws on a null value (`ValueFactory returned null`; null is an ordinary CQL value), and its `Func<T>` forces a heap closure: 40 bytes allocated per invocation *even when the chain short-circuits and nothing is needed*, versus 0 for a hand-rolled flag.
- **A runtime retrieve cache** — blocked on `RetrieveParameters` being a record whose `Codes` member compares by reference (so identical retrieves miss), on `CqlContext.GetOrCompute`'s `long` key being codegen-assigned rather than hashed, and on a materialization semantics decision. Would also show ~0 gain on this harness.

---

## Outstanding

- [ ] Integration suite run against this output — **the real gate**. Compilation and counts are verified; evaluation parity is not, and #1514 previously shipped a silent mis-grouping regression that compiled and passed three local suites.
- [ ] Regenerate `LibrarySets/RR23/CSharp`, `LibrarySets/dqm-content-qicore-2025/Extracted/CSharp`, `Cql/CoreTests/CSharp`, and the runner's vendored resources. Until then the golden tests fail on text.
- [ ] Rewrite #1565's release-note fragments: the skipped-side-effect disclosure now applies only to inline operands, and "generated code grows by 7,126 lines" is now a reduction.
- [ ] Attribute the residual +7.4%, which is entirely CMS0334.

## Questions for review

1. Is **+7.4% retrieve invocations** acceptable for **−6,020 emitted operator calls and ~5,200 fewer generated lines**, given no measurable wall-clock difference on this harness?
2. Do we accept short-circuiting only where it is free (565 sites), or is full short-circuiting worth the memoisation machinery — knowing we currently cannot measure its benefit?
3. Should a benchmark whose `IDataSource` is not a pre-loaded bundle be a prerequisite before claiming any performance result in either direction?

Refs #1514
