### PR TITLE
fix(runtime): keep exclusive interval boundaries exclusive

### DIFF
--- a/Cql/CoreTests/EffectiveIntervalBoundaryOperatorTests.cs
+++ b/Cql/CoreTests/EffectiveIntervalBoundaryOperatorTests.cs
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+#nullable enable
+
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
+
+namespace CoreTests
+{
+    /// <summary>
+    /// The counterpart of <see cref="ExclusiveIntervalBoundaryPrecisionTests"/>: once the Interval selector
+    /// keeps an exclusive date/time boundary exclusive, every operator the specification defines in terms of
+    /// the Start and End operators has to compare the effective boundary - the raw one stepped inward by a
+    /// unit of its own precision - rather than the raw endpoint. The selector's own normalization used to
+    /// hide the difference from these operators, so each test below is a case that reading the raw endpoint
+    /// gets wrong. Each test names the sentence of CQL 1.5.3 Errata 2, Appendix B - CQL Reference, that the
+    /// expectation follows from.
+    /// </summary>
+    [TestClass]
+    [TestCategory("UnitTest")]
+    public class EffectiveIntervalBoundaryOperatorTests
+    {
+        private static readonly CqlContext Context = FhirCqlContext.WithDataSource();
+
+        private static CqlDate D(int y, int m, int d) => new(y, m, d);
+
+        private static CqlDateTime Dt(int y, int m, int d, int h, int min) => new(y, m, d, h, min, 0, 0, 0, 0);
+
+        private static CqlInterval<CqlDate> Ival(CqlDate low, CqlDate high, bool lowClosed, bool highClosed) =>
+            new(low, high, lowClosed, highClosed);
+
+        // The Collapse overload is declared over a nullable point type.
+        private static CqlInterval<CqlDate?> IvalOfNullable(CqlDate low, CqlDate high, bool lowClosed, bool highClosed) =>
+            new(low, high, lowClosed, highClosed);
+
+        // section "Starts": "if the starting point of the first is equal to the starting point of the second
+        // interval and the ending point of the first interval is less than or equal to the ending point of
+        // the second interval. This operator uses the semantics described in the start and end operators to
+        // determine interval boundaries."
+        [TestMethod]
+        public void Starts_ExclusiveLowBoundary_ComparesTheEffectiveStart()
+        {
+            // (@2026-01-01, @2026-01-02] effectively starts on @2026-01-02, a day after the other interval.
+            var exclusiveLow = Ival(D(2026, 1, 1), D(2026, 1, 2), false, true);
+            var other = Ival(D(2026, 1, 1), D(2026, 1, 3), true, true);
+
+            Assert.AreEqual(false, Context.Operators.Starts(exclusiveLow, other, "day"));
+
+            // Stepping the exclusive low inward lands exactly on the other interval's start.
+            var startsOther = Ival(D(2025, 12, 31), D(2026, 1, 2), false, true);
+            Assert.AreEqual(true, Context.Operators.Starts(startsOther, other, "day"));
+        }
+
+        // section "Ends": "if the starting point of the first interval is greater than or equal to the
+        // starting point of the second, and the ending point of the first interval is equal to the ending
+        // point of the second. This operator uses the semantics described in the start and end operators to
+        // determine interval boundaries."
+        [TestMethod]
+        public void Ends_ExclusiveHighBoundary_ComparesTheEffectiveEnd()
+        {
+            // [@2026-01-01, @2026-01-03) effectively ends on @2026-01-02, a day before the other interval.
+            var exclusiveHigh = Ival(D(2026, 1, 1), D(2026, 1, 3), true, false);
+            var other = Ival(D(2026, 1, 1), D(2026, 1, 3), true, true);
+
+            Assert.AreEqual(false, Context.Operators.Ends(exclusiveHigh, other, "day"));
+
+            // An exclusive low does not move the end, so this one still ends the other interval.
+            var exclusiveLow = Ival(D(2026, 1, 1), D(2026, 1, 3), false, true);
+            Assert.AreEqual(true, Context.Operators.Ends(exclusiveLow, other, "day"));
+        }
+
+        // section "Includes": "if the starting point of the first interval is less than or equal to the
+        // starting point of the second interval, and the ending point of the first interval is greater than
+        // or equal to the ending point of the second interval. [...] This operator uses the semantics
+        // described in the Start and End operators to determine interval boundaries."
+        [TestMethod]
+        public void IntervalIncludesInterval_ExclusiveLowBoundary_ComparesTheEffectiveStart()
+        {
+            var exclusiveLow = Ival(D(2026, 1, 1), D(2026, 1, 3), false, true);
+            var closed = Ival(D(2026, 1, 1), D(2026, 1, 3), true, true);
+
+            // (@2026-01-01, @2026-01-03] starts a day into [@2026-01-01, @2026-01-03], so it cannot include it.
+            Assert.AreEqual(false, Context.Operators.IntervalIncludesInterval(exclusiveLow, closed, "day"));
+            Assert.AreEqual(false, Context.Operators.IntervalIncludedIn(closed, exclusiveLow, "day"));
+
+            // The other way round it does include it.
+            Assert.AreEqual(true, Context.Operators.IntervalIncludesInterval(closed, exclusiveLow, "day"));
+            Assert.AreEqual(true, Context.Operators.IntervalIncludedIn(exclusiveLow, closed, "day"));
+        }
+
+        // section "Properly Includes": "if the starting point of the first interval is less than or equal to
+        // the starting point of the second interval, and the ending point of the first interval is greater
+        // than or equal to the ending point of the second interval, and they are not the same interval. [...]
+        // This operator uses the semantics described in the Start and End operators to determine interval
+        // boundaries."
+        [TestMethod]
+        public void IntervalProperlyIncludesInterval_SameEffectiveInterval_IsFalseBothWays()
+        {
+            // (@2026-01-01, @2026-01-05] and [@2026-01-02, @2026-01-05] are the same interval: both run
+            // from @2026-01-02 to @2026-01-05. Neither properly includes the other.
+            var exclusiveLow = Ival(D(2026, 1, 1), D(2026, 1, 5), false, true);
+            var closed = Ival(D(2026, 1, 2), D(2026, 1, 5), true, true);
+
+            Assert.AreEqual(false, Context.Operators.IntervalProperlyIncludesInterval(exclusiveLow, closed, "day"));
+            Assert.AreEqual(false, Context.Operators.IntervalProperlyIncludesInterval(closed, exclusiveLow, "day"));
+            Assert.AreEqual(false, Context.Operators.IntervalProperlyIncludedInInterval(exclusiveLow, closed, "day"));
+            Assert.AreEqual(false, Context.Operators.IntervalProperlyIncludedInInterval(closed, exclusiveLow, "day"));
+
+            // A strictly wider interval still properly includes it.
+            var wider = Ival(D(2026, 1, 1), D(2026, 1, 5), true, true);
+            Assert.AreEqual(true, Context.Operators.IntervalProperlyIncludesInterval(wider, exclusiveLow, "day"));
+        }
+
+        // section "Properly Included In", point-interval overload: "this operator returns true if the point
+        // is in (i.e. included in) the interval, and the interval is not a unit interval containing only the
+        // point", on the boundaries the Start and End operators determine.
+        [TestMethod]
+        public void ElementProperlyIncludedInInterval_ExclusiveLowBoundary_ComparesTheEffectiveStart()
+        {
+            var window = Ival(D(2026, 1, 1), D(2026, 1, 5), false, true);
+
+            // The interval starts on @2026-01-02, so its raw low boundary is not in it at all.
+            Assert.AreEqual(false, Context.Operators.ElementProperlyIncludedInInterval(D(2026, 1, 1), window, "day"));
+            Assert.AreEqual(false, Context.Operators.IntervalProperlyIncludesElement(window, D(2026, 1, 1), "day"));
+
+            // From its effective start onwards the point is properly included: the interval is wider than
+            // the point.
+            Assert.AreEqual(true, Context.Operators.ElementProperlyIncludedInInterval(D(2026, 1, 2), window, "day"));
+            Assert.AreEqual(true, Context.Operators.IntervalProperlyIncludesElement(window, D(2026, 1, 2), "day"));
+        }
+
+        [TestMethod]
+        public void ElementProperlyIncludedInInterval_ExclusiveBoundariesAroundOnePoint_IsAUnitInterval()
+        {
+            // Interval(@2026-01-01, @2026-01-03) effectively runs from @2026-01-02 to @2026-01-02: a unit
+            // interval containing only that point, which therefore is not properly included in it.
+            var unit = Ival(D(2026, 1, 1), D(2026, 1, 3), false, false);
+
+            Assert.AreEqual(false, Context.Operators.ElementProperlyIncludedInInterval(D(2026, 1, 2), unit, "day"));
+            Assert.AreEqual(false, Context.Operators.IntervalProperlyIncludesElement(unit, D(2026, 1, 2), "day"));
+        }
+
+        // section "Intersect": "the operator returns the interval that defines the overlapping portion of
+        // both arguments. If the arguments do not overlap, this operator returns null."
+        [TestMethod]
+        public void Intersect_ExclusiveHighMeetingClosedLow_IsNull()
+        {
+            var left = Ival(D(2026, 1, 1), D(2026, 1, 5), true, false);
+            var right = Ival(D(2026, 1, 5), D(2026, 1, 8), true, true);
+
+            // [@2026-01-01, @2026-01-05) ends on @2026-01-04, so it does not reach the other interval.
+            Assert.IsNull(Context.Operators.Intersect(left, right));
+            Assert.IsNull(Context.Operators.Intersect(right, left));
+        }
+
+        [TestMethod]
+        public void Intersect_ExclusiveHighBoundary_ClipsOnTheEffectiveEnd()
+        {
+            var left = Ival(D(2026, 1, 1), D(2026, 1, 5), true, false);
+            var right = Ival(D(2026, 1, 3), D(2026, 1, 8), true, true);
+
+            var intersection = Context.Operators.Intersect(left, right);
+
+            Assert.IsNotNull(intersection);
+            Assert.AreEqual(D(2026, 1, 3), intersection!.low);
+            Assert.AreEqual(D(2026, 1, 4), intersection.high);
+            Assert.AreEqual(true, intersection.lowClosed);
+            Assert.AreEqual(true, intersection.highClosed);
+        }
+
+        // section "Point From": "define \"PointFromExclusive\": point from Interval[4, 5) // 4"
+        [TestMethod]
+        public void PointFrom_ExclusiveBoundaries_ExtractsTheEffectivePoint()
+        {
+            Assert.AreEqual(4, Context.Operators.PointFrom(new CqlInterval<int?>(4, 5, true, false)));
+            Assert.AreEqual(D(2026, 1, 2), Context.Operators.PointFrom(new CqlInterval<CqlDate?>(D(2026, 1, 1), D(2026, 1, 3), false, false)));
+        }
+
+        [TestMethod]
+        public void PointFrom_WiderThanOnePoint_StillThrows()
+        {
+            Assert.ThrowsExactly<InvalidOperationException>(
+                () => Context.Operators.PointFrom(new CqlInterval<CqlDate?>(D(2026, 1, 1), D(2026, 1, 4), false, false)));
+        }
+
+        // section "Collapse": "adjacent intervals within a sorted list are merged if they either overlap or
+        // meet." The sort is on the effective start, so the merge cannot lose the earlier part of the range.
+        [TestMethod]
+        public void Collapse_ExclusiveLowTyingOnTheRawBoundary_KeepsTheWholeRange()
+        {
+            var exclusiveLow = IvalOfNullable(D(2026, 1, 1), D(2026, 1, 10), false, true);
+            var closed = IvalOfNullable(D(2026, 1, 1), D(2026, 1, 5), true, true);
+
+            var collapsed = Context.Operators.Collapse([exclusiveLow, closed], "day")?.ToList();
+
+            Assert.IsNotNull(collapsed);
+            Assert.AreEqual(1, collapsed!.Count);
+            // Asserted through Start and End: had the merge taken the exclusive interval as the one that
+            // starts first, the result would carry its exclusive low and effectively start on @2026-01-02,
+            // dropping the day the closed interval contributed.
+            Assert.AreEqual(D(2026, 1, 1), Context.Operators.Start(collapsed[0]));
+            Assert.AreEqual(D(2026, 1, 10), Context.Operators.End(collapsed[0]));
+        }
+
+        // sections "Contains" and "In" state the same rule in the same words: "returns true if the given
+        // point is equal to the starting or ending point of the interval, or greater than the starting point
+        // and less than the ending point. For open interval boundaries, exclusive comparison operators are
+        // used." Contains must therefore agree with In - and with Includes, whose point-interval overload
+        // "is a synonym for the contains operator" - including when the comparison runs at a precision
+        // coarser than the boundaries, which is where closing the boundary first turns the exclusive
+        // comparison into an inclusive one.
+        [TestMethod]
+        public void Contains_DayPrecision_ExclusiveHighBoundary_AgreesWithIn()
+        {
+            var window = new CqlInterval<CqlDateTime?>(Dt(2026, 6, 1, 8, 0), Dt(2026, 6, 30, 8, 0), true, false);
+
+            AssertContainsAgreesWithIn(window, Dt(2026, 6, 29, 8, 15), expected: true);
+            AssertContainsAgreesWithIn(window, Dt(2026, 6, 30, 8, 15), expected: false);
+        }
+
+        [TestMethod]
+        public void Contains_DayPrecision_ExclusiveLowBoundary_AgreesWithIn()
+        {
+            var window = new CqlInterval<CqlDateTime?>(Dt(2026, 4, 6, 8, 0), Dt(2026, 10, 6, 8, 0), false, true);
+
+            AssertContainsAgreesWithIn(window, Dt(2026, 4, 6, 23, 59), expected: false);
+            AssertContainsAgreesWithIn(window, Dt(2026, 4, 7, 0, 0), expected: true);
+        }
+
+        private static void AssertContainsAgreesWithIn(CqlInterval<CqlDateTime?> window, CqlDateTime point, bool expected)
+        {
+            Assert.AreEqual(expected, Context.Operators.Contains(window, point, "day"), $"contains {point}");
+            Assert.AreEqual(expected, Context.Operators.In(point, window, "day"), $"in {point}");
+            Assert.AreEqual(expected, Context.Operators.IntervalIncludesElement(window, point, "day"), $"includes {point}");
+        }
+    }
+}

