### PR TITLE
Fix NU1902: bump Microsoft.SourceLink.GitHub to 10.0.401

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The SDK depends on the following key external packages:
 
 - **Antlr4.Runtime.Standard**: Version 4.13.1 - ANTLR4 runtime for CQL grammar parsing
 - **Microsoft.CodeAnalysis.CSharp**: Version 5.3.0 - Roslyn C# compiler APIs
+- **Microsoft.SourceLink.GitHub**: Version 10.0.401 - Source Link integration for GitHub repositories
 
 ### Configuration & Logging
 

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -49,7 +49,7 @@
 
 		<PackageReference
 			Include="Microsoft.SourceLink.GitHub"
-			Version="8.0.0"
+			Version="10.0.401"
 			PrivateAssets="All"/>
 
 		<PackageReference


### PR DESCRIPTION
## Problem

CI restore fails with 14 errors:

```
error NU1902: Warning As Error: Package 'Microsoft.Build.Tasks.Git' 8.0.0 has a known
moderate severity vulnerability, https://github.com/advisories/GHSA-23fw-v26w-5fgq
```

`Microsoft.SourceLink.GitHub` 8.0.0 (referenced in `cql-sdk.props`) pulls in the vulnerable `Microsoft.Build.Tasks.Git` 8.0.0 transitively. Combined with `TreatWarningsAsErrors`, this fails restore for every project importing `cql-sdk.props`.

## Fix

Bump to `Microsoft.SourceLink.GitHub` 10.0.401 (current stable), which brings `Microsoft.Build.Tasks.Git` 10.0.401.

## Verification

Reproduced and verified locally with `-p:NuGetAuditMode=all` (needed because the local SDK 8 defaults to `direct`-only auditing, whereas CI's SDK 10 audits transitively):

- `Version="8.0.0"` → NU1902 raised
- `Version="10.0.401"` → clean restore

Full CI restore on the .NET 10 SDK is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSoSckbbVdYo5WBUeH8zkT