--- a/Cql/CoreTests/ExclusiveIntervalBoundaryPrecisionTests.cs
+++ b/Cql/CoreTests/ExclusiveIntervalBoundaryPrecisionTests.cs
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+#nullable enable
+
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
+
+namespace CoreTests
+{
+    /// <summary>
+    /// An exclusive date/time boundary produced by the Interval selector must stay exclusive, so that
+    /// operators comparing at a coarser precision apply an exclusive comparison at that precision.
+    /// CQL 1.5.3 Errata 2, Appendix B - CQL Reference, section "5.3 in": "For open interval boundaries,
+    /// exclusive comparison operators are used. [...] If precision is specified and the point type is a
+    /// date/time type, comparisons used in the operation are performed at the specified precision."
+    /// Normalizing the boundary to a closed one steps it by one unit of the boundary's own precision
+    /// (a millisecond here), which is invisible at millisecond precision but flips the result at day
+    /// precision - the shape emitted for the CQL timing phrases "X Q or less before P of Y" and
+    /// "X starts Q or less after P of Y".
+    /// </summary>
+    [TestClass]
+    public class ExclusiveIntervalBoundaryPrecisionTests
+    {
+        private static readonly CqlContext Context = FhirCqlContext.WithDataSource();
+
+        private static CqlDateTime Dt(int y, int m, int d, int h, int min) =>
+            new(y, m, d, h, min, 0, 0, 0, 0);
+
+        [TestMethod]
+        public void IntervalSelector_ExclusiveDateTimeBoundaries_AreNotNormalizedToClosed()
+        {
+            var interval = Context.Operators.Interval(Dt(2026, 6, 30, 8, 0), Dt(2026, 12, 30, 8, 0), false, false);
+
+            Assert.IsNotNull(interval);
+            Assert.AreEqual(false, interval!.lowClosed);
+            Assert.AreEqual(false, interval.highClosed);
+            Assert.AreEqual(Dt(2026, 6, 30, 8, 0), interval.low);
+            Assert.AreEqual(Dt(2026, 12, 30, 8, 0), interval.high);
+        }
+
+        [TestMethod]
+        public void In_DayPrecision_ExclusiveHighBoundary_ExcludesTheWholeBoundaryDay()
+        {
+            // CMS646 "Cystectomy Done": Cystectomy.performed.toInterval() 6 months or less before
+            // day of start of staging.performed.toInterval(), which the translator emits as
+            // In(End(cystectomy), Interval[stagingStart - 6 months, stagingStart), Day).
+            var stagingStart = Dt(2026, 6, 30, 8, 0);
+            var low = Context.Operators.Subtract(stagingStart, Context.Operators.Quantity(6m, "months"));
+            var window = Context.Operators.Interval(low, stagingStart, true, false);
+
+            // A cystectomy ending later the same day as the excluded high boundary is not "before" it.
+            Assert.AreEqual(false, Context.Operators.In(Dt(2026, 6, 30, 8, 15), window, "day"));
+            // The day before the boundary is inside the window.
+            Assert.AreEqual(true, Context.Operators.In(Dt(2026, 6, 29, 8, 15), window, "day"));
+        }
+
+        [TestMethod]
+        public void In_DayPrecision_ExclusiveLowBoundary_ExcludesTheWholeBoundaryDay()
+        {
+            // CMS646 "First BCG Administered": BCG.effective.toInterval() starts 6 months or less
+            // after day of start of staging.performed.toInterval(), emitted as
+            // In(Start(bcg), Interval(stagingStart, stagingStart + 6 months], Day).
+            var stagingStart = Dt(2026, 4, 6, 8, 0);
+            var high = Context.Operators.Add(stagingStart, Context.Operators.Quantity(6m, "months"));
+            var window = Context.Operators.Interval(stagingStart, high, false, true);
+
+            // A BCG administration starting on the same day as the staging procedure is not "after" it.
+            Assert.AreEqual(false, Context.Operators.In(Dt(2026, 4, 6, 8, 0), window, "day"));
+            Assert.AreEqual(false, Context.Operators.In(Dt(2026, 4, 6, 23, 59), window, "day"));
+            // The next day is inside the window.
+            Assert.AreEqual(true, Context.Operators.In(Dt(2026, 4, 7, 0, 0), window, "day"));
+        }
+
+        [TestMethod]
+        public void In_NoPrecision_ExclusiveBoundaries_StillCompareAtFullPrecision()
+        {
+            var window = Context.Operators.Interval(Dt(2026, 4, 6, 8, 0), Dt(2026, 4, 6, 9, 0), false, false);
+
+            Assert.AreEqual(false, Context.Operators.In(Dt(2026, 4, 6, 8, 0), window, null));
+            Assert.AreEqual(true, Context.Operators.In(Dt(2026, 4, 6, 8, 1), window, null));
+            Assert.AreEqual(false, Context.Operators.In(Dt(2026, 4, 6, 9, 0), window, null));
+        }
+
+        [TestMethod]
+        public void StartAndEnd_OfExclusiveDateTimeInterval_StillStepByOnePointUnit()
+        {
+            var interval = Context.Operators.Interval(Dt(2026, 4, 6, 8, 0), Dt(2026, 4, 6, 9, 0), false, false);
+
+            Assert.AreEqual(new CqlDateTime(2026, 4, 6, 8, 0, 0, 1, 0, 0), Context.Operators.Start(interval));
+            Assert.AreEqual(new CqlDateTime(2026, 4, 6, 8, 59, 59, 999, 0, 0), Context.Operators.End(interval));
+        }
+    }
+}

--- a/Cql/CoreTests/FhirTypeConverterHostConversionTests.cs
+++ b/Cql/CoreTests/FhirTypeConverterHostConversionTests.cs
@@ -39,6 +39,7 @@ namespace CoreTests
             Assert.IsNotNull(converted);
             Assert.AreEqual("2026-01-01T00:00:00.001Z", converted.Start);
             Assert.AreEqual("2026-06-30T23:59:59.999Z", converted.End);
+            AssertValidFhirDateTimeBoundaries(converted);
         }
 
         [TestMethod]
@@ -53,6 +54,7 @@ namespace CoreTests
             Assert.IsNotNull(converted);
             Assert.AreEqual("2026-01-01T00:00:00.000Z", converted.Start);
             Assert.AreEqual("2026-07-01T00:00:00.000Z", converted.End);
+            AssertValidFhirDateTimeBoundaries(converted);
         }
 
         [TestMethod]
@@ -67,6 +69,131 @@ namespace CoreTests
             Assert.IsNotNull(converted);
             Assert.AreEqual("2026-01-01", converted.Start);
             Assert.AreEqual("2026-12-31", converted.End);
+            AssertValidFhirDateBoundaries(converted);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfDateTime_Period_ExclusiveBoundaryAtTypeExtremum_IsEmittedUnstepped()
+        {
+            // The successor of the maximum DateTime and the predecessor of the minimum are not
+            // representable, so there is no inclusive equivalent to emit: the boundary is emitted as it
+            // stands rather than dereferencing a null step or dropping the boundary altogether (which
+            // would read as an unbounded Period).
+            var interval = new CqlInterval<CqlDateTime>(CqlDateTime.MaxValue, CqlDateTime.MaxValue, lowClosed: false, highClosed: true);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("9999-12-31T23:59:59.999Z", converted.Start);
+            AssertValidFhirDateTimeBoundaries(converted);
+
+            var atMinimum = new CqlInterval<CqlDateTime>(CqlDateTime.MinValue, CqlDateTime.MinValue, lowClosed: true, highClosed: false);
+
+            var convertedAtMinimum = FhirTypeConverter.Convert<Period>(atMinimum);
+
+            Assert.IsNotNull(convertedAtMinimum);
+            Assert.AreEqual("0001-01-01T00:00:00.000Z", convertedAtMinimum.End);
+            AssertValidFhirDateTimeBoundaries(convertedAtMinimum);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfDate_Period_ExclusiveBoundaryAtTypeExtremum_IsEmittedUnstepped()
+        {
+            var interval = new CqlInterval<CqlDate>(CqlDate.MaxValue, CqlDate.MaxValue, lowClosed: false, highClosed: true);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("9999-12-31", converted.Start);
+            AssertValidFhirDateBoundaries(converted);
+
+            var atMinimum = new CqlInterval<CqlDate>(CqlDate.MinValue, CqlDate.MinValue, lowClosed: true, highClosed: false);
+
+            var convertedAtMinimum = FhirTypeConverter.Convert<Period>(atMinimum);
+
+            Assert.IsNotNull(convertedAtMinimum);
+            Assert.AreEqual("0001-01-01", convertedAtMinimum.End);
+            AssertValidFhirDateBoundaries(convertedAtMinimum);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfDate_Period_ExclusiveYearPrecisionBoundaryAtTypeExtremum_IsEmittedUnstepped()
+        {
+            // The step is one unit of the boundary's own precision, so a year-precision @9999 overflows
+            // just as a fully specified @9999-12-31 does.
+            var interval = new CqlInterval<CqlDate>(new CqlDate(9999, null, null), new CqlDate(9999, null, null), lowClosed: false, highClosed: true);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("9999", converted.Start);
+            AssertValidFhirDateBoundaries(converted);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfTime_Period_ExclusiveBoundaryAtTypeExtremum_IsEmittedUnstepped()
+        {
+            // A CqlTime step neither overflows nor returns null: the successor of @T23:59:59.999 wraps to
+            // the start of the day and the predecessor of @T00:00:00.000 yields negative components, so
+            // both are rejected and the boundary is emitted as it stands.
+            var interval = new CqlInterval<CqlTime>(CqlTime.MaxValue, CqlTime.MaxValue, lowClosed: false, highClosed: true);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("0001-01-01T23:59:59.999Z", converted.Start);
+            AssertValidFhirDateTimeBoundaries(converted);
+
+            var atMinimum = new CqlInterval<CqlTime>(CqlTime.MinValue, CqlTime.MinValue, lowClosed: true, highClosed: false);
+
+            var convertedAtMinimum = FhirTypeConverter.Convert<Period>(atMinimum);
+
+            Assert.IsNotNull(convertedAtMinimum);
+            Assert.AreEqual("0001-01-01T00:00:00.000Z", convertedAtMinimum.End);
+            AssertValidFhirDateTimeBoundaries(convertedAtMinimum);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfTime_Period_ExclusiveHourPrecisionBoundaryAtTypeExtremum_IsEmittedUnstepped()
+        {
+            // @T23 steps by an hour and @T00 by an hour, so both wrap at hour precision too.
+            var interval = new CqlInterval<CqlTime>(new CqlTime(23, null, null, null, null, null), new CqlTime(0, null, null, null, null, null), lowClosed: false, highClosed: false);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("0001-01-01T23:00:00Z", converted.Start);
+            Assert.AreEqual("0001-01-01T00:00:00Z", converted.End);
+            AssertValidFhirDateTimeBoundaries(converted);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfTime_Period_StepsExclusiveBoundariesInward()
+        {
+            var interval = new CqlInterval<CqlTime>(new CqlTime(10, 30, 0, 0, 0, 0), new CqlTime(16, 45, 15, 123, 0, 0), lowClosed: false, highClosed: false);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("0001-01-01T10:30:00.001Z", converted.Start);
+            Assert.AreEqual("0001-01-01T16:45:15.122Z", converted.End);
+            AssertValidFhirDateTimeBoundaries(converted);
+        }
+
+        private static void AssertValidFhirDateTimeBoundaries(Period period)
+        {
+            if (period.Start is { } start)
+                Assert.IsTrue(M.FhirDateTime.IsValidValue(start), $"Start is not a valid FHIR dateTime: {start}");
+            if (period.End is { } end)
+                Assert.IsTrue(M.FhirDateTime.IsValidValue(end), $"End is not a valid FHIR dateTime: {end}");
+        }
+
+        private static void AssertValidFhirDateBoundaries(Period period)
+        {
+            if (period.Start is { } start)
+                Assert.IsTrue(M.Date.IsValidValue(start), $"Start is not a valid FHIR date: {start}");
+            if (period.End is { } end)
+                Assert.IsTrue(M.Date.IsValidValue(end), $"End is not a valid FHIR date: {end}");
         }
 
         [TestMethod]

--- a/Cql/CoreTests/FhirTypeConverterHostConversionTests.cs
+++ b/Cql/CoreTests/FhirTypeConverterHostConversionTests.cs
@@ -25,6 +25,51 @@ namespace CoreTests
             Hl7.Cql.Fhir.FhirTypeConverter.Create(ModelInfo.ModelInspector);
 
         [TestMethod]
+        public void ConvertCqlIntervalOfDateTime_Period_StepsExclusiveBoundariesInward()
+        {
+            // A FHIR Period is inclusive on both ends, so Interval(@2026-01-01T00:00:00.000Z, @2026-07-01T00:00:00.000Z)
+            // with both boundaries exclusive covers the first millisecond after the low and the last millisecond
+            // before the high.
+            var low = new CqlDateTime(2026, 1, 1, 0, 0, 0, 0, 0, 0);
+            var high = new CqlDateTime(2026, 7, 1, 0, 0, 0, 0, 0, 0);
+            var interval = new CqlInterval<CqlDateTime>(low, high, lowClosed: false, highClosed: false);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("2026-01-01T00:00:00.001Z", converted.Start);
+            Assert.AreEqual("2026-06-30T23:59:59.999Z", converted.End);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfDateTime_Period_KeepsClosedBoundaries()
+        {
+            var low = new CqlDateTime(2026, 1, 1, 0, 0, 0, 0, 0, 0);
+            var high = new CqlDateTime(2026, 7, 1, 0, 0, 0, 0, 0, 0);
+            var interval = new CqlInterval<CqlDateTime>(low, high, lowClosed: true, highClosed: true);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("2026-01-01T00:00:00.000Z", converted.Start);
+            Assert.AreEqual("2026-07-01T00:00:00.000Z", converted.End);
+        }
+
+        [TestMethod]
+        public void ConvertCqlIntervalOfDate_Period_StepsExclusiveHighToPreviousDay()
+        {
+            var low = new CqlDate(2026, 1, 1);
+            var high = new CqlDate(2027, 1, 1);
+            var interval = new CqlInterval<CqlDate>(low, high, lowClosed: true, highClosed: false);
+
+            var converted = FhirTypeConverter.Convert<Period>(interval);
+
+            Assert.IsNotNull(converted);
+            Assert.AreEqual("2026-01-01", converted.Start);
+            Assert.AreEqual("2026-12-31", converted.End);
+        }
+
+        [TestMethod]
         public void ConvertCqlIntervalOfTime_Period_AnchorsTimesOnMinimumFhirDate()
         {
             var low = new CqlTime(10, 30, 0, null, 0, 0);

--- a/Cql/Cql.Firely/FhirTypeConverter.cs
+++ b/Cql/Cql.Firely/FhirTypeConverter.cs
@@ -362,6 +362,10 @@ namespace Hl7.Cql.Fhir
             converter.AddConversion((CqlInterval<long?> interval) => interval is null
                 ? null
                 : NumericIntervalToRange(interval.low, interval.high, interval.lowClosed, interval.highClosed, 1m));
+            // A FHIR Period has inclusive boundaries, so an exclusive CQL boundary is stepped inward by one
+            // unit of its own precision, exactly like NumericIntervalToRange does for a Range. The CQL
+            // interval itself keeps its exclusivity (the Interval selector no longer normalizes it away),
+            // because operators comparing at a coarser precision need the original boundary.
             converter.AddConversion((CqlInterval<CqlDateTime> interval) =>
             {
                 if (interval is null)
@@ -371,12 +375,12 @@ namespace Hl7.Cql.Fhir
                     var period = new M.Period();
                     if (interval.low is { } low)
                     {
-                        period.StartElement = CqlDateTimeToFhirDateTime(low, dateTimeOffsetWhenAbsent);
+                        period.StartElement = CqlDateTimeToFhirDateTime((interval.lowClosed ?? false) ? low : low.Successor(), dateTimeOffsetWhenAbsent);
                     }
 
                     if (interval.high is { } high)
                     {
-                        period.EndElement = CqlDateTimeToFhirDateTime(high, dateTimeOffsetWhenAbsent);
+                        period.EndElement = CqlDateTimeToFhirDateTime((interval.highClosed ?? false) ? high : high.Predecessor(), dateTimeOffsetWhenAbsent);
                     }
                     return period;
                 }
@@ -390,12 +394,12 @@ namespace Hl7.Cql.Fhir
                     var period = new M.Period();
                     if (interval.low is { } low)
                     {
-                        period.Start = low.ToString();
+                        period.Start = ((interval.lowClosed ?? false) ? low : low.Successor()).ToString();
                     }
 
                     if (interval.high is { } high)
                     {
-                        period.End = high.ToString();
+                        period.End = ((interval.highClosed ?? false) ? high : high.Predecessor()).ToString();
                     }
                     return period;
                 }
@@ -409,12 +413,12 @@ namespace Hl7.Cql.Fhir
                     var period = new M.Period();
                     if (interval.low is { } low)
                     {
-                        period.StartElement = CqlTimeToFhirDateTime(low);
+                        period.StartElement = CqlTimeToFhirDateTime((interval.lowClosed ?? false) ? low : low.Successor());
                     }
 
                     if (interval.high is { } high)
                     {
-                        period.EndElement = CqlTimeToFhirDateTime(high);
+                        period.EndElement = CqlTimeToFhirDateTime((interval.highClosed ?? false) ? high : high.Predecessor());
                     }
                     return period;
                 }

--- a/Cql/Cql.Firely/FhirTypeConverter.cs
+++ b/Cql/Cql.Firely/FhirTypeConverter.cs
@@ -365,7 +365,8 @@ namespace Hl7.Cql.Fhir
             // A FHIR Period has inclusive boundaries, so an exclusive CQL boundary is stepped inward by one
             // unit of its own precision, exactly like NumericIntervalToRange does for a Range. The CQL
             // interval itself keeps its exclusivity (the Interval selector no longer normalizes it away),
-            // because operators comparing at a coarser precision need the original boundary.
+            // because operators comparing at a coarser precision need the original boundary. See
+            // PeriodBoundary for what happens when that step is not representable.
             converter.AddConversion((CqlInterval<CqlDateTime> interval) =>
             {
                 if (interval is null)
@@ -375,12 +376,12 @@ namespace Hl7.Cql.Fhir
                     var period = new M.Period();
                     if (interval.low is { } low)
                     {
-                        period.StartElement = CqlDateTimeToFhirDateTime((interval.lowClosed ?? false) ? low : low.Successor(), dateTimeOffsetWhenAbsent);
+                        period.StartElement = CqlDateTimeToFhirDateTime(PeriodBoundary(low, interval.lowClosed, isLow: true), dateTimeOffsetWhenAbsent);
                     }
 
                     if (interval.high is { } high)
                     {
-                        period.EndElement = CqlDateTimeToFhirDateTime((interval.highClosed ?? false) ? high : high.Predecessor(), dateTimeOffsetWhenAbsent);
+                        period.EndElement = CqlDateTimeToFhirDateTime(PeriodBoundary(high, interval.highClosed, isLow: false), dateTimeOffsetWhenAbsent);
                     }
                     return period;
                 }
@@ -394,12 +395,12 @@ namespace Hl7.Cql.Fhir
                     var period = new M.Period();
                     if (interval.low is { } low)
                     {
-                        period.Start = ((interval.lowClosed ?? false) ? low : low.Successor()).ToString();
+                        period.Start = PeriodBoundary(low, interval.lowClosed, isLow: true).ToString();
                     }
 
                     if (interval.high is { } high)
                     {
-                        period.End = ((interval.highClosed ?? false) ? high : high.Predecessor()).ToString();
+                        period.End = PeriodBoundary(high, interval.highClosed, isLow: false).ToString();
                     }
                     return period;
                 }
@@ -413,12 +414,12 @@ namespace Hl7.Cql.Fhir
                     var period = new M.Period();
                     if (interval.low is { } low)
                     {
-                        period.StartElement = CqlTimeToFhirDateTime((interval.lowClosed ?? false) ? low : low.Successor());
+                        period.StartElement = CqlTimeToFhirDateTime(PeriodBoundary(low, interval.lowClosed, isLow: true));
                     }
 
                     if (interval.high is { } high)
                     {
-                        period.EndElement = CqlTimeToFhirDateTime((interval.highClosed ?? false) ? high : high.Predecessor());
+                        period.EndElement = CqlTimeToFhirDateTime(PeriodBoundary(high, interval.highClosed, isLow: false));
                     }
                     return period;
                 }
@@ -741,6 +742,61 @@ namespace Hl7.Cql.Fhir
         /// the CQL IG's FHIR type mapping to make the precision of a value explicit.
         /// </summary>
         internal const string QuantityPrecisionExtensionUrl = "http://hl7.org/fhir/StructureDefinition/quantity-precision";
+
+        /// <summary>
+        /// The inclusive equivalent of a CQL interval boundary, for conversion to a FHIR Period: a closed
+        /// boundary unchanged, an exclusive one stepped inward by one unit of its own precision - the same
+        /// value the CQL Start and End operators report for that boundary.
+        /// </summary>
+        /// <remarks>
+        /// That step is not always representable. The specification has it produce null at the ends of the
+        /// type range ("If the result of the operation cannot be represented (i.e. would result in an
+        /// overflow), the result is null", Appendix B - CQL Reference, sections "Successor" and
+        /// "Predecessor" of CQL 1.5.3 Errata 2), and <see cref="CqlDate"/>/<see cref="CqlDateTime"/> return
+        /// null there. When the step is not representable the boundary is emitted unstepped: it is off by a
+        /// single unit of its own precision, but it stays a valid FHIR value, whereas omitting the boundary
+        /// would turn a bounded interval into an unbounded Period. Such an interval is degenerate to begin
+        /// with - its own Start or End operator is null for the same reason - so no faithful Period exists.
+        /// </remarks>
+        private static CqlDateTime PeriodBoundary(CqlDateTime boundary, bool? closed, bool isLow)
+        {
+            if (closed ?? false)
+                return boundary;
+
+            CqlDateTime? stepped = isLow ? boundary.Successor() : boundary.Predecessor();
+            return stepped ?? boundary;
+        }
+
+        /// <inheritdoc cref="PeriodBoundary(CqlDateTime, bool?, bool)"/>
+        private static CqlDate PeriodBoundary(CqlDate boundary, bool? closed, bool isLow)
+        {
+            if (closed ?? false)
+                return boundary;
+
+            CqlDate? stepped = isLow ? boundary.Successor() : boundary.Predecessor();
+            return stepped ?? boundary;
+        }
+
+        /// <inheritdoc cref="PeriodBoundary(CqlDateTime, bool?, bool)"/>
+        /// <remarks>
+        /// A <see cref="CqlTime"/> step is TimeSpan arithmetic that neither overflows nor returns null:
+        /// past @T23:59:59.999 the successor wraps around to the start of the day, and below @T00:00:00.000
+        /// the predecessor yields negative components, which are not a valid time of day at all. Both are
+        /// rejected by requiring the stepped value to be a time of day that moved in the expected direction.
+        /// </remarks>
+        private static CqlTime PeriodBoundary(CqlTime boundary, bool? closed, bool isLow)
+        {
+            if (closed ?? false)
+                return boundary;
+
+            var stepped = isLow ? boundary.Successor() : boundary.Predecessor();
+            var steppedTimeOfDay = stepped.Value.TimeSpan;
+            var boundaryTimeOfDay = boundary.Value.TimeSpan;
+            var representable = steppedTimeOfDay >= TimeSpan.Zero
+                && (isLow ? steppedTimeOfDay > boundaryTimeOfDay : steppedTimeOfDay < boundaryTimeOfDay);
+
+            return representable ? stepped : boundary;
+        }
 
         /// <summary>
         /// Converts an interval of Integer, Decimal or Long to a FHIR Range of unit-less Quantities (FHIR-56226).

--- a/Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs
@@ -66,9 +66,9 @@ namespace Hl7.Cql.Operators
                 return null;
             else
             {
-                var interval = new CqlInterval<CqlDate?>(low, high, lowClosed, highClosed);
-                var closed = ToClosed(interval);
-                return closed;
+                // Boundary exclusivity is preserved, not normalized with ToClosed() - see the
+                // CqlDateTime overload for why.
+                return new CqlInterval<CqlDate?>(low, high, lowClosed, highClosed);
             }
         }
 
@@ -78,9 +78,16 @@ namespace Hl7.Cql.Operators
                 return null;
             else
             {
-                var interval = new CqlInterval<CqlDateTime?>(low, high, lowClosed, highClosed);
-                var closed = ToClosed(interval);
-                return closed;
+                // Boundary exclusivity is deliberately preserved rather than normalized away with
+                // ToClosed(): closing an exclusive date/time boundary shifts it by one unit of the
+                // boundary value's own precision, which is lossy for any operator that compares at a
+                // coarser precision. In: "For open interval boundaries, exclusive comparison operators
+                // are used. [...] If precision is specified and the point type is a date/time type,
+                // comparisons used in the operation are performed at the specified precision."
+                // (CQL 1.5.3 Errata 2, Appendix B - CQL Reference, 5.3 in). Pre-closing an exclusive
+                // high of @2026-06-30T08:00 to @2026-06-30T07:59:59.999 turns 'in ... day' from an
+                // exclusive same-day comparison into an inclusive one.
+                return new CqlInterval<CqlDateTime?>(low, high, lowClosed, highClosed);
             }
         }
         public CqlInterval<CqlTime?>? Interval(CqlTime? low, CqlTime? high, bool? lowClosed, bool? highClosed)
@@ -89,9 +96,9 @@ namespace Hl7.Cql.Operators
                 return null;
             else
             {
-                var interval = new CqlInterval<CqlTime?>(low, high, lowClosed, highClosed);
-                var closed = ToClosed(interval);
-                return closed;
+                // Boundary exclusivity is preserved, not normalized with ToClosed() - see the
+                // DateTime overload above for why.
+                return new CqlInterval<CqlTime?>(low, high, lowClosed, highClosed);
             }
         }
         #endregion

--- a/Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs
@@ -354,8 +354,13 @@ namespace Hl7.Cql.Operators
             if (count == 0)
                 return new CqlInterval<T?>[0];
 
+            // Sorted on the effective low boundary, because TryCombine below assumes the interval it merges
+            // into starts no later than the one it merges in. An exclusive low is effectively one unit of
+            // its own precision later than the raw value, so two raw lows can tie - or compare equal - where
+            // the effective ones do not, which would otherwise hand TryCombine its operands the wrong way
+            // round and drop the earlier part of the range.
             // need null check on i because i!.low! causes HL7 unit test TestCollapseNull_Test to fail since i is null
-            var sorted = SortBy(intervals, i => i == null ? null! : i.low!, ListSortDirection.Ascending)?.ToList();
+            var sorted = SortBy(intervals, i => i == null ? null! : toClosed(i)!.low!, ListSortDirection.Ascending)?.ToList();
             if (sorted is null || sorted.Count == 0) return null;
 
             CqlInterval<T?>? TryCombine(CqlInterval<T?>? x, CqlInterval<T?>? y)
@@ -404,60 +409,31 @@ namespace Hl7.Cql.Operators
 
         #region Contains
 
+        // Contains is In with its operands the other way round, and the specification states both in the
+        // same words: "returns true if the given point is equal to the starting or ending point of the
+        // interval, or greater than the starting point and less than the ending point. For open interval
+        // boundaries, exclusive comparison operators are used." (CQL 1.5.3 Errata 2, Appendix B - CQL
+        // Reference, sections "Contains" and "In"). The two therefore share one implementation, which also
+        // keeps contains in step with includes - "For the point-interval overload, this operator is a
+        // synonym for the contains operator" (same appendix, section "Includes"). Normalizing the interval
+        // to closed boundaries first would not do: that steps an exclusive boundary by one unit of the
+        // boundary's own precision, which turns the exclusive comparison into an inclusive one whenever
+        // the comparison itself runs at a coarser precision.
         public bool? Contains(CqlInterval<int?>? left, int? right, string? precision) =>
-            IntervalContainsHelper(left, right, precision, ToClosed);
+            In(right, left, precision);
         public bool? Contains(CqlInterval<long?>? left, long? right, string? precision) =>
-            IntervalContainsHelper(left, right, precision, ToClosed);
+            In(right, left, precision);
         public bool? Contains(CqlInterval<decimal?>? left, decimal? right, string? precision) =>
-            IntervalContainsHelper(left, right, precision, ToClosed);
+            In(right, left, precision);
         public bool? Contains(CqlInterval<CqlQuantity?>? left, CqlQuantity? right, string? precision) =>
-            IntervalContainsHelper(left, right, precision, ToClosed);
+            In(right, left, precision);
 
         public bool? Contains(CqlInterval<CqlDate?>? left, CqlDate? right, string? precision) =>
-            IntervalContainsHelper(left, right, precision, ToClosed);
+            In(right, left, precision);
         public bool? Contains(CqlInterval<CqlDateTime?>? left, CqlDateTime? right, string? precision) =>
-            IntervalContainsHelper(left, right, precision, ToClosed);
+            In(right, left, precision);
         public bool? Contains(CqlInterval<CqlTime?>? left, CqlTime? right, string? precision) =>
-            IntervalContainsHelper(left, right, precision, ToClosed);
-
-        public bool? IntervalContainsHelper<T>(CqlInterval<T?>? argument, T point, string? precision,
-            Func<CqlInterval<T?>?, CqlInterval<T?>?> toClosed)
-        {
-            if (argument == null) return false;
-            else if (point == null) return null;
-
-            var low = argument.low;
-            var high = argument.high;
-
-            // handles scenarios of Interval[3,null) contains 5 or Interval(null, 3] constains 5
-            // If a boundary point is null and the boundary is exclusive, the boundary is considered
-            // unknown and operations involving that point will return null
-            if (low == null)
-            {
-                if (argument.lowClosed ?? false)
-                    low = MinValue<T>();
-                else
-                    return null;
-            }
-            if (high == null)
-            {
-                if (argument.highClosed ?? false)
-                    high = MaxValue<T>();
-                else
-                    return null;
-            }
-
-            var interval = new CqlInterval<T>(low, high, argument.lowClosed, argument.highClosed);
-            var closed = toClosed(interval!);
-
-            var lowCompare = Comparer.Compare(point, closed!.low!, precision);
-            var highCompare = Comparer.Compare(point, closed!.high!, precision);
-            if (lowCompare == 0 || highCompare == 0)
-                return true;
-            else if (lowCompare > 0 && highCompare < 0)
-                return true;
-            else return false;
-        }
+            In(right, left, precision);
 
         #endregion
 
@@ -590,7 +566,16 @@ namespace Hl7.Cql.Operators
             if (left == null) return null;
             else if (right == null) return null;
 
-            if (Comparer.Compare(left!.low!, right!.low!, precision) >= 0 && Comparer.Compare(left.high!, right.high!, precision) == 0)
+            // "This operator uses the semantics described in the start and end operators to determine
+            // interval boundaries." (CQL 1.5.3 Errata 2, Appendix B - CQL Reference, section "Ends"), so
+            // an exclusive boundary is compared as the effective one - a step inward at the boundary's own
+            // precision - not as the raw endpoint. Interval[@2026-01-01, @2026-01-03) ends
+            // Interval[@2026-01-01, @2026-01-03] would otherwise be true on the equal raw high boundaries,
+            // even though the first interval effectively ends a day earlier, on @2026-01-02.
+            var leftClosed = ToClosedForPointType(left)!;
+            var rightClosed = ToClosedForPointType(right)!;
+
+            if (Comparer.Compare(leftClosed.low!, rightClosed.low!, precision) >= 0 && Comparer.Compare(leftClosed.high!, rightClosed.high!, precision) == 0)
                 return true;
             else
                 return false;
@@ -1033,6 +1018,15 @@ namespace Hl7.Cql.Operators
             if (larger == null || smaller == null)
                 return null;
 
+            // "This operator uses the semantics described in the Start and End operators to determine
+            // interval boundaries." (CQL 1.5.3 Errata 2, Appendix B - CQL Reference, section "Includes"),
+            // so an exclusive boundary is compared as the effective one - a step inward at the boundary's
+            // own precision. Without that, Interval[@2026-01-01, @2026-01-03] includes
+            // Interval(@2026-01-01, @2026-01-03] would compare the equal raw low boundaries and never see
+            // that the smaller interval starts a day later.
+            larger = ToClosedForPointType(larger)!;
+            smaller = ToClosedForPointType(smaller)!;
+
             var lowIncluded = IsUnknownBoundary(larger.low, larger.lowClosed) || IsUnknownBoundary(smaller.low, smaller.lowClosed)
                 ? RangeLessOrEqual(LowBoundaryRange(larger), LowBoundaryRange(smaller), precision)
                 : Comparer.Compare(larger.low ?? MinValue<T>()!, smaller.low ?? MinValue<T>()!, precision) switch
@@ -1072,9 +1066,18 @@ namespace Hl7.Cql.Operators
 
         public CqlInterval<T>? Intersect<T>(CqlInterval<T>? left, CqlInterval<T>? right)
         {
-            if (left == null
-               || right == null
-               || left.low == null
+            if (left == null || right == null)
+                return null;
+
+            // The overlapping portion is determined from the effective boundaries. Read raw,
+            // Interval[@2026-01-01, @2026-01-05) intersect Interval[@2026-01-05, @2026-01-08] yields the
+            // empty Interval[@2026-01-05, @2026-01-05), where the two intervals in fact do not overlap at
+            // all - "If the arguments do not overlap, this operator returns null." (CQL 1.5.3 Errata 2,
+            // Appendix B - CQL Reference, section "Intersect").
+            left = ToClosedForPointType(left)!;
+            right = ToClosedForPointType(right)!;
+
+            if (left.low == null
                || left.high == null
                || right.low == null
                || right.high == null)
@@ -1863,8 +1866,14 @@ namespace Hl7.Cql.Operators
 
         #region Point from
 
+        // A unit interval is one whose effective start and end are the same point, so both the unit test
+        // and the extracted point use the effective boundaries: "define \"PointFromExclusive\":
+        // point from Interval[4, 5) // 4" (CQL 1.5.3 Errata 2, Appendix B - CQL Reference, section
+        // "Point From").
         public T? PointFrom<T>(CqlInterval<T?>? argument) =>
-           argument == null ? default : (Comparer.Compare(argument!.low!, argument!.high!, null) == 0 ? argument.low : throw new InvalidOperationException("PointFrom can not be extracted  - interval is too wide"));
+           ToClosedForPointType(argument) is { } closed
+               ? Comparer.Compare(closed.low!, closed.high!, null) == 0 ? closed.low : throw new InvalidOperationException("PointFrom can not be extracted  - interval is too wide")
+               : default;
 
         #endregion
 
@@ -1880,6 +1889,15 @@ namespace Hl7.Cql.Operators
                 return null;
             else if (right.low == null && right.high == null)
                 return null;
+
+            // "This operator uses the semantics described in the Start and End operators to determine
+            // interval boundaries." (CQL 1.5.3 Errata 2, Appendix B - CQL Reference, section "Properly
+            // Included In"), so both operands are compared - and tested for being the same interval - on
+            // their effective boundaries, a step inward at the boundary's own precision for an exclusive
+            // one. Interval(@2026-01-01, @2026-01-05] and Interval[@2026-01-02, @2026-01-05] are the same
+            // interval, so neither properly includes the other, which only the effective boundaries show.
+            left = ToClosedForPointType(left)!;
+            right = ToClosedForPointType(right)!;
 
             var min = MinValue<T>()!;
 
@@ -1904,6 +1922,9 @@ namespace Hl7.Cql.Operators
             if (left == null || right == null || right.low == null || right.high == null)
                 return null;
 
+            // The interval's boundaries are its effective ones - see the interval-interval overload above.
+            right = ToClosedForPointType(right)!;
+
             var low = Comparer.Compare(left, right.low, null);
             var high = Comparer.Compare(left, right.high, null);
             if (low < 0)
@@ -1927,6 +1948,11 @@ namespace Hl7.Cql.Operators
                     || GreaterOrSamePrecision(right.low, precision) == false
                     || GreaterOrSamePrecision(right.high, precision) == false)
                 return null;
+
+            // The interval's boundaries are its effective ones - see the interval-interval overload above.
+            // The precision guards above are applied to the operand as given: closing a date/time boundary
+            // steps it by one unit of its own precision and so preserves that precision either way.
+            right = ToClosedForPointType(right)!;
 
             var low = Comparer.Compare(left, right.low, precision);
             var high = Comparer.Compare(left, right.high, precision);
@@ -1953,6 +1979,11 @@ namespace Hl7.Cql.Operators
                     || GreaterOrSamePrecision(right.high, precision) == false)
                 return null;
 
+            // The interval's boundaries are its effective ones - see the interval-interval overload above.
+            // The precision guards above are applied to the operand as given: closing a date/time boundary
+            // steps it by one unit of its own precision and so preserves that precision either way.
+            right = ToClosedForPointType(right)!;
+
             var low = Comparer.Compare(left, right.low, precision);
             var high = Comparer.Compare(left, right.high, precision);
             if (low < 0)
@@ -1977,6 +2008,11 @@ namespace Hl7.Cql.Operators
                      || GreaterOrSamePrecision(right.low, precision) == false
                      || GreaterOrSamePrecision(right.high, precision) == false)
                 return null;
+
+            // The interval's boundaries are its effective ones - see the interval-interval overload above.
+            // The precision guards above are applied to the operand as given: closing a date/time boundary
+            // steps it by one unit of its own precision and so preserves that precision either way.
+            right = ToClosedForPointType(right)!;
 
             var low = Comparer.Compare(left, right.low, precision);
             var high = Comparer.Compare(left, right.high, precision);
@@ -2162,7 +2198,17 @@ namespace Hl7.Cql.Operators
         {
             if (starts == null || other == null)
                 return null;
-            if (Comparer.Compare(starts.low!, other.low!, precision) == 0 && Comparer.Compare(starts.high!, other.high!, precision) <= 0)
+
+            // "This operator uses the semantics described in the start and end operators to determine
+            // interval boundaries." (CQL 1.5.3 Errata 2, Appendix B - CQL Reference, section "Starts"), so
+            // an exclusive boundary is compared as the effective one - a step inward at the boundary's own
+            // precision - not as the raw endpoint. Interval(@2026-01-01, @2026-01-02] starts
+            // Interval[@2026-01-01, @2026-01-03] would otherwise be true on its raw low boundary, even
+            // though its effective start is @2026-01-02.
+            var startsClosed = ToClosedForPointType(starts)!;
+            var otherClosed = ToClosedForPointType(other)!;
+
+            if (Comparer.Compare(startsClosed.low!, otherClosed.low!, precision) == 0 && Comparer.Compare(startsClosed.high!, otherClosed.high!, precision) <= 0)
                 return true;
             return false;
         }
@@ -2268,6 +2314,31 @@ namespace Hl7.Cql.Operators
         }
 
         #endregion
+
+        /// <summary>
+        /// Normalizes an interval to its effective boundaries - the ones the Start and End operators
+        /// return - by dispatching to the <see cref="ToClosed(CqlInterval{int?}?)"/> overload for the
+        /// runtime point type. An operator over an unconstrained point type cannot call ToClosed
+        /// directly, because closing a boundary needs that point type's predecessor and successor.
+        /// An interval over a point type that has neither - for which Start and End are not defined
+        /// either - is returned unchanged.
+        /// </summary>
+        private CqlInterval<T>? ToClosedForPointType<T>(CqlInterval<T>? interval)
+        {
+            object? closed = interval switch
+            {
+                null                        => null,
+                CqlInterval<int?> i         => (object?)ToClosed(i),
+                CqlInterval<long?> i        => ToClosed(i),
+                CqlInterval<decimal?> i     => ToClosed(i),
+                CqlInterval<CqlQuantity?> i => ToClosed(i),
+                CqlInterval<CqlDate?> i     => ToClosed(i),
+                CqlInterval<CqlDateTime?> i => ToClosed(i),
+                CqlInterval<CqlTime?> i     => ToClosed(i),
+                _                           => interval,
+            };
+            return (CqlInterval<T>?)closed;
+        }
 
         public CqlInterval<int?>? ToClosed(CqlInterval<int?>? interval) => ToClosedHelper(interval, Predecessor, Successor);
         public CqlInterval<long?>? ToClosed(CqlInterval<long?>? interval) => ToClosedHelper(interval, Predecessor, Successor);

--- a/docs/releases/vnext/1602-exclusive-interval-boundaries.md
+++ b/docs/releases/vnext/1602-exclusive-interval-boundaries.md
@@ -11,4 +11,4 @@
   boundary into the FHIR conversion, the conversion to a `Period` steps an exclusive date/time boundary
   inward by one unit of its precision, as the `Range` conversion already did, so emitted Periods are
   unchanged. **CQL evaluation results change** for same-day boundary cases; the three CMS646
-  intravesical BCG therapy test cases of the MADiE corpus that exercise this pattern pass.
+  intravesical BCG therapy test cases of the MADiE corpus that exercise this pattern pass. (#1602)

--- a/docs/releases/vnext/1602-exclusive-interval-boundaries.md
+++ b/docs/releases/vnext/1602-exclusive-interval-boundaries.md
@@ -7,8 +7,28 @@
   with an exclusive high compared with `in ... day`), silently became inclusive, so an event on the
   same day as the boundary counted where the CQL excludes it. `in` now applies the exclusive
   comparison the specification requires ("For open interval boundaries, exclusive comparison
-  operators are used", CQL 1.5.3 Appendix B, 5.3). Because a CQL interval can now carry an exclusive
-  boundary into the FHIR conversion, the conversion to a `Period` steps an exclusive date/time boundary
-  inward by one unit of its precision, as the `Range` conversion already did, so emitted Periods are
-  unchanged. **CQL evaluation results change** for same-day boundary cases; the three CMS646
-  intravesical BCG therapy test cases of the MADiE corpus that exercise this pattern pass. (#1602)
+  operators are used", CQL 1.5.3 Appendix B, section "In"), and `contains` shares that
+  implementation, so it no longer disagrees with `in` and `includes` at a coarser precision.
+  **CQL evaluation results change** for same-day boundary cases; the three CMS646 intravesical BCG
+  therapy test cases of the MADiE corpus that exercise this pattern pass. (#1602)
+
+- **Runtime:** the interval operators the specification defines "using the semantics described in
+  the Start and End operators" now compare the effective boundaries rather than the raw endpoints:
+  `starts`, `ends`, `includes`/`included in`, `properly includes`/`properly included in` (both the
+  interval-interval and the point-interval overloads), `intersect` and `point from`, plus the
+  ordering `collapse` merges intervals in. The selector's own normalization used to hand these
+  operators pre-closed intervals, so an exclusive boundary reaching them read one unit of its own
+  precision too wide - `Interval(@2026-01-01, @2026-01-02] starts Interval[@2026-01-01, @2026-01-03]`
+  was true although its effective start is `@2026-01-02`, and `Interval[@2026-01-01, @2026-01-05)
+  intersect Interval[@2026-01-05, @2026-01-08]` produced an empty interval instead of null. The
+  operators that already normalized their operands (`after`, `before`, `meets`, `overlaps`,
+  `same as`, `same or after`/`same or before`, `except`, `union`, `expand`, `width`, `size`) and
+  interval equality, equivalence and hashing are unaffected. (#1602)
+
+- **FHIR conversion:** because a CQL interval can now carry an exclusive boundary into the FHIR
+  conversion, the conversion to a `Period` steps an exclusive date/time boundary inward by one unit
+  of its precision, as the `Range` conversion already did, so emitted Periods are unchanged for the
+  intervals that were previously representable. An exclusive boundary at the end of the point type's
+  range - where `successor`/`predecessor` is not representable and `CqlDate`/`CqlDateTime` return
+  null while `CqlTime` wraps around midnight - is emitted unstepped instead of throwing a
+  `NullReferenceException` or emitting an invalid FHIR value such as `T00:00:00.-001`. (#1602)

--- a/docs/releases/vnext/exclusive-interval-boundaries.md
+++ b/docs/releases/vnext/exclusive-interval-boundaries.md
@@ -1,0 +1,14 @@
+## Fixes
+
+- **Runtime:** the `Interval` selector keeps an exclusive date, dateTime or time boundary exclusive
+  instead of normalizing it to a closed boundary one unit of the value's own precision inward. That
+  normalization was lossless only for comparisons at the value's own precision; a timing phrase that
+  compares at a coarser precision, such as `6 months or less before day of start of X` (an interval
+  with an exclusive high compared with `in ... day`), silently became inclusive, so an event on the
+  same day as the boundary counted where the CQL excludes it. `in` now applies the exclusive
+  comparison the specification requires ("For open interval boundaries, exclusive comparison
+  operators are used", CQL 1.5.3 Appendix B, 5.3). Because a CQL interval can now carry an exclusive
+  boundary into the FHIR conversion, the conversion to a `Period` steps an exclusive date/time boundary
+  inward by one unit of its precision, as the `Range` conversion already did, so emitted Periods are
+  unchanged. **CQL evaluation results change** for same-day boundary cases; the three CMS646
+  intravesical BCG therapy test cases of the MADiE corpus that exercise this pattern pass.


### PR DESCRIPTION
## Description

The `Interval` selector normalized an exclusive date, dateTime or time boundary into a closed one by stepping it one unit of the boundary value's own precision inward. That is lossless only when the later comparison happens at that same precision. Timing phrases such as `6 months or less before day of start of X` build an interval with an exclusive high and compare with `in ... day`, so the pre-closed boundary (one millisecond before the start of the day) turned the exclusive same-day comparison into an inclusive one. `In` already implements the exclusive comparison the specification requires (CQL 1.5.3 Appendix B, section "In": "For open interval boundaries, exclusive comparison operators are used") but never saw an open boundary.

The selector now returns the interval with its boundary flags intact, and `Contains` shares `In`'s implementation (the spec states both in the same words, and calls the point overload of `Includes` a synonym of `contains`), so `in`, `contains` and `includes` agree at a coarser precision.

**Operators defined through Start/End.** With exclusive boundaries reaching the operators, everything the spec defines "using the semantics described in the Start and End operators" has to compare effective boundaries rather than raw endpoints; the selector's normalization used to provide that implicitly. Those operators now normalize their operands with `ToClosed` at entry: `Starts`, `Ends`, `Includes`/`Included In`, `Properly Includes`/`Properly Included In` (interval-interval and point-interval overloads), `Intersect`, `Point From`, and the ordering `Collapse` merges in. Unchanged, because they already normalized: `After`/`Before`, `Meets*`, `Overlaps*`, `SameAs`, `SameOr*`, `Except`, `Union`, `Expand`, `Width`, `Size`, and interval equality/equivalence/hashing in the comparer. `Start`/`End` keep stepping by one point unit.

**FHIR conversion.** The conversion of a CQL interval to a FHIR `Period` steps an exclusive date/time boundary inward by one unit of its precision, as the `Range` conversion already did, so emitted Periods do not change. Where that step is not representable (`CqlDate`/`CqlDateTime` at the end of their range return null; `CqlTime` wraps around midnight or yields negative components) the boundary is emitted unstepped rather than throwing or emitting an invalid value; omitting it would misstate a bounded interval as unbounded, and such an interval is degenerate anyway since its own `Start`/`End` is null for the same reason.

**CQL evaluation results change** for same-day boundary cases and for the operators listed above when an exclusive boundary is involved. Release-note fragment under `docs/releases/vnext/`. No generated code changes, so `GeneratorToolVersion` is untouched.

## Related issues

None filed. Found while tracing MADiE integration-runner failures for CMS646 (test cases `10cec7db`, `6e9a1974`, `ab48e0c0`: cystectomy on the day of staging, BCG on the day staging started).

## Testing

- `ExclusiveIntervalBoundaryPrecisionTests` (5 tests: selector preserves flags; `in ... day` excludes the boundary day for an exclusive high and an exclusive low; `in` without precision still compares at full precision; `Start`/`End` still step). Three fail without the runtime change.
- `EffectiveIntervalBoundaryOperatorTests` (13 tests): the exclusive-boundary case for each operator above, plus `contains` agreeing with `in` at day precision. Twelve fail without the operator changes; the thirteenth guards that `point from` still throws for an interval wider than one point.
- `FhirTypeConverterHostConversionTests`: Period conversion of exclusive and closed dateTime/date/time boundaries, plus five extrema cases; every emitted boundary validated with `FhirDateTime.IsValidValue`/`Date.IsValidValue`.
- `CoreTests`: 1405 passed, 0 failed, 8 skipped (net10.0).
- Integration runner, full QI-Core 2025 corpus in validate mode against `passed.jsonl`: the three CMS646 cases above start passing; no regressions.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoPNvHfeXidST7F5ypteFd